### PR TITLE
Isolate Claude Code settings per session (fixes #22)

### DIFF
--- a/src/kitty/cli/launcher.py
+++ b/src/kitty/cli/launcher.py
@@ -29,15 +29,16 @@ logger = logging.getLogger(__name__)
 # Module-level state for atexit cleanup.
 # Stores (adapter, original_settings_content, settings_path) after prepare_launch.
 # Cleared after successful cleanup to prevent double-restore.
-# NOTE: the "original" may be a str SUBCLASS (kitty.launchers.claude._SessionSnapshot)
-# carrying overlap-aware restore context — do not round-trip it through str(),
-# formatting, or serialisation here or in _atexit_cleanup, or that context is lost.
+# NOTE: the "original" may be a str SUBCLASS (kitty.launchers.claude's
+# _SessionSettingsFile or _SessionSnapshot) whose TYPE selects the cleanup
+# behaviour — do not round-trip it through str(), formatting, or serialisation
+# here or in _atexit_cleanup, or cleanup_launch will take the wrong branch.
 _atexit_cleanup_state: list[tuple[LauncherAdapter, str, Path]] = []
 _atexit_registered = False
 
 
 def _atexit_cleanup() -> None:
-    """Restore agent settings files that were patched by prepare_launch.
+    """Undo the agent config prepare_launch set up (delete or restore).
 
     Registered via atexit so cleanup runs even on unhandled exceptions,
     sys.exit(), or SIGTERM (which triggers normal Python shutdown).
@@ -135,8 +136,8 @@ async def launch_async(
     3. Start the bridge server
     4. Build spawn config from adapter
     5. Discover the child binary
-    6. Patch agent-specific external config
-    7. Spawn child process with signal forwarding
+    6. Prepare agent-specific external config (per-session settings file)
+    7. Build the child command and spawn it with signal forwarding
     8. Wait for child to exit
     9. Stop the bridge server
     10. Return mapped exit code
@@ -211,8 +212,45 @@ async def launch_async(
     # 5. Discover binary
     binary_path = resolve_binary(adapter.binary_name)
 
-    # 6. Build full command and environment
-    cmd = [str(binary_path)] + spawn_config.cli_args + extra_args
+    # 6. Prepare agent-specific external config (e.g. the Claude Code session
+    # settings file). Must run AFTER build_spawn_config (kilo requires it) and
+    # AFTER resolve_binary — that raises outside any try/finally, so preparing
+    # first would leave a session file behind on a missing-binary abort.
+    original_settings: str | None = None
+    settings_path: Path | None = adapter.default_settings_path
+    if settings_path is not None:
+        # Each adapter owns its agent's config file. Guessing one default here
+        # previously handed every agent Claude Code's settings.json.
+        try:
+            original_settings = adapter.prepare_launch(
+                spawn_config.env_overrides,
+                settings_path=settings_path,
+            )
+        except OSError as exc:
+            # Fail closed: without its settings file the child would fall back
+            # to the user's own settings, whose env block outranks the process
+            # env we hand it — bypassing the bridge, the egress guard, and
+            # usage logging, and billing the user's own account.
+            logger.error("Failed to prepare %s settings: %s", adapter.name, exc)
+            print(
+                f"Error: could not write the {adapter.name} session settings file: {exc}",
+                file=sys.stderr,
+            )
+            await server.stop_async()
+            return 1
+        if original_settings is not None:
+            _register_atexit_cleanup(adapter, original_settings, settings_path)
+        if debug:
+            print(
+                f"[kitty debug] {adapter.name} session settings prepared ({'yes' if original_settings else 'none'})",
+                file=sys.stderr,
+            )
+    elif debug:
+        print(f"[kitty debug] {adapter.name} has no settings file to prepare", file=sys.stderr)
+
+    # 7. Build full command and environment. settings_cli_args goes first so
+    # global flags precede any subcommand a user passed in extra_args.
+    cmd = [str(binary_path)] + adapter.settings_cli_args(original_settings) + spawn_config.cli_args + extra_args
     env = build_child_env(spawn_config)
 
     # Debug: log key env vars for diagnosing connectivity issues
@@ -236,26 +274,6 @@ async def launch_async(
             f"[kitty debug] ANTHROPIC_API_KEY={env.get('ANTHROPIC_API_KEY', '<not set>')[:8]}...",
             file=sys.stderr,
         )
-
-    # 7. Patch agent-specific external config (e.g. Claude Code settings.json)
-    original_settings: str | None = None
-    settings_path: Path | None = adapter.default_settings_path
-    if settings_path is not None:
-        # Each adapter owns its agent's config file. Guessing one default here
-        # previously handed every agent Claude Code's settings.json.
-        original_settings = adapter.prepare_launch(
-            spawn_config.env_overrides,
-            settings_path=settings_path,
-        )
-        if original_settings is not None:
-            _register_atexit_cleanup(adapter, original_settings, settings_path)
-        if debug:
-            print(
-                f"[kitty debug] settings.json patched (original={'saved' if original_settings else 'none'})",
-                file=sys.stderr,
-            )
-    elif debug:
-        print(f"[kitty debug] {adapter.name} has no settings file to patch", file=sys.stderr)
 
     # 8. Spawn child process with signal forwarding
     logger.info("Launching child: %s", " ".join(cmd))
@@ -380,4 +398,3 @@ def launch(
             usage_log_path=usage_log_path,
         )
         return asyncio.run(coro)
-

--- a/src/kitty/launchers/base.py
+++ b/src/kitty/launchers/base.py
@@ -69,10 +69,12 @@ class LauncherAdapter(ABC):
 
     @property
     def default_settings_path(self) -> Path | None:
-        """Location of the agent's own settings file.
+        """Location of the agent's own settings file, if it has one.
 
-        The launcher patches this file to point the agent at the local bridge.
-        Adapters whose agent has no such file return ``None``.
+        Adapters interact with this file differently: some patch it in place
+        for the duration of a session, while ClaudeAdapter only reads it and
+        routes the session through a per-session file instead. Adapters whose
+        agent has no such file return ``None``.
 
         Returns:
             Path to the agent's settings file, or ``None``.
@@ -97,11 +99,30 @@ class LauncherAdapter(ABC):
                 the adapter's own location.
 
         Returns:
-            The original file content, for :meth:`cleanup_launch` to restore, or
-            ``None`` when nothing was patched. Returning ``None`` is what tells
-            the launcher there is nothing to clean up.
+            A value for :meth:`cleanup_launch` to act on — the original file
+            content for adapters that patch in place, or a handle to what was
+            created (see ``ClaudeAdapter``) — or ``None`` when nothing was
+            prepared. Implementations may return a ``str`` subclass carrying
+            extra context; callers must pass it through unchanged rather than
+            round-tripping it through ``str()``.
         """
         return None
+
+    def settings_cli_args(self, prepared: str | None) -> list[str]:
+        """Return CLI args pointing the agent at a per-session settings file.
+
+        Adapters that isolate their configuration per session (ClaudeAdapter)
+        return the flag their agent uses; every other adapter inherits this
+        default and contributes nothing to the command line.
+
+        Args:
+            prepared: The value returned by :meth:`prepare_launch`.
+
+        Returns:
+            CLI arguments to insert after the binary name, or ``[]``.
+        """
+        del prepared  # unused in the default implementation
+        return []
 
     def cleanup_launch(
         self,
@@ -111,10 +132,10 @@ class LauncherAdapter(ABC):
         """Restore whatever :meth:`prepare_launch` patched.
 
         Called on the normal path and again from an atexit handler, so it must
-        be safe to invoke with nothing to restore, and idempotent when called
-        twice with the same value. Implementations that share one settings
-        file across concurrent sessions (ClaudeAdapter) must only restore
-        state this session still owns — see ``_SessionSnapshot`` there.
+        be safe to invoke with nothing to undo, and idempotent when called
+        twice with the same value. Implementations must confine themselves to
+        state this session created: a settings file shared with concurrent
+        sessions must not be rewritten on their behalf.
 
         Args:
             original: Content returned by :meth:`prepare_launch`, or ``None``.

--- a/src/kitty/launchers/claude.py
+++ b/src/kitty/launchers/claude.py
@@ -124,10 +124,14 @@ def _is_local_kitty_url(value: str) -> bool:
 def _kitty_values_present(env: object) -> bool:
     """Return ``True`` when ``env`` looks like a live kitty session wrote it.
 
-    Used by :meth:`ClaudeAdapter.prepare_launch` to decide whether an existing
-    backup file is still trustworthy (the first writer of an overlap chain
-    owns it; later writers must not clobber) and by `kitty cleanup` to decide
-    whether phase-1 crash recovery should restore from it.
+    Used only by `kitty cleanup`, to decide whether phase-1 crash recovery
+    should restore from the backup.
+
+    Deliberately broader than the launch-time check in
+    :meth:`ClaudeAdapter._warn_if_global_carries_kitty_values`, which keys on
+    the auth token alone: `kitty cleanup` is an explicit repair request, so a
+    loopback URL is signal enough, whereas warning on every launch must not
+    fire for someone running their own local proxy. Do not merge the two.
 
     Args:
         env: A parsed ``env`` block from settings.json, or anything else.
@@ -178,6 +182,20 @@ class _SessionSnapshot(str):
         return snapshot
 
 
+class _SessionSettingsFile(str):
+    """Path to this session's own Claude Code settings file.
+
+    A ``str`` subclass so it flows unchanged through the orchestrator's atexit
+    state and the adapter contract, while :meth:`ClaudeAdapter.cleanup_launch`
+    can tell it apart from the legacy bare-``str`` snapshot. The distinction is
+    load-bearing: the legacy branch writes its argument as the *entire content*
+    of the settings file, so a plain path string would overwrite the user's
+    settings.json with a path.
+    """
+
+    __slots__ = ()
+
+
 _CONFLICTING_ENV_VARS: tuple[str, ...] = (
     "ANTHROPIC_BEDROCK_BASE_URL",
     "ANTHROPIC_VERTEX_BASE_URL",
@@ -197,11 +215,6 @@ _SETTINGS_ENV_OVERRIDE_KEYS: tuple[str, ...] = (
     "CLAUDE_CODE_MAX_CONTEXT_TOKENS",
 )
 
-# Keys to remove from settings.json env block — none currently.
-# Previously removed ANTHROPIC_AUTH_TOKEN but Claude Code needs it for
-# /login checks even though the bridge uses Bearer auth.
-_SETTINGS_ENV_REMOVE_KEYS: tuple[str, ...] = ()
-
 _DEFAULT_SETTINGS_PATH = Path.home() / ".claude" / "settings.json"
 
 
@@ -214,10 +227,12 @@ class ClaudeAdapter(LauncherAdapter):
     alias overrides (``ANTHROPIC_DEFAULT_*_MODEL``) so Claude Code uses the
     profile's model regardless of which alias it picks.
 
-    Because Claude Code's ``settings.json`` ``env`` block overrides
-    process-level env vars, :meth:`prepare_launch` temporarily patches the
-    file to inject bridge-specific values, and :meth:`cleanup_launch` restores
-    the original content when the session ends.
+    Because a settings ``env`` block overrides process-level env vars,
+    :meth:`prepare_launch` writes a **per-session** settings file carrying
+    kitty's values and :meth:`settings_cli_args` points Claude Code at it with
+    ``--settings``. The user-global ``~/.claude/settings.json`` is only read
+    (for a stale-value warning), never written, so concurrent sessions cannot
+    disturb each other's configuration.
     """
 
     @property
@@ -285,108 +300,153 @@ class ClaudeAdapter(LauncherAdapter):
         """
         return _DEFAULT_SETTINGS_PATH
 
+    def settings_cli_args(self, prepared: str | None) -> list[str]:
+        """Return the CLI args that point Claude Code at the session file.
+
+        Args:
+            prepared: The value returned by :meth:`prepare_launch`.
+
+        Returns:
+            ``["--settings", <path>]``, or ``[]`` when nothing was prepared
+            (no file to point at, so no dangling flag).
+        """
+        if prepared is None:
+            return []
+        return ["--settings", str(prepared)]
+
     def prepare_launch(
         self,
         env_overrides: dict[str, str],
         settings_path: Path | None = None,
     ) -> str | None:
-        """Temporarily patch Claude Code's settings.json to inject bridge env vars.
+        """Write this session's own Claude Code settings file.
 
-        Claude Code's ``settings.json`` ``env`` block takes priority over
-        process-level environment variables.  This method injects our bridge
-        URL and model into that block so they are guaranteed to take effect.
+        Claude Code's settings ``env`` block overrides process-level
+        environment variables, so pointing it at the bridge requires a settings
+        source rather than the child's env alone. kitty writes a **per-session**
+        file and passes it as ``claude --settings <path>``: that scope outranks
+        the user, project, and local settings files, and — unlike the previous
+        design — leaves the user-global ``~/.claude/settings.json`` untouched,
+        so a second session's start cannot disturb a running session (issue
+        #22).
+
+        Only kitty's own keys are written. Claude Code merges a ``--settings``
+        ``env`` block per variable, so the user's other entries and every other
+        top-level key keep their user-scope values; copying them in would
+        freeze a snapshot of the user's configuration at launch time.
 
         Args:
             env_overrides: The env vars from :meth:`build_spawn_config`.
-            settings_path: Path to the Claude Code settings file (for testing).
+            settings_path: Location of the user-global settings file. Read
+                only, for the stale-value warning below; never written.
 
         Returns:
-            A :class:`_SessionSnapshot` of the original file content for
-            :meth:`cleanup_launch` (compares equal to the original text), or
-            ``None`` if there is no settings file to patch, the file is
-            missing, or the JSON is malformed.
+            A :class:`_SessionSettingsFile` holding the path of the file to
+            pass to ``--settings``.
+
+        Raises:
+            OSError: When the session file cannot be written. The caller must
+                fail closed — without the file the session would silently run
+                on the user's own credentials, bypassing the bridge.
         """
         settings_path = settings_path or _DEFAULT_SETTINGS_PATH
-        logger.info("prepare_launch: settings_path=%s exists=%s", settings_path, settings_path.exists())
-        if not settings_path.exists():
-            logger.warning("prepare_launch: settings.json not found at %s — skipping patch", settings_path)
-            return None
+        self._warn_if_global_carries_kitty_values(settings_path)
 
-        original = settings_path.read_text(encoding="utf-8")
+        session_env = {key: env_overrides[key] for key in _SETTINGS_ENV_OVERRIDE_KEYS if key in env_overrides}
+
+        # mkstemp (0600 on POSIX) in the OS temp dir: the OS reaps orphans left
+        # by a SIGKILL, which a kitty-owned directory would accumulate forever.
+        fd, path_str = tempfile.mkstemp(prefix="kitty-claude-settings-", suffix=".json")
         try:
-            settings = json.loads(original)
-        except json.JSONDecodeError as exc:
-            logger.error("prepare_launch: settings.json is malformed JSON: %s — skipping patch", exc)
-            return None
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                json.dump({"env": session_env}, handle, indent=2)
+        except Exception:
+            with contextlib.suppress(FileNotFoundError):
+                os.unlink(path_str)
+            raise
 
+        logger.info(
+            "prepare_launch: wrote session settings %s with env %s",
+            path_str,
+            {k: (v[:8] + "..." if isinstance(v, str) and len(v) > 8 else v) for k, v in session_env.items()},
+        )
+        return _SessionSettingsFile(path_str)
+
+    def _warn_if_global_carries_kitty_values(self, settings_path: Path) -> None:
+        """Warn when the user-global settings file still holds kitty values.
+
+        kitty no longer rewrites that file, so a session killed by a *pre-fix*
+        version would leave a dead ``127.0.0.1`` base URL there indefinitely:
+        kitty sessions would keep working (they use ``--settings``), while every
+        plain ``claude`` run failed with no hint of the cause.
+
+        Best-effort by design — a missing, unreadable, or malformed file is not
+        an error here, and must never block a launch.
+
+        Args:
+            settings_path: Location of the user-global settings file.
+        """
+        try:
+            settings = json.loads(settings_path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            # ValueError covers both JSONDecodeError and UnicodeDecodeError —
+            # a settings file saved as UTF-16 (Notepad's "Unicode") must warn
+            # at most, never abort a launch.
+            return
         if not isinstance(settings, dict):
-            logger.error("prepare_launch: settings.json root is not an object — skipping patch")
-            return None
+            return
 
-        # Save the crash backup before patching. First writer of an overlap
-        # chain owns it: later sessions must not overwrite it with a file that
-        # already contains another session's patch (issue #21). Exception: a
-        # backup left behind by an ended chain (file carries no live kitty
-        # values) is stale and is refreshed, so a later session can never
-        # "restore" an ancient pre-kitty file over the user's current one.
-        if not _DEFAULT_BACKUP_PATH.exists() or not _kitty_values_present(settings.get("env")):
-            save_settings_backup(original)
-
-        env = settings.setdefault("env", {})
-
-        logger.info(
-            "prepare_launch: settings.json env before patch: %s",
-            {k: (v[:8] + "..." if isinstance(v, str) and len(v) > 8 else v) for k, v in env.items()},
-        )
-
-        # Clean up stale localhost ANTHROPIC_BASE_URL from previous crashed sessions
-        existing_base_url = env.get("ANTHROPIC_BASE_URL", "")
-        if existing_base_url and ("127.0.0.1" in existing_base_url or "localhost" in existing_base_url):
-            logger.info("prepare_launch: removing stale ANTHROPIC_BASE_URL=%s from previous session", existing_base_url)
-            env.pop("ANTHROPIC_BASE_URL", None)
-            # Also remove other kitty-injected keys from the stale session
-            for key in _SETTINGS_ENV_OVERRIDE_KEYS:
-                if key in env and key != "ANTHROPIC_BASE_URL":
-                    logger.debug("prepare_launch: removing stale %s from previous session", key)
-                    env.pop(key, None)
-
-        for key in _SETTINGS_ENV_OVERRIDE_KEYS:
-            if key in env_overrides:
-                env[key] = env_overrides[key]
-
-        for key in _SETTINGS_ENV_REMOVE_KEYS:
-            env.pop(key, None)
-
-        logger.info(
-            "prepare_launch: settings.json env after patch: %s",
-            {k: (v[:8] + "..." if isinstance(v, str) and len(v) > 8 else v) for k, v in env.items()},
-        )
-
-        _atomic_write_json(settings_path, settings)
-        injected = {key: env_overrides[key] for key in _SETTINGS_ENV_OVERRIDE_KEYS if key in env_overrides}
-        return _SessionSnapshot(original, injected)
+        # The auth token is kitty's unambiguous signature. A loopback base URL
+        # alone would also match a user's own local proxy (LiteLLM, Ollama),
+        # and `kitty cleanup` would strip their keys.
+        env = settings.get("env")
+        if isinstance(env, dict) and env.get("ANTHROPIC_AUTH_TOKEN") == "kitty-bridge-token":
+            logger.warning(
+                "%s still carries values from a crashed kitty session; plain `claude` runs may fail. "
+                "Run `kitty cleanup` to restore it.",
+                settings_path,
+            )
 
     def cleanup_launch(
         self,
         original: str | None,
         settings_path: Path | None = None,
     ) -> None:
-        """Restore Claude Code's settings.json to the user's pre-kitty state.
+        """Undo whatever :meth:`prepare_launch` set up for this session.
 
-        Overlap-aware: when the snapshot came from :meth:`prepare_launch` (a
-        :class:`_SessionSnapshot`), the file is restored only if this session
-        still owns it — every value this session injected is still present.
-        A later session (or a user edit) overwrites ownership, and its state
-        must not be disturbed. A bare string restores verbatim (legacy
-        callers/tests).
+        The normal path deletes this session's own settings file and touches
+        nothing else — it is idempotent, because the orchestrator calls it from
+        both a ``finally`` block and an ``atexit`` handler.
+
+        Two legacy paths remain for callers predating per-session isolation: a
+        :class:`_SessionSnapshot` restores the user-global file only if this
+        session still owns it (every value it injected is still present), and a
+        bare string restores that file verbatim.
 
         Args:
-            original: The content returned by :meth:`prepare_launch`.
-            settings_path: Path to the Claude Code settings file (for testing).
+            original: The value returned by :meth:`prepare_launch`.
+            settings_path: Path to the user-global settings file, used only by
+                the legacy paths.
         """
         settings_path = settings_path or _DEFAULT_SETTINGS_PATH
         if original is None:
             return
+        # Per-session file: delete this session's file and nothing else. Checked
+        # FIRST — the legacy branch below writes its argument as the entire file
+        # content, so a path string reaching it would clobber the user's settings.
+        if isinstance(original, _SessionSettingsFile):
+            try:
+                os.unlink(original)
+            except FileNotFoundError:
+                pass  # Already cleaned up: finally + atexit both call this.
+            except OSError as exc:
+                # Never fatal — the session is over either way — but do not
+                # claim success; on Windows the child may still hold the file.
+                logger.warning("cleanup_launch: could not remove %s: %s", original, exc)
+            else:
+                logger.info("cleanup_launch: removed session settings %s", original)
+            return
+
         logger.info("cleanup_launch: restoring %s", settings_path)
         try:
             if isinstance(original, _SessionSnapshot):
@@ -416,7 +476,7 @@ class ClaudeAdapter(LauncherAdapter):
         # changed the landscape — never guess by writing.
         try:
             current = json.loads(settings_path.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError):
+        except (OSError, ValueError):
             logger.warning("cleanup_launch: %s missing or unreadable — leaving it alone", settings_path)
             return
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,6 +35,20 @@ def _reset_egress() -> None:
     set_egress(None)
 
 
+@pytest.fixture(autouse=True)
+def _session_settings_in_tmp(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep per-session agent settings files inside the test's temp directory.
+
+    ``ClaudeAdapter.prepare_launch`` creates its file with ``mkstemp`` and no
+    explicit ``dir``, which resolves to the real OS temp directory. Redirecting
+    ``tempfile.tempdir`` keeps the suite from scattering session files (each
+    holding a test credential) across the developer's machine.
+    """
+    import tempfile
+
+    monkeypatch.setattr(tempfile, "tempdir", str(tmp_path))
+
+
 def pytest_addoption(parser: pytest.Parser) -> None:
     """Add CLI flag to include slow tests."""
     parser.addoption("--runslow", action="store_true", default=False, help="run tests marked as slow")

--- a/tests/integration/test_agent_e2e.py
+++ b/tests/integration/test_agent_e2e.py
@@ -138,10 +138,14 @@ async def _run_agent_through_bridge(
 
     # Build CLI command
     cmd = _build_agent_cmd(agent_name, prompt)
-    # Prepend any adapter-specific CLI args (e.g. Codex -c flags)
-    if spawn_config.cli_args:
-        # Insert adapter CLI args after the binary name
-        cmd = [cmd[0]] + spawn_config.cli_args + cmd[1:]
+    # Insert adapter CLI args after the binary name, mirroring launch_async:
+    # the per-session settings flag first (it must precede any subcommand),
+    # then any adapter-specific args (e.g. Codex -c flags). Without the
+    # settings flag a Claude session would silently fall back to the user's
+    # own settings and never exercise the bridge.
+    adapter_args = adapter.settings_cli_args(original_settings) + spawn_config.cli_args
+    if adapter_args:
+        cmd = [cmd[0]] + adapter_args + cmd[1:]
 
     try:
         proc = await asyncio.create_subprocess_exec(

--- a/tests/test_claude_per_session_settings.py
+++ b/tests/test_claude_per_session_settings.py
@@ -1,0 +1,396 @@
+"""Per-session Claude Code settings isolation (issue #22).
+
+Every ``kitty claude`` session used to patch the one user-global
+``~/.claude/settings.json``, so a second session's start rewrote what the first
+session's settings said — the single ``ANTHROPIC_BASE_URL`` key cannot hold two
+sessions' values. These tests pin the replacement design: each session gets its
+own settings file, passed to Claude Code via ``--settings``, and kitty never
+writes the user-global file at all.
+
+See ``.requirements/20260821T134223Z_fix_issue_22_start_direction_cross_talk/REQUIREMENTS.md``
+and ``.system_design/steps/20260821_per_session_claude_settings.md``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from kitty.launchers import claude as claude_mod
+from kitty.launchers.base import LauncherAdapter
+from kitty.launchers.claude import ClaudeAdapter
+
+USER_SETTINGS = {
+    "env": {"ANTHROPIC_AUTH_TOKEN": "user-token", "CUSTOM_KEY": "keep-me"},
+    "model": "opus[1m]",
+}
+
+
+def _write_user_settings(settings_path: Path) -> str:
+    """Write a pristine user settings.json and return its exact content."""
+    settings_path.parent.mkdir(parents=True, exist_ok=True)
+    content = json.dumps(USER_SETTINGS, indent=2)
+    settings_path.write_text(content, encoding="utf-8")
+    return content
+
+
+def _session_env(port: int) -> dict[str, str]:
+    """Return the env_overrides kitty injects for a bridge on ``port``."""
+    return {
+        "ANTHROPIC_BASE_URL": f"http://127.0.0.1:{port}",
+        "ANTHROPIC_API_KEY": "sk-test",
+        "ANTHROPIC_AUTH_TOKEN": "kitty-bridge-token",
+        "ANTHROPIC_MODEL": "glm-5.3",
+    }
+
+
+def _session_file_env(prepared: str) -> dict:
+    """Return the ``env`` block written into a prepared session file."""
+    return json.loads(Path(prepared).read_text(encoding="utf-8"))["env"]
+
+
+@pytest.fixture
+def _no_global_writes(monkeypatch: pytest.MonkeyPatch):
+    """Make any write to the user-global settings path an immediate failure.
+
+    AC1's primary assertion. Byte-identity alone would also hold for a
+    patch-then-restore implementation — precisely the design being replaced —
+    so the guard proves kitty never writes the file in the first place. Every
+    write in ``claude.py`` goes through these two helpers (pinned by
+    :class:`TestWriteHelperPrecondition`).
+    """
+    guarded: list[Path] = []
+
+    def _install(global_path: Path) -> None:
+        guarded.append(global_path)
+
+    real_json = claude_mod._atomic_write_json
+    real_text = claude_mod._atomic_write_text
+
+    def _check(path: Path) -> None:
+        for forbidden in guarded:
+            if Path(path) == forbidden:
+                raise AssertionError(f"kitty wrote the user-global settings file: {path}")
+
+    def fake_json(path: Path, data: dict) -> None:
+        _check(path)
+        real_json(path, data)
+
+    def fake_text(path: Path, content: str) -> None:
+        _check(path)
+        real_text(path, content)
+
+    monkeypatch.setattr(claude_mod, "_atomic_write_json", fake_json)
+    monkeypatch.setattr(claude_mod, "_atomic_write_text", fake_text)
+    return _install
+
+
+class TestNoGlobalWrites:
+    """AC1: kitty must never write the user-global settings file."""
+
+    def test_second_session_start_leaves_global_file_untouched(self, tmp_path: Path, _no_global_writes):
+        """The issue-#22 invariant: starting B must not disturb A's state.
+
+        Under the old shared-file design B's ``prepare_launch`` rewrote the one
+        ``ANTHROPIC_BASE_URL`` key, so the file no longer described A.
+        """
+        settings_path = tmp_path / ".claude" / "settings.json"
+        original = _write_user_settings(settings_path)
+        _no_global_writes(settings_path)
+        before = settings_path.stat().st_mtime_ns
+        adapter = ClaudeAdapter()
+
+        prepared_a = adapter.prepare_launch(_session_env(10001), settings_path=settings_path)
+        prepared_b = adapter.prepare_launch(_session_env(10002), settings_path=settings_path)
+
+        # Secondary checks: content and mtime are both untouched.
+        assert settings_path.read_text(encoding="utf-8") == original
+        assert settings_path.stat().st_mtime_ns == before
+        # A's routing still describes A's bridge, unaffected by B's start.
+        assert _session_file_env(prepared_a)["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:10001"
+        assert _session_file_env(prepared_b)["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:10002"
+
+    def test_cleanup_never_writes_global_file(self, tmp_path: Path, _no_global_writes):
+        """AC5: neither cleanup call may touch the global file."""
+        settings_path = tmp_path / ".claude" / "settings.json"
+        original = _write_user_settings(settings_path)
+        _no_global_writes(settings_path)
+        adapter = ClaudeAdapter()
+
+        prepared = adapter.prepare_launch(_session_env(10001), settings_path=settings_path)
+        adapter.cleanup_launch(prepared, settings_path=settings_path)
+        # Second call mirrors the finally + atexit double-invocation.
+        adapter.cleanup_launch(prepared, settings_path=settings_path)
+
+        assert settings_path.read_text(encoding="utf-8") == original
+
+
+class TestWriteHelperPrecondition:
+    """Pin the precondition :func:`_no_global_writes` relies on."""
+
+    def test_settings_path_writes_go_through_the_atomic_helpers(self):
+        """No code path writes ``settings_path`` except via the helpers.
+
+        The AC1 guard works by intercepting ``_atomic_write_json`` /
+        ``_atomic_write_text``. If a future edit wrote the settings file
+        directly, the guard would silently stop guarding — so the invariant is
+        asserted rather than assumed. ``prepare_launch`` legitimately writes
+        the *session* file through an ``mkstemp`` handle; that path is a
+        freshly created temp file, never ``settings_path``.
+        """
+        source = Path(claude_mod.__file__).read_text(encoding="utf-8")
+        for line in source.splitlines():
+            stripped = line.strip()
+            if stripped.startswith("#") or "settings_path" not in stripped:
+                continue
+            assert ".write_text(" not in stripped, f"direct write to settings_path: {stripped}"
+            assert "open(" not in stripped or "read" in stripped, f"direct open of settings_path: {stripped}"
+
+
+class TestSessionFileIsolation:
+    """AC2/AC3: independent files carrying exactly kitty's keys."""
+
+    def test_two_sessions_get_distinct_files(self, tmp_path: Path):
+        settings_path = tmp_path / ".claude" / "settings.json"
+        _write_user_settings(settings_path)
+        adapter = ClaudeAdapter()
+
+        prepared_a = adapter.prepare_launch(_session_env(10001), settings_path=settings_path)
+        prepared_b = adapter.prepare_launch(_session_env(10002), settings_path=settings_path)
+
+        assert prepared_a != prepared_b
+        assert Path(prepared_a).exists() and Path(prepared_b).exists()
+
+    def test_session_file_carries_only_kitty_keys(self, tmp_path: Path):
+        """The user's own env entries must NOT be copied in.
+
+        Claude Code merges a ``--settings`` env block per variable, so omitted
+        keys keep their user-scope values. Cloning them would freeze a snapshot
+        of the user's env at launch time.
+        """
+        settings_path = tmp_path / ".claude" / "settings.json"
+        _write_user_settings(settings_path)
+        adapter = ClaudeAdapter()
+
+        env_overrides = _session_env(10001)
+        prepared = adapter.prepare_launch(env_overrides, settings_path=settings_path)
+
+        assert _session_file_env(prepared) == env_overrides
+        assert "CUSTOM_KEY" not in _session_file_env(prepared)
+
+    def test_only_injected_keys_are_written(self, tmp_path: Path):
+        """Keys outside _SETTINGS_ENV_OVERRIDE_KEYS are not smuggled in."""
+        settings_path = tmp_path / ".claude" / "settings.json"
+        _write_user_settings(settings_path)
+        adapter = ClaudeAdapter()
+
+        env_overrides = {**_session_env(10001), "UNRELATED_VAR": "nope"}
+        prepared = adapter.prepare_launch(env_overrides, settings_path=settings_path)
+
+        assert "UNRELATED_VAR" not in _session_file_env(prepared)
+
+
+class TestRoutingWithoutUserSettings:
+    """AC6: a machine with no ~/.claude/settings.json must still be routed."""
+
+    def test_session_file_written_when_global_absent(self, tmp_path: Path):
+        """Previously ``prepare_launch`` returned None here and the session fell
+        back to process env — which the user's settings scopes outrank."""
+        settings_path = tmp_path / ".claude" / "settings.json"
+        adapter = ClaudeAdapter()
+
+        prepared = adapter.prepare_launch(_session_env(10001), settings_path=settings_path)
+
+        assert prepared is not None
+        assert _session_file_env(prepared)["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:10001"
+        assert not settings_path.exists(), "kitty must not create the user's settings file"
+
+    @pytest.mark.parametrize(
+        "content",
+        [
+            b"{not json",
+            b'["a", "list"]',
+            # UTF-16 with a BOM — what Notepad's "Save as -> Unicode" writes.
+            # Decoding it as UTF-8 raises UnicodeDecodeError, which is a
+            # ValueError, not an OSError: it would escape both this read and
+            # the orchestrator's fail-closed handler, killing the launch with
+            # a raw traceback and an orphaned bridge.
+            b'\xff\xfe{\x00"\x00e\x00"\x00:\x001\x00}\x00',
+        ],
+        ids=["invalid-json", "list-root", "utf16-bom"],
+    )
+    def test_malformed_global_file_does_not_block_launch(self, tmp_path: Path, content: bytes):
+        """AC10: R10's read is best-effort; R7 covers the session-file write only."""
+        settings_path = tmp_path / ".claude" / "settings.json"
+        settings_path.parent.mkdir(parents=True, exist_ok=True)
+        settings_path.write_bytes(content)
+        adapter = ClaudeAdapter()
+
+        prepared = adapter.prepare_launch(_session_env(10001), settings_path=settings_path)
+
+        assert prepared is not None
+        assert _session_file_env(prepared)["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:10001"
+        assert settings_path.read_bytes() == content
+
+
+class TestCleanup:
+    """AC5: per-session cleanup, idempotent, nothing global touched."""
+
+    def test_cleanup_removes_session_file(self, tmp_path: Path):
+        settings_path = tmp_path / ".claude" / "settings.json"
+        _write_user_settings(settings_path)
+        adapter = ClaudeAdapter()
+
+        prepared = adapter.prepare_launch(_session_env(10001), settings_path=settings_path)
+        assert Path(prepared).exists()
+        adapter.cleanup_launch(prepared, settings_path=settings_path)
+
+        assert not Path(prepared).exists()
+
+    def test_cleanup_is_idempotent(self, tmp_path: Path):
+        """finally + atexit both call it; the second must be a no-op."""
+        settings_path = tmp_path / ".claude" / "settings.json"
+        _write_user_settings(settings_path)
+        adapter = ClaudeAdapter()
+
+        prepared = adapter.prepare_launch(_session_env(10001), settings_path=settings_path)
+        adapter.cleanup_launch(prepared, settings_path=settings_path)
+        adapter.cleanup_launch(prepared, settings_path=settings_path)
+
+        assert not Path(prepared).exists()
+
+    def test_one_session_cleanup_leaves_the_other_file(self, tmp_path: Path):
+        """A's exit must not disturb B's still-running session."""
+        settings_path = tmp_path / ".claude" / "settings.json"
+        _write_user_settings(settings_path)
+        adapter = ClaudeAdapter()
+
+        prepared_a = adapter.prepare_launch(_session_env(10001), settings_path=settings_path)
+        prepared_b = adapter.prepare_launch(_session_env(10002), settings_path=settings_path)
+        adapter.cleanup_launch(prepared_a, settings_path=settings_path)
+
+        assert not Path(prepared_a).exists()
+        assert Path(prepared_b).exists()
+        assert _session_file_env(prepared_b)["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:10002"
+
+    def test_prepared_value_never_reaches_the_verbatim_restore_branch(self, tmp_path: Path, _no_global_writes):
+        """R9: a bare ``str`` is written as the file's ENTIRE content.
+
+        If the prepared value were a plain path string it would land in that
+        legacy branch and overwrite the user's settings.json with a path.
+        """
+        settings_path = tmp_path / ".claude" / "settings.json"
+        original = _write_user_settings(settings_path)
+        _no_global_writes(settings_path)
+        adapter = ClaudeAdapter()
+
+        prepared = adapter.prepare_launch(_session_env(10001), settings_path=settings_path)
+        assert isinstance(prepared, claude_mod._SessionSettingsFile), (
+            "prepared value must be a distinct type, not a bare str"
+        )
+        adapter.cleanup_launch(prepared, settings_path=settings_path)
+
+        assert settings_path.read_text(encoding="utf-8") == original
+
+
+class TestSettingsCliArgs:
+    """AC4/AC7: how the session file reaches the child command."""
+
+    def test_claude_returns_settings_flag(self, tmp_path: Path):
+        settings_path = tmp_path / ".claude" / "settings.json"
+        _write_user_settings(settings_path)
+        adapter = ClaudeAdapter()
+
+        prepared = adapter.prepare_launch(_session_env(10001), settings_path=settings_path)
+
+        assert adapter.settings_cli_args(prepared) == ["--settings", str(prepared)]
+
+    def test_no_args_when_nothing_prepared(self):
+        """A skipped prepare must not produce a dangling flag."""
+        assert ClaudeAdapter().settings_cli_args(None) == []
+
+    def test_base_adapter_contributes_no_args(self):
+        """AC7: adapters with no per-session settings are unaffected."""
+
+        class _Stub(LauncherAdapter):
+            """Minimal adapter exercising the inherited default."""
+
+            @property
+            def name(self) -> str:
+                return "stub"
+
+            @property
+            def binary_name(self) -> str:
+                return "stub"
+
+            @property
+            def bridge_protocol(self):
+                return None
+
+            def build_spawn_config(self, profile, bridge_port, resolved_key, *, context_tokens=None):
+                raise NotImplementedError
+
+        assert _Stub().settings_cli_args("anything") == []
+
+
+class TestStaleGlobalWarning:
+    """AC10: warn about a pre-fix poisoned global file, never modify it."""
+
+    def test_warns_when_global_carries_kitty_signature(self, tmp_path: Path, caplog):
+        settings_path = tmp_path / ".claude" / "settings.json"
+        settings_path.parent.mkdir(parents=True, exist_ok=True)
+        poisoned = json.dumps(
+            {"env": {"ANTHROPIC_BASE_URL": "http://127.0.0.1:9999", "ANTHROPIC_AUTH_TOKEN": "kitty-bridge-token"}},
+            indent=2,
+        )
+        settings_path.write_text(poisoned, encoding="utf-8")
+        adapter = ClaudeAdapter()
+
+        with caplog.at_level("WARNING"):
+            adapter.prepare_launch(_session_env(10001), settings_path=settings_path)
+
+        assert "kitty cleanup" in caplog.text
+        assert settings_path.read_text(encoding="utf-8") == poisoned
+
+    def test_no_warning_for_a_users_own_local_proxy(self, tmp_path: Path, caplog):
+        """A loopback URL alone is not a kitty signature.
+
+        Users running LiteLLM/Ollama locally must not be nagged toward a
+        command that would strip their own keys.
+        """
+        settings_path = tmp_path / ".claude" / "settings.json"
+        settings_path.parent.mkdir(parents=True, exist_ok=True)
+        settings_path.write_text(
+            json.dumps({"env": {"ANTHROPIC_BASE_URL": "http://127.0.0.1:4000", "ANTHROPIC_API_KEY": "mine"}}, indent=2),
+            encoding="utf-8",
+        )
+        adapter = ClaudeAdapter()
+
+        with caplog.at_level("WARNING"):
+            adapter.prepare_launch(_session_env(10001), settings_path=settings_path)
+
+        assert "kitty cleanup" not in caplog.text
+
+
+class TestPrepareFailure:
+    """AC9 (adapter half): a failed write must propagate, not pass silently."""
+
+    def test_write_failure_raises(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        """R7: the orchestrator turns this into a fail-closed abort.
+
+        Silently continuing would run the session on the user's own
+        credentials, bypassing the bridge and its usage logging.
+        """
+        settings_path = tmp_path / ".claude" / "settings.json"
+        _write_user_settings(settings_path)
+
+        def _boom(*_args, **_kwargs):
+            raise OSError("no space left on device")
+
+        monkeypatch.setattr(claude_mod.tempfile, "mkstemp", _boom)
+        adapter = ClaudeAdapter()
+
+        with pytest.raises(OSError):
+            adapter.prepare_launch(_session_env(10001), settings_path=settings_path)

--- a/tests/test_claude_settings_api_key.py
+++ b/tests/test_claude_settings_api_key.py
@@ -44,11 +44,21 @@ def _write_settings(path: Path, env: dict | None = None, **extra: object) -> str
     return content
 
 
-class TestApiKeyInSettingsEnv:
-    """ANTHROPIC_API_KEY must be injected into settings.json env block so
-    Claude Code authenticates with the bridge."""
+def _session_env(prepared: str | None) -> dict:
+    """Return the ``env`` block of the session file ``prepare_launch`` wrote."""
+    assert prepared is not None, "prepare_launch must produce a session settings file"
+    return json.loads(Path(prepared).read_text(encoding="utf-8"))["env"]
 
-    def test_injects_api_key_into_settings_env(self, tmp_path: Path):
+
+class TestApiKeyInSettingsEnv:
+    """The credential kitty hands Claude Code for this session.
+
+    It travels in the per-session settings file rather than the user-global one
+    (issue #22), because Claude Code's settings env outranks the process env we
+    give the child.
+    """
+
+    def test_injects_api_key(self, tmp_path: Path):
         settings_path = tmp_path / ".claude" / "settings.json"
         _write_settings(settings_path, env={})
 
@@ -57,15 +67,13 @@ class TestApiKeyInSettingsEnv:
             "ANTHROPIC_BASE_URL": "http://127.0.0.1:4242",
             "ANTHROPIC_API_KEY": "sk-test-key-123",
         }
-        adapter.prepare_launch(env_overrides, settings_path=settings_path)
+        prepared = adapter.prepare_launch(env_overrides, settings_path=settings_path)
 
-        patched = json.loads(settings_path.read_text(encoding="utf-8"))
-        assert patched["env"]["ANTHROPIC_API_KEY"] == "sk-test-key-123"
+        assert _session_env(prepared)["ANTHROPIC_API_KEY"] == "sk-test-key-123"
 
-    def test_does_not_remove_auth_token_from_settings_env(self, tmp_path: Path):
-        """ANTHROPIC_AUTH_TOKEN must be present after prepare_launch — kitty injects
-        its own value so Claude Code does not require login.  If the user had a
-        pre-existing token, kitty's value overrides it."""
+    def test_auth_token_is_kittys_not_the_users(self, tmp_path: Path):
+        """kitty always supplies its own token so Claude Code does not demand a
+        login; the user's own value must not shadow it for this session."""
         settings_path = tmp_path / ".claude" / "settings.json"
         _write_settings(
             settings_path,
@@ -76,7 +84,7 @@ class TestApiKeyInSettingsEnv:
         )
 
         adapter = ClaudeAdapter()
-        adapter.prepare_launch(
+        prepared = adapter.prepare_launch(
             {
                 "ANTHROPIC_BASE_URL": "http://127.0.0.1:4242",
                 "ANTHROPIC_AUTH_TOKEN": "kitty-bridge-token",
@@ -84,14 +92,13 @@ class TestApiKeyInSettingsEnv:
             settings_path=settings_path,
         )
 
-        patched = json.loads(settings_path.read_text(encoding="utf-8"))
-        # ANTHROPIC_AUTH_TOKEN must still be present (kitty's value)
-        assert patched["env"]["ANTHROPIC_AUTH_TOKEN"] == "kitty-bridge-token"
+        assert _session_env(prepared)["ANTHROPIC_AUTH_TOKEN"] == "kitty-bridge-token"
 
-    def test_bridge_overrides_win_over_pre_existing_settings(self, tmp_path: Path):
-        """Bridge env_overrides must win over pre-existing settings.json values."""
+    def test_bridge_values_are_the_ones_written(self, tmp_path: Path):
+        """Whatever the user has configured, the session file carries the
+        bridge's values — it outranks user scope, so these are what apply."""
         settings_path = tmp_path / ".claude" / "settings.json"
-        _write_settings(
+        user_original = _write_settings(
             settings_path,
             env={
                 "ANTHROPIC_BASE_URL": "http://127.0.0.1:8080",
@@ -101,7 +108,7 @@ class TestApiKeyInSettingsEnv:
         )
 
         adapter = ClaudeAdapter()
-        original = adapter.prepare_launch(
+        prepared = adapter.prepare_launch(
             {
                 "ANTHROPIC_BASE_URL": "http://127.0.0.1:9999",
                 "ANTHROPIC_API_KEY": "sk-from-bridge",
@@ -110,15 +117,17 @@ class TestApiKeyInSettingsEnv:
             settings_path=settings_path,
         )
 
-        patched = json.loads(settings_path.read_text(encoding="utf-8"))
-        assert patched["env"]["ANTHROPIC_API_KEY"] == "sk-from-bridge"
-        assert patched["env"]["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:9999"
+        env = _session_env(prepared)
+        assert env["ANTHROPIC_API_KEY"] == "sk-from-bridge"
+        assert env["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:9999"
+        # The user's own file is untouched throughout.
+        assert settings_path.read_text(encoding="utf-8") == user_original
 
-        adapter.cleanup_launch(original, settings_path=settings_path)
+        adapter.cleanup_launch(prepared, settings_path=settings_path)
+        assert settings_path.read_text(encoding="utf-8") == user_original
 
-    def test_roundtrip_preserves_auth_token(self, tmp_path: Path):
-        """After prepare_launch + cleanup_launch, ANTHROPIC_AUTH_TOKEN must be
-        restored to its original value."""
+    def test_roundtrip_leaves_the_users_auth_token_alone(self, tmp_path: Path):
+        """The user's own token must survive a kitty session untouched."""
         settings_path = tmp_path / ".claude" / "settings.json"
         original_content = _write_settings(
             settings_path,
@@ -129,80 +138,71 @@ class TestApiKeyInSettingsEnv:
         )
 
         adapter = ClaudeAdapter()
-        saved = adapter.prepare_launch(
+        prepared = adapter.prepare_launch(
             {"ANTHROPIC_BASE_URL": "http://127.0.0.1:4242", "ANTHROPIC_API_KEY": "sk-test"},
             settings_path=settings_path,
         )
 
-        adapter.cleanup_launch(saved, settings_path=settings_path)
+        adapter.cleanup_launch(prepared, settings_path=settings_path)
 
         restored = settings_path.read_text(encoding="utf-8")
         assert restored == original_content
-        parsed = json.loads(restored)
-        assert parsed["env"]["ANTHROPIC_AUTH_TOKEN"] == "my-secret-token"
+        assert json.loads(restored)["env"]["ANTHROPIC_AUTH_TOKEN"] == "my-secret-token"
 
 
 class TestMalformedSettings:
-    """prepare_launch must handle malformed settings.json gracefully."""
+    """A broken user settings.json must never block a launch.
 
-    def test_malformed_json_returns_none_does_not_crash(self, tmp_path: Path):
+    kitty only reads that file now (for the stale-value warning), so malformed
+    content is at most a missed warning — the session still gets its own file.
+    """
+
+    def test_malformed_json_still_routes_the_session(self, tmp_path: Path):
         settings_path = tmp_path / ".claude" / "settings.json"
         settings_path.parent.mkdir(parents=True, exist_ok=True)
-        settings_path.write_text("not valid json {{{", encoding="utf-8")
+        settings_path.write_text("{ this is not valid json", encoding="utf-8")
 
         adapter = ClaudeAdapter()
-        result = adapter.prepare_launch(
+        prepared = adapter.prepare_launch(
             {"ANTHROPIC_BASE_URL": "http://127.0.0.1:4242"},
             settings_path=settings_path,
         )
 
-        # Must return None so cleanup_launch is a no-op
-        assert result is None
-        # Original malformed content must be preserved (fail-closed)
-        assert settings_path.read_text(encoding="utf-8") == "not valid json {{{"
+        assert _session_env(prepared)["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:4242"
 
-    def test_settings_root_is_list_returns_none(self, tmp_path: Path):
+    def test_settings_root_is_list_still_routes_the_session(self, tmp_path: Path):
         settings_path = tmp_path / ".claude" / "settings.json"
         settings_path.parent.mkdir(parents=True, exist_ok=True)
-        settings_path.write_text('["some", "array"]', encoding="utf-8")
+        settings_path.write_text('["not", "an", "object"]', encoding="utf-8")
 
         adapter = ClaudeAdapter()
-        result = adapter.prepare_launch(
+        prepared = adapter.prepare_launch(
             {"ANTHROPIC_BASE_URL": "http://127.0.0.1:4242"},
             settings_path=settings_path,
         )
 
-        assert result is None
-        assert settings_path.read_text(encoding="utf-8") == '["some", "array"]'
+        assert _session_env(prepared)["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:4242"
 
 
 class TestAtomicWrite:
-    """File writes must not corrupt settings.json."""
+    """The session file must be well-formed and self-contained."""
 
-    def test_write_produces_valid_json_and_preserves_existing_fields(self, tmp_path: Path):
-        """After patching, the file must be valid JSON with no data loss."""
+    def test_session_file_is_valid_json_and_user_file_untouched(self, tmp_path: Path):
         settings_path = tmp_path / ".claude" / "settings.json"
-        original_content = _write_settings(settings_path, env={"EXISTING": "value", "ANTHROPIC_AUTH_TOKEN": "keep-me"})
+        original = _write_settings(
+            settings_path,
+            env={"EXISTING_VAR": "keep-me"},
+            model="opus",
+            someOtherField={"nested": "value"},
+        )
 
         adapter = ClaudeAdapter()
-        original = adapter.prepare_launch(
-            {
-                "ANTHROPIC_BASE_URL": "http://127.0.0.1:4242",
-                "ANTHROPIC_API_KEY": "sk-test-key",
-                "ANTHROPIC_MODEL": "minimax-m2.7",
-                "ANTHROPIC_DEFAULT_OPUS_MODEL": "minimax-m2.7",
-                "ANTHROPIC_DEFAULT_SONNET_MODEL": "minimax-m2.7",
-                "ANTHROPIC_DEFAULT_HAIKU_MODEL": "minimax-m2.7",
-            },
+        prepared = adapter.prepare_launch(
+            {"ANTHROPIC_BASE_URL": "http://127.0.0.1:4242", "ANTHROPIC_API_KEY": "sk-test"},
             settings_path=settings_path,
         )
 
-        # File must be valid JSON after patching
-        patched = json.loads(settings_path.read_text(encoding="utf-8"))
-        assert patched["env"]["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:4242"
-        assert patched["env"]["EXISTING"] == "value"  # not corrupted
-        assert patched["env"]["ANTHROPIC_AUTH_TOKEN"] == "keep-me"  # not removed
-
-        # Restore must be byte-identical to original content
-        adapter.cleanup_launch(original, settings_path=settings_path)
-        assert settings_path.read_text(encoding="utf-8") == original_content
+        session = json.loads(Path(prepared).read_text(encoding="utf-8"))
+        assert session["env"]["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:4242"
+        assert list(session) == ["env"], "the session file must only carry an env block"
+        assert settings_path.read_text(encoding="utf-8") == original

--- a/tests/test_claude_settings_multi_session.py
+++ b/tests/test_claude_settings_multi_session.py
@@ -1,23 +1,19 @@
-"""Regression tests: overlapping kitty Claude sessions share ~/.claude/settings.json.
+"""Overlapping kitty Claude sessions must not interfere with each other.
 
-Claude Code hot-reloads settings.json and re-applies its ``env`` block to
-running sessions on change, and every ``kitty claude`` session patches that one
-user-global file. These tests pin the lifecycle invariants that must hold when
-several sessions overlap on the same machine (e.g. Claude Code sessions in
-different worktrees): any exit order restores the user's settings, a running
-session keeps its own bridge routing, and crash recovery can always reconstruct
-the pre-kitty content.
+Several ``kitty claude`` sessions commonly run at once (e.g. one per worktree,
+often on different profiles). Before issue #22 every session patched the one
+user-global ``~/.claude/settings.json``, so the single ``ANTHROPIC_BASE_URL``
+key could only describe whichever session started last. These tests pin the
+replacement invariants: each session's routing lives in its own file, any
+start/exit order leaves the user's settings untouched, and one session's exit
+cannot disturb another's.
 
-See ``.requirements/20260821T113955Z_multi_session_settings_race/REQUIREMENTS.md``.
+See ``.requirements/20260821T134223Z_fix_issue_22_start_direction_cross_talk/REQUIREMENTS.md``.
 """
 
 import json
 from pathlib import Path
-from unittest.mock import patch
 
-import pytest
-
-from kitty.launchers import claude as claude_mod
 from kitty.launchers.claude import ClaudeAdapter
 
 USER_SETTINGS = {
@@ -34,39 +30,6 @@ def _write_user_settings(settings_path: Path) -> str:
     return content
 
 
-def _patch_backup_to_tmp(backup_path: Path):
-    """Redirect the fixed global backup path to a temp file for hermeticity.
-
-    Patches both the module constant ``_DEFAULT_BACKUP_PATH`` (so exists/read
-    checks land on the temp file under the implementation that resolves the
-    constant at call time) and the save/load/delete helpers (with fakes that
-    delegate to the real implementations against the temp path, so real
-    serialization and save-if-absent semantics are exercised). Under the
-    pre-fix code (constant resolved at def-time) the constant patch is inert
-    but the function fakes still keep tests hermetic.
-    """
-    real_save = claude_mod.save_settings_backup
-    real_load = claude_mod.load_settings_backup
-    real_delete = claude_mod.delete_settings_backup
-
-    def fake_save(original: str) -> None:
-        real_save(original, backup_path=backup_path)
-
-    def fake_load() -> str | None:
-        return real_load(backup_path=backup_path)
-
-    def fake_delete() -> None:
-        real_delete(backup_path=backup_path)
-
-    return patch.multiple(
-        claude_mod,
-        _DEFAULT_BACKUP_PATH=backup_path,
-        save_settings_backup=fake_save,
-        load_settings_backup=fake_load,
-        delete_settings_backup=fake_delete,
-    )
-
-
 def _session_env(port: int) -> dict[str, str]:
     """Return the env_overrides kitty injects for a bridge on ``port``."""
     return {
@@ -76,185 +39,123 @@ def _session_env(port: int) -> dict[str, str]:
     }
 
 
-def _env(settings_path: Path) -> dict:
-    """Return the current settings.json env block."""
-    return json.loads(settings_path.read_text(encoding="utf-8")).get("env", {})
-
-
-def _assert_user_settings_restored(settings_path: Path) -> None:
-    """Assert settings.json is semantically equal to the user's pre-kitty content.
-
-    Parsed-JSON equality, not byte equality: a surgical-unpatch fix legitimately
-    re-serialises (key order, whitespace), and byte identity would wrongly imply
-    that a user's own mid-session edits to settings.json must be clobbered.
-    """
-    assert json.loads(settings_path.read_text(encoding="utf-8")) == USER_SETTINGS, (
-        "settings.json differs from the user's pre-kitty content after all sessions exited"
-    )
+def _session_file_env(prepared: str) -> dict:
+    """Return the ``env`` block of a prepared session settings file."""
+    return json.loads(Path(prepared).read_text(encoding="utf-8"))["env"]
 
 
 class TestOverlappingExitOrder:
-    """AC1/AC2: after all sessions exit, the user's settings are intact."""
+    """AC1/AC2: any exit order leaves the user's settings untouched."""
 
-    def test_first_started_session_exiting_first_restores_user_settings(self, tmp_path: Path):
-        """Non-LIFO exit (A starts, B starts, A exits, B exits) must not leave
-        A's dead bridge URL in the user's settings.json."""
+    def test_first_started_session_exiting_first(self, tmp_path: Path):
+        """Non-LIFO exit (A starts, B starts, A exits, B exits).
+
+        This ordering used to leave A's dead bridge URL in the user's file
+        permanently, because B's snapshot had captured A's patch.
+        """
         settings_path = tmp_path / ".claude" / "settings.json"
-        backup_path = tmp_path / "claude-settings-backup.json"
-        _write_user_settings(settings_path)
+        original = _write_user_settings(settings_path)
         adapter = ClaudeAdapter()
 
-        with _patch_backup_to_tmp(backup_path):
-            original_a = adapter.prepare_launch(_session_env(10001), settings_path=settings_path)
-            original_b = adapter.prepare_launch(_session_env(10002), settings_path=settings_path)
-            adapter.cleanup_launch(original_a, settings_path=settings_path)
-            adapter.cleanup_launch(original_b, settings_path=settings_path)
+        prepared_a = adapter.prepare_launch(_session_env(10001), settings_path=settings_path)
+        prepared_b = adapter.prepare_launch(_session_env(10002), settings_path=settings_path)
+        adapter.cleanup_launch(prepared_a, settings_path=settings_path)
+        adapter.cleanup_launch(prepared_b, settings_path=settings_path)
 
-        _assert_user_settings_restored(settings_path)
-        # The last exit must also remove the crash backup; a stale one would
-        # make `kitty cleanup` restore it over future user edits.
-        assert not backup_path.exists(), "stale crash backup left behind after all sessions exited"
+        assert settings_path.read_text(encoding="utf-8") == original
+        assert not Path(prepared_a).exists()
+        assert not Path(prepared_b).exists()
 
-    def test_last_started_session_exiting_first_restores_user_settings(self, tmp_path: Path):
-        """LIFO exit (A starts, B starts, B exits, A exits) is the ordering
-        that works today and must keep working under any fix."""
+    def test_last_started_session_exiting_first(self, tmp_path: Path):
+        """LIFO exit (A starts, B starts, B exits, A exits)."""
         settings_path = tmp_path / ".claude" / "settings.json"
-        backup_path = tmp_path / "claude-settings-backup.json"
-        _write_user_settings(settings_path)
+        original = _write_user_settings(settings_path)
         adapter = ClaudeAdapter()
 
-        with _patch_backup_to_tmp(backup_path):
-            original_a = adapter.prepare_launch(_session_env(10001), settings_path=settings_path)
-            original_b = adapter.prepare_launch(_session_env(10002), settings_path=settings_path)
-            adapter.cleanup_launch(original_b, settings_path=settings_path)
-            adapter.cleanup_launch(original_a, settings_path=settings_path)
+        prepared_a = adapter.prepare_launch(_session_env(10001), settings_path=settings_path)
+        prepared_b = adapter.prepare_launch(_session_env(10002), settings_path=settings_path)
+        adapter.cleanup_launch(prepared_b, settings_path=settings_path)
+        adapter.cleanup_launch(prepared_a, settings_path=settings_path)
 
-        _assert_user_settings_restored(settings_path)
+        assert settings_path.read_text(encoding="utf-8") == original
 
 
 class TestRunningSessionIsolation:
-    """AC3: another session's exit must not strip a running session's routing."""
+    """AC3: another session's exit must not disturb a running session."""
 
     def test_earlier_session_exit_keeps_later_session_routing(self, tmp_path: Path):
-        """While B runs, A's cleanup must not leave settings.json without B's
-        bridge URL (Claude Code hot-reloads this file into running sessions)."""
         settings_path = tmp_path / ".claude" / "settings.json"
-        backup_path = tmp_path / "claude-settings-backup.json"
         _write_user_settings(settings_path)
         adapter = ClaudeAdapter()
 
-        with _patch_backup_to_tmp(backup_path):
-            original_a = adapter.prepare_launch(_session_env(10001), settings_path=settings_path)
-            adapter.prepare_launch(_session_env(10002), settings_path=settings_path)
-            adapter.cleanup_launch(original_a, settings_path=settings_path)
+        prepared_a = adapter.prepare_launch(_session_env(10001), settings_path=settings_path)
+        prepared_b = adapter.prepare_launch(_session_env(10002), settings_path=settings_path)
+        adapter.cleanup_launch(prepared_a, settings_path=settings_path)
 
-        env = _env(settings_path)
-        assert env.get("ANTHROPIC_BASE_URL") == "http://127.0.0.1:10002", (
-            "session B is still running but settings.json no longer routes to B's bridge"
-        )
-        # The user's non-kitty keys MUST survive any other session's exit.
-        assert env.get("CUSTOM_KEY") == "keep-me"
-        # A's exit must not delete the shared crash backup — session B still
-        # needs it for crash recovery.
-        assert backup_path.exists(), "a not-owning session's exit deleted the shared crash backup"
+        assert Path(prepared_b).exists(), "a session's exit deleted another session's settings"
+        assert _session_file_env(prepared_b)["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:10002"
 
 
 class TestStartDirectionCrossTalk:
-    """AC5: starting a second session must not reroute the first session's bridge.
+    """AC5 / issue #22: a second session's start must not reroute the first.
 
-    This is the defect `kitty doctor` cannot detect: a running session silently
-    gets its `ANTHROPIC_BASE_URL` / `ANTHROPIC_API_KEY` rewritten when another
-    session starts. Under the current shared-file design the single
-    `ANTHROPIC_BASE_URL` key can only hold one session's value, so any
-    shared-file patch propagates to every running session — the only fix is
-    per-session isolation (Option B). This test stays red on the current
-    surface and documents the invariant a correct fix must satisfy.
+    Under the shared-file design this was structurally impossible to satisfy —
+    one ``ANTHROPIC_BASE_URL`` key cannot hold two sessions' values, so the
+    second launch always overwrote the first session's routing. Per-session
+    files remove the shared key entirely.
     """
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason=(
-            "Documents open issue #22: any shared-file design reroutes running sessions on "
-            "each new launch (Claude Code hot-reloads the settings env block). Only per-session "
-            "settings isolation fixes it. Strict so the marker is removed when #22 lands."
-        ),
-    )
     def test_second_session_start_keeps_first_session_routing(self, tmp_path: Path):
         settings_path = tmp_path / ".claude" / "settings.json"
-        backup_path = tmp_path / "claude-settings-backup.json"
-        _write_user_settings(settings_path)
+        original = _write_user_settings(settings_path)
         adapter = ClaudeAdapter()
 
-        with _patch_backup_to_tmp(backup_path):
-            adapter.prepare_launch(_session_env(10001), settings_path=settings_path)
-            adapter.prepare_launch(_session_env(10002), settings_path=settings_path)
+        prepared_a = adapter.prepare_launch(_session_env(10001), settings_path=settings_path)
+        adapter.prepare_launch(_session_env(10002), settings_path=settings_path)
 
-        env = _env(settings_path)
-        assert env.get("ANTHROPIC_BASE_URL") == "http://127.0.0.1:10001", (
-            "session A is still running but settings.json now routes to B's bridge — "
-            "Claude Code will hot-reload A's env and reroute A's traffic through B"
+        assert _session_file_env(prepared_a)["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:10001", (
+            "session A is still running but its settings now route to B's bridge"
         )
+        # And the shared file B would have rewritten is never touched at all.
+        assert settings_path.read_text(encoding="utf-8") == original
 
 
 class TestAnyNumberOfSessions:
-    """AC6: representative higher-order interleaving (3 sessions, mixed exit order)."""
+    """AC6: representative higher-order interleaving (3 sessions, mixed order)."""
 
-    def test_three_sessions_with_first_starter_exiting_first_restores_user_settings(self, tmp_path: Path):
+    def test_three_sessions_with_first_starter_exiting_first(self, tmp_path: Path):
         settings_path = tmp_path / ".claude" / "settings.json"
-        backup_path = tmp_path / "claude-settings-backup.json"
+        original = _write_user_settings(settings_path)
+        adapter = ClaudeAdapter()
+
+        prepared = [adapter.prepare_launch(_session_env(10001 + i), settings_path=settings_path) for i in range(3)]
+        for index in (0, 2, 1):
+            adapter.cleanup_launch(prepared[index], settings_path=settings_path)
+
+        assert settings_path.read_text(encoding="utf-8") == original
+        assert not any(Path(item).exists() for item in prepared)
+
+    def test_each_session_keeps_its_own_routing_while_all_run(self, tmp_path: Path):
+        settings_path = tmp_path / ".claude" / "settings.json"
         _write_user_settings(settings_path)
         adapter = ClaudeAdapter()
 
-        with _patch_backup_to_tmp(backup_path):
-            original_a = adapter.prepare_launch(_session_env(10001), settings_path=settings_path)
-            original_b = adapter.prepare_launch(_session_env(10002), settings_path=settings_path)
-            original_c = adapter.prepare_launch(_session_env(10003), settings_path=settings_path)
-            adapter.cleanup_launch(original_a, settings_path=settings_path)
-            adapter.cleanup_launch(original_c, settings_path=settings_path)
-            adapter.cleanup_launch(original_b, settings_path=settings_path)
+        prepared = [adapter.prepare_launch(_session_env(10001 + i), settings_path=settings_path) for i in range(3)]
 
-        _assert_user_settings_restored(settings_path)
-
-
-class TestCrashBackupIntegrity:
-    """AC4: crash recovery must reconstruct the user's settings, not a patch."""
-
-    def test_second_session_start_keeps_user_original_in_backup(self, tmp_path: Path):
-        """While sessions overlap, the backup must hold the user's pre-kitty
-        content so `kitty cleanup` cannot restore a poisoned file."""
-        settings_path = tmp_path / ".claude" / "settings.json"
-        backup_path = tmp_path / "claude-settings-backup.json"
-        user_content = _write_user_settings(settings_path)
-        adapter = ClaudeAdapter()
-
-        with _patch_backup_to_tmp(backup_path):
-            adapter.prepare_launch(_session_env(10001), settings_path=settings_path)
-            adapter.prepare_launch(_session_env(10002), settings_path=settings_path)
-            backup_content = backup_path.read_text(encoding="utf-8") if backup_path.exists() else None
-
-        assert backup_content == user_content, (
-            "the crash-recovery backup holds a previous session's patched content — "
-            "`kitty cleanup` after a crash would restore a dead bridge URL"
-        )
+        for index, item in enumerate(prepared):
+            assert _session_file_env(item)["ANTHROPIC_BASE_URL"] == f"http://127.0.0.1:{10001 + index}"
 
 
 class TestCleanupIdempotency:
-    """AC10: a stray second cleanup call must not re-poison settings.json."""
+    """Cleanup runs from both the finally block and the atexit handler."""
 
-    def test_second_cleanup_of_owning_session_is_noop(self, tmp_path: Path):
-        """If a cleanup is invoked a second time (e.g. finally + atexit both fire),
-        settings.json must stay at the user's pre-kitty content — not be rewritten
-        with the now-stale in-memory snapshot."""
+    def test_double_cleanup_is_safe(self, tmp_path: Path):
         settings_path = tmp_path / ".claude" / "settings.json"
-        backup_path = tmp_path / "claude-settings-backup.json"
-        _write_user_settings(settings_path)
+        original = _write_user_settings(settings_path)
         adapter = ClaudeAdapter()
 
-        with _patch_backup_to_tmp(backup_path):
-            original_a = adapter.prepare_launch(_session_env(10001), settings_path=settings_path)
-            original_b = adapter.prepare_launch(_session_env(10002), settings_path=settings_path)
-            adapter.cleanup_launch(original_a, settings_path=settings_path)
-            adapter.cleanup_launch(original_b, settings_path=settings_path)
-            adapter.cleanup_launch(original_b, settings_path=settings_path)  # stray double cleanup
+        prepared = adapter.prepare_launch(_session_env(10001), settings_path=settings_path)
+        adapter.cleanup_launch(prepared, settings_path=settings_path)
+        adapter.cleanup_launch(prepared, settings_path=settings_path)
 
-        _assert_user_settings_restored(settings_path)
+        assert settings_path.read_text(encoding="utf-8") == original

--- a/tests/test_claude_settings_override.py
+++ b/tests/test_claude_settings_override.py
@@ -1,7 +1,9 @@
-"""Tests for Claude Code settings.json override logic.
+"""Tests for the env kitty hands Claude Code through its settings source.
 
-Claude Code's settings.json ``env`` block overrides process-level env vars,
-so kitty must temporarily patch the file to inject the bridge URL and model.
+Claude Code's settings ``env`` block overrides process-level env vars, so kitty
+must supply a settings file to route the child at the bridge. Since issue #22
+that is a **per-session** file passed via ``--settings``; the user-global
+``~/.claude/settings.json`` is only read, never written.
 """
 
 import json
@@ -11,6 +13,7 @@ from unittest.mock import patch
 
 import pytest
 
+from kitty.launchers import claude as claude_mod
 from kitty.launchers.claude import ClaudeAdapter
 from kitty.profiles.schema import Profile
 
@@ -45,6 +48,12 @@ def _make_profile(model: str = "minimax-m2.7") -> Profile:
     )
 
 
+def _session_env(prepared: str | None) -> dict:
+    """Return the ``env`` block of the session file ``prepare_launch`` wrote."""
+    assert prepared is not None, "prepare_launch must produce a session settings file"
+    return json.loads(Path(prepared).read_text(encoding="utf-8"))["env"]
+
+
 def _write_settings(path: Path, env: dict | None = None, **extra: object) -> str:
     """Write a Claude Code settings.json and return its content."""
     settings: dict = {**extra}
@@ -57,19 +66,18 @@ def _write_settings(path: Path, env: dict | None = None, **extra: object) -> str
 
 
 class TestPrepareLaunch:
-    def test_injects_base_url_into_settings_env(self, tmp_path: Path):
+    """What kitty puts in front of Claude Code for this session."""
+
+    def test_injects_base_url(self, tmp_path: Path):
         settings_path = tmp_path / ".claude" / "settings.json"
         _write_settings(settings_path, env={"ANTHROPIC_BASE_URL": "https://api.z.ai/api/anthropic"})
 
         adapter = ClaudeAdapter()
-        env_overrides = {"ANTHROPIC_BASE_URL": "http://127.0.0.1:4242"}
-        original = adapter.prepare_launch(env_overrides, settings_path=settings_path)
+        prepared = adapter.prepare_launch({"ANTHROPIC_BASE_URL": "http://127.0.0.1:4242"}, settings_path=settings_path)
 
-        patched = json.loads(settings_path.read_text(encoding="utf-8"))
-        assert patched["env"]["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:4242"
-        assert original is not None
+        assert _session_env(prepared)["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:4242"
 
-    def test_injects_model_vars_into_settings_env(self, tmp_path: Path):
+    def test_injects_model_vars(self, tmp_path: Path):
         settings_path = tmp_path / ".claude" / "settings.json"
         _write_settings(settings_path, env={})
 
@@ -80,26 +88,23 @@ class TestPrepareLaunch:
             "ANTHROPIC_DEFAULT_SONNET_MODEL": "minimax-m2.7",
             "ANTHROPIC_DEFAULT_HAIKU_MODEL": "minimax-m2.7",
         }
-        adapter.prepare_launch(env_overrides, settings_path=settings_path)
+        prepared = adapter.prepare_launch(env_overrides, settings_path=settings_path)
 
-        patched = json.loads(settings_path.read_text(encoding="utf-8"))
-        assert patched["env"]["ANTHROPIC_MODEL"] == "minimax-m2.7"
-        assert patched["env"]["ANTHROPIC_DEFAULT_OPUS_MODEL"] == "minimax-m2.7"
-        assert patched["env"]["ANTHROPIC_DEFAULT_SONNET_MODEL"] == "minimax-m2.7"
-        assert patched["env"]["ANTHROPIC_DEFAULT_HAIKU_MODEL"] == "minimax-m2.7"
+        env = _session_env(prepared)
+        assert env["ANTHROPIC_MODEL"] == "minimax-m2.7"
+        assert env["ANTHROPIC_DEFAULT_OPUS_MODEL"] == "minimax-m2.7"
+        assert env["ANTHROPIC_DEFAULT_SONNET_MODEL"] == "minimax-m2.7"
+        assert env["ANTHROPIC_DEFAULT_HAIKU_MODEL"] == "minimax-m2.7"
 
-    def test_auth_token_preserved_when_present(self, tmp_path: Path):
-        """ANTHROPIC_AUTH_TOKEN must NOT be removed from settings.json env.
-        The bridge uses Bearer auth (Authorization header) independently of
-        ANTHROPIC_AUTH_TOKEN, and removing it causes 'Not logged in' errors."""
+    def test_kitty_auth_token_wins_over_the_users(self, tmp_path: Path):
+        """kitty's token must be the one Claude Code uses for this session.
+
+        The bridge uses Bearer auth independently of ANTHROPIC_AUTH_TOKEN, but
+        Claude Code refuses to start without one ('Not logged in'). The session
+        file outranks user scope, so the user's own token cannot leak in.
+        """
         settings_path = tmp_path / ".claude" / "settings.json"
-        _write_settings(
-            settings_path,
-            env={
-                "ANTHROPIC_AUTH_TOKEN": "secret-token",
-                "ANTHROPIC_BASE_URL": "https://api.z.ai/api/anthropic",
-            },
-        )
+        _write_settings(settings_path, env={"ANTHROPIC_AUTH_TOKEN": "secret-token"})
 
         adapter = ClaudeAdapter()
         env_overrides = {
@@ -107,16 +112,13 @@ class TestPrepareLaunch:
             "ANTHROPIC_API_KEY": "sk-test",
             "ANTHROPIC_AUTH_TOKEN": "kitty-bridge-token",
         }
-        adapter.prepare_launch(env_overrides, settings_path=settings_path)
+        prepared = adapter.prepare_launch(env_overrides, settings_path=settings_path)
 
-        patched = json.loads(settings_path.read_text(encoding="utf-8"))
-        # kitty's token must override the existing one
-        assert patched["env"]["ANTHROPIC_AUTH_TOKEN"] == "kitty-bridge-token"
+        assert _session_env(prepared)["ANTHROPIC_AUTH_TOKEN"] == "kitty-bridge-token"
 
-    def test_auth_token_injected_when_missing(self, tmp_path: Path):
-        """ANTHROPIC_AUTH_TOKEN must be injected into settings.json even when
-        the user is logged out (no prior token).  Without it, Claude Code
-        requires an Anthropic account login and ignores ANTHROPIC_API_KEY."""
+    def test_auth_token_present_when_user_is_logged_out(self, tmp_path: Path):
+        """Without a token Claude Code demands an Anthropic login and ignores
+        ANTHROPIC_API_KEY, so kitty always supplies its own."""
         settings_path = tmp_path / ".claude" / "settings.json"
         _write_settings(settings_path, env={})
 
@@ -126,14 +128,15 @@ class TestPrepareLaunch:
             "ANTHROPIC_API_KEY": "sk-test",
             "ANTHROPIC_AUTH_TOKEN": "kitty-bridge-token",
         }
-        adapter.prepare_launch(env_overrides, settings_path=settings_path)
+        prepared = adapter.prepare_launch(env_overrides, settings_path=settings_path)
 
-        patched = json.loads(settings_path.read_text(encoding="utf-8"))
-        assert patched["env"]["ANTHROPIC_AUTH_TOKEN"] == "kitty-bridge-token"
+        assert _session_env(prepared)["ANTHROPIC_AUTH_TOKEN"] == "kitty-bridge-token"
 
-    def test_preserves_other_settings_fields(self, tmp_path: Path):
+    def test_users_other_settings_are_left_alone(self, tmp_path: Path):
+        """The user's top-level keys keep their values — kitty neither copies
+        nor rewrites them; Claude Code inherits them from user scope."""
         settings_path = tmp_path / ".claude" / "settings.json"
-        _write_settings(
+        original = _write_settings(
             settings_path,
             env={"ANTHROPIC_BASE_URL": "https://old.example.com"},
             model="opus[1m]",
@@ -141,37 +144,33 @@ class TestPrepareLaunch:
         )
 
         adapter = ClaudeAdapter()
-        adapter.prepare_launch({"ANTHROPIC_BASE_URL": "http://127.0.0.1:4242"}, settings_path=settings_path)
+        prepared = adapter.prepare_launch({"ANTHROPIC_BASE_URL": "http://127.0.0.1:4242"}, settings_path=settings_path)
 
-        patched = json.loads(settings_path.read_text(encoding="utf-8"))
-        assert patched["model"] == "opus[1m]"
-        assert patched["effortLevel"] == "high"
+        assert settings_path.read_text(encoding="utf-8") == original
+        assert "model" not in json.loads(Path(prepared).read_text(encoding="utf-8"))
 
-    def test_creates_env_block_if_missing(self, tmp_path: Path):
+    def test_prepares_a_file_even_without_a_user_env_block(self, tmp_path: Path):
         settings_path = tmp_path / ".claude" / "settings.json"
         _write_settings(settings_path, model="opus[1m]")
 
         adapter = ClaudeAdapter()
-        adapter.prepare_launch({"ANTHROPIC_BASE_URL": "http://127.0.0.1:4242"}, settings_path=settings_path)
+        prepared = adapter.prepare_launch({"ANTHROPIC_BASE_URL": "http://127.0.0.1:4242"}, settings_path=settings_path)
 
-        patched = json.loads(settings_path.read_text(encoding="utf-8"))
-        assert "env" in patched
-        assert patched["env"]["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:4242"
+        assert _session_env(prepared)["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:4242"
 
-    def test_returns_none_if_no_settings_file(self, tmp_path: Path):
+    def test_prepares_a_file_when_the_user_has_no_settings_at_all(self, tmp_path: Path):
+        """Previously this returned None and the session was left unrouted."""
         settings_path = tmp_path / ".claude" / "settings.json"
 
         adapter = ClaudeAdapter()
-        original = adapter.prepare_launch({"ANTHROPIC_BASE_URL": "http://127.0.0.1:4242"}, settings_path=settings_path)
+        prepared = adapter.prepare_launch({"ANTHROPIC_BASE_URL": "http://127.0.0.1:4242"}, settings_path=settings_path)
 
-        assert original is None
+        assert _session_env(prepared)["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:4242"
+        assert not settings_path.exists()
 
-    def test_injects_context_tokens_into_settings_env(self, tmp_path: Path):
-        """AC5.3: the context window also lands in the settings.json env block.
-
-        That block overrides process-level env in Claude Code, so the value
-        must be written there too or the child would ignore it.
-        """
+    def test_injects_context_tokens(self, tmp_path: Path):
+        """AC5.3: the context window must reach the child through the settings
+        source, since that outranks the process env."""
         settings_path = tmp_path / ".claude" / "settings.json"
         _write_settings(settings_path, env={})
 
@@ -180,11 +179,9 @@ class TestPrepareLaunch:
             "ANTHROPIC_BASE_URL": "http://127.0.0.1:4242",
             "CLAUDE_CODE_MAX_CONTEXT_TOKENS": "1000000",
         }
-        original = adapter.prepare_launch(env_overrides, settings_path=settings_path)
+        prepared = adapter.prepare_launch(env_overrides, settings_path=settings_path)
 
-        patched = json.loads(settings_path.read_text(encoding="utf-8"))
-        assert patched["env"]["CLAUDE_CODE_MAX_CONTEXT_TOKENS"] == "1000000"
-        assert original is not None
+        assert _session_env(prepared)["CLAUDE_CODE_MAX_CONTEXT_TOKENS"] == "1000000"
 
 
 class TestCleanupLaunch:
@@ -207,7 +204,9 @@ class TestCleanupLaunch:
 
 
 class TestRoundTrip:
-    def test_prepare_then_cleanup_restores_exactly(self, tmp_path: Path):
+    """A full session lifecycle must leave the user's file untouched."""
+
+    def test_prepare_then_cleanup_leaves_user_settings_byte_identical(self, tmp_path: Path):
         settings_path = tmp_path / ".claude" / "settings.json"
         _write_settings(
             settings_path,
@@ -230,33 +229,34 @@ class TestRoundTrip:
             "ANTHROPIC_DEFAULT_HAIKU_MODEL": "minimax-m2.7",
         }
 
-        # Prepare
-        original = adapter.prepare_launch(env_overrides, settings_path=settings_path)
+        prepared = adapter.prepare_launch(env_overrides, settings_path=settings_path)
 
-        # Verify patched
-        patched = json.loads(settings_path.read_text(encoding="utf-8"))
-        assert patched["env"]["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:4242"
-        assert patched["env"]["ANTHROPIC_MODEL"] == "minimax-m2.7"
-        assert patched["env"]["ANTHROPIC_AUTH_TOKEN"] == "secret-token"
-
-        # Cleanup
-        adapter.cleanup_launch(original, settings_path=settings_path)
-
-        # Verify restored
+        # The session's values live in the session file, not the user's.
+        session_env = _session_env(prepared)
+        assert session_env["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:4242"
+        assert session_env["ANTHROPIC_MODEL"] == "minimax-m2.7"
         assert settings_path.read_text(encoding="utf-8") == original_content
+
+        adapter.cleanup_launch(prepared, settings_path=settings_path)
+
+        assert settings_path.read_text(encoding="utf-8") == original_content
+        assert not Path(prepared).exists()
 
 
 class TestSettingsBackup:
-    """Tests for on-disk backup of Claude settings (crash recovery)."""
+    """Crash-recovery backup helpers.
 
-    def test_prepare_launch_writes_backup(self, tmp_path: Path):
-        """prepare_launch must save original settings to a backup file."""
+    Since issue #22 the launch path no longer patches the user-global file, so
+    nothing writes a backup during a normal session. These helpers stay for
+    ``kitty cleanup``, which repairs files poisoned by *pre-fix* kitty versions
+    during rollout, and are exercised directly rather than through
+    ``prepare_launch``.
+    """
+
+    def test_prepare_launch_does_not_write_a_backup(self, tmp_path: Path):
+        """The backup existed to undo a patch kitty no longer makes."""
         settings_path = tmp_path / ".claude" / "settings.json"
-        original_content = _write_settings(
-            settings_path,
-            env={"ANTHROPIC_AUTH_TOKEN": "my-real-token"},
-            model="opus",
-        )
+        _write_settings(settings_path, env={"ANTHROPIC_AUTH_TOKEN": "my-real-token"}, model="opus")
 
         adapter = ClaudeAdapter()
         env_overrides = {
@@ -267,133 +267,113 @@ class TestSettingsBackup:
 
         with patch("kitty.launchers.claude.save_settings_backup") as mock_save:
             adapter.prepare_launch(env_overrides, settings_path=settings_path)
-            mock_save.assert_called_once_with(original_content)
 
-    def test_cleanup_launch_deletes_backup(self, tmp_path: Path):
-        """cleanup_launch must delete the backup file after restoring."""
+        mock_save.assert_not_called()
+
+    def test_cleanup_launch_deletes_backup_on_the_legacy_path(self, tmp_path: Path):
+        """A bare ``str`` still means "restore this verbatim and drop the
+        backup" — the documented contract for legacy callers."""
         settings_path = tmp_path / ".claude" / "settings.json"
-        original_content = _write_settings(
-            settings_path,
-            env={"ANTHROPIC_AUTH_TOKEN": "my-real-token"},
-        )
+        original_content = _write_settings(settings_path, env={"ANTHROPIC_AUTH_TOKEN": "my-real-token"})
 
         adapter = ClaudeAdapter()
         with patch("kitty.launchers.claude.delete_settings_backup") as mock_delete:
             adapter.cleanup_launch(original_content, settings_path=settings_path)
             mock_delete.assert_called_once()
 
-    def test_prepare_launch_no_backup_when_no_settings(self, tmp_path: Path):
-        """No backup should be created when there is no settings.json."""
-        settings_path = tmp_path / ".claude" / "settings.json"
+    def test_save_then_load_round_trips(self, tmp_path: Path, _backup_in_tmp: Path):
+        """The helpers `kitty cleanup` depends on must round-trip exactly."""
+        content = '{"env": {"ANTHROPIC_AUTH_TOKEN": "user-token"}}'
 
-        adapter = ClaudeAdapter()
-        with patch("kitty.launchers.claude.save_settings_backup") as mock_save:
-            result = adapter.prepare_launch(
-                {"ANTHROPIC_BASE_URL": "http://127.0.0.1:4242"},
-                settings_path=settings_path,
-            )
+        claude_mod.save_settings_backup(content)
 
-        assert result is None
-        mock_save.assert_not_called()
-
-    def test_prepare_refreshes_stale_backup_when_no_live_kitty_values(self, tmp_path: Path, _backup_in_tmp: Path):
-        """If a backup is left from a finished chain and the settings carry no
-        kitty values, prepare must refresh the backup to the current file so
-        later crash recovery cannot revert the user's changes."""
-        settings_path = tmp_path / ".claude" / "settings.json"
-        ancient = '{"env": {"ANTHROPIC_AUTH_TOKEN": "token-from-weeks-ago"}}'
-        _backup_in_tmp.write_text(ancient, encoding="utf-8")
-        current = _write_settings(
-            settings_path,
-            env={"ANTHROPIC_BASE_URL": "https://my-proxy.example.com", "API_TIMEOUT_MS": "3000000"},
-        )
-
-        adapter = ClaudeAdapter()
-        adapter.prepare_launch(
-            {"ANTHROPIC_BASE_URL": "http://127.0.0.1:4242"}, settings_path=settings_path
-        )
-
-        assert _backup_in_tmp.read_text(encoding="utf-8") == current, (
-            "stale backup was kept; kitty cleanup would later restore it over the user's changes"
-        )
-
-    def test_prepare_keeps_existing_backup_when_live_kitty_values_present(
-        self, tmp_path: Path, _backup_in_tmp: Path
-    ):
-        """While a chain is live the backup must NOT be overwritten by a later
-        session's snapshot — that is the AC4 contract from issue #21."""
-        settings_path = tmp_path / ".claude" / "settings.json"
-        user_original = _write_settings(
-            settings_path,
-            env={"CUSTOM_KEY": "keep-me"},
-        )
-        _backup_in_tmp.write_text(user_original, encoding="utf-8")
-
-        # Simulate session A having already patched the file (live kitty values).
-        settings_path.write_text(
-            json.dumps(
-                {
-                    "env": {
-                        "CUSTOM_KEY": "keep-me",
-                        "ANTHROPIC_BASE_URL": "http://127.0.0.1:10001",
-                        "ANTHROPIC_AUTH_TOKEN": "kitty-bridge-token",
-                    }
-                }
-            ),
-            encoding="utf-8",
-        )
-
-        adapter = ClaudeAdapter()
-        adapter.prepare_launch(
-            {"ANTHROPIC_BASE_URL": "http://127.0.0.1:10002"}, settings_path=settings_path
-        )
-
-        assert _backup_in_tmp.read_text(encoding="utf-8") == user_original
+        assert claude_mod.load_settings_backup() == content
+        claude_mod.delete_settings_backup()
+        assert claude_mod.load_settings_backup() is None
 
 
 class TestCleanupOwnership:
-    """AC8/AC9: what cleanup restores depends on who owns the file now."""
+    """Ownership-checked restore — the legacy shared-file path.
+
+    ``prepare_launch`` no longer produces a ``_SessionSnapshot`` (it returns a
+    per-session file handle instead), so this machinery is unreachable from the
+    launch path. It is retained as revert insurance and to keep ``kitty
+    cleanup``'s repair of pre-fix leftovers meaningful, and is therefore driven
+    directly here with a hand-built snapshot — going through ``prepare_launch``
+    would silently exercise nothing.
+    """
+
+    @staticmethod
+    def _snapshot(original_content: str, injected: dict[str, str]):
+        """Build the snapshot a pre-#22 ``prepare_launch`` would have returned."""
+        return claude_mod._SessionSnapshot(original_content, injected)
 
     def test_cleanup_restores_snapshot_when_backup_missing(self, tmp_path: Path, _backup_in_tmp: Path):
-        """AC8: when the crash backup is gone, cleanup still restores this
-        session's snapshot — the single-session path must not depend on the backup."""
+        """When the crash backup is gone, the owner still restores its snapshot."""
         settings_path = tmp_path / ".claude" / "settings.json"
         original_content = _write_settings(
             settings_path,
             env={"ANTHROPIC_BASE_URL": "https://api.z.ai/api/anthropic"},
         )
+        injected = {"ANTHROPIC_BASE_URL": "http://127.0.0.1:4242"}
+        snapshot = self._snapshot(original_content, injected)
 
-        adapter = ClaudeAdapter()
-        original = adapter.prepare_launch(
-            {"ANTHROPIC_BASE_URL": "http://127.0.0.1:4242"}, settings_path=settings_path
-        )
-
-        # Simulate the backup disappearing before cleanup (crash recovery ran
-        # first, user deleted it).
+        # Stand in for the patch a pre-#22 prepare_launch would have written.
+        _write_settings(settings_path, env=dict(injected))
         _backup_in_tmp.unlink(missing_ok=True)
-        adapter.cleanup_launch(original, settings_path=settings_path)
+
+        ClaudeAdapter().cleanup_launch(snapshot, settings_path=settings_path)
 
         assert settings_path.read_text(encoding="utf-8") == original_content
 
-    def test_cleanup_leaves_file_when_user_hand_edited_kitty_key(self, tmp_path: Path, _backup_in_tmp: Path):
-        """AC9: if the user changes a kitty-injected value while the session
-        runs, cleanup must not overwrite their edit with the old snapshot."""
+    def test_cleanup_prefers_the_backup_over_its_own_snapshot(self, tmp_path: Path, _backup_in_tmp: Path):
+        """The backup holds the user's true pre-kitty content.
+
+        A later session's own snapshot captured an earlier session's patch, so
+        restoring it would reintroduce a dead bridge URL (issue #19).
+        """
         settings_path = tmp_path / ".claude" / "settings.json"
-        _write_settings(settings_path, env={"CUSTOM_KEY": "keep-me"})
+        user_original = '{\n  "env": {\n    "CUSTOM_KEY": "keep-me"\n  }\n}'
+        _backup_in_tmp.write_text(user_original, encoding="utf-8")
 
-        adapter = ClaudeAdapter()
-        original = adapter.prepare_launch(
-            {"ANTHROPIC_BASE_URL": "http://127.0.0.1:4242"}, settings_path=settings_path
+        injected = {"ANTHROPIC_BASE_URL": "http://127.0.0.1:10002"}
+        polluted_snapshot = self._snapshot(
+            '{"env": {"ANTHROPIC_BASE_URL": "http://127.0.0.1:10001"}}',
+            injected,
         )
+        _write_settings(settings_path, env=dict(injected))
 
-        # User hand-edits the injected base URL mid-session.
-        patched = json.loads(settings_path.read_text(encoding="utf-8"))
-        patched["env"]["ANTHROPIC_BASE_URL"] = "http://127.0.0.1:5555"
-        settings_path.write_text(json.dumps(patched, indent=2), encoding="utf-8")
+        ClaudeAdapter().cleanup_launch(polluted_snapshot, settings_path=settings_path)
 
-        adapter.cleanup_launch(original, settings_path=settings_path)
+        assert settings_path.read_text(encoding="utf-8") == user_original
+
+    def test_cleanup_leaves_file_when_user_hand_edited_kitty_key(self, tmp_path: Path, _backup_in_tmp: Path):
+        """A non-owner must not overwrite whoever holds the file now.
+
+        If the user (or a later session) changes a kitty-injected value while
+        this session runs, this session no longer owns the file.
+        """
+        settings_path = tmp_path / ".claude" / "settings.json"
+        injected = {"ANTHROPIC_BASE_URL": "http://127.0.0.1:4242"}
+        snapshot = self._snapshot('{"env": {"CUSTOM_KEY": "keep-me"}}', injected)
+
+        # The value on disk differs from what this session injected.
+        _write_settings(settings_path, env={"ANTHROPIC_BASE_URL": "http://127.0.0.1:5555"})
+
+        ClaudeAdapter().cleanup_launch(snapshot, settings_path=settings_path)
 
         restored = json.loads(settings_path.read_text(encoding="utf-8"))
         assert restored["env"]["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:5555", (
-            "cleanup overwrote the user's mid-session edit with the stale snapshot"
+            "cleanup overwrote another owner's value with its stale snapshot"
         )
+
+    def test_cleanup_leaves_an_unreadable_file_alone(self, tmp_path: Path, _backup_in_tmp: Path):
+        """Ownership is unknowable without a parseable file — never guess."""
+        settings_path = tmp_path / ".claude" / "settings.json"
+        settings_path.parent.mkdir(parents=True, exist_ok=True)
+        settings_path.write_text("{ broken", encoding="utf-8")
+        snapshot = self._snapshot('{"env": {}}', {"ANTHROPIC_BASE_URL": "http://127.0.0.1:4242"})
+
+        ClaudeAdapter().cleanup_launch(snapshot, settings_path=settings_path)
+
+        assert settings_path.read_text(encoding="utf-8") == "{ broken"

--- a/tests/test_launch_orchestrator.py
+++ b/tests/test_launch_orchestrator.py
@@ -9,9 +9,11 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from kitty.bridge.server import BridgeServer
 from kitty.credentials.file_backend import FileBackend
 from kitty.credentials.store import CredentialStore
 from kitty.launchers.base import LauncherAdapter, SpawnConfig
+from kitty.launchers.claude import ClaudeAdapter
 from kitty.profiles.schema import Profile
 from kitty.providers.base import ProviderAdapter
 from kitty.types import BridgeProtocol
@@ -417,3 +419,209 @@ class TestLaunchPassesContextTokens:
             ("stub", "model-a", {}),
             ("stub", "model-b", {}),
         ]
+
+
+# ── Test: per-session settings reach the child command (issue #22) ───────────
+
+
+class _RecordingClaudeAdapter(ClaudeAdapter):
+    """ClaudeAdapter that records what ``prepare_launch`` handed back.
+
+    The seam between ``prepare_launch`` and command construction is the one
+    place where the #22 fix can silently fail: kitty could write a perfectly
+    isolated session file and then never tell Claude Code about it, falling
+    back to the user-global file with no test noticing.
+    """
+
+    def __init__(self, settings_path: Path):
+        self._settings_path = settings_path
+        self.prepared: str | None = None
+
+    @property
+    def binary_name(self) -> str:
+        return "python"
+
+    @property
+    def default_settings_path(self) -> Path:
+        return self._settings_path
+
+    def build_spawn_config(self, profile, bridge_port, resolved_key, *, context_tokens=None):
+        del context_tokens
+        return SpawnConfig(
+            cli_args=["-c", "import sys; sys.exit(0)"],
+            env_overrides={"ANTHROPIC_BASE_URL": f"http://127.0.0.1:{bridge_port}"},
+            env_clear=[],
+        )
+
+    def prepare_launch(self, env_overrides, settings_path=None):
+        self.prepared = super().prepare_launch(env_overrides, settings_path=settings_path)
+        return self.prepared
+
+
+class TestSessionSettingsReachTheChild:
+    """AC11: the spawned argv must point at the file prepare_launch wrote."""
+
+    @pytest.mark.asyncio
+    async def test_spawned_command_carries_the_prepared_settings_path(self, tmp_path: Path):
+        from kitty.cli.launcher import launch_async
+
+        adapter = _RecordingClaudeAdapter(tmp_path / ".claude" / "settings.json")
+        spawned: list[list[str]] = []
+
+        # Record the argv and stand in for the child: the stub binary is the
+        # Python interpreter, which would reject Claude Code's own --settings
+        # flag. What matters here is the command kitty built.
+        async def _record(*cmd, **kwargs):
+            del kwargs
+            spawned.append(list(cmd))
+            proc = MagicMock()
+
+            async def _wait():
+                return 0
+
+            proc.wait = _wait
+            proc.pid = 4242
+            proc.returncode = 0
+            return proc
+
+        with (
+            patch("kitty.cli.launcher.discover_binary", return_value=Path(sys.executable)),
+            patch("asyncio.create_subprocess_exec", side_effect=_record),
+        ):
+            exit_code = await launch_async(
+                adapter=adapter,
+                provider=StubProvider(),
+                profile=_make_profile(),
+                cred_store=_make_cred_store(),
+                extra_args=[],
+            )
+
+        assert exit_code == 0
+        assert adapter.prepared is not None
+        argv = spawned[0]
+        assert "--settings" in argv, "kitty never told Claude Code about the session file"
+        assert argv[argv.index("--settings") + 1] == str(adapter.prepared)
+        # Global flags must precede the binary's own args.
+        assert argv.index("--settings") < argv.index("-c")
+
+    @pytest.mark.asyncio
+    async def test_settings_flag_precedes_a_user_supplied_subcommand(self, tmp_path: Path):
+        """AC4: `kitty claude mcp list` must still be routed through the bridge.
+
+        Claude Code's global options have to come before a subcommand, so a
+        regression that appended the flag after ``extra_args`` would silently
+        drop the session's routing for every subcommand invocation.
+        """
+        from kitty.cli.launcher import launch_async
+
+        adapter = _RecordingClaudeAdapter(tmp_path / ".claude" / "settings.json")
+        spawned: list[list[str]] = []
+
+        async def _record(*cmd, **kwargs):
+            del kwargs
+            spawned.append(list(cmd))
+            proc = MagicMock()
+
+            async def _wait():
+                return 0
+
+            proc.wait = _wait
+            proc.pid = 4242
+            proc.returncode = 0
+            return proc
+
+        with (
+            patch("kitty.cli.launcher.discover_binary", return_value=Path(sys.executable)),
+            patch("asyncio.create_subprocess_exec", side_effect=_record),
+        ):
+            await launch_async(
+                adapter=adapter,
+                provider=StubProvider(),
+                profile=_make_profile(),
+                cred_store=_make_cred_store(),
+                extra_args=["mcp", "list"],
+            )
+
+        argv = spawned[0]
+        assert argv.index("--settings") < argv.index("mcp")
+
+    @pytest.mark.asyncio
+    async def test_launch_fails_closed_when_the_session_file_cannot_be_written(self, tmp_path: Path, capsys):
+        """AC9: continuing would run the session on the user's own credentials,
+        bypassing the bridge, the egress guard, and usage logging."""
+        from kitty.cli import launcher as launcher_mod
+        from kitty.cli.launcher import launch_async
+
+        adapter = _RecordingClaudeAdapter(tmp_path / ".claude" / "settings.json")
+        stopped: list[bool] = []
+
+        def _boom(*_args, **_kwargs):
+            raise OSError("no space left on device")
+
+        real_stop = BridgeServer.stop_async
+
+        async def _record_stop(self):
+            stopped.append(True)
+            return await real_stop(self)
+
+        with (
+            patch("kitty.cli.launcher.discover_binary", return_value=Path(sys.executable)),
+            patch("kitty.launchers.claude.tempfile.mkstemp", side_effect=_boom),
+            patch.object(BridgeServer, "stop_async", _record_stop),
+            patch("asyncio.create_subprocess_exec") as mock_spawn,
+        ):
+            exit_code = await launch_async(
+                adapter=adapter,
+                provider=StubProvider(),
+                profile=_make_profile(),
+                cred_store=_make_cred_store(),
+                extra_args=[],
+            )
+
+        assert exit_code == 1
+        assert "session settings file" in capsys.readouterr().err
+        mock_spawn.assert_not_called()
+        assert stopped, "the bridge must be stopped when the launch aborts"
+        assert launcher_mod._atexit_cleanup_state == []
+
+
+class TestAdaptersWithoutSessionSettings:
+    """AC7: adapters that own their config file keep their existing contract."""
+
+    @pytest.mark.asyncio
+    async def test_kilo_config_is_removed_even_though_nothing_was_prepared(self, tmp_path: Path):
+        """``original is None`` means "I created this file — delete it".
+
+        Gating cleanup on the prepared value would strand a Kilo config
+        containing the real API key for anyone without a pre-existing one.
+        """
+        from kitty.cli.launcher import launch_async
+        from kitty.launchers.kilo import KiloAdapter
+
+        config_path = tmp_path / "kilo.json"
+
+        class _TmpKilo(KiloAdapter):
+            @property
+            def binary_name(self) -> str:
+                return "python"
+
+            @property
+            def default_settings_path(self) -> Path:
+                return config_path
+
+            def build_spawn_config(self, profile, bridge_port, resolved_key, *, context_tokens=None):
+                super().build_spawn_config(profile, bridge_port, resolved_key, context_tokens=context_tokens)
+                return SpawnConfig(cli_args=["-c", "import sys; sys.exit(0)"], env_overrides={}, env_clear=[])
+
+        adapter = _TmpKilo()
+        with patch("kitty.cli.launcher.discover_binary", return_value=Path(sys.executable)):
+            exit_code = await launch_async(
+                adapter=adapter,
+                provider=StubProvider(),
+                profile=_make_profile(),
+                cred_store=_make_cred_store(),
+                extra_args=[],
+            )
+
+        assert exit_code == 0
+        assert not config_path.exists(), "kitty left a Kilo config holding the real API key"

--- a/tests/test_launcher_base.py
+++ b/tests/test_launcher_base.py
@@ -208,6 +208,20 @@ class TestEachAdapterOwnsItsSettingsPath:
         inspect.signature(adapter.prepare_launch).bind({"X": "1"}, settings_path=tmp_path / "cfg.json")
         inspect.signature(adapter.cleanup_launch).bind(None, settings_path=tmp_path / "cfg.json")
 
+    @pytest.mark.parametrize("name", _REGISTERED_ADAPTERS)
+    def test_settings_cli_args_returns_a_list_for_every_adapter(self, name: str):
+        """``launch_async`` splices the result straight into the child command.
+
+        The call is not wrapped in a try/except, so an adapter returning a
+        non-list (or raising) breaks every launch for that agent.
+        """
+        adapter = _adapter(name)
+
+        for prepared in (None, "some-prepared-value"):
+            args = adapter.settings_cli_args(prepared)
+            assert isinstance(args, list)
+            assert all(isinstance(item, str) for item in args)
+
 
 class TestBuildSpawnConfigContextTokens:
     """AC5.4: every adapter accepts the ``context_tokens`` keyword.


### PR DESCRIPTION
Fixes #22.

## Problem

Every `kitty claude` launch patched the user-global `~/.claude/settings.json`. That file has a single `ANTHROPIC_BASE_URL` key, so it can only ever describe **one** session — starting a second session overwrote what the first session's settings said. PR #23 made the shared-file lifecycle safe in any exit order, but could not fix this: the shared key is the bottleneck, not the write strategy.

Two latent defects on the same path:
- With **no** `~/.claude/settings.json`, `prepare_launch` returned `None` and the session got no deterministic routing (process env loses to the user's settings scopes).
- kitty wrote the user's real provider key into their global settings file, where a crash left it until the next launch or `kitty cleanup`.

## Fix

`ClaudeAdapter.prepare_launch` writes a **per-session** settings file (`mkstemp`) carrying only kitty's injected env keys, and the child is spawned with `claude --settings <path>` — a scope that outranks user, project, and local settings. The global file is never written; it is only read, to warn when a pre-fix crash left kitty values behind (pointing at `kitty cleanup`).

`cleanup_launch` deletes that one file. There is no shared file to restore and no cross-session ownership question on the launch path — which also makes concurrent same-instant starts safe, previously an unguarded read-modify-write.

**Fail-closed:** if the session file cannot be written the launch stops the bridge and returns 1. Continuing would silently run the session on the user's own credentials, bypassing the bridge, the egress guard, and usage logging.

## Verified empirically (Claude Code 2.1.238)

Hermetic probes — isolated `CLAUDE_CONFIG_DIR`, mock HTTP servers recording which port was hit and the inbound auth headers:

| Question | Result |
|---|---|
| Does `--settings` `env` merge per-variable? | **Yes** — the session file needs only kitty's keys; the user's own entries survive |
| Does it override the same key in user settings? | Yes, 100% of requests |
| Does process env beat user-scope settings env? | **No** — why `SpawnConfig.env_overrides` alone cannot fix this |
| Works with no user `settings.json`? | Yes |
| Beats a project-scope `.claude/settings.json`? | Yes |

**On the issue's stated mechanism — stated conservatively on purpose.** #22 attributes the mid-session symptom to Claude Code hot-reloading the `env` block into *running* sessions. That is documented, but it **could not be reproduced**: an initial probe suggested `--settings` protected a running session, and a **negative control** (same harness without `--settings`) behaved identically — making the first result a null result, not evidence of protection. In `-p` mode no reload reaches the running process at all, and a long-lived stream-json harness was inconclusive. The defect fixed here is therefore the **proven** one: start-of-session cross-talk over shared mutable state. The docs record the retraction so no future reader treats it as settled.

## Not in this PR

- **Placeholder API key.** Verified a dummy key works end-to-end (the bridge accepts any inbound credential on this path and substitutes the real one upstream), which would keep the key off disk entirely. Deferred: Claude Code's `customApiKeyResponses` approval dialog defaults to "No" and stores the answer permanently by key substring — a sticky rejection would break every later launch, and non-interactive probes can't clear that risk. Omitting the key is worse: the user's own key then flows through from user scope.
- Backup-lifecycle removal, `env_clear` being ineffective against settings-file entries, and the unreachable block in `cleanup_cmd.py` — all recorded as follow-ups.

## Verification

- Full suite: **2765 passed, 36 skipped, 0 failed** (22 errors are pre-existing environmental `test_pypi_packaging` failures — a stray `nul` file breaks the sdist build in this worktree; CI is unaffected).
- `mypy src` clean; `ruff check src tests` clean.
- `TestStartDirectionCrossTalk` — the regression test for this issue — **passes with its `xfail(strict=True)` marker removed**.
- Two design-review rounds and two code-review rounds. Three code-review must-fixes were real and are fixed, each with a test proven load-bearing by mutation:
  1. A UTF-16 `settings.json` raised `UnicodeDecodeError` (a `ValueError`), escaping the fail-closed handler — reachable via Notepad's "Save as → Unicode".
  2. `TestCleanupOwnership` had gone false-green: it no longer reached the code it named, and would have passed with the ownership logic deleted.
  3. `kitty claude mcp list` was unpinned — the ordering assertion compared against a list that is empty in production.
- Suite hermeticity: `prepare_launch`'s `mkstemp` had scattered ~350 session files into the OS temp dir; one autouse fixture in `tests/conftest.py` brings that to zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)