### PR TITLE
Refresh model metadata weekly, not on every push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,14 @@ permissions:
 
 jobs:
   update-metadata:
+    # Not on push. The refresh opened a pull request every time anything landed
+    # on main, and merging one of those is itself a push to main, so it partly
+    # fed itself -- #9 merged at 19:36:30 and #10 was opened two seconds later.
+    # The bundled catalogue is a convenience copy that needs to be current to
+    # the week, not the minute, so the weekly schedule (plus a manual run when
+    # someone wants it sooner) is the right cadence. Pull requests still get the
+    # advisory drift notice below.
+    if: github.event_name != 'push'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -57,7 +65,13 @@ jobs:
           git checkout -B "$BRANCH"
           git add src/kitty/providers/model_metadata.json
           git commit -m "Update OpenRouter model metadata"
-          git push --force-with-lease origin "$BRANCH"
+          # Plain --force: actions/checkout fetches only main at depth 1, so
+          # there is no remote-tracking ref for $BRANCH and --force-with-lease
+          # cannot evaluate its lease -- it rejects the push as "stale info"
+          # whenever the branch still exists on the remote, turning main red and
+          # skipping the refresh. The lease guards nothing here anyway; the
+          # branch is this job's own scratch space.
+          git push --force origin "$BRANCH"
 
           if [ -z "$(gh pr list --head "$BRANCH" --state open --json number --jq '.[].number')" ]; then
             gh pr create --base main --head "$BRANCH"               --title "Update OpenRouter model metadata"               --body "Automated refresh of the bundled model catalogue from the OpenRouter API."
@@ -68,7 +82,7 @@ jobs:
       # Reported, not enforced. This compares against the OpenRouter API as it
       # is right now, so it can drift between a refresh and a pull request
       # through no fault of that pull request -- which used to fail unrelated
-      # work. Freshness is maintained by the scheduled refresh above.
+      # work. Freshness is maintained by the weekly scheduled refresh above.
       - name: Report model metadata drift
         if: github.event_name == 'pull_request'
         run: |

--- a/tests/test_github_actions.py
+++ b/tests/test_github_actions.py
@@ -333,10 +333,52 @@ class TestMetadataRefreshRespectsBranchProtection:
         offenders = [
             step.get("name")
             for step in steps
-            if re.search(r"git push(?!\s+--force-with-lease origin \"\$BRANCH\")\s*$", step.get("run", ""), re.M)
+            if re.search(r"git push(?!\s+--force origin \"\$BRANCH\")\s*$", step.get("run", ""), re.M)
         ]
 
         assert not offenders, f"these steps push directly to main, which branch protection rejects: {offenders}"
+
+    def test_push_does_not_use_a_lease_it_cannot_verify(self, steps: list[dict]):
+        """``--force-with-lease`` fails outright on a shallow checkout.
+
+        actions/checkout fetches only the default branch at depth 1, so the
+        runner holds no remote-tracking ref for the refresh branch. git cannot
+        evaluate the lease and rejects the push with "stale info" whenever that
+        branch still exists on the remote -- turning main red and skipping the
+        refresh. The lease protects nothing here: the branch is this job's own
+        scratch space and is meant to be overwritten.
+        """
+        pushes = [
+            line.strip()
+            for step in steps
+            for line in step.get("run", "").splitlines()
+            if line.strip().startswith("git push")
+        ]
+
+        assert pushes, "expected the refresh to push its branch"
+        assert not [p for p in pushes if "--force-with-lease" in p], pushes
+
+    def test_refresh_does_not_run_on_every_push_to_main(self):
+        """One refresh a week, not one per merge.
+
+        The job opened a pull request on every push to main, and merging one of
+        those is itself a push to main, so the refresh partly fed itself -- #9
+        merged at 19:36:30 and #10 was opened two seconds later. On a busy day
+        that is several near-empty pull requests against a catalogue that needs
+        to be current to the week, not to the minute.
+        """
+        job = _load_workflow("ci.yml")["jobs"]["update-metadata"]
+        condition = str(job.get("if", ""))
+
+        assert condition, "update-metadata runs on every event the workflow declares, including push"
+        assert "push" in condition, f"expected the job to exclude push events, got if: {condition!r}"
+
+    def test_gating_the_refresh_does_not_stop_main_being_tested(self):
+        """The gate belongs on the job, not on the workflow's triggers."""
+        workflow = _load_workflow("ci.yml")
+
+        assert "main" in _get_trigger(workflow).get("push", {}).get("branches", [])
+        assert "if" not in workflow["jobs"]["test"]
 
     def test_refresh_opens_a_pull_request(self, steps: list[dict]):
         run_commands = " ".join(step.get("run", "") for step in steps)


### PR DESCRIPTION
Fixes the stream of near-empty `Update OpenRouter model metadata` pull requests.

## What was happening

The `update-metadata` job ran on **every push to `main`**, not just the weekly schedule it was designed around. Going back to June the run history is one `schedule` event per week; the flood starts on 19 Aug, the day merges became frequent.

Worse, it partly fed itself — merging a metadata PR is a push to `main`, which triggers the job that opens the next one. #9 merged at 19:36:30 and #10 was opened two seconds later. Six of the eight merges on 19–20 Aug spawned one.

The catalogue is a bundled convenience copy. It needs to be current to the week, not the minute.

## Changes

**Gate the job to non-push events.** The weekly cron and `workflow_dispatch` still refresh it; pull requests still get the advisory drift notice. The gate is on the *job*, not the workflow trigger, so `main` keeps running the full test suite on every push — there's a test pinning that, because moving the condition up to `on:` would be the obvious wrong fix.

**Drop `--force-with-lease`.** This one was turning `main` red:

```
! [rejected]  chore/model-metadata -> chore/model-metadata (stale info)
```

`actions/checkout` fetches only `main` at depth 1, so the runner has no remote-tracking ref for the refresh branch, and git cannot evaluate a lease it has no reference for. It rejects the push whenever the branch still exists on the remote — so the job succeeded or failed depending on whether someone had clicked "Delete branch" after the previous merge. It failed exactly that way after #12 merged. The lease guards nothing here: the branch is the job's own scratch space and is meant to be overwritten.

**Repo setting:** `delete_branch_on_merge` is now on, so refresh branches clean themselves up.

## Testing

Three new tests in `tests/test_github_actions.py`, all mutation-verified — restoring the push trigger, restoring the lease, and widening the gate to `if: false` each turn the suite red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
