### PR TITLE
Release 1.3.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kitty-bridge"
-version = "1.3.0"
+version = "1.3.1"
 description = "Kitty Bridge — launch coding agents through a local API bridge"
 readme = "README.md"
 license = "MIT"

--- a/src/kitty/__init__.py
+++ b/src/kitty/__init__.py
@@ -4,5 +4,5 @@ import logging
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
-__version__ = "1.3.0"
+__version__ = "1.3.1"
 __all__ = ["__version__"]


### PR DESCRIPTION
Version bump for the 1.3.1 release. Bug fixes only since 1.3.0 — no new features, no breaking changes.

## What ships

**A bridge running under another user account no longer confuses kitty** (#3, #11). `is_pid_alive` mapped "permission denied" to "the process is gone", which is the opposite of what EPERM means. `status` claimed the state file was stale, `start` launched a second bridge beside the orphaned first, and `stop` deleted the only record of a process it had just failed to stop. Liveness is now three-way, with the ambiguous case settled by checking whether anything answers at the recorded address.

**Kilo Code no longer risks writing its provider block into Claude Code's `settings.json`** (#8). A `TypeError` had been accidentally protecting that file; the fix gives each adapter ownership of its own agent's config path.

**`kitty doctor` shows real check results** (#8). Every row stayed on the pending spinner in a TTY — the code assigned to a Rich attribute that does not exist, so the update silently did nothing.

**The OAuth callback page escapes provider-supplied error text** (#8). Reflected XSS on the localhost callback, flagged by CodeQL.

**Bedrock and Codex type errors** that mypy had been reporting on paths the tests do not execute (#8).

## Internal

mypy is now clean and blocking in CI; workflow permissions pinned least-privilege; model metadata refreshed (#9, #10, #12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
