### PR TITLE
Refresh model metadata via a pull request, not a push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   update-metadata:
@@ -36,22 +37,48 @@ jobs:
             echo "OPENROUTER_API_KEY not set; skipping metadata update"
           fi
 
-      - name: Commit refreshed model metadata
+      # Branch protection requires every change to main to go through a pull
+      # request, so this opens one instead of pushing directly. The previous
+      # version pushed straight to main and had been failing since that rule
+      # was added, which is why the committed metadata drifted.
+      - name: Propose refreshed model metadata
         if: github.event_name != 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: chore/model-metadata
         run: |
           if git diff --quiet -- src/kitty/providers/model_metadata.json; then
             echo "Model metadata is already up to date"
-          else
-            git add src/kitty/providers/model_metadata.json
-            git -c user.name="github-actions[bot]" \
-                -c user.email="41898282+github-actions[bot]@users.noreply.github.com" \
-                commit -m "Update OpenRouter model metadata"
-            git push
+            exit 0
           fi
 
-      - name: Check model metadata is current
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -B "$BRANCH"
+          git add src/kitty/providers/model_metadata.json
+          git commit -m "Update OpenRouter model metadata"
+          git push --force-with-lease origin "$BRANCH"
+
+          if [ -z "$(gh pr list --head "$BRANCH" --state open --json number --jq '.[].number')" ]; then
+            gh pr create --base main --head "$BRANCH"               --title "Update OpenRouter model metadata"               --body "Automated refresh of the bundled model catalogue from the OpenRouter API."
+          else
+            echo "Existing pull request updated"
+          fi
+
+      # Reported, not enforced. This compares against the OpenRouter API as it
+      # is right now, so it can drift between a refresh and a pull request
+      # through no fault of that pull request -- which used to fail unrelated
+      # work. Freshness is maintained by the scheduled refresh above.
+      - name: Report model metadata drift
         if: github.event_name == 'pull_request'
-        run: git diff --exit-code -- src/kitty/providers/model_metadata.json
+        run: |
+          if git diff --quiet -- src/kitty/providers/model_metadata.json; then
+            echo "Model metadata is current."
+          else
+            echo "::notice::Bundled model metadata differs from the live OpenRouter catalogue."
+            echo "The scheduled refresh will open a pull request; no action needed here."
+            git diff --stat -- src/kitty/providers/model_metadata.json
+          fi
 
   test:
     # Shared with publish.yml so a release runs exactly these checks.

--- a/tests/test_github_actions.py
+++ b/tests/test_github_actions.py
@@ -309,3 +309,55 @@ class TestReleaseIsGatedOnTests:
 
         assert claimed, "expected Python version classifiers in pyproject.toml"
         assert claimed <= tested, f"classifiers claim {sorted(claimed - tested)} but CI never tests them"
+
+
+# ── R6: metadata refresh must work under branch protection ────────────────
+
+
+class TestMetadataRefreshRespectsBranchProtection:
+    """The refresh job must not push to a protected branch.
+
+    `main` requires changes to arrive via pull request. The job used to run
+    `git push` directly and had been failing on every push since that rule was
+    enabled, so the bundled catalogue silently stopped being refreshed and
+    unrelated pull requests started failing a freshness check nothing could
+    satisfy.
+    """
+
+    @pytest.fixture()
+    def steps(self) -> list[dict]:
+        workflow = _load_workflow("ci.yml")
+        return workflow["jobs"]["update-metadata"]["steps"]
+
+    def test_no_step_pushes_to_the_default_branch(self, steps: list[dict]):
+        offenders = [
+            step.get("name")
+            for step in steps
+            if re.search(r"git push(?!\s+--force-with-lease origin \"\$BRANCH\")\s*$", step.get("run", ""), re.M)
+        ]
+
+        assert not offenders, f"these steps push directly to main, which branch protection rejects: {offenders}"
+
+    def test_refresh_opens_a_pull_request(self, steps: list[dict]):
+        run_commands = " ".join(step.get("run", "") for step in steps)
+
+        assert "gh pr create" in run_commands, "the refresh must propose its change as a pull request"
+
+    def test_refresh_has_permission_to_open_one(self):
+        workflow = _load_workflow("ci.yml")
+
+        assert workflow.get("permissions", {}).get("pull-requests") == "write"
+
+    def test_pull_requests_are_not_failed_by_metadata_drift(self, steps: list[dict]):
+        """The check compares against a live API, so it can never be satisfiable.
+
+        Enforcing it means unrelated pull requests go red whenever OpenRouter
+        publishes a model between the last refresh and the pull request.
+        """
+        pr_steps = [s for s in steps if "pull_request'" in str(s.get("if", ""))]
+        assert pr_steps, "expected a pull_request-scoped metadata step"
+
+        for step in pr_steps:
+            assert "--exit-code" not in step.get("run", ""), (
+                f"step {step.get('name')!r} fails the build on metadata drift; it should report instead"
+            )


### PR DESCRIPTION
## Summary

Unblocks the v1.3.0 release by fixing the CI job that has been failing on **every push to `main`**.

## What was wrong

`main` has a branch protection rule requiring all changes to arrive via pull request. The `update-metadata` job refreshes the bundled OpenRouter catalogue and `git push`es straight to `main`, so it has been rejected ever since that rule was enabled:

```
remote: error: GH013: Repository rule violations found for refs/heads/main.
remote: - Changes must be made through a pull request.
 ! [remote rejected] main -> main (push declined due to repository rule violations)
```

Two consequences, both observed in the last few days:

1. **The catalogue stopped being refreshed.** The "weekly auto-refresh" has not worked at all. `model_metadata.json` only got updated when a human happened to include it in a PR — which is what happened, manually, on #2 and #5.
2. **Unrelated PRs went red.** The `pull_request` half of the same job compares the committed file against the *live* API and fails if they differ. Both #2 and #5 failed on a file neither touched.

So the job was enforcing a freshness policy that its own automation was forbidden from maintaining.

## The fix

**Refresh now opens a PR.** The job commits to `chore/model-metadata` and creates or updates a pull request, which works within the branch protection rule and keeps the change reviewable.

**The PR-side check becomes advisory.** This is the part worth being explicit about: that check compares against the OpenRouter API *as it is at that moment*, so **no periodic refresh can ever satisfy it**. A model published between the last refresh and your PR fails your PR. Drift is now reported as a GitHub notice with a diffstat; freshness is maintained by the scheduled job that can actually act on it.

Nothing real is weakened — the check never guaranteed release freshness, it only compared to live data at PR time.

## Testing

Four tests in `tests/test_github_actions.py`, which already parses the workflows:

- no step pushes directly to the default branch;
- the refresh opens a pull request;
- the job has `pull-requests: write`;
- no `pull_request`-scoped step uses `--exit-code`, i.e. metadata drift cannot fail unrelated work.

31 workflow tests pass.

## One caveat

PRs opened with `GITHUB_TOKEN` do not trigger workflows, by GitHub's design. The metadata PR will therefore show no checks. It touches a single generated data file, and merging it runs `main`'s CI. If you would rather it be verified before merge, that needs a PAT or a GitHub App — happy to follow up.

## Why now

This is the last thing standing between `main` and a green board, and you asked to fix it before tagging **v1.3.0** (backup profiles + static egress, both already merged and unreleased).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
