### PR TITLE
Distinguish "not my process" from "no such process" (fixes #3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,16 @@ Point your tool at `http://localhost:<port>` and it just works.
 | `POST /v1/gemini/generateContent` | Gemini             | Gemini CLI      |
 | `GET /healthz`                    | Health check       | Monitoring      |
 
+**Background bridges:** `kitty bridge start`, `stop`, `restart`, and `status` manage a bridge running in the background,
+tracked in `bridge_state.json`.
+
+If `status` reports **"Running under another user account"**, a bridge is serving at the recorded address but was started
+by a different user (via `sudo`, a service account, or another session). kitty will not stop or restart it, and will not
+start a second one beside it — signalling a process it does not own is unsafe, because the operating system may have
+recycled that process ID onto something unrelated. Stop it from the account that started it, or from an
+administrator shell. If you are sure that process is not a kitty bridge, delete `bridge_state.json` — kitty prints
+its full path in the message.
+
 ## Supported Agents
 
 | Agent                                                         | Command        | What it is               |

--- a/src/kitty/bridge/manage.py
+++ b/src/kitty/bridge/manage.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import contextlib
 import enum
+import ipaddress
 import os
 import signal
+import socket
 import subprocess
 import sys
 import threading
@@ -21,39 +23,138 @@ class BridgeStatus(enum.Enum):
     RUNNING = "running"
     STOPPED = "stopped"
     STALE = "stale"  # State file exists but PID is dead
+    UNMANAGEABLE = "unmanageable"  # Bridge is serving, but under another user
 
 
 _DEFAULT_STATE_PATH = Path.home() / ".config" / "kitty" / "bridge_state.json"
 
+PROBE_TIMEOUT_SECONDS = 0.5
 
-def is_pid_alive(pid: int) -> bool:
-    """Check if a process with the given PID is alive.
+
+class ProcessLiveness(enum.Enum):
+    """Outcome of probing a PID.
+
+    Attributes:
+        ALIVE: The process exists and this user may signal it.
+        DEAD: No process holds that PID.
+        UNKNOWN: A process holds that PID but it is not ours to signal.
+    """
+
+    ALIVE = "alive"
+    DEAD = "dead"
+    UNKNOWN = "unknown"
+
+
+def probe_pid(pid: int) -> ProcessLiveness:
+    """Probe whether a process exists and whether this user may signal it.
 
     Signal ``0`` performs no action and only probes for the process, on Windows
-    as well as POSIX — it does not terminate the target.
+    as well as POSIX — it does not terminate the target. The three outcomes are
+    kept apart because they call for different handling: a permission-denied
+    probe proves the process is *running* under another account, which is the
+    opposite conclusion from a missing process, yet both raise from
+    :func:`os.kill`.
 
     Args:
         pid: Process ID to probe.
 
     Returns:
-        True if a process with that PID exists, False otherwise.
+        :attr:`ProcessLiveness.ALIVE`, :attr:`ProcessLiveness.DEAD`, or
+        :attr:`ProcessLiveness.UNKNOWN`.
     """
     # Reject non-positive PIDs before signalling. On POSIX a pid of 0 addresses
     # the caller's whole process group and -1 addresses every process the caller
     # may signal, so a corrupt bridge_state.json would turn stop_bridge() into a
     # SIGTERM/SIGKILL against the user's own shell session.
     if pid <= 0:
-        return False
+        return ProcessLiveness.DEAD
     try:
         os.kill(pid, 0)
-        return True
-    except (ProcessLookupError, PermissionError):
-        return False
+        return ProcessLiveness.ALIVE
+    except ProcessLookupError:
+        return ProcessLiveness.DEAD
+    except PermissionError:
+        # EPERM (POSIX) / ERROR_ACCESS_DENIED (Windows) proves the process
+        # exists — we simply may not signal it. Reporting it as dead is what
+        # issue #3 is about; reporting it as alive would let stop_bridge()
+        # signal a stranger's process after PID recycling.
+        return ProcessLiveness.UNKNOWN
     except OSError:
         # Windows has no ProcessLookupError for this: OpenProcess fails with
         # ERROR_INVALID_PARAMETER (87) for a PID that does not exist, which
         # surfaces as a plain OSError. Without this branch every stale-state
         # code path (bridge status/stop/start/restart) crashes on Windows.
+        return ProcessLiveness.DEAD
+
+
+def _connect_target(host: str) -> str:
+    """Map a bind address to an address this machine can connect to.
+
+    A bridge bound to a wildcard records that address verbatim in
+    ``bridge_state.json``, but a wildcard is a bind target, not a connect
+    target: Windows rejects a connect to it with ``WSAEADDRNOTAVAIL`` (10049)
+    even while the socket is listening. Such a bridge is always reachable from
+    this machine over loopback.
+
+    The check is by value rather than by spelling, because ``bridge.yaml``
+    passes ``host`` through untouched and ``::``, ``::0`` and
+    ``0:0:0:0:0:0:0:0`` all name the same unspecified address.
+
+    Args:
+        host: Host as recorded in the state file.
+
+    Returns:
+        The loopback address of the matching family for a wildcard host, and
+        ``host`` unchanged for anything else — including hostnames.
+    """
+    if host == "":
+        return "127.0.0.1"
+    # A hostname is not an address literal and is probed exactly as recorded.
+    try:
+        address = ipaddress.ip_address(host)
+    except ValueError:
+        return host
+    if not address.is_unspecified:
+        return host
+    # ``is_unspecified`` is also true for the IPv4-mapped form ``::ffff:0.0.0.0``,
+    # which wants an IPv4 loopback despite reporting version 6.
+    if address.version == 6 and address.ipv4_mapped is None:
+        return "::1"
+    return "127.0.0.1"
+
+
+def bridge_reachable(host: str, port: int, timeout: float = PROBE_TIMEOUT_SECONDS) -> bool:
+    """Report whether something accepts TCP connections at ``host:port``.
+
+    Used to settle :attr:`ProcessLiveness.UNKNOWN`: a process kitty may not
+    signal is only *this* bridge if it is serving at the address the state file
+    recorded. The probe connects and immediately closes; it does not speak HTTP,
+    because ``/healthz`` sits behind the auth middleware whenever ``keys_file``
+    is set and would additionally need TLS handling for a bridge started with
+    ``--tls-cert``. Whether the connection is accepted answers the only question
+    being asked.
+
+    Args:
+        host: Host recorded in ``bridge_state.json``.
+        port: Port recorded in ``bridge_state.json``.
+        timeout: Connect timeout in seconds. The probe runs on user-facing
+            commands and never retries, so it stays short.
+
+    Note:
+        A wildcard bind address is probed over loopback instead — see
+        ``_connect_target``.
+
+    Returns:
+        True if the connection was accepted, False for any failure — refused,
+        timed out, or unresolvable.
+    """
+    target = _connect_target(host)
+    # Every failure mode here (refused, timeout, DNS, unreachable network) is an
+    # OSError subclass, and all of them mean the same thing to the caller.
+    try:
+        with socket.create_connection((target, port), timeout=timeout):
+            return True
+    except OSError:
         return False
 
 
@@ -62,13 +163,29 @@ def _get_state_path() -> Path:
 
 
 def bridge_status(state_path: Path | str | None = None) -> BridgeStatus:
-    """Check the status of the bridge."""
+    """Check the status of the bridge.
+
+    Args:
+        state_path: Path to ``bridge_state.json``; the default location is used
+            when omitted.
+
+    Returns:
+        :attr:`BridgeStatus.STOPPED` when no state file exists,
+        :attr:`BridgeStatus.RUNNING` for a bridge this user owns,
+        :attr:`BridgeStatus.UNMANAGEABLE` for one running under another account,
+        and :attr:`BridgeStatus.STALE` when the recorded process is gone.
+    """
     state_path = Path(state_path) if state_path else _get_state_path()
     state = load_state(state_path)
     if state is None:
         return BridgeStatus.STOPPED
-    if is_pid_alive(state.pid):
+    liveness = probe_pid(state.pid)
+    if liveness is ProcessLiveness.ALIVE:
         return BridgeStatus.RUNNING
+    # A PID we may not signal is only *this* bridge if it is still serving at the
+    # recorded address; otherwise the PID was recycled and the file is stale.
+    if liveness is ProcessLiveness.UNKNOWN and bridge_reachable(state.host, state.port):
+        return BridgeStatus.UNMANAGEABLE
     return BridgeStatus.STALE
 
 
@@ -129,8 +246,17 @@ def stop_bridge(state_path: Path | str | None = None) -> None:
     """Stop a running bridge instance.
 
     Sends SIGTERM, waits up to 10 seconds, then force-kills if needed (SIGKILL
-    where available, SIGTERM on Windows where it does not exist).
-    Always removes the state file.
+    where available, SIGTERM on Windows where it does not exist), and removes
+    the state file.
+
+    Args:
+        state_path: Path to ``bridge_state.json``; the default location is used
+            when omitted.
+
+    Raises:
+        SystemExit: When the recorded process is running under another user
+            account and is still serving, so kitty can neither stop it nor
+            safely forget it.
     """
     state_path = Path(state_path) if state_path else _get_state_path()
     state = load_state(state_path)
@@ -138,13 +264,34 @@ def stop_bridge(state_path: Path | str | None = None) -> None:
     if state is None:
         return
 
-    if is_pid_alive(state.pid):
+    liveness = probe_pid(state.pid)
+
+    # A PID we may not signal is never signalled: after PID recycling it would
+    # belong to an unrelated process. If the bridge is still serving, say so and
+    # keep the state file — deleting it would strand the process with nothing
+    # pointing at it. If nothing answers, the PID was recycled and the file is
+    # merely stale, which is exactly what this command exists to clear.
+    if liveness is ProcessLiveness.UNKNOWN:
+        if bridge_reachable(state.host, state.port):
+            print(
+                f"Error: Bridge (PID {state.pid}, {state.host}:{state.port}, "
+                f"profile={state.profile}) is running under another user account. "
+                f"kitty cannot stop it — stop it from that account, or as an "
+                f"administrator. The state file was left in place; delete "
+                f"{state_path} if you are sure that process is not a kitty bridge.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        remove_state(state_path)
+        return
+
+    if liveness is ProcessLiveness.ALIVE:
         with contextlib.suppress(ProcessLookupError):
             os.kill(state.pid, signal.SIGTERM)
 
         # Wait up to 10 seconds for process to exit
         for _ in range(100):
-            if not is_pid_alive(state.pid):
+            if probe_pid(state.pid) is not ProcessLiveness.ALIVE:
                 break
             time.sleep(0.1)
 
@@ -153,7 +300,7 @@ def stop_bridge(state_path: Path | str | None = None) -> None:
         # control events, so SIGTERM is the right fallback there. Without this,
         # the branch raised AttributeError and skipped remove_state() below,
         # leaving the stale state file this command exists to clear.
-        if is_pid_alive(state.pid):
+        if probe_pid(state.pid) is ProcessLiveness.ALIVE:
             force_signal = getattr(signal, "SIGKILL", signal.SIGTERM)
             with contextlib.suppress(ProcessLookupError):
                 os.kill(state.pid, force_signal)
@@ -175,6 +322,22 @@ def start_bridge(
     """Start the bridge in the background.
 
     Checks for running instances, clears stale state, spawns background process.
