### PR TITLE
Make mypy clean and enforce it in CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - "v*"
 
+permissions:
+  contents: read
+
 jobs:
   # Gate the release on the same suite pull requests must pass. A tag that
   # fails the tests must never reach PyPI, where a version can't be reused.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,9 @@ name: Tests
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Python ${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,11 +33,12 @@ jobs:
       - name: Check import layering
         run: lint-imports
 
+      # A gate, not a report. mypy found four user-visible defects the suite
+      # could not: each lived on a path tests do not execute -- an interactive
+      # terminal, a non-Linux OS, or a second implementation of an interface.
+      - name: Type check
+        run: mypy src/kitty
+
       - name: Test
         run: pytest -q
 
-      # Not yet a gate: the codebase currently has pre-existing annotation
-      # errors. Reported so the debt stays visible and can be burned down.
-      - name: Type check (informational)
-        continue-on-error: true
-        run: mypy src/kitty

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ dev = [
     "aioresponses>=0.7",
     "ruff>=0.4",
     "mypy>=1.10",
+    "types-PyYAML>=6.0",
     "import-linter>=2.0",
     "build>=1.0",
     "hatchling>=1.0",

--- a/src/kitty/auth/oauth_session.py
+++ b/src/kitty/auth/oauth_session.py
@@ -69,7 +69,7 @@ class OAuthSession:
     access_token_expires_at: float  # epoch seconds
     api_key_expires_at: float  # epoch seconds
     _file_path: str | None = field(default=None, repr=False)
-    _refresh_lock: asyncio.Lock = field(default=None, repr=False)
+    _refresh_lock: asyncio.Lock | None = field(default=None, repr=False)
 
     def __post_init__(self) -> None:
         if self._refresh_lock is None:
@@ -282,7 +282,7 @@ class OAuthSession:
                     body.get("error_description"),
                 )
             result = await resp.json()
-        return result["openai_api_key"]
+        return str(result["openai_api_key"])
 
     # ── Public API ─────────────────────────────────────────────────────────
 
@@ -304,6 +304,7 @@ class OAuthSession:
         Raises:
             OAuthRefreshFailed: If refresh fails and cannot be recovered.
         """
+        assert self._refresh_lock is not None  # created in __post_init__
         async with self._refresh_lock:
             # Re-check after acquiring the lock — another coroutine may have refreshed
             if (

--- a/src/kitty/auth/openai_oauth.py
+++ b/src/kitty/auth/openai_oauth.py
@@ -23,7 +23,7 @@ import logging
 import secrets
 import urllib.parse
 import webbrowser
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import aiohttp
 from aiohttp import web
@@ -111,7 +111,7 @@ def _decode_jwt_payload(token: str) -> dict:
         payload += "=" * padding
     try:
         decoded = base64.urlsafe_b64decode(payload)
-        return json.loads(decoded)
+        return cast(dict, json.loads(decoded))
     except Exception:
         return {}
 
@@ -266,7 +266,7 @@ async def _exchange_code_for_tokens(
                 list(tokens.keys()),
             )
             raise OAuthAuthorizationError("Token response missing required fields")
-        return tokens
+        return cast(dict, tokens)
 
 
 async def _exchange_id_token_for_api_key(
@@ -320,7 +320,7 @@ async def _exchange_id_token_for_api_key(
                 "token_exchange_failed",
                 f"Response missing openai_api_key: {result}",
             )
-    return api_key
+    return cast(str, api_key)
 
 
 # ── Main orchestrator ────────────────────────────────────────────────────

--- a/src/kitty/auth/openai_oauth.py
+++ b/src/kitty/auth/openai_oauth.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import contextlib
+import html
 import json
 import logging
 import secrets
@@ -200,9 +201,18 @@ async def _start_callback_server(
             error_description = request.query.get("error_description", "")
             oauth_error = OAuthAuthorizationError(error, error_description)
             code_future.set_result(oauth_error)
+            # Escaped: both values come straight from the callback query
+            # string, so reflecting them raw makes this page an XSS sink for
+            # anyone who can get the browser to hit the loopback callback
+            # while a login is in progress.
             return web.Response(
                 status=400,
-                text=f"<html><body><p>Authorization error: {error}</p><p>{error_description}</p></body></html>",
+                text=(
+                    "<html><body>"
+                    f"<p>Authorization error: {html.escape(error)}</p>"
+                    f"<p>{html.escape(error_description)}</p>"
+                    "</body></html>"
+                ),
                 content_type="text/html",
             )
 

--- a/src/kitty/bridge/config.py
+++ b/src/kitty/bridge/config.py
@@ -92,7 +92,7 @@ def load_bridge_config(
 
     config = BridgeConfig(
         host=str(_get("host", cli_host, _DEFAULT_HOST)),
-        port=int(_get("port", cli_port, _DEFAULT_PORT)),
+        port=int(_get("port", cli_port, _DEFAULT_PORT)),  # type: ignore[call-overload]  # _get returns object
         profile=_get("profile", cli_profile, None),  # type: ignore[arg-type]
         keys_file=str(_expand_path(str(_get("keys_file", None, _DEFAULT_KEYS_FILE))) or _DEFAULT_KEYS_FILE),  # type: ignore[arg-type]
         log_access=_get("log_access", cli_log_access, None),  # type: ignore[arg-type]

--- a/src/kitty/bridge/manage.py
+++ b/src/kitty/bridge/manage.py
@@ -128,7 +128,8 @@ def _health_monitor(
 def stop_bridge(state_path: Path | str | None = None) -> None:
     """Stop a running bridge instance.
 
-    Sends SIGTERM, waits up to 10 seconds, then SIGKILL if needed.
+    Sends SIGTERM, waits up to 10 seconds, then force-kills if needed (SIGKILL
+    where available, SIGTERM on Windows where it does not exist).
     Always removes the state file.
     """
     state_path = Path(state_path) if state_path else _get_state_path()
@@ -147,10 +148,15 @@ def stop_bridge(state_path: Path | str | None = None) -> None:
                 break
             time.sleep(0.1)
 
-        # Force kill if still alive
+        # Force kill if still alive. SIGKILL is POSIX-only; on Windows os.kill
+        # terminates unconditionally for any signal other than the console
+        # control events, so SIGTERM is the right fallback there. Without this,
+        # the branch raised AttributeError and skipped remove_state() below,
+        # leaving the stale state file this command exists to clear.
         if is_pid_alive(state.pid):
+            force_signal = getattr(signal, "SIGKILL", signal.SIGTERM)
             with contextlib.suppress(ProcessLookupError):
-                os.kill(state.pid, signal.SIGKILL)
+                os.kill(state.pid, force_signal)
 
     remove_state(state_path)
 

--- a/src/kitty/bridge/messages/translator.py
+++ b/src/kitty/bridge/messages/translator.py
@@ -218,7 +218,7 @@ class MessagesTranslator:
 
         return result
 
-    def _translate_message(self, msg: dict) -> dict | None:
+    def _translate_message(self, msg: dict) -> dict | list[dict] | None:
         """Translate a single Messages API message to Chat Completions format.
 
         Returns the translated message dict. For user messages with multiple
@@ -371,7 +371,7 @@ class MessagesTranslator:
         """Emit `message_start` once per streaming response."""
         if self._message_started:
             return
-        message_obj = {
+        message_obj: dict = {
             "id": message_id,
             "type": "message",
             "role": "assistant",

--- a/src/kitty/bridge/responses/translator.py
+++ b/src/kitty/bridge/responses/translator.py
@@ -78,8 +78,9 @@ class ResponsesTranslator:
         self._accumulated_text: str = ""
         self._accumulated_reasoning: str = ""
         self._seq: int = 0
-        self._text_item_id: str | None = None
-        self._reasoning_item_id: str | None = None
+        # Empty string means "not started"; every read is a truthiness test.
+        self._text_item_id: str = ""
+        self._reasoning_item_id: str = ""
         self._text_started: bool = False
         self._reasoning_started: bool = False
         self._last_was_empty: bool = False
@@ -96,8 +97,8 @@ class ResponsesTranslator:
         self._accumulated_text = ""
         self._accumulated_reasoning = ""
         self._seq = 0
-        self._text_item_id = None
-        self._reasoning_item_id = None
+        self._text_item_id = ""
+        self._reasoning_item_id = ""
         self._text_started = False
         self._reasoning_started = False
         self._last_was_empty = False
@@ -219,8 +220,9 @@ class ResponsesTranslator:
                         parts.append(part)
                     # Other types: skip
             # If all parts are strings, concatenate into single string
-            if all(isinstance(p, str) for p in parts):
-                return "\n".join(parts) if parts else ""
+            text_parts = [p for p in parts if isinstance(p, str)]
+            if len(text_parts) == len(parts):
+                return "\n".join(text_parts) if parts else ""
             return parts
         return content
 

--- a/src/kitty/bridge/server.py
+++ b/src/kitty/bridge/server.py
@@ -18,7 +18,8 @@ import traceback
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, NoReturn
+from types import TracebackType
+from typing import TYPE_CHECKING, NoReturn, TextIO, TypedDict, cast
 
 import aiohttp
 from aiohttp import web
@@ -108,7 +109,9 @@ def _setup_crash_handlers(log_path: Path, *, state_path: str | None = None) -> N
         crash_logger.warning("Could not open log file for faulthandler: %s", log_path)
 
     # sys.excepthook: unhandled Python exceptions
-    def _crash_excepthook(exc_type: type[BaseException], exc_value: BaseException, exc_tb: object) -> NoReturn:
+    def _crash_excepthook(
+        exc_type: type[BaseException], exc_value: BaseException, exc_tb: TracebackType | None
+    ) -> NoReturn:
         crash_logger.critical(
             "Unhandled exception — process will exit. %s: %s\n%s",
             exc_type.__name__,
@@ -608,8 +611,23 @@ class UpstreamError(Exception):
 # health marking, usage logging) reads from the context var, ensuring
 # concurrent requests within the same event loop never accidentally
 # use another request's backend.
-_backend_context: contextvars.ContextVar[dict] = contextvars.ContextVar("backend_context")
-_EMPTY_CTX: dict = {}  # Sentinel default for _backend_context.get() — avoids per-access allocation
+class _BackendContext(TypedDict, total=False):
+    """Per-request record of which balancing backend was selected.
+
+    Concurrent requests each need their own view of the chosen backend, so this
+    is carried in a ContextVar rather than on the server. Declaring the shape
+    keeps the ``_active_*`` properties typed instead of returning Any.
+    """
+
+    provider: ProviderAdapter
+    key: str
+    model: str | None
+    idx: int
+    provider_config: dict
+
+
+_backend_context: contextvars.ContextVar[_BackendContext] = contextvars.ContextVar("backend_context")
+_EMPTY_CTX: _BackendContext = {}  # Sentinel default for .get() — avoids per-access allocation
 
 
 class BridgeServer:
@@ -617,7 +635,7 @@ class BridgeServer:
 
     def __init__(
         self,
-        adapter: LauncherAdapter,
+        adapter: LauncherAdapter | None,
         provider: ProviderAdapter,
         resolved_key: str,
         host: str = "127.0.0.1",
@@ -665,7 +683,7 @@ class BridgeServer:
 
         # Access logging
         self._access_log_path = access_log_path
-        self._access_log_file = None
+        self._access_log_file: TextIO | None = None
         self._profile_name = profile_name
 
         # State file
@@ -779,7 +797,7 @@ class BridgeServer:
     def _active_provider_config(self, value: dict) -> None:
         self.__dict__["_provider_config"] = value
 
-    def _get_backend_context(self) -> dict:
+    def _get_backend_context(self) -> _BackendContext:
         """Return the current request's backend context from the ContextVar."""
         return _backend_context.get(_EMPTY_CTX)
 
@@ -1074,8 +1092,8 @@ class BridgeServer:
         # First failure: start at 30s regardless of initial cooldown
         if health["healthy"] or health.get("stream_error_count", 0) == 0:
             return 30
-        count = health.get("stream_error_count", 0)
-        return min(30 * (2**count), self._backend_cooldown)
+        count = int(health.get("stream_error_count", 0))
+        return int(min(30 * (2**count), self._backend_cooldown))
 
     def _get_transport_error_cooldown(self, backend_idx: int) -> int:
         """Return cooldown for a transport/connection-reset failure.
@@ -1191,7 +1209,7 @@ class BridgeServer:
             return choices[0].get("finish_reason") is not None
         return False
 
-    def _select_backend(self, *, require_streaming: bool = False) -> dict:
+    def _select_backend(self, *, require_streaming: bool = False) -> _BackendContext:
         """Select next backend and set active fields for the current request.
 
         When require_streaming is True, only selects backends whose provider
@@ -1215,7 +1233,7 @@ class BridgeServer:
         # requests within the same event loop get their own ContextVar
         # value and never see this one, even if the instance fields are
         # overwritten by another request's _select_backend().
-        result = {
+        result: _BackendContext = {
             "provider": provider,
             "key": key,
             "model": model,
@@ -1475,7 +1493,7 @@ class BridgeServer:
     async def _auth_middleware(self, request: web.Request, handler: object) -> web.StreamResponse:
         # If no keys configured, allow all
         if not self._keys_entries:
-            return await handler(request)  # type: ignore[misc]
+            return await handler(request)  # type: ignore[misc, no-any-return, operator]
 
         auth_header = request.headers.get("Authorization", "")
         token = auth_header[7:] if auth_header.startswith("Bearer ") else None
@@ -1493,7 +1511,7 @@ class BridgeServer:
         if mapped_profile is not None:
             request["_mapped_profile"] = mapped_profile
 
-        return await handler(request)  # type: ignore[misc]
+        return await handler(request)  # type: ignore[misc, no-any-return, operator]
 
     # ── Access log middleware ─────────────────────────────────────────────
 
@@ -1502,7 +1520,7 @@ class BridgeServer:
         start = time.monotonic()
         response: web.StreamResponse | None = None
         try:
-            response = await handler(request)  # type: ignore[misc]
+            response = await handler(request)  # type: ignore[misc, operator]
         except web.HTTPException:
             raise
         except Exception as exc:
@@ -1776,7 +1794,7 @@ class BridgeServer:
                     except (ConnectionResetError, BrokenPipeError, OSError):
                         logger.debug("Client disconnected before error event")
                     break
-                upstream_status = 200
+                upstream_status: int | None = 200
                 break
 
             cc_request.pop("_resolved_key", None)
@@ -2456,11 +2474,25 @@ class BridgeServer:
                     type(self._active_provider).__name__,
                 )
             else:
-                if sr is not None:
-                    try:
-                        await sr.write_eof()
-                    except (ConnectionResetError, BrokenPipeError, OSError):
-                        logger.debug("Client disconnected before stream EOF")
+                # Defensive. Reaching this needs the loop to exit after a
+                # transport failure but before any bytes are written, which
+                # every constructed scenario short-circuits into the 503
+                # all-backends-unhealthy response first. Kept because the
+                # alternative -- returning None -- makes aiohttp raise
+                # "handler should return a response" and the caller sees an
+                # opaque 500 with no diagnosis. Not covered by a test.
+                if sr is None:
+                    return _make_error_response(
+                        {
+                            "type": "error",
+                            "error": {"type": "api_error", "message": "Upstream returned an empty stream"},
+                        },
+                        status=_last_error_status,
+                    )
+                try:
+                    await sr.write_eof()
+                except (ConnectionResetError, BrokenPipeError, OSError):
+                    logger.debug("Client disconnected before stream EOF")
                 return sr
 
         try:
@@ -3470,6 +3502,7 @@ class BridgeServer:
 
     async def _request_with_retry_balancing(self, cc_request: dict) -> dict:
         """Balancing retry: failover across backends on errors or empty responses."""
+        assert self._backends is not None  # balancing mode only
         n_backends = len(self._backends)
         last_exc: UpstreamError | Exception | None = None
         last_response: dict | None = None
@@ -3638,6 +3671,11 @@ class BridgeServer:
         if last_exc is not None:
             raise last_exc
         # All backends returned empty — return the empty response
+        if last_response is None:
+            # Defensive: this function is only entered under `if self._backends:`,
+            # so one of last_exc/last_response is always set. Kept so the dict
+            # contract every caller relies on cannot be violated silently.
+            raise UpstreamError(502, "All backends failed without returning a response")
         return last_response
 
     async def _handle_chat_completions(self, request: web.Request) -> web.StreamResponse:
@@ -4595,7 +4633,9 @@ class BridgeServer:
         The result is capped at _MAX_REQUEST_CHARS (absolute safety limit).
         """
         if self._backends:
-            backend_tuples = [(b[0].provider_type, b[2].model, b[2].provider_config) for b in self._backends]
+            backend_tuples: list[tuple[str, str, dict | None]] = [
+                (b[0].provider_type, b[2].model, b[2].provider_config) for b in self._backends
+            ]
             context_tokens = get_balancing_min_context_tokens(backend_tuples)
             return min(tokens_to_chars(context_tokens), _MAX_REQUEST_CHARS)
 
@@ -5208,7 +5248,7 @@ class BridgeServer:
         # model-aware header construction (e.g. OpenCode Go).
         if hasattr(provider, "build_upstream_headers_for_model"):
             model = self._active_model or ""
-            return provider.build_upstream_headers_for_model(self._active_key, model)
+            return cast("dict[str, str]", provider.build_upstream_headers_for_model(self._active_key, model))  # type: ignore[attr-defined]  # optional provider hook
         return provider.build_upstream_headers(self._active_key)
 
     async def _make_upstream_request(self, cc_request: dict, *, retry_rate_limit: bool = True) -> dict:
@@ -5256,7 +5296,7 @@ class BridgeServer:
                         and last_body.get("type") == "message"
                     ):
                         return last_body
-                    return self._active_provider.translate_from_upstream(last_body)
+                    return self._active_provider.translate_from_upstream(cast(dict, last_body))
 
                 # In balancing mode (retry_rate_limit=False), raise 429 immediately
                 # so the caller can fail over to another backend.

--- a/src/kitty/cli/auth_cmd.py
+++ b/src/kitty/cli/auth_cmd.py
@@ -55,7 +55,7 @@ async def run_oauth_for_provider(
     config_dir = profile_store._path.parent  # type: ignore[attr-defined]
     session = OAuthSession.create_session_file(session, auth_ref, config_dir)
 
-    session_file_path = Path(session._file_path)  # type: ignore[assignment]
+    session_file_path = Path(session._file_path)  # type: ignore[arg-type, assignment]
     cred_store.set(auth_ref, str(session_file_path))
 
     return auth_ref, str(session_file_path)

--- a/src/kitty/cli/launcher.py
+++ b/src/kitty/cli/launcher.py
@@ -217,14 +217,10 @@ async def launch_async(
 
     # 7. Patch agent-specific external config (e.g. Claude Code settings.json)
     original_settings: str | None = None
-    settings_path: Path | None = None
-    if hasattr(adapter, "prepare_launch"):
-        # Resolve the settings path before calling prepare_launch so we can
-        # pass it explicitly for both patching and cleanup.
-        if hasattr(adapter, "_DEFAULT_SETTINGS_PATH"):
-            settings_path = adapter._DEFAULT_SETTINGS_PATH
-        else:
-            settings_path = Path.home() / ".claude" / "settings.json"
+    settings_path: Path | None = adapter.default_settings_path
+    if settings_path is not None:
+        # Each adapter owns its agent's config file. Guessing one default here
+        # previously handed every agent Claude Code's settings.json.
         original_settings = adapter.prepare_launch(
             spawn_config.env_overrides,
             settings_path=settings_path,
@@ -236,9 +232,8 @@ async def launch_async(
                 f"[kitty debug] settings.json patched (original={'saved' if original_settings else 'none'})",
                 file=sys.stderr,
             )
-    else:
-        if debug:
-            print("[kitty debug] adapter has no prepare_launch method", file=sys.stderr)
+    elif debug:
+        print(f"[kitty debug] {adapter.name} has no settings file to patch", file=sys.stderr)
 
     # 8. Spawn child process with signal forwarding
     logger.info("Launching child: %s", " ".join(cmd))
@@ -286,7 +281,7 @@ async def launch_async(
                     proc.kill()
     finally:
         # 9. Restore external config (must not prevent server shutdown on failure)
-        if hasattr(adapter, "cleanup_launch"):
+        if settings_path is not None:
             with contextlib.suppress(Exception):
                 adapter.cleanup_launch(
                     original_settings,

--- a/src/kitty/cli/main.py
+++ b/src/kitty/cli/main.py
@@ -13,6 +13,7 @@ __all__ = ["main", "map_child_exit_code"]
 
 if TYPE_CHECKING:
     from kitty.profiles.schema import BalancingProfile
+    from kitty.profiles.store import ProfileStore
 
 
 def map_child_exit_code(code: int) -> int:
@@ -200,6 +201,9 @@ def main() -> None:
         status = bridge_status(_state_path)
         if status == BridgeStatus.RUNNING:
             state = load_state(_state_path)
+            if state is None:
+                print("Bridge is not running.")
+                sys.exit(1)
             scheme = "https" if state.tls else "http"
             print(f"Running: {scheme}://{state.host}:{state.port} (profile={state.profile}, PID {state.pid})")
             sys.exit(0)
@@ -231,12 +235,12 @@ def main() -> None:
 
         from platformdirs import user_config_dir as _ucd
 
-        _config_path = str(_Path(_ucd("kitty")) / "bridge.yaml")
+        _service_config_path = str(_Path(_ucd("kitty")) / "bridge.yaml")
         dry_run = "--dry-run" in result.extra_args
         from kitty.bridge.service import generate_launchd_plist, generate_systemd_unit, generate_windows_script
 
         if sys.platform == "linux":
-            content = generate_systemd_unit(executable=sys.executable, config_path=_config_path)
+            content = generate_systemd_unit(executable=sys.executable, config_path=_service_config_path)
             if dry_run:
                 print(content)
             else:
@@ -249,7 +253,7 @@ def main() -> None:
                 print(f"Installed: {unit_path}")
                 print("Enable: systemctl --user enable --now kitty-bridge")
         elif sys.platform == "darwin":
-            content = generate_launchd_plist(executable=sys.executable, config_path=_config_path)
+            content = generate_launchd_plist(executable=sys.executable, config_path=_service_config_path)
             if dry_run:
                 print(content)
             else:
@@ -259,7 +263,7 @@ def main() -> None:
                 print(f"Installed: {plist_path}")
                 print("Load: launchctl load " + str(plist_path))
         else:
-            content = generate_windows_script(executable=sys.executable, config_path=_config_path)
+            content = generate_windows_script(executable=sys.executable, config_path=_service_config_path)
             if dry_run:
                 print(content)
             else:
@@ -331,7 +335,7 @@ def _run_auth(profile_store: object, cred_store: object, extra_args: list[str]) 
         print(f"Unknown auth provider: {args[0]!r}")
 
 
-def _print_unknown_command(args: list[str], adapters: dict, store: object) -> None:
+def _print_unknown_command(args: list[str], adapters: dict, store: ProfileStore) -> None:
     """Print a friendly error message for unrecognized commands."""
     from kitty.tui.display import print_error
 
@@ -419,15 +423,15 @@ def _run_bridge(
     profile = backend  # type: ignore[assignment]
 
     # Resolve API key from credential store
-    auth_ref = profile.auth_ref  # type: ignore[union-attr]
-    resolved_key = cred_store.get(auth_ref)  # type: ignore[union-attr]
+    auth_ref = profile.auth_ref  # type: ignore[attr-defined, union-attr]
+    resolved_key = cred_store.get(auth_ref)  # type: ignore[attr-defined, union-attr]
     if not resolved_key:
-        print_error(f"No API key found for profile {profile.name!r}")
+        print_error(f"No API key found for profile {profile.name!r}")  # type: ignore[attr-defined, union-attr]
         sys.exit(1)
 
     # Get provider adapter
     provider = get_provider(
-        profile.provider,  # type: ignore[union-attr]
+        profile.provider,  # type: ignore[attr-defined, union-attr]
         getattr(profile, "provider_config", None),
     )
 
@@ -448,7 +452,7 @@ def _run_bridge(
         adapter=None,  # type: ignore[arg-type]
         provider=provider,
         resolved_key=resolved_key,
-        model=profile.model,  # type: ignore[union-attr]
+        model=profile.model,  # type: ignore[attr-defined, union-attr]
         debug=effective_debug,
         provider_config=getattr(profile, "provider_config", {}),
         logging_enabled=logging_enabled,
@@ -462,9 +466,9 @@ def _run_bridge(
         print_panel(
             "Kitty Bridge Mode",
             f"[kitty.ok]Bridge server running on http://127.0.0.1:{port}[/kitty.ok]\n\n"
-            f"Profile: [kitty.accent]{profile.name}[/kitty.accent]\n"  # type: ignore[union-attr]
-            f"Provider: [kitty.accent]{profile.provider}[/kitty.accent]\n"  # type: ignore[union-attr]
-            f"Model: [kitty.accent]{profile.model}[/kitty.accent]\n\n"  # type: ignore[union-attr]
+            f"Profile: [kitty.accent]{profile.name}[/kitty.accent]\n"  # type: ignore[attr-defined, union-attr]
+            f"Provider: [kitty.accent]{profile.provider}[/kitty.accent]\n"  # type: ignore[attr-defined, union-attr]
+            f"Model: [kitty.accent]{profile.model}[/kitty.accent]\n\n"  # type: ignore[attr-defined, union-attr]
             f"Endpoints:\n"
             f"  • POST /v1/chat/completions\n"
             f"  • POST /v1/messages\n"
@@ -525,7 +529,7 @@ def _run_bridge_balancing(
     # Build backends list: (provider, resolved_key, profile)
     backends = []
     for mp in member_profiles:
-        key = cred_store.get(mp.auth_ref)  # type: ignore[union-attr]
+        key = cred_store.get(mp.auth_ref)  # type: ignore[attr-defined, union-attr]
         if not key:
             print_error(f"No API key found for member profile {mp.name!r}")
             sys.exit(1)
@@ -626,7 +630,7 @@ def _launch_target(
     return launch(
         adapter=adapter,  # type: ignore[arg-type]
         provider=get_provider(
-            profile.provider,  # type: ignore[union-attr]
+            profile.provider,  # type: ignore[attr-defined, union-attr]
             getattr(profile, "provider_config", None),
         ),
         profile=profile,  # type: ignore[arg-type]
@@ -663,7 +667,7 @@ def _launch_target_balancing(
     # Build backends list
     backends = []
     for mp in member_profiles:
-        key = cred_store.get(mp.auth_ref)  # type: ignore[union-attr]
+        key = cred_store.get(mp.auth_ref)  # type: ignore[attr-defined, union-attr]
         if not key:
             from kitty.tui.display import print_error
 

--- a/src/kitty/cli/router.py
+++ b/src/kitty/cli/router.py
@@ -123,7 +123,7 @@ class CLIRouter:
                 sub_builtin = _BUILTIN_MAP.get(sub_key)
                 if sub_builtin is not None:
                     return RouteResult(builtin=sub_builtin, extra_args=rest[1:])
-            backend = self._resolver.resolve_default_backend()
+            backend: BackendConfig | None = self._resolver.resolve_default_backend()
             profile = backend if isinstance(backend, Profile) else None
             return RouteResult(builtin=builtin, profile=profile, backend=backend, extra_args=rest)
 

--- a/src/kitty/launchers/base.py
+++ b/src/kitty/launchers/base.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
+from pathlib import Path
 
 from kitty.profiles.schema import Profile
 from kitty.types import BridgeProtocol
@@ -59,3 +60,43 @@ class LauncherAdapter(ABC):
             bridge_port: Port the local bridge is listening on.
             resolved_key: Raw API key string resolved from the credential store.
         """
+
+    def prepare_launch(
+        self,
+        env_overrides: dict[str, str],
+        settings_path: Path | None = None,
+    ) -> str | None:
+        """Patch the agent's own config file before spawning it, if needed.
+
+        Some agents read a settings file whose ``env`` block overrides
+        process-level environment variables, so pointing them at the local
+        bridge requires editing that file for the duration of the session.
+        Adapters whose agent needs no such patching inherit this default.
+
+        Args:
+            env_overrides: Environment values the bridge needs the agent to use.
+            settings_path: Location of the agent's settings file. Defaults to
+                the adapter's own location.
+
+        Returns:
+            The original file content, for :meth:`cleanup_launch` to restore, or
+            ``None`` when nothing was patched. Returning ``None`` is what tells
+            the launcher there is nothing to clean up.
+        """
+        return None
+
+    def cleanup_launch(
+        self,
+        original: str | None,
+        settings_path: Path | None = None,
+    ) -> None:
+        """Restore whatever :meth:`prepare_launch` patched.
+
+        Called on the normal path and again from an atexit handler, so it must
+        be safe to invoke with nothing to restore.
+
+        Args:
+            original: Content returned by :meth:`prepare_launch`, or ``None``.
+            settings_path: Location of the agent's settings file.
+        """
+        return None

--- a/src/kitty/launchers/base.py
+++ b/src/kitty/launchers/base.py
@@ -61,6 +61,18 @@ class LauncherAdapter(ABC):
             resolved_key: Raw API key string resolved from the credential store.
         """
 
+    @property
+    def default_settings_path(self) -> Path | None:
+        """Location of the agent's own settings file.
+
+        The launcher patches this file to point the agent at the local bridge.
+        Adapters whose agent has no such file return ``None``.
+
+        Returns:
+            Path to the agent's settings file, or ``None``.
+        """
+        return None
+
     def prepare_launch(
         self,
         env_overrides: dict[str, str],

--- a/src/kitty/launchers/claude.py
+++ b/src/kitty/launchers/claude.py
@@ -145,7 +145,7 @@ class ClaudeAdapter(LauncherAdapter):
     def prepare_launch(
         self,
         env_overrides: dict[str, str],
-        settings_path: Path = _DEFAULT_SETTINGS_PATH,
+        settings_path: Path | None = None,
     ) -> str | None:
         """Temporarily patch Claude Code's settings.json to inject bridge env vars.
 
@@ -162,6 +162,7 @@ class ClaudeAdapter(LauncherAdapter):
             if there is no settings file to patch, the file is missing, or
             the JSON is malformed.
         """
+        settings_path = settings_path or _DEFAULT_SETTINGS_PATH
         logger.info("prepare_launch: settings_path=%s exists=%s", settings_path, settings_path.exists())
         if not settings_path.exists():
             logger.warning("prepare_launch: settings.json not found at %s — skipping patch", settings_path)
@@ -217,7 +218,7 @@ class ClaudeAdapter(LauncherAdapter):
     def cleanup_launch(
         self,
         original: str | None,
-        settings_path: Path = _DEFAULT_SETTINGS_PATH,
+        settings_path: Path | None = None,
     ) -> None:
         """Restore Claude Code's settings.json to its original state.
 
@@ -225,6 +226,7 @@ class ClaudeAdapter(LauncherAdapter):
             original: The content returned by :meth:`prepare_launch`.
             settings_path: Path to the Claude Code settings file (for testing).
         """
+        settings_path = settings_path or _DEFAULT_SETTINGS_PATH
         if original is None:
             return
         logger.info("cleanup_launch: restoring %s", settings_path)

--- a/src/kitty/launchers/claude.py
+++ b/src/kitty/launchers/claude.py
@@ -142,6 +142,15 @@ class ClaudeAdapter(LauncherAdapter):
             env_clear=list(_CONFLICTING_ENV_VARS),
         )
 
+    @property
+    def default_settings_path(self) -> Path | None:
+        """Location of Claude Code's settings file.
+
+        Returns:
+            Path to ``~/.claude/settings.json``.
+        """
+        return _DEFAULT_SETTINGS_PATH
+
     def prepare_launch(
         self,
         env_overrides: dict[str, str],

--- a/src/kitty/launchers/kilo.py
+++ b/src/kitty/launchers/kilo.py
@@ -97,7 +97,7 @@ class KiloAdapter(LauncherAdapter):
     def prepare_launch(
         self,
         env_overrides: dict[str, str],
-        config_path: Path = _DEFAULT_CONFIG_PATH,
+        settings_path: Path | None = None,
     ) -> str | None:
         """Write a temporary Kilo CLI config pointing at the bridge.
 
@@ -105,7 +105,7 @@ class KiloAdapter(LauncherAdapter):
             env_overrides: Env vars from ``build_spawn_config`` (unused; values
                 are read from instance attributes stashed during
                 ``build_spawn_config``).
-            config_path: Path to the Kilo CLI config file (for testing).
+            settings_path: Path to the Kilo CLI config file (for testing).
 
         Returns:
             The original file content for ``cleanup_launch``, or ``None``.
@@ -113,6 +113,7 @@ class KiloAdapter(LauncherAdapter):
         Raises:
             RuntimeError: If ``build_spawn_config`` was not called first.
         """
+        config_path = settings_path or _DEFAULT_CONFIG_PATH
         if not self._bridge_port:
             raise RuntimeError("build_spawn_config must be called before prepare_launch")
 
@@ -153,14 +154,15 @@ class KiloAdapter(LauncherAdapter):
     def cleanup_launch(
         self,
         original: str | None,
-        config_path: Path = _DEFAULT_CONFIG_PATH,
+        settings_path: Path | None = None,
     ) -> None:
         """Restore the original Kilo CLI config file.
 
         Args:
             original: The content returned by ``prepare_launch``.
-            config_path: Path to the Kilo CLI config file (for testing).
+            settings_path: Path to the Kilo CLI config file (for testing).
         """
+        config_path = settings_path or _DEFAULT_CONFIG_PATH
         if original is None:
             # We created the file from scratch; remove it
             try:

--- a/src/kitty/launchers/kilo.py
+++ b/src/kitty/launchers/kilo.py
@@ -94,6 +94,15 @@ class KiloAdapter(LauncherAdapter):
             env_clear=[],
         )
 
+    @property
+    def default_settings_path(self) -> Path | None:
+        """Location of the Kilo CLI config file.
+
+        Returns:
+            Path to ``~/.config/kilo/kilo.json``.
+        """
+        return _DEFAULT_CONFIG_PATH
+
     def prepare_launch(
         self,
         env_overrides: dict[str, str],

--- a/src/kitty/profiles/schema.py
+++ b/src/kitty/profiles/schema.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import re
 import typing
 import uuid
+from collections.abc import Callable
 from typing import Literal
 
 from pydantic import BaseModel, UrlConstraints, field_validator, model_validator
@@ -202,7 +203,7 @@ class BalancingProfile(BaseModel):
             raise ValueError(f"balancing profile {self.name!r} must not self-reference in members")
         return self
 
-    def validate_member_existence(self, member_exists: callable) -> BalancingProfile:
+    def validate_member_existence(self, member_exists: Callable[[str], bool]) -> BalancingProfile:
         """F36: Verify all members reference existing profiles.
 
         Args:

--- a/src/kitty/providers/anthropic.py
+++ b/src/kitty/providers/anthropic.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import uuid
+from typing import cast
 
 from kitty.providers.base import ProviderAdapter, ProviderError
 
@@ -41,7 +42,9 @@ def _safe_json_load_args(arguments: str | None) -> dict:
     """
     raw = arguments or "{}"
     try:
-        return json.loads(raw)
+        # json.loads is typed as returning Any; the guard below covers the
+        # only failure mode, and callers require a mapping.
+        return cast(dict, json.loads(raw))
     except json.JSONDecodeError:
         return {}
 

--- a/src/kitty/providers/bedrock.py
+++ b/src/kitty/providers/bedrock.py
@@ -70,7 +70,8 @@ class BedrockAdapter(ProviderAdapter):
 
     def get_region(self, provider_config: dict) -> str:
         """Get AWS region from provider_config."""
-        return provider_config.get("region", _DEFAULT_REGION)
+        region = provider_config.get("region")
+        return str(region) if region else _DEFAULT_REGION
 
     def get_profile_name(self, provider_config: dict) -> str | None:
         """Get AWS profile name from provider_config."""

--- a/src/kitty/providers/custom_anthropic.py
+++ b/src/kitty/providers/custom_anthropic.py
@@ -66,7 +66,7 @@ class CustomAnthropicAdapter(AnthropicAdapter):
                 raise ValueError(
                     f"Invalid base_url in provider_config: {url!r}. Must be a non-empty http:// or https:// URL."
                 )
-            return url
+            return str(url)
         return self.default_base_url
 
     def translate_to_upstream(self, cc_request: dict) -> dict:

--- a/src/kitty/providers/custom_openai.py
+++ b/src/kitty/providers/custom_openai.py
@@ -45,7 +45,7 @@ class CustomOpenAIAdapter(ProviderAdapter):
                 raise ValueError(
                     f"Invalid base_url in provider_config: {url!r}. Must be a non-empty http:// or https:// URL."
                 )
-            return url
+            return str(url)
         return self.default_base_url
 
     def build_upstream_headers(self, api_key: str) -> dict[str, str]:

--- a/src/kitty/providers/model_context.py
+++ b/src/kitty/providers/model_context.py
@@ -65,7 +65,7 @@ def _coerce_context_tokens(value: object) -> int | None:
     if isinstance(value, bool):
         return None
     try:
-        result = int(value)
+        result = int(value)  # type: ignore[call-overload]  # value comes from untyped JSON
         return result if result > 0 else None
     except (TypeError, ValueError):
         return None

--- a/src/kitty/providers/ollama.py
+++ b/src/kitty/providers/ollama.py
@@ -53,9 +53,8 @@ class OllamaAdapter(ProviderAdapter):
         Returns:
             Base URL string.
         """
-        if provider_config and "base_url" in provider_config:
-            return provider_config["base_url"]
-        return self.default_base_url
+        url = (provider_config or {}).get("base_url")
+        return str(url) if url else self.default_base_url
 
     def build_upstream_headers(self, api_key: str) -> dict[str, str]:
         """Build headers for Ollama.

--- a/src/kitty/providers/ollama_cloud.py
+++ b/src/kitty/providers/ollama_cloud.py
@@ -262,7 +262,7 @@ class OllamaCloudAdapter(ProviderAdapter):
     @staticmethod
     def _translate_tool_calls(tool_calls: list[dict]) -> list[dict]:
         """Translate Ollama tool calls to CC format (arguments as JSON string)."""
-        cc_tool_calls = []
+        cc_tool_calls: list[dict] = []
         for tc in tool_calls:
             func = tc.get("function", {})
             args = func.get("arguments", {})

--- a/src/kitty/providers/openai_subscription.py
+++ b/src/kitty/providers/openai_subscription.py
@@ -33,8 +33,9 @@ import platform
 import random
 import time
 import uuid
-from collections.abc import Awaitable, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable
 from pathlib import Path
+from typing import Protocol
 
 import curl_cffi.requests
 
@@ -49,6 +50,28 @@ from kitty.providers.openai import OpenAIAdapter
 __all__ = ["OpenAISubscriptionAdapter"]
 
 logger = logging.getLogger(__name__)
+
+
+class _CurlResponse(Protocol):
+    """The part of a ``curl_cffi`` response this adapter relies on.
+
+    curl_cffi publishes no type stubs, so its response object is untyped.
+    Declaring the handful of members actually used keeps the rest of this
+    module type-checked instead of silently opting out of it.
+    """
+
+    status_code: int
+    text: str
+    content: bytes
+
+    def aiter_content(self) -> AsyncIterator[bytes]:
+        """Stream the response body.
+
+        Returns:
+            An async iterator over the body chunks.
+        """
+        ...
+
 
 # Codex backend endpoint for ChatGPT subscription access
 _CODEX_BACKEND_URL = "https://chatgpt.com/backend-api/codex/responses"
@@ -69,7 +92,7 @@ def _codex_backoff(attempt: int) -> float:
     exp = 2 ** (attempt - 1)
     millis = _CODEX_RETRY_BASE_DELAY_MS * exp
     jitter = random.uniform(0.9, 1.1)  # noqa: S311
-    return (millis * jitter) / 1000.0
+    return float((millis * jitter) / 1000.0)
 
 
 # Codex CLI version sent in the version header.
@@ -245,7 +268,8 @@ class OpenAISubscriptionAdapter(OpenAIAdapter):
             payload_b64 += "=" * missing
             payload = json.loads(__import__("base64").urlsafe_b64decode(payload_b64))
             auth_ns = payload.get("https://api.openai.com/auth", {})
-            return auth_ns.get("chatgpt_account_id")
+            account_id = auth_ns.get("chatgpt_account_id")
+            return str(account_id) if account_id is not None else None
         except Exception:
             return None
 
@@ -397,7 +421,7 @@ class OpenAISubscriptionAdapter(OpenAIAdapter):
         """Log which Cloudflare cookies are present for ChatGPT hosts."""
         jar = cookies.jar
         cf_cookies = [
-            f"{c.name}={c.value[:8]}..." if len(c.value) > 8 else f"{c.name}={c.value}"
+            f"{c.name}={(c.value or '')[:8]}..." if len(c.value or "") > 8 else f"{c.name}={c.value or ''}"
             for c in jar
             if _is_chatgpt_host(c.domain) and (c.name in _CF_COOKIE_ALLOWLIST or c.name.startswith(_CF_COOKIE_PREFIX))
         ]
@@ -502,7 +526,7 @@ class OpenAISubscriptionAdapter(OpenAIAdapter):
         # Step 0: initial attempt, Step 1: reload from disk, Step 2: force-refresh.
         import aiohttp
 
-        resp: object | None = None
+        resp: _CurlResponse | None = None
         got_401 = False
         async with aiohttp.ClientSession(**aiohttp_session_kwargs()) as oauth_http:
             for _auth_step in range(3):
@@ -617,6 +641,8 @@ class OpenAISubscriptionAdapter(OpenAIAdapter):
                     logger.warning("Codex backend 401: forcing token refresh")
 
         # Auth recovery exhausted — still 401
+        if resp is None:
+            raise ProviderError("Codex backend returned no response")
         if got_401:
             logger.warning("Codex backend 401: auth recovery exhausted")
             raw = resp.text
@@ -673,7 +699,7 @@ class OpenAISubscriptionAdapter(OpenAIAdapter):
         import aiohttp
 
         got_401 = False
-        resp: object | None = None
+        resp: _CurlResponse | None = None
         async with aiohttp.ClientSession(**aiohttp_session_kwargs()) as oauth_http:
             for _auth_step in range(3):
                 resp = None
@@ -816,6 +842,8 @@ class OpenAISubscriptionAdapter(OpenAIAdapter):
                     logger.warning("Codex backend 401: forcing token refresh")
 
         # Auth recovery exhausted — still 401
+        if resp is None:
+            raise ProviderError("Codex backend returned no response")
         if got_401:
             logger.warning("Codex backend 401: auth recovery exhausted")
             raw = resp.text
@@ -1135,7 +1163,7 @@ class OpenAISubscriptionAdapter(OpenAIAdapter):
             return None
         return max(1, seconds)
 
-    def _attach_retry_after(self, err: Exception, resp: object) -> None:
+    def _attach_retry_after(self, err: Exception, resp: _CurlResponse) -> None:
         if not isinstance(err, ProviderError) or err.http_status != 429:
             return
         headers = getattr(resp, "headers", None) or {}
@@ -1144,7 +1172,7 @@ class OpenAISubscriptionAdapter(OpenAIAdapter):
             err.retry_after = retry_after
             logger.info("OpenAI subscription rate limited; retry_after=%ds", retry_after)
 
-    def map_error(self, status_code: int, body: dict) -> Exception:
+    def map_error(self, status_code: int, body: dict) -> ProviderError:
         error_obj = body.get("error", body)
         msg = error_obj.get("message", str(error_obj)) if isinstance(error_obj, dict) else str(error_obj)
         if status_code == 401:

--- a/src/kitty/providers/registry.py
+++ b/src/kitty/providers/registry.py
@@ -93,7 +93,7 @@ def get_provider(provider_type: str, provider_config: dict | None = None) -> Pro
     if cls is None:
         raise KeyError(f"Unknown provider type: {provider_type!r}. Available: {sorted(_registry)}")
     if provider_config is not None and _supports_provider_config(cls):
-        return cls(provider_config=provider_config)
+        return cls(provider_config=provider_config)  # type: ignore[call-arg]  # checked by _supports_provider_config
     return cls()
 
 

--- a/src/kitty/tui/display.py
+++ b/src/kitty/tui/display.py
@@ -221,6 +221,9 @@ class LiveChecklist:
                 each refresh rebuilds the table. The previous version assigned to
                 a non-existent ``Row.cells`` attribute, which silently did
                 nothing and left every check showing the pending spinner.
+
+                Returns:
+                    A table reflecting every check's current status and detail.
                 """
                 table = Table.grid(padding=(0, 2))
                 table.add_column()
@@ -240,7 +243,7 @@ class LiveChecklist:
                     item.detail = detail
                     live.update(_render())
         else:
-            items: list[CheckItem] = []
+            items = []
             for label, check_fn in checks:
                 item = CheckItem(label)
                 items.append(item)

--- a/src/kitty/tui/display.py
+++ b/src/kitty/tui/display.py
@@ -211,18 +211,26 @@ class LiveChecklist:
         print_section(self._title)
 
         if self._is_tty:
-            table = Table.grid(padding=(0, 2))
-            table.add_column()
-            table.add_column()
-            table.add_column()
+            items: list[CheckItem] = [CheckItem(label) for label, _ in checks]
 
-            items: list[CheckItem] = []
-            for label, _ in checks:
-                item = CheckItem(label)
-                items.append(item)
-                table.add_row(item.status_text, label, "")
+            def _render() -> Table:
+                """Build a table reflecting the current state of every check.
 
-            with Live(table, console=_console, refresh_per_second=4):
+                Rich exposes no supported way to mutate a rendered row — ``Row``
+                carries only styling, and row content lives on the columns — so
+                each refresh rebuilds the table. The previous version assigned to
+                a non-existent ``Row.cells`` attribute, which silently did
+                nothing and left every check showing the pending spinner.
+                """
+                table = Table.grid(padding=(0, 2))
+                table.add_column()
+                table.add_column()
+                table.add_column()
+                for entry in items:
+                    table.add_row(entry.status_text, entry.label, entry.detail)
+                return table
+
+            with Live(_render(), console=_console, refresh_per_second=4) as live:
                 for item, (_, check_fn) in zip(items, checks, strict=True):
                     try:
                         ok, detail = check_fn()
@@ -230,11 +238,7 @@ class LiveChecklist:
                         ok, detail = False, str(exc)
                     item.ok = ok
                     item.detail = detail
-                    table.rows[items.index(item)].cells = (
-                        item.status_text,
-                        item.label,
-                        detail,
-                    )
+                    live.update(_render())
         else:
             items: list[CheckItem] = []
             for label, check_fn in checks:

--- a/src/kitty/tui/menu.py
+++ b/src/kitty/tui/menu.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import sys
 from collections.abc import Callable
-from typing import Any
+from typing import Any, cast
 
 import questionary
 
@@ -32,10 +32,11 @@ class SelectionMenu:
             return None
         if not self._options:
             return None
-        return questionary.select(
+        # questionary ships no stubs; ask() returns the choice or None.
+        return cast("str | None", questionary.select(
             self._title,
             choices=self._options,
-        ).ask()
+        ).ask())
 
 
 class CheckboxMenu:
@@ -76,4 +77,4 @@ class CheckboxMenu:
         if self._validate is not None:
             kwargs["validate"] = self._validate
 
-        return questionary.checkbox(self._title, **kwargs).ask()
+        return cast("list[str] | None", questionary.checkbox(self._title, **kwargs).ask())

--- a/src/kitty/validation.py
+++ b/src/kitty/validation.py
@@ -169,7 +169,7 @@ def _extract_error_message(body: dict | list | str) -> str:
     if isinstance(body, dict):
         error = body.get("error")
         if isinstance(error, dict):
-            return error.get("message", str(error))
+            return str(error.get("message", str(error)))
         if isinstance(error, str):
             return error
     return str(body)

--- a/tests/auth/test_openai_oauth.py
+++ b/tests/auth/test_openai_oauth.py
@@ -447,3 +447,40 @@ class TestOAuthTokenResponseValidation:
             async with aiohttp.ClientSession() as http:
                 with pytest.raises(OAuthAuthorizationError, match="Token response missing required fields"):
                     await _exchange_code_for_tokens("code", "verifier", CLIENT_ID, http)
+
+
+class TestCallbackErrorPageEscaping(TestCallbackServer):
+    """The loopback callback page must not reflect its query string raw.
+
+    ``error`` and ``error_description`` arrive from the browser's redirect and
+    were interpolated straight into the HTML response, making the page kitty
+    serves during login an XSS sink for anyone who can get the browser to hit
+    the loopback callback while a login is in progress.
+    """
+
+    async def test_error_values_are_html_escaped(self, state: str) -> None:
+        code_future: asyncio.Future = asyncio.get_running_loop().create_future()
+        _, client = await self._server_client(state, code_future)
+        payload = '<script>alert("xss")</script>'
+
+        resp = await client.get(
+            "/auth/callback",
+            params={"state": state, "error": "access_denied", "error_description": payload},
+        )
+        body = await resp.text()
+
+        assert resp.status == 400
+        assert "<script>" not in body, f"unescaped markup reached the page: {body}"
+        assert "&lt;script&gt;" in body, "the description was dropped rather than escaped"
+
+    async def test_error_code_itself_is_escaped(self, state: str) -> None:
+        code_future: asyncio.Future = asyncio.get_running_loop().create_future()
+        _, client = await self._server_client(state, code_future)
+
+        resp = await client.get(
+            "/auth/callback",
+            params={"state": state, "error": "<img src=x onerror=alert(1)>"},
+        )
+        body = await resp.text()
+
+        assert "<img" not in body, f"unescaped markup reached the page: {body}"

--- a/tests/bridge/test_bridge_management.py
+++ b/tests/bridge/test_bridge_management.py
@@ -7,6 +7,7 @@ import os
 import signal
 from contextlib import suppress
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -338,3 +339,84 @@ class TestIsPidAliveErrorMapping:
         winerror_87 = OSError(22, "The parameter is incorrect", None, 87, None)
         with patch("kitty.bridge.manage.os.kill", side_effect=winerror_87):
             assert bridge_status(state_path) is BridgeStatus.STALE
+
+
+class TestStopBridgeForceKillIsCrossPlatform:
+    """`kitty bridge stop` must work on Windows, where SIGKILL does not exist.
+
+    The force-kill branch runs when a bridge has not exited ~10s after SIGTERM —
+    i.e. exactly when the user is trying to clear a wedged process. Raising there
+    also skipped `remove_state`, leaving behind the stale state file the command
+    exists to clean up.
+    """
+
+    @staticmethod
+    def _write_state(state_path: Path, pid: int = 4321) -> None:
+        write_state(
+            state_path,
+            BridgeState(
+                pid=pid,
+                host="127.0.0.1",
+                port=8080,
+                profile="test",
+                started_at="2026-04-11T10:30:00Z",
+                tls=False,
+            ),
+        )
+
+    def test_falls_back_to_sigterm_when_sigkill_is_unavailable(self, tmp_path: Path):
+        """Simulates win32, where signal.SIGKILL is absent."""
+        from kitty.bridge import manage
+
+        state_path = tmp_path / "state.json"
+        self._write_state(state_path)
+
+        windows_signal = SimpleNamespace(SIGTERM=signal.SIGTERM)
+        assert not hasattr(windows_signal, "SIGKILL")
+
+        with (
+            patch.object(manage, "signal", windows_signal),
+            patch.object(manage, "is_pid_alive", return_value=True),
+            patch.object(manage, "time"),
+            patch.object(manage.os, "kill") as mock_kill,
+        ):
+            manage.stop_bridge(state_path)
+
+        signals_sent = [call.args[1] for call in mock_kill.call_args_list]
+        assert signals_sent, "no signal was sent to the wedged process"
+        assert all(sig == signal.SIGTERM for sig in signals_sent)
+        assert not state_path.exists(), "the stale state file was left behind"
+
+    @pytest.mark.skipif(not hasattr(signal, "SIGKILL"), reason="POSIX-only behaviour")
+    def test_uses_sigkill_where_available(self, tmp_path: Path):
+        """POSIX behaviour must be unchanged — SIGTERM first, then SIGKILL."""
+        from kitty.bridge import manage
+
+        state_path = tmp_path / "state.json"
+        self._write_state(state_path)
+
+        with (
+            patch.object(manage, "is_pid_alive", return_value=True),
+            patch.object(manage, "time"),
+            patch.object(manage.os, "kill") as mock_kill,
+        ):
+            manage.stop_bridge(state_path)
+
+        signals_sent = [call.args[1] for call in mock_kill.call_args_list]
+        assert signals_sent[0] == signal.SIGTERM
+        assert signals_sent[-1] == signal.SIGKILL
+
+    def test_state_file_is_removed_even_if_the_signal_fails(self, tmp_path: Path):
+        from kitty.bridge import manage
+
+        state_path = tmp_path / "state.json"
+        self._write_state(state_path)
+
+        with (
+            patch.object(manage, "is_pid_alive", return_value=True),
+            patch.object(manage, "time"),
+            patch.object(manage.os, "kill", side_effect=ProcessLookupError),
+        ):
+            manage.stop_bridge(state_path)
+
+        assert not state_path.exists()

--- a/tests/bridge/test_egress_routing.py
+++ b/tests/bridge/test_egress_routing.py
@@ -270,3 +270,11 @@ class TestRequestsActuallyGoOutProxied:
 
         assert routed
         assert all(proxy is None for _url, proxy in routed)
+
+
+class _MessagesLauncher(_StubLauncher):
+    """Launcher that makes the bridge serve the Anthropic Messages API."""
+
+    @property
+    def bridge_protocol(self) -> BridgeProtocol:
+        return BridgeProtocol.MESSAGES_API

--- a/tests/bridge/test_responses_translator.py
+++ b/tests/bridge/test_responses_translator.py
@@ -700,7 +700,7 @@ class TestTranslateStreamChunk:
         assert self.t._tool_call_buffers == {}
         assert self.t._tool_call_meta == {}
         assert self.t._accumulated_text == ""
-        assert self.t._text_item_id is None
+        assert not self.t._text_item_id
         assert self.t._text_started is False
 
     def test_finish_with_null_usage_does_not_crash(self):
@@ -874,7 +874,7 @@ class TestTranslateStreamChunk:
         self.t.translate_stream_chunk("resp_1", chunk)
         self.t.reset()
         assert self.t._accumulated_text == ""
-        assert self.t._text_item_id is None
+        assert not self.t._text_item_id
         assert self.t._text_started is False
 
         # After reset, should work with new state
@@ -991,7 +991,7 @@ class TestSynthesizeCompletedEvents:
         self.t.translate_stream_chunk("resp_test", chunk)
         self.t.synthesize_completed_events("resp_test", "gpt-4o")
         assert self.t._accumulated_text == ""
-        assert self.t._text_item_id is None
+        assert not self.t._text_item_id
 
     def test_no_double_completed_when_finish_reason_already_sent(self):
         # Normal flow: finish_reason produces completed event

--- a/tests/test_egress_coverage.py
+++ b/tests/test_egress_coverage.py
@@ -206,3 +206,42 @@ class TestEveryStartPathIsGuarded:
         constructors = self._files_calling("BridgeServer") - {"bridge/server.py"}
 
         assert constructors == {"cli/launcher.py", "cli/main.py", "bridge_runner.py"}
+
+
+class TestTypeSuppressionsAreSpecific:
+    """R5: a clean type check must not be achieved by silencing it.
+
+    With mypy now blocking, the cheapest way to make it pass is a blanket
+    `# type: ignore`, which disables every check on that line — including the
+    class of error that turned up four real defects. Each suppression must name
+    the codes it silences, so it stops applying when the code changes.
+    """
+
+    @staticmethod
+    def _suppressions() -> list[tuple[str, int, str]]:
+        """Return every ``type: ignore`` in the source, with its location."""
+        found = []
+        for path in sorted(SRC.rglob("*.py")):
+            for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+                if "type: ignore" in line:
+                    found.append((path.relative_to(SRC).as_posix(), lineno, line.strip()))
+        return found
+
+    def test_no_bare_type_ignore(self):
+        bare = re.compile(r"type:\s*ignore(?!\[)")
+        offenders = [f"{rel}:{lineno}" for rel, lineno, line in self._suppressions() if bare.search(line)]
+
+        assert not offenders, (
+            "these suppressions disable every check on their line; name the specific "
+            f"error codes instead: {offenders}"
+        )
+
+    def test_no_blanket_file_level_suppression(self):
+        """`# mypy: ignore-errors` would silence a whole module at once."""
+        offenders = [
+            path.relative_to(SRC).as_posix()
+            for path in sorted(SRC.rglob("*.py"))
+            if re.search(r"^#\s*mypy:\s*ignore-errors", path.read_text(encoding="utf-8"), re.M)
+        ]
+
+        assert not offenders, f"whole-file type suppression found in {offenders}"

--- a/tests/test_github_actions.py
+++ b/tests/test_github_actions.py
@@ -361,3 +361,32 @@ class TestMetadataRefreshRespectsBranchProtection:
             assert "--exit-code" not in step.get("run", ""), (
                 f"step {step.get('name')!r} fails the build on metadata drift; it should report instead"
             )
+
+# ── R5/R6: the type check is enforced, and not gamed ──────
+
+
+class TestTypeCheckIsEnforced:
+    """mypy must fail the build, not merely report.
+
+    It was advisory while the codebase carried 98 errors. Those are now zero,
+    and five of them turned out to be real defects, so the check earns a gate:
+    nothing else stops the count climbing back.
+    """
+
+    def test_mypy_step_exists_and_is_blocking(self):
+        steps = _get_all_steps(_load_workflow("tests.yml"))
+        mypy_steps = [s for s in steps if "mypy" in s.get("run", "")]
+
+        assert mypy_steps, "no mypy step found in the reusable test workflow"
+        for step in mypy_steps:
+            assert not step.get("continue-on-error"), (
+                f"step {step.get('name')!r} runs mypy but swallows its failures"
+            )
+
+    def test_mypy_runs_before_the_test_suite(self):
+        """A type error should surface in seconds, not after an 11-minute run."""
+        commands = [s.get("run", "") for s in _get_all_steps(_load_workflow("tests.yml"))]
+        mypy_at = next(i for i, c in enumerate(commands) if "mypy" in c)
+        pytest_at = next(i for i, c in enumerate(commands) if "pytest" in c)
+
+        assert mypy_at < pytest_at, "mypy runs after the suite, so type errors are reported last"

--- a/tests/test_kilo_config.py
+++ b/tests/test_kilo_config.py
@@ -41,7 +41,7 @@ def config_path(config_dir):
 class TestPrepareLaunch:
     def test_creates_config_when_none_exists(self, adapter, config_path):
         adapter.build_spawn_config(_make_profile(), 18080, "my-api-key")
-        original = adapter.prepare_launch({"KILO_PROVIDER": "kitty"}, config_path=config_path)
+        original = adapter.prepare_launch({"KILO_PROVIDER": "kitty"}, settings_path=config_path)
 
         assert original is None  # No previous file
         assert config_path.exists()
@@ -50,7 +50,7 @@ class TestPrepareLaunch:
 
     def test_config_contains_provider_with_base_url(self, adapter, config_path):
         adapter.build_spawn_config(_make_profile(), 18080, "my-api-key")
-        adapter.prepare_launch({"KILO_PROVIDER": "kitty"}, config_path=config_path)
+        adapter.prepare_launch({"KILO_PROVIDER": "kitty"}, settings_path=config_path)
 
         data = json.loads(config_path.read_text())
         kitty = data["provider"]["kitty"]
@@ -58,14 +58,14 @@ class TestPrepareLaunch:
 
     def test_config_contains_provider_with_api_key(self, adapter, config_path):
         adapter.build_spawn_config(_make_profile(), 18080, "my-api-key")
-        adapter.prepare_launch({"KILO_PROVIDER": "kitty"}, config_path=config_path)
+        adapter.prepare_launch({"KILO_PROVIDER": "kitty"}, settings_path=config_path)
 
         data = json.loads(config_path.read_text())
         assert data["provider"]["kitty"]["options"]["apiKey"] == "my-api-key"
 
     def test_config_contains_model(self, adapter, config_path):
         adapter.build_spawn_config(_make_profile(model="gpt-4o"), 18080, "key")
-        adapter.prepare_launch({"KILO_PROVIDER": "kitty"}, config_path=config_path)
+        adapter.prepare_launch({"KILO_PROVIDER": "kitty"}, settings_path=config_path)
 
         data = json.loads(config_path.read_text())
         models = data["provider"]["kitty"]["models"]
@@ -81,7 +81,7 @@ class TestPrepareLaunch:
         config_path.write_text(json.dumps(existing))
 
         adapter.build_spawn_config(_make_profile(), 18080, "my-key")
-        original = adapter.prepare_launch({"KILO_PROVIDER": "kitty"}, config_path=config_path)
+        original = adapter.prepare_launch({"KILO_PROVIDER": "kitty"}, settings_path=config_path)
 
         data = json.loads(config_path.read_text())
         assert "openai" in data["provider"]  # Preserved
@@ -93,7 +93,7 @@ class TestPrepareLaunch:
         config_path.write_text(json.dumps(existing))
 
         adapter.build_spawn_config(_make_profile(), 18080, "key")
-        original = adapter.prepare_launch({"KILO_PROVIDER": "kitty"}, config_path=config_path)
+        original = adapter.prepare_launch({"KILO_PROVIDER": "kitty"}, settings_path=config_path)
 
         assert json.loads(original) == existing
 
@@ -101,7 +101,7 @@ class TestPrepareLaunch:
         config_path.write_text("not valid json {{{")
 
         adapter.build_spawn_config(_make_profile(), 18080, "key")
-        original = adapter.prepare_launch({"KILO_PROVIDER": "kitty"}, config_path=config_path)
+        original = adapter.prepare_launch({"KILO_PROVIDER": "kitty"}, settings_path=config_path)
 
         # Should still create valid config, original saved as-is
         assert original == "not valid json {{{"
@@ -110,7 +110,7 @@ class TestPrepareLaunch:
 
     def test_config_has_npm_field(self, adapter, config_path):
         adapter.build_spawn_config(_make_profile(), 18080, "key")
-        adapter.prepare_launch({"KILO_PROVIDER": "kitty"}, config_path=config_path)
+        adapter.prepare_launch({"KILO_PROVIDER": "kitty"}, settings_path=config_path)
 
         data = json.loads(config_path.read_text())
         assert data["provider"]["kitty"]["npm"] == "@ai-sdk/openai-compatible"
@@ -122,24 +122,24 @@ class TestCleanupLaunch:
         config_path.write_text(json.dumps(existing))
 
         adapter.build_spawn_config(_make_profile(), 18080, "key")
-        original = adapter.prepare_launch({"KILO_PROVIDER": "kitty"}, config_path=config_path)
+        original = adapter.prepare_launch({"KILO_PROVIDER": "kitty"}, settings_path=config_path)
 
         # Config now has kitty provider
         assert "kitty" in json.loads(config_path.read_text())["provider"]
 
         # Cleanup restores original
-        adapter.cleanup_launch(original, config_path=config_path)
+        adapter.cleanup_launch(original, settings_path=config_path)
         assert json.loads(config_path.read_text()) == existing
 
     def test_removes_temporary_config_when_no_original(self, adapter, config_path):
         adapter.build_spawn_config(_make_profile(), 18080, "key")
-        original = adapter.prepare_launch({"KILO_PROVIDER": "kitty"}, config_path=config_path)
+        original = adapter.prepare_launch({"KILO_PROVIDER": "kitty"}, settings_path=config_path)
 
         assert config_path.exists()
-        adapter.cleanup_launch(original, config_path=config_path)
+        adapter.cleanup_launch(original, settings_path=config_path)
         assert not config_path.exists()
 
     def test_cleanup_with_none_is_noop(self, adapter, config_path):
         # If prepare_launch was never called or returned None
-        adapter.cleanup_launch(None, config_path=config_path)
+        adapter.cleanup_launch(None, settings_path=config_path)
         assert not config_path.exists()

--- a/tests/test_launcher_base.py
+++ b/tests/test_launcher_base.py
@@ -68,3 +68,107 @@ class TestLauncherAdapter:
 
         with pytest.raises(TypeError):
             LauncherAdapter()  # type: ignore[abstract]
+
+
+class TestLaunchLifecycleHooks:
+    """Every adapter must expose the launch lifecycle, not just Claude's.
+
+    `cli/launcher.py` patches an agent's own settings file before spawning it and
+    restores it afterwards, including from an atexit handler. Only ClaudeAdapter
+    implemented those hooks, so the base class did not describe the interface the
+    launcher actually relies on — a second adapter needing cleanup would have
+    failed silently, because the call site swallows exceptions.
+    """
+
+    @staticmethod
+    def _bare_adapter():
+        """Build a minimal adapter that implements only the abstract members."""
+        from kitty.launchers.base import LauncherAdapter, SpawnConfig
+
+        class _Bare(LauncherAdapter):
+            @property
+            def name(self) -> str:
+                return "bare"
+
+            @property
+            def binary_name(self) -> str:
+                return "bare"
+
+            @property
+            def bridge_protocol(self) -> BridgeProtocol:
+                return BridgeProtocol.CHAT_COMPLETIONS_API
+
+            def build_spawn_config(self, profile, bridge_port: int, resolved_key: str) -> SpawnConfig:
+                return SpawnConfig(env_overrides={}, env_clear=[], cli_args=[])
+
+        return _Bare()
+
+    def test_prepare_launch_is_part_of_the_interface(self):
+        adapter = self._bare_adapter()
+
+        assert hasattr(adapter, "prepare_launch")
+
+    def test_cleanup_launch_is_part_of_the_interface(self):
+        adapter = self._bare_adapter()
+
+        assert hasattr(adapter, "cleanup_launch")
+
+    def test_prepare_launch_defaults_to_no_patching(self):
+        """Returning None is what tells the launcher there is nothing to restore."""
+        adapter = self._bare_adapter()
+
+        assert adapter.prepare_launch({}) is None
+
+    def test_cleanup_launch_defaults_to_a_no_op(self):
+        """Must not raise: the atexit handler calls it without a hasattr guard."""
+        adapter = self._bare_adapter()
+
+        assert adapter.cleanup_launch(None) is None
+
+    def test_claude_still_overrides_both(self):
+        from kitty.launchers.base import LauncherAdapter
+        from kitty.launchers.claude import ClaudeAdapter
+
+        assert ClaudeAdapter.prepare_launch is not LauncherAdapter.prepare_launch
+        assert ClaudeAdapter.cleanup_launch is not LauncherAdapter.cleanup_launch
+
+
+class TestAdaptersAreCallableTheWayTheLauncherCallsThem:
+    """Every registered adapter must accept the launcher's actual call shape.
+
+    `cli/launcher.py` invokes the lifecycle hooks with the keyword
+    ``settings_path=``. KiloAdapter named the same parameter ``config_path``,
+    so `kitty <profile> kilo` raised TypeError before it ever spawned the agent
+    — the target was unusable. Nothing caught it because the launch path is
+    exercised per-adapter only for Claude.
+    """
+
+    @staticmethod
+    def _registered_adapters():
+        """Return the adapters the CLI actually offers, as (name, instance)."""
+        from kitty.launchers.claude import ClaudeAdapter
+        from kitty.launchers.codex import CodexAdapter
+        from kitty.launchers.gemini import GeminiAdapter
+        from kitty.launchers.kilo import KiloAdapter
+
+        return [
+            ("codex", CodexAdapter()),
+            ("claude", ClaudeAdapter()),
+            ("gemini", GeminiAdapter()),
+            ("kilo", KiloAdapter()),
+        ]
+
+    @pytest.mark.parametrize("name,adapter", _registered_adapters.__func__())
+    def test_prepare_launch_accepts_the_launcher_call_shape(self, name: str, adapter, tmp_path):
+        """Mirrors cli/launcher.py exactly: positional env, keyword settings_path."""
+        import inspect
+
+        signature = inspect.signature(adapter.prepare_launch)
+        signature.bind({"ANTHROPIC_BASE_URL": "http://127.0.0.1:1"}, settings_path=tmp_path / "cfg.json")
+
+    @pytest.mark.parametrize("name,adapter", _registered_adapters.__func__())
+    def test_cleanup_launch_accepts_the_launcher_call_shape(self, name: str, adapter, tmp_path):
+        import inspect
+
+        signature = inspect.signature(adapter.cleanup_launch)
+        signature.bind(None, settings_path=tmp_path / "cfg.json")

--- a/tests/test_launcher_base.py
+++ b/tests/test_launcher_base.py
@@ -1,5 +1,7 @@
 """Tests for launchers/base.py — LauncherAdapter interface, SpawnConfig, BridgeProtocol re-export."""
 
+import inspect
+
 import pytest
 
 from kitty.types import BridgeProtocol
@@ -133,42 +135,75 @@ class TestLaunchLifecycleHooks:
         assert ClaudeAdapter.cleanup_launch is not LauncherAdapter.cleanup_launch
 
 
-class TestAdaptersAreCallableTheWayTheLauncherCallsThem:
-    """Every registered adapter must accept the launcher's actual call shape.
+_REGISTERED_ADAPTERS = ("codex", "claude", "gemini", "kilo")
 
-    `cli/launcher.py` invokes the lifecycle hooks with the keyword
-    ``settings_path=``. KiloAdapter named the same parameter ``config_path``,
-    so `kitty <profile> kilo` raised TypeError before it ever spawned the agent
-    — the target was unusable. Nothing caught it because the launch path is
-    exercised per-adapter only for Claude.
+
+def _adapter(name: str):
+    """Build one of the adapters the CLI registers.
+
+    Args:
+        name: Target name as typed by the user, e.g. ``"kilo"``.
+
+    Returns:
+        The adapter instance.
+    """
+    from kitty.launchers.claude import ClaudeAdapter
+    from kitty.launchers.codex import CodexAdapter
+    from kitty.launchers.gemini import GeminiAdapter
+    from kitty.launchers.kilo import KiloAdapter
+
+    return {"codex": CodexAdapter, "claude": ClaudeAdapter, "gemini": GeminiAdapter, "kilo": KiloAdapter}[name]()
+
+
+class TestEachAdapterOwnsItsSettingsPath:
+    """The launcher must patch each agent's own config file, and no other.
+
+    It used to sniff for a module-level constant that was never an adapter
+    attribute, so the lookup always failed and every agent was handed Claude
+    Code's ``settings.json``. Kilo then wrote its provider block into that file
+    while its own config went untouched — the agent stayed misconfigured and an
+    unrelated file was modified. A signature-shape test cannot see any of that;
+    these assert on the path actually resolved.
     """
 
-    @staticmethod
-    def _registered_adapters():
-        """Return the adapters the CLI actually offers, as (name, instance)."""
-        from kitty.launchers.claude import ClaudeAdapter
-        from kitty.launchers.codex import CodexAdapter
-        from kitty.launchers.gemini import GeminiAdapter
-        from kitty.launchers.kilo import KiloAdapter
+    @pytest.mark.parametrize("name", _REGISTERED_ADAPTERS)
+    def test_settings_path_is_declared_on_the_adapter(self, name: str):
+        adapter = _adapter(name)
 
-        return [
-            ("codex", CodexAdapter()),
-            ("claude", ClaudeAdapter()),
-            ("gemini", GeminiAdapter()),
-            ("kilo", KiloAdapter()),
-        ]
+        assert hasattr(adapter, "default_settings_path"), "the launcher asks every adapter for this"
 
-    @pytest.mark.parametrize("name,adapter", _registered_adapters.__func__())
-    def test_prepare_launch_accepts_the_launcher_call_shape(self, name: str, adapter, tmp_path):
-        """Mirrors cli/launcher.py exactly: positional env, keyword settings_path."""
-        import inspect
+    def test_claude_resolves_to_claude_settings(self):
+        path = _adapter("claude").default_settings_path
 
-        signature = inspect.signature(adapter.prepare_launch)
-        signature.bind({"ANTHROPIC_BASE_URL": "http://127.0.0.1:1"}, settings_path=tmp_path / "cfg.json")
+        assert path is not None
+        assert path.name == "settings.json"
+        assert ".claude" in path.parts
 
-    @pytest.mark.parametrize("name,adapter", _registered_adapters.__func__())
-    def test_cleanup_launch_accepts_the_launcher_call_shape(self, name: str, adapter, tmp_path):
-        import inspect
+    def test_kilo_resolves_to_its_own_config_not_claudes(self):
+        """The exact confusion that corrupted an unrelated file."""
+        path = _adapter("kilo").default_settings_path
 
-        signature = inspect.signature(adapter.cleanup_launch)
-        signature.bind(None, settings_path=tmp_path / "cfg.json")
+        assert path is not None
+        assert path.name == "kilo.json"
+        assert ".claude" not in path.parts
+
+    @pytest.mark.parametrize("name", ["codex", "gemini"])
+    def test_agents_without_a_settings_file_resolve_to_none(self, name: str):
+        """None means 'do not patch anything', not 'use somebody else's file'."""
+        assert _adapter(name).default_settings_path is None
+
+    def test_no_two_adapters_share_a_settings_path(self):
+        paths = [(n, _adapter(n).default_settings_path) for n in _REGISTERED_ADAPTERS]
+        configured = [(n, p) for n, p in paths if p is not None]
+        distinct = {p for _n, p in configured}
+
+        assert len(distinct) == len(configured), f"adapters share a config file: {configured}"
+
+    @pytest.mark.parametrize("name", _REGISTERED_ADAPTERS)
+    def test_prepare_launch_accepts_the_launchers_call_shape(self, name: str, tmp_path):
+        """Mirrors cli/launcher.py: positional env, keyword settings_path."""
+        adapter = _adapter(name)
+
+        # bind() raises TypeError if the keyword does not exist — that is the assertion.
+        inspect.signature(adapter.prepare_launch).bind({"X": "1"}, settings_path=tmp_path / "cfg.json")
+        inspect.signature(adapter.cleanup_launch).bind(None, settings_path=tmp_path / "cfg.json")

--- a/tests/tui/test_live_checklist.py
+++ b/tests/tui/test_live_checklist.py
@@ -99,7 +99,7 @@ class TestLiveChecklistTTY:
 
     def test_run_checks_uses_live(self) -> None:
         with patch("kitty.tui.display.Live") as mock_live:
-            mock_live.return_value.__enter__ = MagicMock(return_value=None)
+            mock_live.return_value.__enter__ = MagicMock(return_value=mock_live.return_value)
             mock_live.return_value.__exit__ = MagicMock(return_value=None)
             cl = self._make_tty_checklist()
             with patch("sys.stdout", new=StringIO()):
@@ -108,7 +108,7 @@ class TestLiveChecklistTTY:
 
     def test_run_checks_returns_correct_failure_count(self) -> None:
         with patch("kitty.tui.display.Live") as mock_live:
-            mock_live.return_value.__enter__ = MagicMock(return_value=None)
+            mock_live.return_value.__enter__ = MagicMock(return_value=mock_live.return_value)
             mock_live.return_value.__exit__ = MagicMock(return_value=None)
             cl = self._make_tty_checklist()
             with patch("sys.stdout", new=StringIO()):
@@ -123,7 +123,7 @@ class TestLiveChecklistTTY:
 
     def test_run_checks_exception_caught(self) -> None:
         with patch("kitty.tui.display.Live") as mock_live:
-            mock_live.return_value.__enter__ = MagicMock(return_value=None)
+            mock_live.return_value.__enter__ = MagicMock(return_value=mock_live.return_value)
             mock_live.return_value.__exit__ = MagicMock(return_value=None)
             cl = self._make_tty_checklist()
 
@@ -133,3 +133,74 @@ class TestLiveChecklistTTY:
             with patch("sys.stdout", new=StringIO()):
                 failures = cl.run_checks([("boom", _boom)])
         assert failures == 1
+
+
+class TestLiveChecklistTTYRendering:
+    """What a person actually sees in a terminal.
+
+    The tests above mock ``Live`` away, so they verify the return value but
+    never the display — which is how `kitty doctor` came to show nothing but
+    pending spinners for every check while still exiting with the right code.
+    These render for real and assert on the output.
+    """
+
+    @staticmethod
+    def _render(checks: list[tuple[str, object]]) -> tuple[str, int]:
+        """Run checks through the TTY path and capture what was drawn.
+
+        Args:
+            checks: ``(label, callable)`` pairs, as ``run_checks`` takes.
+
+        Returns:
+            ``(rendered_output, failure_count)``.
+        """
+        from rich.console import Console
+
+        buf = StringIO()
+        console = Console(file=buf, width=90, force_terminal=False)
+        with (
+            patch("sys.stdout.isatty", return_value=True),
+            patch("kitty.tui.display._console", console),
+        ):
+            checklist = LiveChecklist("kitty doctor")
+            failures = checklist.run_checks(checks)  # type: ignore[arg-type]
+        return buf.getvalue(), failures
+
+    def test_resolved_checks_show_their_status_symbol(self) -> None:
+        out, failures = self._render(
+            [("Target claude", lambda: (True, "binary found")), ("Creds", lambda: (False, "no key"))]
+        )
+
+        assert "✓" in out, f"passing check never rendered its result:\n{out}"
+        assert "✗" in out, f"failing check never rendered its result:\n{out}"
+        assert failures == 1
+
+    def test_detail_text_reaches_the_user(self) -> None:
+        """A bare pass/fail is not a diagnosis — the reason has to be shown."""
+        out, _ = self._render([("Target claude", lambda: (False, "binary not found on PATH"))])
+
+        assert "binary not found on PATH" in out, f"the reason for the failure was never displayed:\n{out}"
+
+    def test_no_check_is_left_pending(self) -> None:
+        out, _ = self._render([("a", lambda: (True, "ok")), ("b", lambda: (True, "ok"))])
+
+        assert "⠿" not in out, f"a finished check is still showing the pending spinner:\n{out}"
+
+    def test_checks_sharing_a_label_both_resolve(self) -> None:
+        """Two profiles can produce identically-labelled checks."""
+        out, failures = self._render(
+            [("Credentials", lambda: (True, "resolved-first")), ("Credentials", lambda: (False, "missing-second"))]
+        )
+
+        assert "resolved-first" in out
+        assert "missing-second" in out
+        assert failures == 1
+
+    def test_a_raising_check_reports_its_exception(self) -> None:
+        def _boom() -> tuple[bool, str]:
+            raise ValueError("upstream unreachable")
+
+        out, failures = self._render([("boom", _boom)])
+
+        assert failures == 1
+        assert "upstream unreachable" in out


### PR DESCRIPTION
## Summary

Takes `mypy src/kitty` from **98 errors to zero** and turns the advisory CI step into a blocking gate.

The clean checker is not the point. Triaging those 98 errors found **five real defects**, four of them user-visible. The pattern is identical every time: each lives on a path the test suite structurally cannot execute — an interactive terminal, a non-Linux OS, or a second implementation of an interface.

Closes #4.

## The defects

| Defect | User impact |
|---|---|
| **`kitty doctor` showed no results in a terminal** | The command you run when something is broken displayed spinners and a bare failure count; the failing check was never named |
| **`kitty <profile> kilo` could not launch** | `TypeError` before the agent spawned — one of four advertised targets was unusable |
| **`kitty bridge stop` crashed on Windows** | Traceback, and the stale state file it exists to clear was left behind |
| **`LauncherAdapter` did not declare its own lifecycle** | A second adapter needing cleanup would fail silently, swallowed by `except Exception` |
| **Two handlers could return `None` where callers require a value** | An empty custom-transport stream made aiohttp raise, surfacing as an opaque 500 with no diagnosis |

Each fix has a regression test written first and observed failing, except one noted below.

### The doctor bug, concretely

`LiveChecklist` assigned to `rich.table.Row.cells`. That attribute does not exist, and `Row` has no `__slots__`, so the assignment **silently succeeded and did nothing** — the rendered table kept the pending spinner:

```
──────────────── kitty doctor ─────────────────
⠿  Target claude
⠿  Credentials for minimax-1     <- this check returned (False, "no key")
returned failures: 1
```

The exit code was right, so scripts worked. Only humans saw nothing. The existing TTY tests mocked `Live` away entirely and asserted the return count, which is exactly why it survived. The new tests render through a real `Console`.

### The Kilo bug got worse before it got better

Worth calling out because I introduced the regression and review caught it.

`cli/launcher.py` looked for `_DEFAULT_SETTINGS_PATH` on the adapter. That is a **module-level constant**, never an adapter attribute, so the lookup always failed and every agent was handed Claude Code's `settings.json`. This was harmless only because `KiloAdapter.prepare_launch` took a differently-named parameter and raised `TypeError` first.

Renaming that parameter removed the crash — and with it the accident that had been protecting the file. Kilo would then have written its provider block into `~/.claude/settings.json` while its own config stayed untouched: still misconfigured, now also damaging an unrelated file.

Fixed properly: adapters declare `default_settings_path`; the launcher asks instead of guessing. Kilo → `~/.config/kilo/kilo.json`, Claude → `~/.claude/settings.json`, Codex and Gemini → `None` (nothing to patch).

**The lesson is about the test.** My first attempt asserted the keyword name on the signature — it passed while the feature was broken. The replacement asserts the path actually resolved, and mutation-checking confirms pointing Kilo back at Claude's path fails two tests.

## How the typing was done

Type-level only. Where a value is genuinely untyped, the shape is **declared** rather than suppressed, so surrounding code stays checked:

- `curl_cffi` ships no stubs → a `Protocol` for the four response members actually used. That one change cleared 27 of the 98.
- The per-request backend record → a `TypedDict`, clearing four `Any`-returning properties at the source.

Suppressions name the specific codes they silence. One of them, on the access-log handle, was hiding a wrong inferred type that left three statements — including the actual log writes — completely unchecked; annotating the attribute restored them.

## Enforcement

- mypy now runs **before** pytest, so a type error surfaces in seconds rather than after an eleven-minute suite.
- Two tests guard the gate: the step may not be `continue-on-error`, and no bare `# type: ignore` or file-level `# mypy: ignore-errors` may appear in the source. Otherwise the cheapest way to keep the gate green is to blind it.
- Verified by injecting a deliberate type error (caught) and reverting.

## One test I deleted

I wrote a test for the empty-stream guard. It passed with the guard removed. I tightened the assertions; it still passed. Investigating, every scenario I could construct short-circuits into the 503 all-backends-unhealthy response before reaching the guard.

So I deleted it and documented the guard as defensive and untested, in both the code and the requirements. **False coverage is worse than none** — a green test proving nothing is how the Kilo bug survived.

## Verification

| Gate | Result |
|---|---|
| `mypy src/kitty` | **Success** — 0 errors, 85 files (was 98) |
| `pytest` | **2617 passed**, 36 skipped, 0 failed |
| `ruff check .` | clean |
| `lint-imports` | 3/3 contracts kept |

Behaviour-neutrality rests on the suite: this touches ~30 files, and the risk of type work is a silent behaviour change. I caught one myself mid-way — restructuring the streaming translator's control flow to satisfy the checker — and reverted it in favour of an equivalent sentinel.

Three test assertions changed: they pinned a sentinel value (`is None`) rather than the behaviour (`not ...`). That is over-specification, and I flag it rather than let it look like tests were bent to fit.

## Follow-up worth considering

Two of these defects were Windows-only and CI is Ubuntu-only. Adding `windows-latest` to the existing matrix is a few lines and would have caught both directly rather than by inference. Not in this PR — it roughly doubles CI minutes, which is your call.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
