### PR TITLE
Release 1.4.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kitty-bridge"
-version = "1.4.0"
+version = "1.4.1"
 description = "Kitty Bridge — launch coding agents through a local API bridge"
 readme = "README.md"
 license = "MIT"

--- a/src/kitty/__init__.py
+++ b/src/kitty/__init__.py
@@ -4,5 +4,5 @@ import logging
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
-__version__ = "1.4.0"
+__version__ = "1.4.1"
 __all__ = ["__version__"]


### PR DESCRIPTION
Version bump for the 1.4.1 release. Bug fixes only since 1.4.0 — no new features, no breaking changes.

## What ships

**Overlapping `kitty claude` sessions no longer fight over `~/.claude/settings.json`** (#22, #19, #20, #21). Every session used to patch that one user-global file, which holds a single `ANTHROPIC_BASE_URL` key and therefore can only ever describe one session. Two fixes land together:

- **Per-session settings isolation** (#24, closes #22). `prepare_launch` now writes a per-session settings file and spawns `claude --settings <path>` — a scope that outranks user, project, and local settings. kitty never writes the user-global file again; it only reads it, to warn when a pre-fix crash left kitty values behind. Starting a second session can no longer disturb a running one, and concurrent same-instant starts are safe by construction.
- **Overlap-safe lifecycle for the shared file** (#23, closes #19/#20/#21). Exit-order poisoning that left `ANTHROPIC_BASE_URL=http://127.0.0.1:<dead port>` in the user's settings permanently, a session's exit stripping another session's routing, and crash-backup corruption across overlapping sessions.

**Two latent defects fixed on the same path** (#24):
- A machine with **no** `~/.claude/settings.json` previously got no deterministic routing at all — `prepare_launch` returned `None`, and process env loses to the user's settings scopes.
- If the session settings file cannot be written, the launch now **fails closed** (stops the bridge, exits 1) instead of silently running on the user's own credentials and bypassing the bridge, the egress guard, and usage logging.

## Note on the reported symptom

Issue #22 attributed a mid-session failure to Claude Code hot-reloading the settings `env` block into running sessions. That mechanism is documented but **could not be reproduced** — a negative control showed the unprotected case behaves identically, so the supporting evidence was a null result. The defect fixed here is the proven one: start-of-session cross-talk over shared mutable state. Recorded in the design docs so the claim is not repeated as settled.

## Internal

Claude Code `--settings` semantics verified empirically against 2.1.238 (per-variable `env` merge, precedence over user/project scope, behaviour with no user settings file). Test-suite hermeticity fix: session files no longer leak into the OS temp directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)