+
+    Args:
+        state_path: Path to ``bridge_state.json``; the default location is used
+            when omitted.
+        config_path: Path to ``bridge.yaml`` for the spawned child.
+        host: Bind address override for the child.
+        port: Bind port override for the child.
+        profile: Profile name override for the child.
+        log_access: Whether the child writes an access log.
+        tls_cert: Path to a TLS certificate for the child.
+        tls_key: Path to the matching TLS private key.
+
+    Raises:
+        SystemExit: When a bridge is already running — including one owned by
+            another user account that is still serving at the recorded address —
+            or when the spawned child fails to come up.
     """
     state_path = Path(state_path) if state_path else _get_state_path()
 
@@ -191,13 +354,28 @@ def start_bridge(
     try:
         # Check for running instance
         state = load_state(state_path)
-        if state is not None and is_pid_alive(state.pid):
-            print(
-                f"Error: Bridge is already running (PID {state.pid}, "
-                f"{state.host}:{state.port}, profile={state.profile})",
-                file=sys.stderr,
-            )
-            sys.exit(1)
+        if state is not None:
+            liveness = probe_pid(state.pid)
+            if liveness is ProcessLiveness.ALIVE:
+                print(
+                    f"Error: Bridge is already running (PID {state.pid}, "
+                    f"{state.host}:{state.port}, profile={state.profile})",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+            # Another user's bridge still serving at the recorded address:
+            # starting a second one would leave the first orphaned but holding
+            # its port. An unreachable address means the PID was recycled, so
+            # the state file really is stale and the start proceeds below.
+            if liveness is ProcessLiveness.UNKNOWN and bridge_reachable(state.host, state.port):
+                print(
+                    f"Error: Bridge is already running under another user account "
+                    f"(PID {state.pid}, {state.host}:{state.port}, profile={state.profile}). "
+                    f"kitty cannot manage it — stop it from that account, or delete "
+                    f"{state_path} if you are sure that process is not a kitty bridge.",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
 
         # Clear stale state
         remove_state(state_path)
@@ -271,7 +449,19 @@ def restart_bridge(
     config_path: Path | str | None = None,
     **kwargs,
 ) -> None:
-    """Restart the bridge. Re-reads bridge.yaml for new start."""
+    """Restart the bridge. Re-reads bridge.yaml for new start.
+
+    Args:
+        state_path: Path to ``bridge_state.json``; the default location is used
+            when omitted.
+        config_path: Path to ``bridge.yaml``, re-read for the new instance.
+        **kwargs: Forwarded to :func:`start_bridge`.
+
+    Raises:
+        SystemExit: Propagated from :func:`stop_bridge` or :func:`start_bridge`.
+            A bridge running under another user account aborts the restart in
+            the stop phase, so no second instance is started beside it.
+    """
     state_path = Path(state_path) if state_path else _get_state_path()
 
     # Stop the old instance

--- a/src/kitty/cli/main.py
+++ b/src/kitty/cli/main.py
@@ -207,6 +207,21 @@ def main() -> None:
             scheme = "https" if state.tls else "http"
             print(f"Running: {scheme}://{state.host}:{state.port} (profile={state.profile}, PID {state.pid})")
             sys.exit(0)
+        elif status == BridgeStatus.UNMANAGEABLE:
+            state = load_state(_state_path)
+            if state is None:
+                print("Bridge is not running.")
+                sys.exit(1)
+            scheme = "https" if state.tls else "http"
+            print(
+                f"Running under another user account: {scheme}://{state.host}:{state.port} "
+                f"(profile={state.profile}, PID {state.pid})"
+            )
+            print(
+                "kitty cannot stop or restart it. Stop it from that account or from an administrator "
+                f"shell; if you are sure that process is not a kitty bridge, delete {_state_path}."
+            )
+            sys.exit(1)
         elif status == BridgeStatus.STALE:
             print("Stale state file found (process not running). Run 'kitty bridge stop' to clean up.")
             sys.exit(1)

--- a/tests/bridge/test_bridge_management.py
+++ b/tests/bridge/test_bridge_management.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import signal
+import socket
 from contextlib import suppress
 from pathlib import Path
 from types import SimpleNamespace
@@ -22,16 +23,16 @@ from kitty.bridge.state import BridgeState, load_state, write_state
 class TestBridgeManagementHelpers:
     """Tests for management logic that uses the state file."""
 
-    def test_is_pid_alive_for_current_process(self):
-        from kitty.bridge.manage import is_pid_alive
+    def test_probe_pid_for_current_process(self):
+        from kitty.bridge.manage import ProcessLiveness, probe_pid
 
-        assert is_pid_alive(os.getpid()) is True
+        assert probe_pid(os.getpid()) is ProcessLiveness.ALIVE
 
-    def test_is_pid_alive_for_dead_pid(self):
-        from kitty.bridge.manage import is_pid_alive
+    def test_probe_pid_for_dead_pid(self):
+        from kitty.bridge.manage import ProcessLiveness, probe_pid
 
         # Use a very high PID that's extremely unlikely to exist
-        assert is_pid_alive(999999999) is False
+        assert probe_pid(999999999) is ProcessLiveness.DEAD
 
     def test_stop_bridge_removes_state_file(self, tmp_path: Path):
         from kitty.bridge.manage import stop_bridge
@@ -124,7 +125,7 @@ class TestBridgeManagementHelpers:
 
     def test_start_bridge_clears_stale_state(self, tmp_path: Path):
         """start_bridge clears stale state before starting."""
-        from kitty.bridge.manage import is_pid_alive, start_bridge
+        from kitty.bridge.manage import ProcessLiveness, probe_pid, start_bridge
 
         state_path = tmp_path / "state.json"
         state = BridgeState(
@@ -149,7 +150,7 @@ class TestBridgeManagementHelpers:
 
         # Clean up: kill any spawned bridge process
         final_state = load_state(state_path)
-        if final_state is not None and is_pid_alive(final_state.pid):
+        if final_state is not None and probe_pid(final_state.pid) is ProcessLiveness.ALIVE:
             os.kill(final_state.pid, signal.SIGTERM)
 
         # The stale state should be gone (cleared before spawn)
@@ -227,43 +228,488 @@ class TestBridgeSubcommandRouting:
         assert hasattr(BuiltinCommand, "BRIDGE_UNINSTALL")
 
 
-class TestIsPidAliveErrorMapping:
-    """Cross-platform mapping of os.kill(pid, 0) failures to liveness.
+class TestBridgeStatusCommandOutput:
+    """R7: what the user actually reads when the bridge is not theirs."""
+
+    def test_status_names_the_address_and_says_kitty_cannot_manage_it(self, capsys):
+        from kitty.bridge.manage import BridgeStatus
+        from kitty.cli.main import main
+
+        state = BridgeState(
+            pid=4321,
+            host="127.0.0.1",
+            port=8080,
+            profile="work",
+            started_at="2026-08-19T10:30:00Z",
+            tls=False,
+        )
+
+        with (
+            patch("sys.argv", ["kitty", "bridge", "status"]),
+            patch("kitty.bridge.manage.bridge_status", return_value=BridgeStatus.UNMANAGEABLE),
+            patch("kitty.bridge.state.load_state", return_value=state),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            main()
+
+        assert exc_info.value.code == 1
+
+        out = capsys.readouterr().out
+        assert "http://127.0.0.1:8080" in out
+        assert "4321" in out
+        assert "another user" in out.lower()
+        # `status` is the first command users run, so it carries the same
+        # escape hatch as `stop` and `start` rather than only naming the file.
+        assert "bridge_state.json" in out
+        # The old message for this situation; reporting it would send the user
+        # to `bridge stop`, which now (correctly) refuses.
+        assert "stale" not in out.lower()
+
+
+class TestStatusForAProcessWeMayNotSignal:
+    """R3: the decision table for a PID owned by another user.
+
+    ``probe_pid`` and ``bridge_reachable`` are patched here because their own
+    behaviour is pinned by the two classes below; what is under test is how
+    ``bridge_status`` combines them.
+    """
+
+    @staticmethod
+    def _write_state(state_path: Path) -> None:
+        write_state(
+            state_path,
+            BridgeState(
+                pid=4321,
+                host="127.0.0.1",
+                port=8080,
+                profile="test",
+                started_at="2026-08-19T10:30:00Z",
+                tls=False,
+            ),
+        )
+
+    def test_unsignallable_and_reachable_is_unmanageable(self, tmp_path: Path):
+        """The bug in #3: this used to report STALE for a healthy bridge."""
+        from kitty.bridge.manage import BridgeStatus, ProcessLiveness, bridge_status
+
+        state_path = tmp_path / "state.json"
+        self._write_state(state_path)
+
+        with (
+            patch("kitty.bridge.manage.probe_pid", return_value=ProcessLiveness.UNKNOWN),
+            patch("kitty.bridge.manage.bridge_reachable", return_value=True) as mock_probe,
+        ):
+            assert bridge_status(state_path) is BridgeStatus.UNMANAGEABLE
+
+        mock_probe.assert_called_once_with("127.0.0.1", 8080)
+
+    def test_unsignallable_and_unreachable_is_stale(self, tmp_path: Path):
+        """Nothing serving at the recorded address — the PID was recycled."""
+        from kitty.bridge.manage import BridgeStatus, ProcessLiveness, bridge_status
+
+        state_path = tmp_path / "state.json"
+        self._write_state(state_path)
+
+        with (
+            patch("kitty.bridge.manage.probe_pid", return_value=ProcessLiveness.UNKNOWN),
+            patch("kitty.bridge.manage.bridge_reachable", return_value=False),
+        ):
+            assert bridge_status(state_path) is BridgeStatus.STALE
+
+    def test_alive_does_not_probe_the_socket(self, tmp_path: Path):
+        """A bridge we own is RUNNING without paying for a connect attempt."""
+        from kitty.bridge.manage import BridgeStatus, ProcessLiveness, bridge_status
+
+        state_path = tmp_path / "state.json"
+        self._write_state(state_path)
+
+        with (
+            patch("kitty.bridge.manage.probe_pid", return_value=ProcessLiveness.ALIVE),
+            patch("kitty.bridge.manage.bridge_reachable") as mock_probe,
+        ):
+            assert bridge_status(state_path) is BridgeStatus.RUNNING
+
+        mock_probe.assert_not_called()
+
+    def test_dead_does_not_probe_the_socket(self, tmp_path: Path):
+        """A missing process is stale regardless of who else holds the port."""
+        from kitty.bridge.manage import BridgeStatus, ProcessLiveness, bridge_status
+
+        state_path = tmp_path / "state.json"
+        self._write_state(state_path)
+
+        with (
+            patch("kitty.bridge.manage.probe_pid", return_value=ProcessLiveness.DEAD),
+            patch("kitty.bridge.manage.bridge_reachable") as mock_probe,
+        ):
+            assert bridge_status(state_path) is BridgeStatus.STALE
+
+        mock_probe.assert_not_called()
+
+
+class TestStopBridgeWithAProcessWeMayNotSignal:
+    """R4: the defect's most damaging branch.
+
+    Before the fix, ``stop`` deleted the state file for a bridge it had not
+    stopped, leaving an orphaned process and no record pointing at it.
+    """
+
+    @staticmethod
+    def _write_state(state_path: Path) -> None:
+        write_state(
+            state_path,
+            BridgeState(
+                pid=4321,
+                host="127.0.0.1",
+                port=8080,
+                profile="test",
+                started_at="2026-08-19T10:30:00Z",
+                tls=False,
+            ),
+        )
+
+    def test_refuses_and_keeps_the_state_file_when_reachable(self, tmp_path: Path, capsys):
+        from kitty.bridge.manage import ProcessLiveness, stop_bridge
+
+        state_path = tmp_path / "state.json"
+        self._write_state(state_path)
+
+        with (
+            patch("kitty.bridge.manage.probe_pid", return_value=ProcessLiveness.UNKNOWN),
+            patch("kitty.bridge.manage.bridge_reachable", return_value=True),
+            patch("kitty.bridge.manage.os.kill") as mock_kill,
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            stop_bridge(state_path)
+
+        assert exc_info.value.code == 1
+        mock_kill.assert_not_called()
+        assert state_path.exists()
+
+        message = capsys.readouterr().err
+        assert "4321" in message
+        assert "127.0.0.1:8080" in message
+        assert "cannot stop" in message.lower()
+        assert str(state_path) in message
+
+    def test_clears_the_state_file_without_signalling_when_unreachable(self, tmp_path: Path):
+        """PID recycled onto a stranger's process: clean up, signal nobody.
+
+        This is the same situation ``bridge_status`` reports as STALE, so
+        ``stop`` must be able to clear it — otherwise the user is left with a
+        state file no command will remove.
+        """
+        from kitty.bridge.manage import ProcessLiveness, stop_bridge
+
+        state_path = tmp_path / "state.json"
+        self._write_state(state_path)
+
+        with (
+            patch("kitty.bridge.manage.probe_pid", return_value=ProcessLiveness.UNKNOWN),
+            patch("kitty.bridge.manage.bridge_reachable", return_value=False),
+            patch("kitty.bridge.manage.os.kill") as mock_kill,
+        ):
+            stop_bridge(state_path)
+
+        mock_kill.assert_not_called()
+        assert not state_path.exists()
+
+    def test_a_bridge_we_own_is_still_stopped(self, tmp_path: Path):
+        """R6: the ALIVE path is untouched by this change."""
+        from kitty.bridge.manage import ProcessLiveness, stop_bridge
+
+        state_path = tmp_path / "state.json"
+        self._write_state(state_path)
+
+        # Alive on the first probe, gone on every probe after the signal.
+        probes: list[int] = []
+
+        def _liveness(_pid: int):
+            probes.append(_pid)
+            return ProcessLiveness.ALIVE if len(probes) == 1 else ProcessLiveness.DEAD
+
+        with (
+            patch("kitty.bridge.manage.probe_pid", side_effect=_liveness),
+            patch("kitty.bridge.manage.os.kill") as mock_kill,
+        ):
+            stop_bridge(state_path)
+
+        mock_kill.assert_called_once_with(4321, signal.SIGTERM)
+        assert not state_path.exists()
+
+
+class TestStartBridgeWithAProcessWeMayNotSignal:
+    """R5: refuse rather than start a second bridge beside an orphan."""
+
+    @staticmethod
+    def _write_state(state_path: Path) -> None:
+        write_state(
+            state_path,
+            BridgeState(
+                pid=4321,
+                host="127.0.0.1",
+                port=8080,
+                profile="test",
+                started_at="2026-08-19T10:30:00Z",
+                tls=False,
+            ),
+        )
+
+    def test_refuses_and_spawns_nothing_when_reachable(self, tmp_path: Path, capsys):
+        from kitty.bridge.manage import ProcessLiveness, start_bridge
+
+        state_path = tmp_path / "state.json"
+        self._write_state(state_path)
+
+        with (
+            patch("kitty.bridge.manage.probe_pid", return_value=ProcessLiveness.UNKNOWN),
+            patch("kitty.bridge.manage.bridge_reachable", return_value=True),
+            patch("kitty.bridge.manage.subprocess.Popen") as mock_popen,
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            start_bridge(state_path=state_path)
+
+        assert exc_info.value.code == 1
+        mock_popen.assert_not_called()
+        assert state_path.exists(), "the running bridge's state file was cleared"
+
+        message = capsys.readouterr().err
+        assert "4321" in message
+        assert "127.0.0.1:8080" in message
+        assert "cannot manage" in message.lower()
+        # The way out must be one the user can act on: `bridge start` takes no
+        # --port flag, so the message names the state file instead.
+        assert str(state_path) in message
+
+    def test_proceeds_when_the_recycled_pid_serves_nothing(self, tmp_path: Path):
+        """Unreachable means the PID was recycled — the state file is stale."""
+        from kitty.bridge.manage import ProcessLiveness, start_bridge
+
+        state_path = tmp_path / "state.json"
+        self._write_state(state_path)
+
+        # The spawned child is what writes the state file; stand in for it so
+        # start_bridge takes its success path instead of timing out.
+        def _spawn(*_args, **_kwargs):
+            self._write_state(state_path)
+            return SimpleNamespace(poll=lambda: None, stderr=None, returncode=None)
+
+        with (
+            patch("kitty.bridge.manage.probe_pid", return_value=ProcessLiveness.UNKNOWN),
+            patch("kitty.bridge.manage.bridge_reachable", return_value=False),
+            patch("kitty.bridge.manage.subprocess.Popen", side_effect=_spawn) as mock_popen,
+        ):
+            start_bridge(state_path=state_path)
+
+        mock_popen.assert_called_once()
+
+
+class TestRestartWithAProcessWeMayNotSignal:
+    """`bridge status` tells the user kitty cannot restart it — prove that.
+
+    ``restart_bridge`` calls stop then start, and both refuse independently.
+    Without this test, a change that made ``stop`` return quietly on this branch
+    would let ``restart`` spawn a second bridge with nothing going red.
+    """
+
+    def test_restart_aborts_in_the_stop_phase(self, tmp_path: Path):
+        from kitty.bridge.manage import ProcessLiveness, restart_bridge
+
+        state_path = tmp_path / "state.json"
+        write_state(
+            state_path,
+            BridgeState(
+                pid=4321,
+                host="127.0.0.1",
+                port=8080,
+                profile="test",
+                started_at="2026-08-19T10:30:00Z",
+                tls=False,
+            ),
+        )
+
+        with (
+            patch("kitty.bridge.manage.probe_pid", return_value=ProcessLiveness.UNKNOWN),
+            patch("kitty.bridge.manage.bridge_reachable", return_value=True),
+            patch("kitty.bridge.manage.subprocess.Popen") as mock_popen,
+            patch("kitty.bridge.manage.os.kill") as mock_kill,
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            restart_bridge(state_path=state_path)
+
+        assert exc_info.value.code == 1
+        mock_kill.assert_not_called()
+        mock_popen.assert_not_called()
+        assert state_path.exists()
+
+
+class TestBridgeReachable:
+    """TCP reachability of the address recorded in the state file.
+
+    Real sockets, not mocks: the behaviour under test *is* the socket
+    behaviour, so a mock would only assert that the code calls the function it
+    obviously calls.
+    """
+
+    def test_listening_socket_is_reachable(self):
+        from kitty.bridge.manage import bridge_reachable
+
+        server = socket.socket()
+        try:
+            server.bind(("127.0.0.1", 0))
+            server.listen(1)
+            _, port = server.getsockname()
+            assert bridge_reachable("127.0.0.1", port) is True
+        finally:
+            server.close()
+
+    # "" is included for completeness, not as coverage: getaddrinfo("") already
+    # yields loopback, so that case passes even with the normalisation removed.
+    @pytest.mark.parametrize("bind_host", ["0.0.0.0", ""])
+    def test_wildcard_bind_is_reachable_over_loopback(self, bind_host: str):
+        """A bridge on 0.0.0.0 records 0.0.0.0, which is not a connectable address.
+
+        Windows rejects a connect to the wildcard with WSAEADDRNOTAVAIL (10049)
+        even while the socket is listening, so without normalisation kitty would
+        report a live foreign bridge as gone — and ``stop`` would then delete its
+        state file. A wildcard bind is the natural configuration for exactly the
+        shared bridge this feature is about.
+        """
+        from kitty.bridge.manage import bridge_reachable
+
+        server = socket.socket()
+        try:
+            server.bind(("0.0.0.0", 0))
+            server.listen(1)
+            _, port = server.getsockname()
+            assert bridge_reachable(bind_host, port) is True
+        finally:
+            server.close()
+
+    @pytest.mark.parametrize("bind_host", ["::", "::0", "0:0:0:0:0:0:0:0"])
+    def test_ipv6_wildcard_bind_is_reachable_over_loopback(self, bind_host: str):
+        """`::` is not the only spelling of the IPv6 unspecified address.
+
+        ``bridge.yaml`` passes ``host`` through untouched and getaddrinfo
+        accepts every one of these, so each can reach the state file.
+        """
+        from kitty.bridge.manage import bridge_reachable
+
+        server = socket.socket(socket.AF_INET6)
+        try:
+            server.bind(("::", 0))
+            server.listen(1)
+            port = server.getsockname()[1]
+            assert bridge_reachable(bind_host, port) is True
+        finally:
+            server.close()
+
+    def test_closed_port_is_not_reachable(self):
+        """Same address after the listener goes away — a stale state file."""
+        from kitty.bridge.manage import bridge_reachable
+
+        server = socket.socket()
+        server.bind(("127.0.0.1", 0))
+        server.listen(1)
+        _, port = server.getsockname()
+        server.close()
+
+        assert bridge_reachable("127.0.0.1", port) is False
+
+    def test_unroutable_address_returns_false_without_raising(self):
+        """TEST-NET-1 (RFC 5737) is reserved and never routed.
+
+        The probe runs on user-facing commands, so an address that neither
+        accepts nor refuses must resolve to a bounded ``False`` rather than
+        hanging or propagating a timeout.
+        """
+        from kitty.bridge.manage import bridge_reachable
+
+        assert bridge_reachable("192.0.2.1", 9, timeout=0.2) is False
+
+    def test_a_real_address_is_not_rewritten_to_loopback(self):
+        """Only the unspecified address is normalised — nothing else.
+
+        A listener runs on loopback while the probe targets a different, real
+        address on the same port. Over-eager normalisation would redirect the
+        probe to the local listener and claim a bridge that is not there.
+        """
+        from kitty.bridge.manage import bridge_reachable
+
+        server = socket.socket()
+        try:
+            server.bind(("127.0.0.1", 0))
+            server.listen(1)
+            _, port = server.getsockname()
+            assert bridge_reachable("192.0.2.1", port, timeout=0.2) is False
+        finally:
+            server.close()
+
+    @pytest.mark.parametrize(
+        ("host", "expected"),
+        [
+            ("0.0.0.0", "127.0.0.1"),
+            ("", "127.0.0.1"),
+            ("::", "::1"),
+            ("::0", "::1"),
+            ("0:0:0:0:0:0:0:0", "::1"),
+            # IPv4-mapped: unspecified, but wants an IPv4 loopback.
+            ("::ffff:0.0.0.0", "127.0.0.1"),
+            ("127.0.0.1", "127.0.0.1"),
+            ("192.0.2.1", "192.0.2.1"),
+            ("::1", "::1"),
+            ("localhost", "localhost"),
+            ("bridge.internal", "bridge.internal"),
+        ],
+    )
+    def test_connect_target_table(self, host: str, expected: str):
+        """The normalisation itself, with no socket in the way."""
+        from kitty.bridge.manage import _connect_target
+
+        assert _connect_target(host) == expected
+
+    def test_unresolvable_hostname_returns_false(self):
+        """DNS failure is an OSError subclass and must not escape either."""
+        from kitty.bridge.manage import bridge_reachable
+
+        assert bridge_reachable("kitty-bridge.invalid", 9, timeout=0.2) is False
+
+
+class TestProbePidErrorMapping:
+    """Cross-platform mapping of os.kill(pid, 0) outcomes to liveness.
 
     Signal 0 performs no action and only probes the process — on Windows as
     well as POSIX. The platforms differ in how they report a missing PID, and
     that difference previously crashed every stale-state code path on Windows.
     """
 
-    def test_returns_true_when_probe_succeeds(self):
-        from kitty.bridge.manage import is_pid_alive
+    def test_signallable_process_is_alive(self):
+        from kitty.bridge.manage import ProcessLiveness, probe_pid
 
         with patch("kitty.bridge.manage.os.kill", return_value=None) as mock_kill:
-            assert is_pid_alive(4321) is True
+            assert probe_pid(4321) is ProcessLiveness.ALIVE
 
         mock_kill.assert_called_once_with(4321, 0)
 
     def test_process_lookup_error_means_dead(self):
         """POSIX reports a missing PID as ProcessLookupError (ESRCH)."""
-        from kitty.bridge.manage import is_pid_alive
+        from kitty.bridge.manage import ProcessLiveness, probe_pid
 
         with patch("kitty.bridge.manage.os.kill", side_effect=ProcessLookupError()):
-            assert is_pid_alive(4321) is False
+            assert probe_pid(4321) is ProcessLiveness.DEAD
 
-    def test_permission_error_is_not_treated_as_alive(self):
-        """Pins a KNOWN-INCORRECT behaviour, deliberately left unchanged.
+    def test_permission_denied_means_unknown_not_dead(self):
+        """EPERM proves the process exists — it is simply not ours to signal.
 
-        EPERM actually proves the process exists — it is simply not ours to
-        signal — so reporting it as dead makes ``bridge_status`` say STALE for a
-        running bridge. Changing it risks the opposite failure (signalling a
-        recycled PID belonging to someone else), so it is deferred rather than
-        flipped here. See ``.system_design/cross_platform_defects.md`` → X1
-        "Known limitation, unchanged".
+        Reporting it as dead made ``bridge status`` claim STALE for a running
+        bridge, ``start`` launch a second one, and ``stop`` delete the state
+        file without stopping anything. Reporting it as alive would have been
+        worse: ``stop`` would then signal whatever inherited a recycled PID.
         """
-        from kitty.bridge.manage import is_pid_alive
+        from kitty.bridge.manage import ProcessLiveness, probe_pid
 
         with patch("kitty.bridge.manage.os.kill", side_effect=PermissionError()):
-            assert is_pid_alive(4321) is False
+            assert probe_pid(4321) is ProcessLiveness.UNKNOWN
 
     @pytest.mark.parametrize("pid", [0, -1, -12345])
     def test_non_positive_pids_are_never_alive(self, pid: int):
@@ -274,10 +720,10 @@ class TestIsPidAliveErrorMapping:
         or hand-edited bridge_state.json carrying such a value would otherwise
         make ``stop_bridge`` SIGTERM then SIGKILL the user's own shell session.
         """
-        from kitty.bridge.manage import is_pid_alive
+        from kitty.bridge.manage import ProcessLiveness, probe_pid
 
         with patch("kitty.bridge.manage.os.kill") as mock_kill:
-            assert is_pid_alive(pid) is False
+            assert probe_pid(pid) is ProcessLiveness.DEAD
 
         mock_kill.assert_not_called()
 
@@ -313,11 +759,11 @@ class TestIsPidAliveErrorMapping:
         bridge status/stop/start/restart on Windows whenever the recorded PID
         was already gone — exactly the stale-state case they exist to clean up.
         """
-        from kitty.bridge.manage import is_pid_alive
+        from kitty.bridge.manage import ProcessLiveness, probe_pid
 
         winerror_87 = OSError(22, "The parameter is incorrect", None, 87, None)
         with patch("kitty.bridge.manage.os.kill", side_effect=winerror_87):
-            assert is_pid_alive(999999999) is False
+            assert probe_pid(999999999) is ProcessLiveness.DEAD
 
     def test_bridge_status_reports_stale_instead_of_raising(self, tmp_path: Path):
         """The end-to-end consequence of the mapping above."""
@@ -376,7 +822,7 @@ class TestStopBridgeForceKillIsCrossPlatform:
 
         with (
             patch.object(manage, "signal", windows_signal),
-            patch.object(manage, "is_pid_alive", return_value=True),
+            patch.object(manage, "probe_pid", return_value=manage.ProcessLiveness.ALIVE),
             patch.object(manage, "time"),
             patch.object(manage.os, "kill") as mock_kill,
         ):
@@ -396,7 +842,7 @@ class TestStopBridgeForceKillIsCrossPlatform:
         self._write_state(state_path)
 
         with (
-            patch.object(manage, "is_pid_alive", return_value=True),
+            patch.object(manage, "probe_pid", return_value=manage.ProcessLiveness.ALIVE),
             patch.object(manage, "time"),
             patch.object(manage.os, "kill") as mock_kill,
         ):
@@ -413,7 +859,7 @@ class TestStopBridgeForceKillIsCrossPlatform:
         self._write_state(state_path)
 
         with (
-            patch.object(manage, "is_pid_alive", return_value=True),
+            patch.object(manage, "probe_pid", return_value=manage.ProcessLiveness.ALIVE),
             patch.object(manage, "time"),
             patch.object(manage.os, "kill", side_effect=ProcessLookupError),
         ):

--- a/tests/bridge/test_bridge_management.py
+++ b/tests/bridge/test_bridge_management.py
@@ -234,6 +234,7 @@ class TestBridgeStatusCommandOutput:
     def test_status_names_the_address_and_says_kitty_cannot_manage_it(self, capsys):
         from kitty.bridge.manage import BridgeStatus
         from kitty.cli.main import main
+        from kitty.cli.router import BuiltinCommand, RouteResult
 
         state = BridgeState(
             pid=4321,
@@ -244,8 +245,14 @@ class TestBridgeStatusCommandOutput:
             tls=False,
         )
 
+        # Route explicitly: with an empty profile store the router sends every
+        # command to the setup wizard, so this test would otherwise pass or fail
+        # depending on whether the machine running it has profiles configured.
+        route = RouteResult(builtin=BuiltinCommand.BRIDGE_STATUS)
+
         with (
             patch("sys.argv", ["kitty", "bridge", "status"]),
+            patch("kitty.cli.router.CLIRouter.route", return_value=route),
             patch("kitty.bridge.manage.bridge_status", return_value=BridgeStatus.UNMANAGEABLE),
             patch("kitty.bridge.state.load_state", return_value=state),
             pytest.raises(SystemExit) as exc_info,


### PR DESCRIPTION
Closes #3.

## The problem, in product terms

`kitty bridge` decides what to do from one boolean: is the recorded process alive? That boolean answered "no" to two very different questions — *no such process*, and *that process is not yours to signal*.

So whenever a bridge ran under another account (`sudo`, a service account, another session), kitty silently did the wrong thing:

| Command | What the user saw | What actually happened |
|---|---|---|
| `bridge status` | "Stale state file found" | The bridge was running fine |
| `bridge start` | Started successfully | A **second** bridge started; the first kept running, orphaned, holding its port |
| `bridge stop` | Exited cleanly | The state file was deleted; the real process kept running with nothing pointing at it |

The last one is the worst: kitty deleted the only record of a process it had just failed to stop.

Simply flipping `PermissionError` to "alive" would have been worse — after PID recycling, `stop` would SIGTERM then SIGKILL a stranger's process.

## What changed

Liveness is now three-way. `probe_pid()` returns `ALIVE` / `DEAD` / `UNKNOWN`, and `UNKNOWN` is settled by a bounded TCP connect to the host and port already recorded in `bridge_state.json`:

- **something answers** → new `BridgeStatus.UNMANAGEABLE`. `status` names the address and says kitty cannot manage it; `stop` and `start` both refuse and leave the state file alone.
- **nothing answers** → the PID was recycled, the file really is stale, and `stop` clears it *without ever sending a signal*.

The probe is TCP-only, not HTTP: `/healthz` sits behind the auth middleware whenever `keys_file` is set, and would additionally need TLS handling for a `--tls-cert` bridge. Whether the connection is accepted answers the only question being asked.

`is_pid_alive` is removed — no callers remained, and its contract is the one this issue exists to correct.

## Two things review caught that would have shipped broken

**A bridge bound to `0.0.0.0` got none of the fix on Windows.** The server records its bind address verbatim, and a wildcard is a bind target, not a connect target — Windows rejects connecting to it with `WSAEADDRNOTAVAIL` even while the socket is listening. The probe said "nothing there", `status` fell back to stale, and `stop` deleted the state file of a live foreign bridge. That is exactly the harm this PR exists to prevent, in exactly the shared-bridge configuration it exists to serve. Linux hides it by treating the wildcard as loopback, so it would have looked fine in CI.

The first fix matched three literal spellings. That was still wrong: `bridge.yaml` passes `host` through untouched, and `::0` and `0:0:0:0:0:0:0:0` name the same address as `::`. Normalisation is now by value (`ipaddress.is_unspecified`), returning the loopback of the matching family.

**The remediation advice did not work.** The refusal messages said "start on a different port". There is no such flag — `bridge start` reads the port from `bridge.yaml`, and the guard probes the recorded address regardless. There was no command-line way out of the state at all. All three commands now name the full path of `bridge_state.json`, and the tests assert the path is in the message so it cannot drift out again.

## Testing

Spec, acceptance criteria and the design decisions (including why process start-time identity is out of scope) are in `.requirements/20260819T183620Z_pid_liveness/REQUIREMENTS.md`; `.system_design/cross_platform_defects.md` X1 is updated — it previously recorded the broken behaviour as a deliberate, untested limitation.

- 20 new tests. Real sockets for the reachability layer, since the socket behaviour *is* what is under test; patched probes for the decision table.
- Two pre-existing tests had silently stopped exercising their branch when `stop_bridge` changed seams — both retargeted.
- **19 targeted mutants killed**, including restoring the original `PermissionError` → dead mapping, removing the wildcard normalisation, and dropping the state-file path from each message. One survivor exposed a test of mine that was passing for the wrong reason; it was replaced.
- Full suite: **2655 passed, 36 skipped**. ruff, ruff format, mypy, and import-linter all clean.

Three code-review rounds; the first two returned REQUEST CHANGES on the two defects above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
