### PR TITLE
Release 1.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kitty-bridge"
-version = "1.3.1"
+version = "1.4.0"
 description = "Kitty Bridge — launch coding agents through a local API bridge"
 readme = "README.md"
 license = "MIT"

--- a/src/kitty/__init__.py
+++ b/src/kitty/__init__.py
@@ -4,5 +4,5 @@ import logging
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
-__version__ = "1.3.1"
+__version__ = "1.4.0"
 __all__ = ["__version__"]


### PR DESCRIPTION
Version bump for the 1.4.0 release. One user-facing fix and new capability, the rest internal.

## What ships

**Claude Code no longer compacts at ~165K on large-context models** (#17). Claude Code assumes a 200K window for any non-`claude-*` model and compacts at ~165K, whatever the model's real window. kitty resolved larger windows internally but never propagated them, so e.g. the `qwen` profile with `qwen3.8-max` (1M tokens) compacted ~6x too early. kitty now exports `CLAUDE_CODE_MAX_CONTEXT_TOKENS` (and the equivalents for Codex/Gemini/Kilo) from the resolved window, and the bridge request budget uses the same lookup.

**A runtime model-context configuration plane** (#17). `model_context_overrides.json` is the highest-priority source for context windows — provider-agnostic, case-insensitive, overriding provider config, bundled metadata, and the 200K default. kitty syncs it from this repo's `main` at startup (24h TTL, local cache, packaged fallback), so adding a model is a one-line JSON edit here — **no kitty rebuild**. Seeded with `qwen3.8-max` (1M), `MiniMax-M3`, `glm-5.3`, `glm-5.2`, and `deepseek-v4-flash` (1 Mi tokens each).

## Internal

- Hermetic TLS-in-TLS transport tests for `https://` egress proxies (#16).
- Model metadata refreshed (#14); metadata refresh now runs weekly instead of on every push to main (#15).

🤖 Generated with [Claude Code](https://claude.com/claude-code)