### PR TITLE
Bug Fix: Prompt for API base URL in setup wizard for custom providers

### DIFF
--- a/src/kitty/cli/setup_cmd.py
+++ b/src/kitty/cli/setup_cmd.py
@@ -71,6 +71,15 @@ def run_setup_wizard(store: ProfileStore, cred_store: CredentialStore) -> Profil
     from kitty.providers.registry import get_provider as _get_provider
     provider_adapter = _get_provider(provider)
 
+    provider_config: dict = {}
+    if provider_adapter.requires_custom_url:
+        while True:
+            base_url = prompt_text("API base URL (e.g. https://api.deepseek.com/v1): ")
+            if base_url and base_url.strip():
+                provider_config = {"base_url": base_url.strip()}
+                break
+            print_error("Base URL is required for this provider")
+
     if provider_adapter.requires_oauth:
         print_step(2, 6, "OAuth login")
         from kitty.cli.auth_cmd import run_oauth_for_provider
@@ -141,6 +150,7 @@ def run_setup_wizard(store: ProfileStore, cred_store: CredentialStore) -> Profil
         provider=provider,  # type: ignore[arg-type]
         model=model,
         auth_ref=auth_ref,
+        provider_config=provider_config,
         is_default=set_default,
     )
 


### PR DESCRIPTION
### What does this PR do?
Adds the missing API base URL prompt to the initial `kitty setup` command wizard (`run_setup_wizard`) for providers that require it.

### Why is this needed?
Currently, `custom_openai` providers have `requires_custom_url = True`. The interactive profile management menu (`kitty profile`) already handled this correctly, but the initial first-run `kitty setup` wizard was missing this logic. 

Because of this, users selecting "Custom OpenAI-Compatible" during their very first setup were never asked for a base URL, resulting in it not being configured.

### Changes made:
* Added a prompt the user for the "API base URL" if `provider_adapter.requires_custom_url` is True.
* Passed the resulting `provider_config` dictionary into the `Profile` creation step.