### PR TITLE
Expose which backend and model actually served a session (#26)

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,7 @@ Point your tool at `http://localhost:<port>` and it just works.
 | `POST /v1/responses`              | OpenAI Responses   | Codex           |
 | `POST /v1/gemini/generateContent` | Gemini             | Gemini CLI      |
 | `GET /healthz`                    | Health check       | Monitoring      |
+| `GET /stats`                      | Session record     | Attribution     |
 
 **Background bridges:** `kitty bridge start`, `stop`, `restart`, and `status` manage a bridge running in the background,
 tracked in `bridge_state.json`.
@@ -331,6 +332,42 @@ start a second one beside it — signalling a process it does not own is unsafe,
 recycled that process ID onto something unrelated. Stop it from the account that started it, or from an
 administrator shell. If you are sure that process is not a kitty bridge, delete `bridge_state.json` — kitty prints
 its full path in the message.
+
+## Knowing which model actually served you
+
+kitty replaces the model name your agent asks for with the one its profile configures — that is the point of the
+product. The agent's own cost and error records therefore name the *alias*, not the model that ran. Three surfaces tell
+you the truth.
+
+**Per response.** Every proxied response carries:
+
+| Header            | Value                                                       |
+|-------------------|-------------------------------------------------------------|
+| `X-Kitty-Backend` | Profile name of the backend that served it                   |
+| `X-Kitty-Model`   | The real model sent upstream (absent if no override is set)   |
+| `X-Kitty-Tier`    | `primary` or `backup` (reserve-tier members)                 |
+
+These name the backend that produced the **first byte** of the response. A stream that fails over after that has
+already sent its headers, so `/stats` is authoritative for the session.
+
+**Live.** `GET /stats` returns JSON for the running bridge: per-backend request counts, the real models served with
+their token totals, how many times a request switched backend (`failovers`), and whether the pool was ever exhausted
+(`all_backends_unhealthy`). Like `/healthz`, it is readable without credentials unless a keys file is configured — and
+`kitty claude` deliberately runs without one.
+
+**After the run.** `--session-summary PATH` (or `KITTY_SESSION_SUMMARY`) writes the same document to a file when the
+bridge shuts down — a small artifact CI can upload, instead of a multi-megabyte debug log:
+
+```bash
+kitty --session-summary "$RUNNER_TEMP/kitty-session.json" claude -p "review this diff"
+```
+
+The summary is written on **graceful shutdown**. If the bridge is killed (job cancelled, step timeout, `SIGKILL`) there
+is no file, so poll `/stats` before teardown if you need a record from those runs.
+
+Two things the numbers do not mean: `attempts` counts backend *selections*, so it reads lower than the upstream POST
+count in the debug log (retries against the same backend are not re-selections); and in single-profile mode `failovers`
+is always `0` because there is nowhere to fail over to — check `mode` first.
 
 ## Supported Agents
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kitty-bridge"
-version = "1.4.1"
+version = "1.5.0"
 description = "Kitty Bridge — launch coding agents through a local API bridge"
 readme = "README.md"
 license = "MIT"

--- a/src/kitty/__init__.py
+++ b/src/kitty/__init__.py
@@ -4,5 +4,5 @@ import logging
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
-__version__ = "1.4.1"
+__version__ = "1.5.0"
 __all__ = ["__version__"]

--- a/src/kitty/bridge/server.py
+++ b/src/kitty/bridge/server.py
@@ -461,6 +461,7 @@ _SINGLE_BACKEND_COOLDOWN_CAP = 30  # seconds — cap cooldown for single-backend
 _CLOUDFLARE_FIRST_HIT_COOLDOWN = 15  # seconds — short cooldown for first Cloudflare block
 _ALL_UNHEALTHY_FAST_FAIL_THRESHOLD = 60  # seconds — fast-fail if soonest retry exceeds this
 _SSE_MAX_LINE_BYTES = 10 * 1024 * 1024  # 10 MiB — guards against unbounded line_buffer growth
+_MAX_HEADER_VALUE_CHARS = 256  # cap on X-Kitty-* values — names are config-supplied, so unbounded
 
 
 class AllBackendsUnhealthyError(Exception):
@@ -482,6 +483,43 @@ _TOOL_RESULT_TRUNCATION_LIMIT = 50_000  # Max chars for a tool result before tru
 # z.ai GLM-5.2. Crossing it emits a WARNING; on-failure recovery uses it as a
 # heuristic that the request is oversized (it does NOT gate the retry itself).
 _OVERSIZED_INPUT_THRESHOLD = 600_000
+
+
+def _header_value(value: str) -> str:
+    """Return a header-safe rendering of a profile or model name.
+
+    aiohttp rejects CR, LF and NUL in header values as header injection, and
+    model ids are validated only for non-emptiness — so an unsanitised name
+    could fail *every* response on a backend, with the attribution header as
+    the sole cause.  Non-ASCII bytes do not raise but reach the consumer as
+    mojibake (RFC 9110 frames header values as ISO-8859-1), so they are folded
+    rather than passed through.
+
+    Args:
+        value: The raw name to place in a header.
+
+    Returns:
+        The name with control characters dropped, non-ASCII characters
+        replaced by ``?``, and length capped.
+    """
+    folded = value.encode("ascii", "replace").decode("ascii")
+    return "".join(ch for ch in folded if ch.isprintable())[:_MAX_HEADER_VALUE_CHARS]
+
+
+def _token_count(value: object) -> int:
+    """Return an upstream token count as an int, treating anything else as zero.
+
+    Usage blocks come from third-party providers, so a missing or malformed
+    counter must degrade the attribution record rather than fail the request
+    that produced it.
+
+    Args:
+        value: The raw value read from an upstream ``usage`` block.
+
+    Returns:
+        The value when it is an integer, otherwise ``0``.
+    """
+    return value if isinstance(value, int) else 0
 
 
 def _is_retryable_exception(exc: Exception) -> bool:
@@ -624,6 +662,7 @@ class _BackendContext(TypedDict, total=False):
     model: str | None
     idx: int
     provider_config: dict
+    attempt: int
 
 
 _backend_context: contextvars.ContextVar[_BackendContext] = contextvars.ContextVar("backend_context")
@@ -654,6 +693,7 @@ class BridgeServer:
         backend_cooldown: int = 300,
         logging_enabled: bool = False,
         egress: EgressConfig | None = None,
+        session_summary_path: str | Path | None = None,
         _usage_log_path: Path | None = None,
     ) -> None:
         # TLS validation: both or neither
@@ -743,6 +783,29 @@ class BridgeServer:
         # Usage logging
         self._logging_enabled = logging_enabled
         self._usage_log_path = _usage_log_path or (_DEBUG_LOG_DIR / "usage.log")
+
+        # Session attribution (issue #26): one accumulator behind three
+        # surfaces — GET /stats, the shutdown summary file, and the X-Kitty-*
+        # response headers — so no two records of a session can disagree about
+        # which backend and which real model served it.
+        self._stats_requests = 0
+        self._stats_attempts = 0
+        self._stats_failovers = 0
+        self._stats_retries = 0
+        self._stats_all_unhealthy = 0
+        self._stats_backend_attempts: dict[int, int] = {}
+        self._stats_models: dict[str, dict[str, int]] = {}
+        self._started_at: str | None = None
+
+        # The summary path is nominated, never guessed. The environment
+        # fallback covers bridges that never pass through the CLI parser
+        # (service mode, embedded use), which have no flag to carry it.
+        _env_summary = os.environ.get("KITTY_SESSION_SUMMARY")
+        self._session_summary_path: Path | None = None
+        if session_summary_path:
+            self._session_summary_path = Path(session_summary_path)
+        elif _env_summary:
+            self._session_summary_path = Path(_env_summary)
 
     # ── Context-var-aware properties for backend selection ────────────────
     #
@@ -896,6 +959,7 @@ class BridgeServer:
                     }
                     for idx in range(n)
                 ]
+                self._stats_all_unhealthy += 1
                 raise AllBackendsUnhealthyError(backend_status, 300)
             candidates = []
             backend_status = []
@@ -923,6 +987,7 @@ class BridgeServer:
             if candidates:
                 retry_after = min(remaining for remaining, _idx in candidates)
                 if retry_after > _ALL_UNHEALTHY_FAST_FAIL_THRESHOLD:
+                    self._stats_all_unhealthy += 1
                     raise AllBackendsUnhealthyError(backend_status, retry_after)
                 near_retry_indices = [
                     idx for remaining, idx in candidates if remaining <= _ALL_UNHEALTHY_FAST_FAIL_THRESHOLD
@@ -1229,6 +1294,14 @@ class BridgeServer:
         self._active_provider_config = provider_config
         self._current_backend_idx = backend_idx
 
+        # The attempt ordinal rides on the same ContextVar that already makes
+        # selection concurrency-safe: attempt 1 is the request itself, later
+        # attempts are its failovers or retries.  aiohttp runs each request in
+        # its own task (a fresh context copy), so a keep-alive peer cannot leak
+        # a non-zero ordinal into the next request.
+        previous = _backend_context.get(_EMPTY_CTX)
+        attempt = previous.get("attempt", 0) + 1
+
         # Isolate this selection for the current request.  Concurrent
         # requests within the same event loop get their own ContextVar
         # value and never see this one, even if the instance fields are
@@ -1239,9 +1312,166 @@ class BridgeServer:
             "model": model,
             "idx": backend_idx,
             "provider_config": provider_config,
+            "attempt": attempt,
         }
         _backend_context.set(result)
+        self._record_attempt(backend_idx, model, attempt, previous.get("idx"))
         return result
+
+    def _record_attempt(self, backend_idx: int, model: str | None, attempt: int, previous_idx: int | None) -> None:
+        """Record one upstream attempt in the session attribution counters.
+
+        A re-selection only counts as a failover when it lands on a *different*
+        backend. Several paths re-select after an empty-but-successful response,
+        and the weighted draw can return the same member; counting those as
+        failovers would inflate the one number this record exists to make
+        trustworthy.
+
+        Args:
+            backend_idx: Index of the selected backend, or ``-1`` in
+                single-backend mode.
+            model: The backend's real model — the name the work should be
+                attributed to, not the alias the client asked for.
+            attempt: The 1-based ordinal of this selection within its request.
+            previous_idx: Index selected earlier in the same request, or
+                ``None`` when this is the request's first selection.
+        """
+        self._stats_attempts += 1
+        if attempt == 1:
+            self._stats_requests += 1
+        elif backend_idx != previous_idx:
+            self._stats_failovers += 1
+        else:
+            self._stats_retries += 1
+        self._stats_backend_attempts[backend_idx] = self._stats_backend_attempts.get(backend_idx, 0) + 1
+        self._model_stats(model)["attempts"] += 1
+
+    def _attribution_headers(self) -> dict[str, str]:
+        """Return the ``X-Kitty-*`` headers describing the current request's backend.
+
+        Names the backend that produced the response's first byte. A stream
+        that fails over after that has already flushed its headers, so
+        ``/stats`` and the session summary — which count every attempt —
+        remain the authoritative record for a session.
+
+        Returns:
+            ``X-Kitty-Backend`` and ``X-Kitty-Tier``, plus ``X-Kitty-Model``
+            when a model override is configured; or an empty dict when no
+            backend was selected for this request (``/healthz``, ``/stats``).
+        """
+        ctx = _backend_context.get(_EMPTY_CTX)
+        if "idx" not in ctx:
+            return {}
+        idx = ctx["idx"]
+        if self._backends and 0 <= idx < len(self._backends):
+            name = self._backends[idx][2].name
+            tier = "backup" if self._backend_is_backup[idx] else "primary"
+        else:
+            name = self._profile_name
+            tier = "primary"
+        headers = {
+            "X-Kitty-Backend": _header_value(name),
+            "X-Kitty-Tier": tier,
+        }
+        # No configured model means the client's own model was passed through;
+        # an empty header would assert an attribution the bridge cannot make.
+        model = ctx.get("model")
+        if model:
+            headers["X-Kitty-Model"] = _header_value(model)
+        return headers
+
+    def _model_stats(self, model: str | None) -> dict[str, int]:
+        """Return the mutable attribution record for a real model name.
+
+        Args:
+            model: The backend's model, or ``None`` when no override is
+                configured and the client's own model is passed through — that
+                case is recorded under the empty string.
+
+        Returns:
+            The record for that model, created zeroed on first use.
+        """
+        return self._stats_models.setdefault(
+            model or "",
+            {"attempts": 0, "completions": 0, "input_tokens": 0, "output_tokens": 0},
+        )
+
+    def _session_stats(self) -> dict:
+        """Build the machine-readable record of what actually served this session.
+
+        This is the single document behind ``GET /stats`` and the shutdown
+        summary file, so the two can never disagree. In ``balancing`` mode
+        ``failovers == 0`` on a completed session is the explicit refutation of
+        a "the provider was unavailable" story; in ``single`` mode it is
+        structurally zero and carries no signal, so read ``mode`` first.
+
+        Three caveats a consumer needs: ``attempts`` counts backend
+        *selections*, not upstream POSTs — same-backend HTTP retries inside one
+        selection are not counted; ``all_backends_unhealthy`` counts every
+        raise, including ones a failover loop absorbed without the client
+        seeing a 503; and ``requests`` counts requests that *reached a
+        backend*, so one rejected because the whole pool was in cooldown raises
+        ``all_backends_unhealthy`` without incrementing ``requests``.
+
+        Returns:
+            A JSON-serialisable dict describing the session.
+        """
+        now = time.monotonic()
+        backends: list[dict] = []
+        # Balancing pools describe every member, healthy or not, so a consumer
+        # can see the backend that was never contacted as well as the one that
+        # served everything.
+        if self._backends:
+            for idx, (provider, _key, profile) in enumerate(self._backends):
+                health = self._backend_health[idx]
+                remaining = 0
+                if not health["healthy"] and health["failed_at"] is not None:
+                    remaining = max(0, int(health["cooldown"] - (now - health["failed_at"])))
+                backends.append(
+                    {
+                        "name": profile.name,
+                        "provider": provider.provider_type,
+                        "model": profile.model,
+                        "tier": "backup" if self._backend_is_backup[idx] else "primary",
+                        "attempts": self._stats_backend_attempts.get(idx, 0),
+                        "healthy": health["healthy"],
+                        "remaining_cooldown": remaining,
+                        "cooldown_events": health.get("failure_count", 0),
+                    }
+                )
+        else:
+            # Single-backend mode has no health tracking, but consumers must
+            # parse one shape regardless of how the bridge was launched.
+            backends.append(
+                {
+                    "name": self._profile_name,
+                    "provider": self._provider.provider_type,
+                    "model": self._model,
+                    "tier": "primary",
+                    "attempts": self._stats_backend_attempts.get(-1, 0),
+                    "healthy": True,
+                    "remaining_cooldown": 0,
+                    "cooldown_events": 0,
+                }
+            )
+        return {
+            "profile": self._profile_name,
+            "mode": "balancing" if self._backends else "single",
+            # Two bridges can be pointed at one summary path (the environment
+            # variable is inherited by children), so the record has to say
+            # which process wrote it.
+            "pid": os.getpid(),
+            "port": self._port,
+            "started_at": self._started_at,
+            "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "requests": self._stats_requests,
+            "attempts": self._stats_attempts,
+            "failovers": self._stats_failovers,
+            "retries": self._stats_retries,
+            "all_backends_unhealthy": self._stats_all_unhealthy,
+            "models_served": {model: dict(record) for model, record in self._stats_models.items()},
+            "backends": backends,
+        }
 
     def _log_backend_selection(self) -> None:
         """Log diagnostic info about the currently selected backend."""
@@ -1311,14 +1541,29 @@ class BridgeServer:
         return log_path
 
     def _log_usage(self, usage: dict | None) -> None:
-        """Append a JSONL usage entry to the usage log file.
+        """Record a completed upstream call and append a JSONL usage entry.
 
-        Fire-and-forget: failures are logged but never raised.
+        Attribution counting happens unconditionally — it is what tells a
+        consumer which real model the cost belongs to — while the usage log
+        file stays behind the opt-in ``--logging`` flag.
+
+        Fire-and-forget: file failures are logged but never raised.
+
+        Args:
+            usage: The upstream ``usage`` block, or ``None`` when the response
+                carried none.
         """
+        usage = usage or {}
+
+        # Attribute the completion and its tokens to the backend's real model.
+        model_record = self._model_stats(self._active_model)
+        model_record["completions"] += 1
+        model_record["input_tokens"] += _token_count(usage.get("prompt_tokens"))
+        model_record["output_tokens"] += _token_count(usage.get("completion_tokens"))
+
         if not self._logging_enabled:
             return
         try:
-            usage = usage or {}
             entry = {
                 "timestamp": datetime.now(timezone.utc).isoformat(),
                 "profile": self._profile_name,
@@ -1345,6 +1590,7 @@ class BridgeServer:
 
     async def start_async(self) -> int:
         """Create the aiohttp app, register routes, start listening. Returns bound port."""
+        self._started_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
         self._log_path = self._setup_debug_logging()
 
         # Crash handlers are always installed, even without --debug.
@@ -1368,8 +1614,14 @@ class BridgeServer:
                 file=sys.stderr,
             )
 
+        # Registration order is outermost-first. Attribution sits *inside* auth
+        # (an unauthenticated caller gets no backend details) but *outside* the
+        # access log, whose except-clause synthesises the 500 for an unhandled
+        # handler error — the "why did this model fail?" case issue #26 is
+        # about, which must carry attribution like any other response.
         self._app = web.Application(
-            client_max_size=_CLIENT_MAX_SIZE, middlewares=[self._auth_middleware, self._access_log_middleware]
+            client_max_size=_CLIENT_MAX_SIZE,
+            middlewares=[self._auth_middleware, self._attribution_middleware, self._access_log_middleware],
         )
         self._register_routes(self._app)
         self._runner = web.AppRunner(self._app)
@@ -1404,7 +1656,7 @@ class BridgeServer:
                 host=self._host,
                 port=self._port,
                 profile=self._profile_name,
-                started_at=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                started_at=self._started_at,
                 tls=bool(self._tls_cert and self._tls_key),
             )
             try:
@@ -1423,35 +1675,69 @@ class BridgeServer:
         return asyncio.get_event_loop().run_until_complete(self.start_async())
 
     async def stop_async(self) -> None:
-        """Gracefully stop the server and close the HTTP client session."""
-        if self._runner is not None:
-            await self._runner.cleanup()
-            self._runner = None
-        if self._session is not None and not self._session.closed:
-            await self._session.close()
-            self._session = None
-        if self._proxy_session is not None and not self._proxy_session.closed:
-            await self._proxy_session.close()
-            self._proxy_session = None
-        self._app = None
-        if self._access_log_file is not None:
-            self._access_log_file.close()
-            self._access_log_file = None
-        # Remove state file
-        if self._state_file:
-            from kitty.bridge.state import remove_state
+        """Gracefully stop the server and close the HTTP client session.
 
-            remove_state(self._state_file)
+        The session summary is written in a ``finally``: a teardown step that
+        raises must not cost a gracefully-shut-down bridge its only durable
+        record of what served the session.
+        """
+        try:
+            if self._runner is not None:
+                await self._runner.cleanup()
+                self._runner = None
+            if self._session is not None and not self._session.closed:
+                await self._session.close()
+                self._session = None
+            if self._proxy_session is not None and not self._proxy_session.closed:
+                await self._proxy_session.close()
+                self._proxy_session = None
+            self._app = None
+            if self._access_log_file is not None:
+                self._access_log_file.close()
+                self._access_log_file = None
+            # Remove state file
+            if self._state_file:
+                from kitty.bridge.state import remove_state
+
+                remove_state(self._state_file)
+        finally:
+            self._write_session_summary()
         logger.info("Bridge server stopped")
 
     def stop(self) -> None:
         """Synchronous wrapper around stop_async."""
         asyncio.get_event_loop().run_until_complete(self.stop_async())
 
+    def _write_session_summary(self) -> None:
+        """Write the session attribution document to the nominated path.
+
+        Written last, so the record covers the whole session. This is the
+        surface built for CI: the bridge is torn down at job end and a small
+        JSON file can be uploaded as an artifact without touching the
+        multi-megabyte debug log.
+
+        A failure here is logged and swallowed — observability must never be
+        able to fail the thing it observes. The catch is deliberately broad:
+        a Windows path with an embedded NUL raises ``ValueError``, not
+        ``OSError``, and that must not propagate out of ``stop_async()`` either.
+        """
+        if self._session_summary_path is None:
+            return
+        try:
+            self._session_summary_path.parent.mkdir(parents=True, exist_ok=True)
+            self._session_summary_path.write_text(
+                json.dumps(self._session_stats(), indent=2) + "\n",
+                encoding="utf-8",
+            )
+            logger.info("Session summary written to %s", self._session_summary_path)
+        except Exception as exc:
+            logger.warning("Failed to write session summary to %s: %s", self._session_summary_path, exc)
+
     # ── Route registration ────────────────────────────────────────────────
 
     def _register_routes(self, app: web.Application) -> None:
         app.router.add_get("/healthz", self._handle_healthz)
+        app.router.add_get("/stats", self._handle_stats)
 
         # Bridge mode (no adapter): register ALL protocol endpoints
         if self._adapter is None:
@@ -1512,6 +1798,29 @@ class BridgeServer:
             request["_mapped_profile"] = mapped_profile
 
         return await handler(request)  # type: ignore[misc, no-any-return, operator]
+
+    # ── Attribution middleware ────────────────────────────────────────────
+
+    @web.middleware
+    async def _attribution_middleware(self, request: web.Request, handler: object) -> web.StreamResponse:
+        """Stamp the backend attribution headers onto the outgoing response.
+
+        Streaming handlers prepare their own response and therefore stamp
+        themselves at construction time; this covers every non-streaming path
+        without touching each handler.
+
+        Args:
+            request: The inbound request.
+            handler: The next handler in the middleware chain.
+
+        Returns:
+            The handler's response, with attribution headers when it has not
+            already been sent.
+        """
+        response: web.StreamResponse = await handler(request)  # type: ignore[misc, operator]
+        if not response.prepared:
+            response.headers.update(self._attribution_headers())
+        return response
 
     # ── Access log middleware ─────────────────────────────────────────────
 
@@ -1587,6 +1896,22 @@ class BridgeServer:
         status = "ok" if any_healthy else "degraded"
         http_status = 200 if any_healthy else 503
         return web.json_response({"status": status, "backends": backends}, status=http_status)
+
+    async def _handle_stats(self, request: web.Request) -> web.Response:
+        """Serve the live session attribution record.
+
+        Sibling of ``/healthz``: where that reports whether the bridge can
+        serve the *next* request, this reports which backend and which real
+        model served the ones already made.
+
+        Args:
+            request: The inbound aiohttp request (unused).
+
+        Returns:
+            A 200 JSON response carrying the session document.
+        """
+        del request  # The document describes the session, not the caller.
+        return web.json_response(self._session_stats())
 
     async def _handle_models(self, request: web.Request) -> web.Response:
         """Return OpenAI-compatible model list."""
@@ -1707,7 +2032,11 @@ class BridgeServer:
         logger.debug("═══ STREAM RESPONSES START ═══ response_id=%s model=%s", response_id, model)
         sr = web.StreamResponse(
             status=200,
-            headers={"Content-Type": "text/event-stream", "Cache-Control": "no-cache"},
+            headers={
+                "Content-Type": "text/event-stream",
+                "Cache-Control": "no-cache",
+                **self._attribution_headers(),
+            },
         )
         await sr.prepare(request)
 
@@ -2275,7 +2604,11 @@ class BridgeServer:
             if sr is None:
                 sr = web.StreamResponse(
                     status=200,
-                    headers={"Content-Type": "text/event-stream", "Cache-Control": "no-cache"},
+                    headers={
+                        "Content-Type": "text/event-stream",
+                        "Cache-Control": "no-cache",
+                        **self._attribution_headers(),
+                    },
                 )
                 await sr.prepare(request)
             return sr
@@ -3070,7 +3403,11 @@ class BridgeServer:
 
         sr = web.StreamResponse(
             status=200,
-            headers={"Content-Type": "text/event-stream", "Cache-Control": "no-cache"},
+            headers={
+                "Content-Type": "text/event-stream",
+                "Cache-Control": "no-cache",
+                **self._attribution_headers(),
+            },
         )
         await sr.prepare(request)
 
@@ -3753,7 +4090,11 @@ class BridgeServer:
 
         sr = web.StreamResponse(
             status=200,
-            headers={"Content-Type": "text/event-stream", "Cache-Control": "no-cache"},
+            headers={
+                "Content-Type": "text/event-stream",
+                "Cache-Control": "no-cache",
+                **self._attribution_headers(),
+            },
         )
         await sr.prepare(request)
 

--- a/src/kitty/cli/launcher.py
+++ b/src/kitty/cli/launcher.py
@@ -126,6 +126,8 @@ async def launch_async(
     backends: list[tuple[ProviderAdapter, str, Profile]] | None = None,
     logging_enabled: bool = False,
     usage_log_path: Path | None = None,
+    session_summary_path: Path | None = None,
+    profile_name: str | None = None,
 ) -> int:
     """Launch the full bridge + child process lifecycle.
 
@@ -187,6 +189,11 @@ async def launch_async(
         backends=backends,
         logging_enabled=logging_enabled,
         egress=get_egress(),
+        session_summary_path=session_summary_path,
+        # Attribution surfaces that call every session "default" name nothing;
+        # a balancing launch passes the pool name, which the member profile
+        # here cannot supply.
+        profile_name=profile_name or profile.name,
         _usage_log_path=usage_log_path,
     )
     port = await server.start_async()
@@ -349,6 +356,8 @@ def launch(
     backends: list[tuple[ProviderAdapter, str, Profile]] | None = None,
     logging_enabled: bool = False,
     usage_log_path: Path | None = None,
+    session_summary_path: Path | None = None,
+    profile_name: str | None = None,
 ) -> int:
     """Synchronous wrapper around launch_async."""
     try:
@@ -368,6 +377,8 @@ def launch(
                     backends=backends,
                     logging_enabled=logging_enabled,
                     usage_log_path=usage_log_path,
+                    session_summary_path=session_summary_path,
+                    profile_name=profile_name,
                 )
                 future = pool.submit(asyncio.run, coro)
                 return future.result()
@@ -382,6 +393,8 @@ def launch(
             backends=backends,
             logging_enabled=logging_enabled,
             usage_log_path=usage_log_path,
+            session_summary_path=session_summary_path,
+            profile_name=profile_name,
         )
         return loop.run_until_complete(coro)
     except RuntimeError:
@@ -396,5 +409,7 @@ def launch(
             backends=backends,
             logging_enabled=logging_enabled,
             usage_log_path=usage_log_path,
+            session_summary_path=session_summary_path,
+            profile_name=profile_name,
         )
         return asyncio.run(coro)

--- a/src/kitty/cli/main.py
+++ b/src/kitty/cli/main.py
@@ -106,6 +106,16 @@ def _build_parser():
         help="Write usage logs to PATH instead of ~/.cache/kitty/usage.log (implies --logging)",
     )
     parser.add_argument(
+        "--session-summary",
+        type=Path,
+        default=None,
+        metavar="PATH",
+        help=(
+            "Write a machine-readable record of which backend and model served the session to PATH "
+            "on shutdown (overrides KITTY_SESSION_SUMMARY)"
+        ),
+    )
+    parser.add_argument(
         "--egress-proxy",
         default=None,
         metavar="URL",
@@ -365,6 +375,7 @@ def main() -> None:
             validate=not args.no_validate,
             logging_enabled=args.logging or args.log_file is not None,
             usage_log_path=args.log_file,
+            session_summary_path=args.session_summary,
         )
     elif result.adapter is not None and (result.backend is not None or result.profile is not None):
         backend = result.backend or result.profile
@@ -378,6 +389,7 @@ def main() -> None:
             validate=not args.no_validate,
             logging_enabled=args.logging or args.log_file is not None,
             usage_log_path=args.log_file,
+            session_summary_path=args.session_summary,
         )
         sys.exit(exit_code)
     else:
@@ -474,6 +486,7 @@ def _run_bridge(
     validate: bool = True,
     logging_enabled: bool = False,
     usage_log_path: Path | None = None,
+    session_summary_path: Path | None = None,
 ) -> None:
     """Run bridge mode — start OpenAI-compatible API server without launching agent."""
     import asyncio
@@ -498,6 +511,7 @@ def _run_bridge(
             validate=validate,
             logging_enabled=logging_enabled,
             usage_log_path=usage_log_path,
+            session_summary_path=session_summary_path,
         )
         return
 
@@ -538,6 +552,8 @@ def _run_bridge(
         provider_config=getattr(profile, "provider_config", {}),
         logging_enabled=logging_enabled,
         egress=_get_egress(),
+        session_summary_path=session_summary_path,
+        profile_name=profile.name,  # type: ignore[attr-defined, union-attr]
         _usage_log_path=usage_log_path,
     )
 
@@ -557,7 +573,8 @@ def _run_bridge(
             f"  • POST /v1/responses\n"
             f"  • POST /v1beta/models/{{model}}:generateContent\n"
             f"  • GET  /v1/models\n"
-            f"  • GET  /healthz\n\n"
+            f"  • GET  /healthz\n"
+            f"  • GET  /stats\n\n"
             f"Press Ctrl+C to stop",
         )
 
@@ -588,6 +605,7 @@ def _run_bridge_balancing(
     validate: bool = True,
     logging_enabled: bool = False,
     usage_log_path: Path | None = None,
+    session_summary_path: Path | None = None,
 ) -> None:
     """Run bridge mode with a balancing profile — random selection across healthy members."""
     import asyncio
@@ -638,6 +656,8 @@ def _run_bridge_balancing(
         backends=backends,
         logging_enabled=logging_enabled,
         egress=_get_egress(),
+        session_summary_path=session_summary_path,
+        profile_name=balancing.name,
         _usage_log_path=usage_log_path,
     )
 
@@ -659,7 +679,8 @@ def _run_bridge_balancing(
             f"  • POST /v1/responses\n"
             f"  • POST /v1beta/models/{{model}}:generateContent\n"
             f"  • GET  /v1/models\n"
-            f"  • GET  /healthz\n\n"
+            f"  • GET  /healthz\n"
+            f"  • GET  /stats\n\n"
             f"Press Ctrl+C to stop",
         )
 
@@ -691,6 +712,7 @@ def _launch_target(
     validate: bool = True,
     logging_enabled: bool = False,
     usage_log_path: Path | None = None,
+    session_summary_path: Path | None = None,
 ) -> int:
     from kitty.cli.launcher import launch
     from kitty.profiles.schema import BalancingProfile
@@ -708,6 +730,7 @@ def _launch_target(
             validate=validate,
             logging_enabled=logging_enabled,
             usage_log_path=usage_log_path,
+            session_summary_path=session_summary_path,
         )
 
     profile = backend
@@ -724,6 +747,7 @@ def _launch_target(
         validate=validate,
         logging_enabled=logging_enabled,
         usage_log_path=usage_log_path,
+        session_summary_path=session_summary_path,
     )
 
 
@@ -737,6 +761,7 @@ def _launch_target_balancing(
     validate: bool = True,
     logging_enabled: bool = False,
     usage_log_path: Path | None = None,
+    session_summary_path: Path | None = None,
 ) -> int:
     """Launch a coding agent with a balancing profile (random healthy member selection)."""
     from kitty.cli.launcher import launch
@@ -775,4 +800,6 @@ def _launch_target_balancing(
         backends=backends,
         logging_enabled=logging_enabled,
         usage_log_path=usage_log_path,
+        session_summary_path=session_summary_path,
+        profile_name=balancing.name,
     )

--- a/tests/bridge/test_attribution_headers.py
+++ b/tests/bridge/test_attribution_headers.py
@@ -1,0 +1,387 @@
+"""Tests for the ``X-Kitty-*`` per-response backend attribution headers.
+
+Issue #26: a consumer that captures response headers can attribute an
+individual call to the backend and real model that served it, rather than to
+the alias it asked for.  The headers name the backend selected when the
+response began; ``GET /stats`` remains the authoritative session record when a
+stream fails over mid-flight.
+"""
+
+import uuid
+
+import aiohttp
+import pytest
+from aioresponses import aioresponses
+
+from kitty.bridge.server import BridgeServer
+from kitty.profiles.schema import Profile
+from kitty.providers.base import ProviderAdapter
+
+UPSTREAM_RESPONSE = {
+    "id": "chatcmpl-1",
+    "model": "whatever-the-upstream-says",
+    "choices": [{"index": 0, "message": {"role": "assistant", "content": "Hello!"}, "finish_reason": "stop"}],
+    "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+}
+
+UPSTREAM_SSE = (
+    'data: {"id":"1","choices":[{"index":0,"delta":{"role":"assistant","content":"Hi"},"finish_reason":null}]}\n\n'
+    'data: {"id":"1","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}\n\n'
+    "data: [DONE]\n\n"
+)
+
+
+class StubProvider(ProviderAdapter):
+    """Provider adapter with a fixed upstream base URL.
+
+    Args:
+        provider_type: Value reported by the :attr:`provider_type` property.
+        base_url: Upstream base URL the bridge will call.
+    """
+
+    def __init__(self, provider_type: str = "stub", base_url: str = "https://api.example.com/v1") -> None:
+        self._provider_type = provider_type
+        self._base_url = base_url
+
+    @property
+    def provider_type(self) -> str:
+        """Return the provider identifier."""
+        return self._provider_type
+
+    @property
+    def default_base_url(self) -> str:
+        """Return the upstream base URL."""
+        return self._base_url
+
+    def build_request(self, model: str, messages: list[dict], **kwargs) -> dict:
+        """Return a Chat Completions payload for the given model and messages."""
+        return {"model": model, "messages": messages}
+
+    def parse_response(self, response_data: dict) -> dict:
+        """Return the upstream response unchanged."""
+        return response_data
+
+    def map_error(self, status_code: int, body: dict) -> Exception:
+        """Return a generic exception for an upstream error status."""
+        return Exception(f"Error {status_code}")
+
+
+def _one_backend(name: str = "minimax-small", model: str = "MiniMax-M3", *, backup: bool = False):
+    """Build a single-member balancing pool with a known name, model and tier.
+
+    A one-member pool makes the selected backend deterministic, so the test can
+    assert exact header values instead of "one of these".
+
+    Args:
+        name: Profile name the header should report.
+        model: Real model the header should report.
+        backup: Whether the member is a reserve-tier profile.
+
+    Returns:
+        A one-element list of ``(provider, resolved_key, profile)``.
+    """
+    profile = Profile(
+        name=name,
+        provider="openai",
+        model=model,
+        auth_ref=str(uuid.uuid4()),
+        backup=backup,
+    )
+    return [(StubProvider(), "key-0", profile)]
+
+
+def _make_server(backends=None, **kwargs) -> BridgeServer:
+    """Build a bridge server over a stub provider.
+
+    Args:
+        backends: Balancing backends, or ``None`` for single-backend mode.
+        **kwargs: Extra keyword arguments forwarded to ``BridgeServer``.
+
+    Returns:
+        An unstarted server.
+    """
+    provider = backends[0][0] if backends else StubProvider()
+    return BridgeServer(
+        adapter=None,
+        provider=provider,
+        resolved_key="key-0",
+        model=backends[0][2].model if backends else "real-model",
+        backends=backends,
+        profile_name=kwargs.pop("profile_name", "solo"),
+        **kwargs,
+    )
+
+
+async def _post(port: int, body: dict) -> dict[str, str]:
+    """POST a chat completion through the bridge and return its response headers.
+
+    Args:
+        port: Port the bridge is listening on.
+        body: Request body to send.
+
+    Returns:
+        The response headers as a plain dict.
+    """
+    url = f"http://127.0.0.1:{port}/v1/chat/completions"
+    async with aiohttp.ClientSession() as session, session.post(url, json=body) as resp:
+        assert resp.status == 200
+        await resp.read()
+        return dict(resp.headers)
+
+
+class TestNonStreamingAttribution:
+    """A plain JSON response names what served it."""
+
+    @pytest.mark.asyncio
+    async def test_headers_name_the_backend_model_and_tier(self) -> None:
+        """A5.1: the three fields a consumer needs to attribute one call."""
+        server = _make_server(_one_backend())
+        port = await server.start_async()
+        try:
+            with aioresponses(passthrough=["http://127.0.0.1"]) as m:
+                m.post("https://api.example.com/v1/chat/completions", payload=UPSTREAM_RESPONSE)
+                request = {"model": "deepseek-v4-flash", "messages": [{"role": "user", "content": "hi"}]}
+                headers = await _post(port, request)
+        finally:
+            await server.stop_async()
+
+        assert headers["X-Kitty-Backend"] == "minimax-small"
+        assert headers["X-Kitty-Model"] == "MiniMax-M3"
+        assert headers["X-Kitty-Tier"] == "primary"
+
+    @pytest.mark.asyncio
+    async def test_the_header_model_is_not_the_requested_alias(self) -> None:
+        """A5.1: the alias is exactly what the consumer must stop trusting."""
+        server = _make_server(_one_backend())
+        port = await server.start_async()
+        try:
+            with aioresponses(passthrough=["http://127.0.0.1"]) as m:
+                m.post("https://api.example.com/v1/chat/completions", payload=UPSTREAM_RESPONSE)
+                request = {"model": "deepseek-v4-flash", "messages": [{"role": "user", "content": "hi"}]}
+                headers = await _post(port, request)
+        finally:
+            await server.stop_async()
+
+        assert headers["X-Kitty-Model"] != "deepseek-v4-flash"
+
+    @pytest.mark.asyncio
+    async def test_reserve_tier_members_report_the_backup_tier(self) -> None:
+        """A5.1: tier distinguishes "the plan served this" from "the metered key did"."""
+        server = _make_server(_one_backend(backup=True))
+        port = await server.start_async()
+        try:
+            with aioresponses(passthrough=["http://127.0.0.1"]) as m:
+                m.post("https://api.example.com/v1/chat/completions", payload=UPSTREAM_RESPONSE)
+                headers = await _post(port, {"model": "alias", "messages": [{"role": "user", "content": "hi"}]})
+        finally:
+            await server.stop_async()
+
+        assert headers["X-Kitty-Tier"] == "backup"
+
+    @pytest.mark.asyncio
+    async def test_single_backend_mode_reports_the_profile_and_its_model(self) -> None:
+        """A5.5: attribution does not depend on running a balancing pool."""
+        server = _make_server(profile_name="solo-profile")
+        port = await server.start_async()
+        try:
+            with aioresponses(passthrough=["http://127.0.0.1"]) as m:
+                m.post("https://api.example.com/v1/chat/completions", payload=UPSTREAM_RESPONSE)
+                headers = await _post(port, {"model": "alias", "messages": [{"role": "user", "content": "hi"}]})
+        finally:
+            await server.stop_async()
+
+        assert headers["X-Kitty-Backend"] == "solo-profile"
+        assert headers["X-Kitty-Model"] == "real-model"
+        assert headers["X-Kitty-Tier"] == "primary"
+
+    @pytest.mark.asyncio
+    async def test_a_non_ascii_model_name_does_not_break_the_response(self) -> None:
+        """A5.4: model ids are only checked for non-emptiness, so unicode is reachable.
+
+        Header values are framed as latin-1; an unsanitised name would fail the
+        whole response, costing the caller their answer for the sake of a
+        diagnostic header.
+        """
+        server = _make_server(_one_backend(model="Ми́ниМакс"))
+        port = await server.start_async()
+        try:
+            with aioresponses(passthrough=["http://127.0.0.1"]) as m:
+                m.post("https://api.example.com/v1/chat/completions", payload=UPSTREAM_RESPONSE)
+                headers = await _post(port, {"model": "alias", "messages": [{"role": "user", "content": "hi"}]})
+        finally:
+            await server.stop_async()
+
+        assert headers["X-Kitty-Model"].isascii()
+
+    @pytest.mark.asyncio
+    async def test_a_control_character_in_a_model_name_does_not_break_the_response(self) -> None:
+        """A5.6: aiohttp rejects CR/LF/NUL in header values as header injection.
+
+        Model ids are validated only for non-emptiness, so a newline is
+        reachable — and unsanitised it would fail *every* response on that
+        backend, with the observability feature as the sole cause.
+        """
+        server = _make_server(_one_backend(model="MiniMax\r\nX-Injected: yes"))
+        port = await server.start_async()
+        try:
+            with aioresponses(passthrough=["http://127.0.0.1"]) as m:
+                m.post("https://api.example.com/v1/chat/completions", payload=UPSTREAM_RESPONSE)
+                headers = await _post(port, {"model": "alias", "messages": [{"role": "user", "content": "hi"}]})
+        finally:
+            await server.stop_async()
+
+        assert "X-Injected" not in headers
+        assert "\n" not in headers["X-Kitty-Model"]
+        assert "\r" not in headers["X-Kitty-Model"]
+
+    @pytest.mark.asyncio
+    async def test_no_model_header_is_sent_when_no_override_is_configured(self) -> None:
+        """A5.7: an empty header would assert an attribution the bridge cannot make."""
+        server = BridgeServer(
+            adapter=None,
+            provider=StubProvider(),
+            resolved_key="key-0",
+            model=None,
+            profile_name="passthrough",
+        )
+        port = await server.start_async()
+        try:
+            with aioresponses(passthrough=["http://127.0.0.1"]) as m:
+                m.post("https://api.example.com/v1/chat/completions", payload=UPSTREAM_RESPONSE)
+                headers = await _post(port, {"model": "alias", "messages": [{"role": "user", "content": "hi"}]})
+        finally:
+            await server.stop_async()
+
+        assert headers["X-Kitty-Backend"] == "passthrough"
+        assert "X-Kitty-Model" not in headers
+
+
+class TestStreamingAttribution:
+    """An SSE response carries the headers too, flushed before the first event."""
+
+    @pytest.mark.asyncio
+    async def test_streaming_response_carries_attribution_headers(self) -> None:
+        """A5.2: the streaming path is the one Claude Code actually uses."""
+        server = _make_server(_one_backend())
+        port = await server.start_async()
+        url = f"http://127.0.0.1:{port}/v1/chat/completions"
+        body = {"model": "alias", "messages": [{"role": "user", "content": "hi"}], "stream": True}
+        try:
+            with aioresponses(passthrough=["http://127.0.0.1"]) as m:
+                m.post(
+                    "https://api.example.com/v1/chat/completions",
+                    body=UPSTREAM_SSE,
+                    headers={"Content-Type": "text/event-stream"},
+                )
+                async with aiohttp.ClientSession() as session, session.post(url, json=body) as resp:
+                    assert resp.status == 200
+                    assert resp.content_type == "text/event-stream"
+                    headers = dict(resp.headers)
+                    await resp.read()
+        finally:
+            await server.stop_async()
+
+        assert headers["X-Kitty-Backend"] == "minimax-small"
+        assert headers["X-Kitty-Model"] == "MiniMax-M3"
+        assert headers["X-Kitty-Tier"] == "primary"
+
+
+class TestErrorResponseAttribution:
+    """A failed response is the one a consumer most needs attributed."""
+
+    @pytest.mark.asyncio
+    async def test_an_internal_error_still_names_the_backend(self, monkeypatch) -> None:
+        """A5.8: "why can't this model produce valid JSON?" starts here.
+
+        The access-log middleware synthesises the 500 for an unhandled handler
+        error. Attribution must sit outside it, or the one response that
+        represents a model-capability failure is the one that names no model.
+        """
+        server = _make_server(_one_backend())
+
+        async def _boom(self, request):
+            """Fail after backend selection, as a handler bug would."""
+            self._select_backend()
+            raise RuntimeError("handler exploded")
+
+        monkeypatch.setattr(BridgeServer, "_handle_chat_completions", _boom)
+        port = await server.start_async()
+        url = f"http://127.0.0.1:{port}/v1/chat/completions"
+        try:
+            async with aiohttp.ClientSession() as session, session.post(url, json={"model": "alias"}) as resp:
+                assert resp.status == 500
+                headers = dict(resp.headers)
+        finally:
+            await server.stop_async()
+
+        assert headers["X-Kitty-Backend"] == "minimax-small"
+        assert headers["X-Kitty-Model"] == "MiniMax-M3"
+
+    @pytest.mark.asyncio
+    async def test_an_unauthenticated_caller_learns_nothing_about_backends(self, tmp_path) -> None:
+        """A5.9: attribution sits inside auth, so a 401 discloses no backend."""
+        keys_file = tmp_path / "keys.txt"
+        keys_file.write_text("sk-test-key\n", encoding="utf-8")
+        server = _make_server(_one_backend(), keys_file=str(keys_file))
+        port = await server.start_async()
+        url = f"http://127.0.0.1:{port}/v1/chat/completions"
+        try:
+            async with aiohttp.ClientSession() as session, session.post(url, json={"model": "alias"}) as resp:
+                assert resp.status == 401
+                assert "X-Kitty-Backend" not in resp.headers
+        finally:
+            await server.stop_async()
+
+
+class TestMessagesPathAttribution:
+    """The Messages path defers preparation, so its header means something subtler."""
+
+    @pytest.mark.asyncio
+    async def test_messages_stream_carries_attribution_headers(self) -> None:
+        """A5.10: the Messages path is the one Claude Code actually uses.
+
+        Its ``StreamResponse`` is prepared only once content is ready, so the
+        header names the backend that produced the first byte rather than the
+        one selected at request entry.
+        """
+        server = _make_server(_one_backend())
+        port = await server.start_async()
+        url = f"http://127.0.0.1:{port}/v1/messages"
+        body = {"model": "alias", "messages": [{"role": "user", "content": "hi"}], "stream": True}
+        try:
+            with aioresponses(passthrough=["http://127.0.0.1"]) as m:
+                m.post(
+                    "https://api.example.com/v1/chat/completions",
+                    body=UPSTREAM_SSE,
+                    headers={"Content-Type": "text/event-stream"},
+                )
+                async with aiohttp.ClientSession() as session, session.post(url, json=body) as resp:
+                    assert resp.status == 200
+                    headers = dict(resp.headers)
+                    await resp.read()
+        finally:
+            await server.stop_async()
+
+        assert headers["X-Kitty-Backend"] == "minimax-small"
+        assert headers["X-Kitty-Model"] == "MiniMax-M3"
+        assert headers["X-Kitty-Tier"] == "primary"
+
+    @pytest.mark.asyncio
+    async def test_messages_non_streaming_carries_attribution_headers(self) -> None:
+        """A5.10: the non-streaming Messages response is stamped by the middleware."""
+        server = _make_server(_one_backend())
+        port = await server.start_async()
+        url = f"http://127.0.0.1:{port}/v1/messages"
+        body = {"model": "alias", "messages": [{"role": "user", "content": "hi"}]}
+        try:
+            with aioresponses(passthrough=["http://127.0.0.1"]) as m:
+                m.post("https://api.example.com/v1/chat/completions", payload=UPSTREAM_RESPONSE)
+                async with aiohttp.ClientSession() as session, session.post(url, json=body) as resp:
+                    assert resp.status == 200
+                    headers = dict(resp.headers)
+                    await resp.read()
+        finally:
+            await server.stop_async()
+
+        assert headers["X-Kitty-Backend"] == "minimax-small"
+        assert headers["X-Kitty-Model"] == "MiniMax-M3"

--- a/tests/bridge/test_session_stats.py
+++ b/tests/bridge/test_session_stats.py
@@ -1,0 +1,738 @@
+"""Tests for the bridge's session attribution counters and ``/stats`` surface.
+
+Issue #26: the bridge substitutes the backend's real model for the requested
+one but exposes no machine-readable record of it, so consumers attribute cost
+and failures to the alias.  These tests pin the accumulator that feeds all
+three attribution surfaces (``GET /stats``, the shutdown summary file, and the
+``X-Kitty-*`` headers).
+"""
+
+import contextvars
+import json
+import uuid
+
+import aiohttp
+import pytest
+
+from kitty.bridge.server import AllBackendsUnhealthyError, BridgeServer
+from kitty.profiles.schema import Profile
+from kitty.providers.base import ProviderAdapter
+
+
+class StubProvider(ProviderAdapter):
+    """Minimal provider adapter standing in for a real upstream.
+
+    Args:
+        provider_type: Value reported by the :attr:`provider_type` property.
+    """
+
+    def __init__(self, provider_type: str = "stub") -> None:
+        self._provider_type = provider_type
+
+    @property
+    def provider_type(self) -> str:
+        """Return the provider identifier used in attribution records."""
+        return self._provider_type
+
+    @property
+    def default_base_url(self) -> str:
+        """Return the upstream base URL (never contacted in these tests)."""
+        return "https://api.example.com/v1"
+
+    def build_request(self, model: str, messages: list[dict], **kwargs) -> dict:
+        """Return a Chat Completions payload for the given model and messages."""
+        return {"model": model, "messages": messages}
+
+    def parse_response(self, response_data: dict) -> dict:
+        """Return the upstream response unchanged."""
+        return response_data
+
+    def map_error(self, status_code: int, body: dict) -> Exception:
+        """Return a generic exception for an upstream error status."""
+        return Exception(f"Error {status_code}")
+
+
+def _make_backends(n: int, backup_indices: set[int] | None = None):
+    """Build ``n`` balancing backend tuples with distinct providers and models.
+
+    Args:
+        n: Number of backends to build.
+        backup_indices: Indices whose profile is a reserve-tier member.
+
+    Returns:
+        A list of ``(provider, resolved_key, profile)`` tuples.
+    """
+    backup_indices = backup_indices or set()
+    backends = []
+    for i in range(n):
+        provider = StubProvider(provider_type=f"stub-{i}")
+        profile = Profile(
+            name=f"profile-{i}",
+            provider="openai",
+            model=f"real-model-{i}",
+            auth_ref=str(uuid.uuid4()),
+            backup=i in backup_indices,
+        )
+        backends.append((provider, f"key-{i}", profile))
+    return backends
+
+
+def _make_server(n: int = 2, backup_indices: set[int] | None = None, **kwargs) -> BridgeServer:
+    """Build a balancing ``BridgeServer`` over ``n`` stub backends.
+
+    Args:
+        n: Number of balancing backends.
+        backup_indices: Indices marked as reserve tier.
+        **kwargs: Extra keyword arguments forwarded to ``BridgeServer``.
+
+    Returns:
+        An unstarted server — ``__init__`` performs no I/O.
+    """
+    backends = _make_backends(n, backup_indices)
+    return BridgeServer(
+        adapter=None,
+        provider=backends[0][0],
+        resolved_key=backends[0][1],
+        model=backends[0][2].model,
+        backends=backends,
+        profile_name="test-pool",
+        **kwargs,
+    )
+
+
+def _make_single_server(**kwargs) -> BridgeServer:
+    """Build a non-balancing ``BridgeServer`` with one configured model.
+
+    Args:
+        **kwargs: Extra keyword arguments forwarded to ``BridgeServer``.
+
+    Returns:
+        An unstarted single-backend server.
+    """
+    return BridgeServer(
+        adapter=None,
+        provider=StubProvider(provider_type="stub-single"),
+        resolved_key="key",
+        model="real-model-single",
+        profile_name="solo",
+        **kwargs,
+    )
+
+
+class TestCounterBaseline:
+    """A server that has served nothing reports zeroes, not absent keys."""
+
+    def test_fresh_server_reports_zero_counters(self) -> None:
+        """A1.1: every counter starts at zero on an unused server."""
+        stats = _make_server()._session_stats()
+
+        assert stats["requests"] == 0
+        assert stats["attempts"] == 0
+        assert stats["failovers"] == 0
+        assert stats["retries"] == 0
+        assert stats["all_backends_unhealthy"] == 0
+        assert stats["models_served"] == {}
+
+    def test_fresh_server_lists_every_backend_with_zero_attempts(self) -> None:
+        """A1.1: backends appear before they are used, so consumers see the pool."""
+        stats = _make_server(3)._session_stats()
+
+        assert [b["name"] for b in stats["backends"]] == ["profile-0", "profile-1", "profile-2"]
+        assert all(b["attempts"] == 0 for b in stats["backends"])
+
+
+class TestSelectionCounting:
+    """``_select_backend`` is the single funnel every upstream attempt goes through."""
+
+    def test_one_selection_counts_one_request_and_no_failover(self) -> None:
+        """A1.2: the first selection in a request is the request, not a failover."""
+        server = _make_server()
+
+        contextvars.copy_context().run(server._select_backend)
+
+        stats = server._session_stats()
+        assert stats["requests"] == 1
+        assert stats["attempts"] == 1
+        assert stats["failovers"] == 0
+
+    def test_switching_backend_within_one_request_counts_a_failover(self, monkeypatch) -> None:
+        """A1.3: a failover is a switch to a *different* backend mid-request."""
+        import kitty.bridge.server as server_mod
+
+        server = _make_server(2)
+        chosen = iter([[0], [1]])
+        monkeypatch.setattr(server_mod.random, "choices", lambda *a, **kw: next(chosen))
+
+        def _one_request() -> None:
+            """Select backend 0, then fail over to backend 1."""
+            server._select_backend()
+            server._select_backend()
+
+        contextvars.copy_context().run(_one_request)
+
+        stats = server._session_stats()
+        assert stats["requests"] == 1
+        assert stats["attempts"] == 2
+        assert stats["failovers"] == 1
+        assert stats["retries"] == 0
+
+    def test_reselecting_the_same_backend_is_a_retry_not_a_failover(self) -> None:
+        """A1.3: a same-backend re-selection is not evidence a provider failed over.
+
+        Several paths re-select after an empty-but-successful response, and a
+        weighted draw can return the same member. Counting those as failovers
+        would inflate the one number the issue was filed to obtain.
+        """
+        server = _make_server(1)
+
+        def _one_request() -> None:
+            """Select the only backend twice, as an empty-response retry does."""
+            server._select_backend()
+            server._select_backend()
+
+        contextvars.copy_context().run(_one_request)
+
+        stats = server._session_stats()
+        assert stats["requests"] == 1
+        assert stats["attempts"] == 2
+        assert stats["failovers"] == 0
+        assert stats["retries"] == 1
+
+    def test_separate_requests_do_not_inflate_the_failover_count(self) -> None:
+        """A7.2: a fresh request context starts at attempt 1, so failovers stay 0."""
+        server = _make_server()
+
+        for _ in range(3):
+            contextvars.copy_context().run(server._select_backend)
+
+        stats = server._session_stats()
+        assert stats["requests"] == 3
+        assert stats["attempts"] == 3
+        assert stats["failovers"] == 0
+
+    def test_attempts_are_attributed_to_the_backend_actually_selected(self) -> None:
+        """A1.6: per-backend attempts follow the chosen index, not the first one."""
+        server = _make_server(3)
+        # Park backends 0 and 2 so selection can only land on backend 1.
+        server._mark_backend_unhealthy(0)
+        server._mark_backend_unhealthy(2)
+
+        contextvars.copy_context().run(server._select_backend)
+
+        by_name = {b["name"]: b for b in server._session_stats()["backends"]}
+        assert by_name["profile-1"]["attempts"] == 1
+        assert by_name["profile-0"]["attempts"] == 0
+        assert by_name["profile-2"]["attempts"] == 0
+
+    def test_model_attempts_are_keyed_by_the_real_model(self) -> None:
+        """A1.6: attribution keys on the backend's model, never the requested alias."""
+        server = _make_server(3)
+        server._mark_backend_unhealthy(0)
+        server._mark_backend_unhealthy(2)
+
+        contextvars.copy_context().run(server._select_backend)
+
+        assert server._session_stats()["models_served"]["real-model-1"]["attempts"] == 1
+
+
+class TestUsageCounting:
+    """Token totals belong to the model that produced them."""
+
+    def test_completion_tokens_are_attributed_to_the_serving_model(self) -> None:
+        """A1.4: a completed call records completions and both token counts."""
+        server = _make_server(1)
+
+        def _one_request() -> None:
+            """Select the only backend, then report its usage."""
+            server._select_backend()
+            server._log_usage({"prompt_tokens": 10, "completion_tokens": 3})
+
+        contextvars.copy_context().run(_one_request)
+
+        served = server._session_stats()["models_served"]["real-model-0"]
+        assert served["completions"] == 1
+        assert served["input_tokens"] == 10
+        assert served["output_tokens"] == 3
+
+    def test_usage_is_counted_even_when_usage_logging_is_disabled(self) -> None:
+        """A1.4: attribution must not depend on the opt-in ``--logging`` flag."""
+        server = _make_server(1, logging_enabled=False)
+
+        def _one_request() -> None:
+            """Select a backend and report usage with file logging off."""
+            server._select_backend()
+            server._log_usage({"prompt_tokens": 7, "completion_tokens": 2})
+
+        contextvars.copy_context().run(_one_request)
+
+        assert server._session_stats()["models_served"]["real-model-0"]["input_tokens"] == 7
+
+    def test_usage_log_file_still_requires_logging_enabled(self, tmp_path) -> None:
+        """A6.3: counting usage must not start writing the usage log by itself."""
+        usage_log = tmp_path / "usage.log"
+        server = _make_server(1, logging_enabled=False, _usage_log_path=usage_log)
+
+        def _one_request() -> None:
+            """Select a backend and report usage with file logging off."""
+            server._select_backend()
+            server._log_usage({"prompt_tokens": 1, "completion_tokens": 1})
+
+        contextvars.copy_context().run(_one_request)
+
+        assert not usage_log.exists()
+
+    def test_a_call_with_no_usage_record_counts_as_a_completion(self) -> None:
+        """A1.4: a completion with no usage block still happened; tokens stay 0."""
+        server = _make_server(1)
+
+        def _one_request() -> None:
+            """Select a backend and report a completion carrying no usage."""
+            server._select_backend()
+            server._log_usage(None)
+
+        contextvars.copy_context().run(_one_request)
+
+        served = server._session_stats()["models_served"]["real-model-0"]
+        assert served["completions"] == 1
+        assert served["input_tokens"] == 0
+        assert served["output_tokens"] == 0
+
+
+class TestAllBackendsUnhealthyCounting:
+    """The "all backends unhealthy: never" flag the issue asks for by name."""
+
+    def test_far_cooldown_raise_is_counted(self, monkeypatch) -> None:
+        """A1.5: the fast-fail raise site increments the counter."""
+        import kitty.bridge.server as server_mod
+
+        server = _make_server(2)
+        now = 1000.0
+        for idx in range(2):
+            health = server._backend_health[idx]
+            health["healthy"] = False
+            health["failed_at"] = now
+            health["cooldown"] = 300
+        monkeypatch.setattr(server_mod.time, "monotonic", lambda: now + 10)
+
+        with pytest.raises(AllBackendsUnhealthyError):
+            server._get_next_backend()
+
+        assert server._session_stats()["all_backends_unhealthy"] == 1
+
+    def test_no_stream_capable_backend_raise_is_counted(self) -> None:
+        """A1.5: the require_streaming raise site increments the counter too."""
+        server = _make_server(2)
+
+        with pytest.raises(AllBackendsUnhealthyError):
+            server._get_next_backend(require_streaming=True)
+
+        assert server._session_stats()["all_backends_unhealthy"] == 1
+
+    def test_a_healthy_session_reports_it_never_happened(self) -> None:
+        """A1.5: a session that never exhausted its pool says so explicitly."""
+        server = _make_server(2)
+
+        contextvars.copy_context().run(server._select_backend)
+
+        assert server._session_stats()["all_backends_unhealthy"] == 0
+
+
+class TestBackendDescription:
+    """Each backend entry names what a consumer needs to attribute a call."""
+
+    def test_reserve_members_are_reported_as_the_backup_tier(self) -> None:
+        """A2.3: tier distinguishes the reserve pool from the primary pool."""
+        stats = _make_server(2, backup_indices={1})._session_stats()
+
+        by_name = {b["name"]: b for b in stats["backends"]}
+        assert by_name["profile-0"]["tier"] == "primary"
+        assert by_name["profile-1"]["tier"] == "backup"
+
+    def test_backend_entries_name_provider_and_real_model(self) -> None:
+        """A2.2: provider and model come from the backend, not the request."""
+        entry = _make_server(1)._session_stats()["backends"][0]
+
+        assert entry["provider"] == "stub-0"
+        assert entry["model"] == "real-model-0"
+
+    def test_cooldown_events_track_lifetime_failures(self) -> None:
+        """A2.4: cooldown_events is the lifetime failure count, not current health."""
+        server = _make_server(1)
+        server._mark_backend_unhealthy(0)
+        server._mark_backend_healthy(0)
+
+        entry = server._session_stats()["backends"][0]
+        assert entry["cooldown_events"] == 1
+        assert entry["healthy"] is True
+
+    def test_single_backend_mode_reports_one_synthesised_entry(self) -> None:
+        """A2.1: consumers parse one shape whether or not balancing is on."""
+        stats = _make_single_server()._session_stats()
+
+        assert stats["mode"] == "single"
+        assert stats["backends"] == [
+            {
+                "name": "solo",
+                "provider": "stub-single",
+                "model": "real-model-single",
+                "tier": "primary",
+                "attempts": 0,
+                "healthy": True,
+                "remaining_cooldown": 0,
+                "cooldown_events": 0,
+            }
+        ]
+
+    def test_balancing_mode_is_labelled_as_such(self) -> None:
+        """A2.2: mode tells the consumer whether failover was even possible."""
+        assert _make_server(2)._session_stats()["mode"] == "balancing"
+
+    def test_single_mode_can_never_report_a_failover(self) -> None:
+        """A2.8: in single mode ``failovers`` is structurally 0 and carries no signal.
+
+        A consumer must read ``mode`` first: zero failovers here is not
+        evidence that nothing went wrong, only that there was nowhere to go.
+        """
+        server = _make_single_server()
+
+        def _one_request() -> None:
+            """Re-select the only backend, as a retry path does."""
+            server._select_backend()
+            server._select_backend()
+
+        contextvars.copy_context().run(_one_request)
+
+        stats = server._session_stats()
+        assert stats["failovers"] == 0
+        assert stats["retries"] == 1
+
+    def test_single_backend_selection_is_counted(self) -> None:
+        """A1.6: attribution works without a balancing pool."""
+        server = _make_single_server()
+
+        contextvars.copy_context().run(server._select_backend)
+
+        stats = server._session_stats()
+        assert stats["attempts"] == 1
+        assert stats["backends"][0]["attempts"] == 1
+        assert stats["models_served"]["real-model-single"]["attempts"] == 1
+
+
+class TestDocumentContract:
+    """The document is what two independent surfaces both serve."""
+
+    def test_document_is_json_serialisable(self) -> None:
+        """A2.6: the same object is served over HTTP and written to a file.
+
+        One snapshot is round-tripped rather than compared against a second
+        call — ``generated_at`` has second resolution and can tick between two.
+        """
+        server = _make_server(2, backup_indices={1})
+        contextvars.copy_context().run(server._select_backend)
+        snapshot = server._session_stats()
+
+        assert json.loads(json.dumps(snapshot)) == snapshot
+
+    def test_document_names_the_profile_and_a_generation_time(self) -> None:
+        """A2.2: a summary read hours later must say what it describes and when."""
+        stats = _make_server()._session_stats()
+
+        assert stats["profile"] == "test-pool"
+        assert stats["generated_at"].endswith("Z")
+
+    def test_started_at_is_absent_before_the_server_starts(self) -> None:
+        """A2.2: an unstarted server has no start time to report."""
+        assert _make_server()._session_stats()["started_at"] is None
+
+
+class TestSummaryPathResolution:
+    """Where the shutdown summary goes is nominated, never guessed."""
+
+    def test_no_nomination_means_no_summary(self, monkeypatch) -> None:
+        """A4.4: the summary is strictly opt-in."""
+        monkeypatch.delenv("KITTY_SESSION_SUMMARY", raising=False)
+
+        assert _make_server()._session_summary_path is None
+
+    def test_environment_variable_nominates_the_path(self, monkeypatch, tmp_path) -> None:
+        """A4.3: service and embedded bridges have no CLI flag to pass."""
+        monkeypatch.setenv("KITTY_SESSION_SUMMARY", str(tmp_path / "env.json"))
+
+        assert _make_server()._session_summary_path == tmp_path / "env.json"
+
+    def test_explicit_argument_wins_over_the_environment(self, monkeypatch, tmp_path) -> None:
+        """A4.3: the CLI flag overrides an inherited environment variable."""
+        monkeypatch.setenv("KITTY_SESSION_SUMMARY", str(tmp_path / "env.json"))
+
+        server = _make_server(session_summary_path=tmp_path / "flag.json")
+
+        assert server._session_summary_path == tmp_path / "flag.json"
+
+
+class TestConcurrentRequests:
+    """Interleaved requests each keep their own attempt ordinal."""
+
+    @pytest.mark.asyncio
+    async def test_two_interleaved_requests_each_count_one_request(self) -> None:
+        """A7.1: concurrency must not turn one request's retry into another's."""
+        import asyncio
+
+        server = _make_server(2)
+        gate = asyncio.Event()
+
+        async def _request() -> None:
+            """Select, yield to the peer request, then select again."""
+            server._select_backend()
+            gate.set()
+            await asyncio.sleep(0)
+            server._select_backend()
+
+        await asyncio.gather(_request(), _request())
+
+        stats = server._session_stats()
+        assert stats["requests"] == 2
+        assert stats["attempts"] == 4
+        # Which of the two second selections switched backend is a random draw;
+        # what must hold is that neither request's re-selection was mistaken
+        # for the other request's first one.
+        assert stats["failovers"] + stats["retries"] == 2
+
+
+class TestStatsEndpoint:
+    """``GET /stats`` is the live sibling of ``/healthz``."""
+
+    @pytest.mark.asyncio
+    async def test_stats_endpoint_serves_the_document(self) -> None:
+        """A2.1: the endpoint exists and returns the session document."""
+        server = _make_single_server()
+        port = await server.start_async()
+        try:
+            async with aiohttp.ClientSession() as session, session.get(f"http://127.0.0.1:{port}/stats") as resp:
+                assert resp.status == 200
+                body = await resp.json()
+        finally:
+            await server.stop_async()
+
+        assert body["mode"] == "single"
+        assert len(body["backends"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_stats_endpoint_lists_every_balancing_member(self) -> None:
+        """A2.2: the pool is described member by member."""
+        server = _make_server(3, backup_indices={2})
+        port = await server.start_async()
+        try:
+            async with aiohttp.ClientSession() as session, session.get(f"http://127.0.0.1:{port}/stats") as resp:
+                body = await resp.json()
+        finally:
+            await server.stop_async()
+
+        assert [b["name"] for b in body["backends"]] == ["profile-0", "profile-1", "profile-2"]
+        assert body["backends"][2]["tier"] == "backup"
+
+    @pytest.mark.asyncio
+    async def test_stats_agrees_with_healthz_about_backend_health(self, monkeypatch) -> None:
+        """A2.4: two surfaces over one state must never disagree.
+
+        The clock is frozen for both requests: ``remaining_cooldown`` is an
+        ``int()`` of a live subtraction, so two unfrozen reads straddling a
+        whole-second boundary differ by 1 and the test would flake.
+        """
+        import kitty.bridge.server as server_mod
+
+        server = _make_server(2)
+        server._mark_backend_unhealthy(0)
+        monkeypatch.setattr(server_mod.time, "monotonic", lambda: server._backend_health[0]["failed_at"] + 5)
+        port = await server.start_async()
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(f"http://127.0.0.1:{port}/healthz") as resp:
+                    health = await resp.json()
+                async with session.get(f"http://127.0.0.1:{port}/stats") as resp:
+                    stats = await resp.json()
+        finally:
+            await server.stop_async()
+
+        health_by_name = {b["name"]: b for b in health["backends"]}
+        for entry in stats["backends"]:
+            peer = health_by_name[entry["name"]]
+            assert entry["healthy"] == peer["healthy"]
+            assert entry["remaining_cooldown"] == peer["remaining_cooldown"]
+            # /stats renames two /healthz fields; the values must still agree.
+            assert entry["cooldown_events"] == peer["failure_count"]
+            assert (entry["tier"] == "backup") == peer["backup"]
+
+    @pytest.mark.asyncio
+    async def test_stats_is_open_when_no_keys_file_is_configured(self) -> None:
+        """A2.7: ``kitty claude`` deliberately runs the bridge without a keys file.
+
+        On that path ``/stats`` is readable by any local process, exactly like
+        ``/healthz``. Asserted so the exposure is a recorded decision rather
+        than an accident of middleware ordering.
+        """
+        server = _make_server(1)
+        port = await server.start_async()
+        try:
+            async with aiohttp.ClientSession() as session, session.get(f"http://127.0.0.1:{port}/stats") as resp:
+                assert resp.status == 200
+        finally:
+            await server.stop_async()
+
+    @pytest.mark.asyncio
+    async def test_stats_identifies_the_process_that_produced_it(self) -> None:
+        """A2.9: two bridges nominating one summary path must be tellable apart."""
+        import os
+
+        server = _make_single_server()
+        port = await server.start_async()
+        try:
+            async with aiohttp.ClientSession() as session, session.get(f"http://127.0.0.1:{port}/stats") as resp:
+                body = await resp.json()
+        finally:
+            await server.stop_async()
+
+        assert body["pid"] == os.getpid()
+        assert body["port"] == port
+
+    @pytest.mark.asyncio
+    async def test_stats_requires_a_key_when_one_is_configured(self, tmp_path) -> None:
+        """A2.5: the document names profiles, providers and models."""
+        keys_file = tmp_path / "keys.txt"
+        keys_file.write_text("sk-test-key\n", encoding="utf-8")
+        server = _make_server(1, keys_file=str(keys_file))
+        port = await server.start_async()
+        try:
+            async with aiohttp.ClientSession() as session, session.get(f"http://127.0.0.1:{port}/stats") as resp:
+                assert resp.status == 401
+        finally:
+            await server.stop_async()
+
+    @pytest.mark.asyncio
+    async def test_stats_reports_the_start_time_once_running(self) -> None:
+        """A2.2: a live bridge can say how long the session has been open."""
+        server = _make_single_server()
+        port = await server.start_async()
+        try:
+            async with aiohttp.ClientSession() as session, session.get(f"http://127.0.0.1:{port}/stats") as resp:
+                body = await resp.json()
+        finally:
+            await server.stop_async()
+
+        assert body["started_at"].endswith("Z")
+
+    @pytest.mark.asyncio
+    async def test_stats_carries_no_attribution_headers(self) -> None:
+        """A5.3: no backend serves ``/stats``, so nothing may be attributed to one."""
+        server = _make_single_server()
+        port = await server.start_async()
+        try:
+            async with aiohttp.ClientSession() as session, session.get(f"http://127.0.0.1:{port}/stats") as resp:
+                assert "X-Kitty-Backend" not in resp.headers
+            async with aiohttp.ClientSession() as session, session.get(f"http://127.0.0.1:{port}/healthz") as resp:
+                assert "X-Kitty-Backend" not in resp.headers
+        finally:
+            await server.stop_async()
+
+
+class TestSessionSummaryFile:
+    """The record that survives the bridge being torn down."""
+
+    @pytest.mark.asyncio
+    async def test_summary_is_written_on_shutdown(self, tmp_path) -> None:
+        """A3.1: CI uploads a file, not a 42 MB debug log."""
+        target = tmp_path / "summary.json"
+        server = _make_single_server(session_summary_path=target)
+        await server.start_async()
+        await server.stop_async()
+
+        assert json.loads(target.read_text(encoding="utf-8"))["mode"] == "single"
+
+    @pytest.mark.asyncio
+    async def test_summary_matches_the_live_document(self, tmp_path) -> None:
+        """A3.1: the file and the endpoint are two readings of one accumulator."""
+        target = tmp_path / "summary.json"
+        server = _make_single_server(session_summary_path=target)
+        port = await server.start_async()
+        async with aiohttp.ClientSession() as session, session.get(f"http://127.0.0.1:{port}/stats") as resp:
+            live = await resp.json()
+        await server.stop_async()
+
+        written = json.loads(target.read_text(encoding="utf-8"))
+        live.pop("generated_at")
+        written.pop("generated_at")
+        assert written == live
+
+    @pytest.mark.asyncio
+    async def test_summary_reflects_counters_accumulated_before_shutdown(self, tmp_path) -> None:
+        """A3.5: a summary that always reports zero would be worthless."""
+        target = tmp_path / "summary.json"
+        server = _make_single_server(session_summary_path=target)
+        await server.start_async()
+        contextvars.copy_context().run(server._select_backend)
+        await server.stop_async()
+
+        assert json.loads(target.read_text(encoding="utf-8"))["attempts"] == 1
+
+    @pytest.mark.asyncio
+    async def test_missing_parent_directories_are_created(self, tmp_path) -> None:
+        """A3.2: CI nominates a path inside a directory it has not made yet."""
+        target = tmp_path / "artifacts" / "run-1" / "summary.json"
+        server = _make_single_server(session_summary_path=target)
+        await server.start_async()
+        await server.stop_async()
+
+        assert target.exists()
+
+    @pytest.mark.asyncio
+    async def test_no_summary_is_written_when_none_is_nominated(self, monkeypatch) -> None:
+        """A3.3: an un-nominated bridge writes nothing, anywhere.
+
+        Asserting on an empty ``tmp_path`` would hold whatever the code did,
+        since the server is never told about it — so the write itself is spied.
+        """
+        monkeypatch.delenv("KITTY_SESSION_SUMMARY", raising=False)
+        server = _make_single_server()
+        writes: list = []
+        monkeypatch.setattr(
+            type(server._usage_log_path),
+            "write_text",
+            lambda self, *a, **kw: writes.append(self),
+        )
+        await server.start_async()
+        await server.stop_async()
+
+        assert server._session_summary_path is None
+        assert writes == []
+
+    @pytest.mark.asyncio
+    async def test_an_unwritable_path_does_not_break_shutdown(self, tmp_path, caplog) -> None:
+        """A3.4: observability must never be able to fail the thing observed."""
+        blocker = tmp_path / "blocker"
+        blocker.write_text("not a directory", encoding="utf-8")
+        server = _make_single_server(session_summary_path=blocker / "summary.json")
+        await server.start_async()
+
+        with caplog.at_level("WARNING", logger="kitty.bridge.server"):
+            await server.stop_async()
+
+        assert server._runner is None
+        assert any("Failed to write session summary" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_a_failing_teardown_still_leaves_the_record(self, tmp_path, monkeypatch) -> None:
+        """A3.8: a graceful shutdown that trips must not cost CI its artifact."""
+        target = tmp_path / "summary.json"
+        server = _make_single_server(session_summary_path=target)
+        await server.start_async()
+
+        def _boom(path: str) -> None:
+            """Fail the state-file removal, as a locked file would."""
+            raise OSError("state file locked")
+
+        monkeypatch.setattr("kitty.bridge.state.remove_state", _boom)
+        server._state_file = str(tmp_path / "state.json")
+
+        with pytest.raises(OSError, match="state file locked"):
+            await server.stop_async()
+
+        assert target.exists()

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -374,3 +374,329 @@ class TestNonTTYExit:
             pytest.raises(RuntimeError, match="wizard exploded"),
         ):
             main()
+
+
+class TestSessionSummaryFlag:
+    """The shutdown summary path is nominated on the command line (issue #26)."""
+
+    def test_parser_accepts_the_session_summary_flag(self) -> None:
+        """A4.1: the flag exists and yields a Path."""
+        from pathlib import Path
+
+        from kitty.cli.main import _build_parser
+
+        args, _unknown = _build_parser().parse_known_args(["--session-summary", "out/run.json", "claude"])
+
+        assert args.session_summary == Path("out/run.json")
+
+    def test_session_summary_defaults_to_none(self) -> None:
+        """A4.4: nothing is written unless the operator asks for it."""
+        from kitty.cli.main import _build_parser
+
+        args, _unknown = _build_parser().parse_known_args(["claude"])
+
+        assert args.session_summary is None
+
+
+# ── Bridge-mode CLI seams for the attribution surfaces (issue #26) ───────────
+
+
+class _WiringSentinel(Exception):
+    """Raised from a stubbed ``BridgeServer.__init__`` to stop the flow."""
+
+
+def _profile_stub(name: str = "my-profile") -> object:
+    """Build a minimal single-profile stand-in for bridge construction.
+
+    Args:
+        name: Profile name the attribution surfaces should report.
+
+    Returns:
+        A namespace carrying the attributes ``_run_bridge`` reads.
+    """
+    from types import SimpleNamespace
+
+    return SimpleNamespace(
+        name=name,
+        provider="zai_regular",
+        model="test-model",
+        auth_ref="ref-1",
+        provider_config={},
+        backup=False,
+    )
+
+
+def _patch_bridge_prerequisites(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Neutralise everything ``_run_bridge*`` touches before constructing a server.
+
+    Args:
+        monkeypatch: The pytest monkeypatch fixture.
+    """
+    monkeypatch.setattr("kitty.egress_guard.egress_block_reason", lambda *a, **k: None)
+    monkeypatch.setattr("kitty.cli.main.egress_block_reason", lambda *a, **k: None, raising=False)
+    monkeypatch.setattr("kitty.providers.registry.get_provider", lambda *a, **k: object())
+    monkeypatch.setattr("kitty.cli.main.get_provider", lambda *a, **k: object(), raising=False)
+
+
+def _record_bridge_kwargs(monkeypatch: pytest.MonkeyPatch) -> list[dict]:
+    """Replace ``BridgeServer`` with a stub that records its keyword arguments.
+
+    Raising from ``__init__`` stops the flow before any event loop starts, so
+    the assertion runs against the exact construction call under test.
+
+    Args:
+        monkeypatch: The pytest monkeypatch fixture.
+
+    Returns:
+        A list that receives one kwargs dict per construction attempt.
+    """
+    seen: list[dict] = []
+
+    class _RecordingServer:
+        """Stand-in for ``BridgeServer`` that records and aborts."""
+
+        def __init__(self, *args, **kwargs):
+            """Record the construction kwargs, then abort the flow."""
+            seen.append(kwargs)
+            raise _WiringSentinel
+
+    monkeypatch.setattr("kitty.bridge.server.BridgeServer", _RecordingServer)
+    return seen
+
+
+def _balancing_stubs(monkeypatch: pytest.MonkeyPatch, member: object) -> None:
+    """Stub the profile store and resolver a balancing bridge builds members from.
+
+    Args:
+        monkeypatch: The pytest monkeypatch fixture.
+        member: The single member profile to resolve.
+    """
+
+    class FakeProfileStore:
+        """Stand-in for ``ProfileStore`` — constructed inside the function."""
+
+        def __init__(self, *args, **kwargs):
+            """Accept and ignore the real store's arguments."""
+
+    class FakeProfileResolver:
+        """Stand-in resolver returning one balancing member."""
+
+        def __init__(self, store):
+            """Accept and ignore the store."""
+
+        def resolve_balancing(self, name):
+            """Return the single member profile."""
+            return [member]
+
+    monkeypatch.setattr("kitty.profiles.store.ProfileStore", FakeProfileStore)
+    monkeypatch.setattr("kitty.profiles.resolver.ProfileResolver", FakeProfileResolver)
+
+
+class TestBridgeModeAttributionWiring:
+    """``kitty bridge`` must hand the bridge what the attribution surfaces need."""
+
+    def test_run_bridge_passes_the_summary_path(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A4.2: the single-profile ``kitty bridge`` path nominates the summary."""
+        from pathlib import Path
+        from types import SimpleNamespace
+
+        import kitty.cli.main as cli_main
+
+        _patch_bridge_prerequisites(monkeypatch)
+        seen = _record_bridge_kwargs(monkeypatch)
+        cred_store = SimpleNamespace(get=lambda ref: "sk-test-key")
+
+        with pytest.raises(_WiringSentinel):
+            cli_main._run_bridge(
+                _profile_stub(),
+                cred_store,
+                validate=False,
+                session_summary_path=Path("out/run.json"),
+            )
+
+        assert seen[0]["session_summary_path"] == Path("out/run.json")
+
+    def test_run_bridge_names_the_profile(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A9.1: without this the bridge calls every session "default"."""
+        from types import SimpleNamespace
+
+        import kitty.cli.main as cli_main
+
+        _patch_bridge_prerequisites(monkeypatch)
+        seen = _record_bridge_kwargs(monkeypatch)
+        cred_store = SimpleNamespace(get=lambda ref: "sk-test-key")
+
+        with pytest.raises(_WiringSentinel):
+            cli_main._run_bridge(_profile_stub(name="my-profile"), cred_store, validate=False)
+
+        assert seen[0]["profile_name"] == "my-profile"
+
+    def test_run_bridge_balancing_passes_the_summary_path(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A4.2: the balancing ``kitty bridge`` path nominates the summary too."""
+        from pathlib import Path
+        from types import SimpleNamespace
+
+        import kitty.cli.main as cli_main
+
+        _patch_bridge_prerequisites(monkeypatch)
+        _balancing_stubs(monkeypatch, _profile_stub(name="member-1"))
+        seen = _record_bridge_kwargs(monkeypatch)
+        cred_store = SimpleNamespace(get=lambda ref: "sk-test-key")
+
+        with pytest.raises(_WiringSentinel):
+            cli_main._run_bridge_balancing(
+                SimpleNamespace(name="ci-pool"),
+                cred_store,
+                validate=False,
+                session_summary_path=Path("out/pool.json"),
+            )
+
+        assert seen[0]["session_summary_path"] == Path("out/pool.json")
+
+    def test_run_bridge_balancing_names_the_pool_not_its_member(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A9.2: the session ran as a pool; naming one member misdescribes it."""
+        from types import SimpleNamespace
+
+        import kitty.cli.main as cli_main
+
+        _patch_bridge_prerequisites(monkeypatch)
+        _balancing_stubs(monkeypatch, _profile_stub(name="member-1"))
+        seen = _record_bridge_kwargs(monkeypatch)
+        cred_store = SimpleNamespace(get=lambda ref: "sk-test-key")
+
+        with pytest.raises(_WiringSentinel):
+            cli_main._run_bridge_balancing(SimpleNamespace(name="ci-pool"), cred_store, validate=False)
+
+        assert seen[0]["profile_name"] == "ci-pool"
+
+
+class TestLaunchTargetBalancingNaming:
+    """The agent-launch balancing path names the pool, not its first member."""
+
+    def test_balancing_launch_passes_the_pool_name(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A9.2 at the seam that implements it — ``_launch_target_balancing``."""
+        from types import SimpleNamespace
+
+        import kitty.cli.launcher as launcher_mod
+        import kitty.cli.main as cli_main
+
+        seen: list[dict] = []
+
+        def _record_launch(**kwargs):
+            """Record the launch kwargs instead of starting anything."""
+            seen.append(kwargs)
+            return 0
+
+        monkeypatch.setattr(launcher_mod, "launch", _record_launch)
+        monkeypatch.setattr("kitty.providers.registry.get_provider", lambda *a, **k: object())
+        _balancing_stubs(monkeypatch, _profile_stub(name="member-1"))
+        cred_store = SimpleNamespace(get=lambda ref: "sk-test-key")
+
+        exit_code = cli_main._launch_target_balancing(
+            object(),
+            SimpleNamespace(name="ci-pool"),
+            cred_store,
+            [],
+        )
+
+        assert exit_code == 0
+        assert seen[0]["profile_name"] == "ci-pool"
+
+
+class TestBridgeModePanelAdvertisesStats:
+    """An endpoint nobody is told about is an endpoint nobody uses."""
+
+    @staticmethod
+    def _capture_panel(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+        """Stub the panel renderer to capture its body, then abort the flow.
+
+        Args:
+            monkeypatch: The pytest monkeypatch fixture.
+
+        Returns:
+            A list receiving the rendered panel body.
+        """
+        bodies: list[str] = []
+
+        def _record_panel(title, body, *args, **kwargs):
+            """Record the panel body, then stop before the server blocks."""
+            bodies.append(body)
+            raise _WiringSentinel
+
+        monkeypatch.setattr("kitty.tui.display.print_panel", _record_panel)
+        return bodies
+
+    @staticmethod
+    def _stub_server(monkeypatch: pytest.MonkeyPatch) -> None:
+        """Replace ``BridgeServer`` with one that starts and stops instantly.
+
+        Args:
+            monkeypatch: The pytest monkeypatch fixture.
+        """
+
+        class _NoopServer:
+            """Stand-in for ``BridgeServer`` that never binds a socket."""
+
+            def __init__(self, *args, **kwargs):
+                """Accept and ignore the real server's arguments."""
+
+            async def start_async(self) -> int:
+                """Report a fixed port without listening."""
+                return 12345
+
+            async def stop_async(self) -> None:
+                """Do nothing — no resources were acquired."""
+
+        monkeypatch.setattr("kitty.bridge.server.BridgeServer", _NoopServer)
+
+    @staticmethod
+    def _skip_catalog_refresh(monkeypatch: pytest.MonkeyPatch) -> None:
+        """Keep the panel tests offline.
+
+        Args:
+            monkeypatch: The pytest monkeypatch fixture.
+        """
+        import kitty.providers.model_context_sync as sync
+
+        async def _skip_refresh(**kwargs):
+            """Report success without touching the network."""
+            return True
+
+        monkeypatch.setattr(sync, "refresh_model_context_overrides", _skip_refresh)
+
+    def test_single_profile_panel_lists_stats(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A8.1: the single-profile bridge panel advertises ``GET /stats``."""
+        from types import SimpleNamespace
+
+        import kitty.cli.main as cli_main
+
+        self._skip_catalog_refresh(monkeypatch)
+        _patch_bridge_prerequisites(monkeypatch)
+        self._stub_server(monkeypatch)
+        bodies = self._capture_panel(monkeypatch)
+        cred_store = SimpleNamespace(get=lambda ref: "sk-test-key")
+
+        with pytest.raises(_WiringSentinel):
+            cli_main._run_bridge(_profile_stub(), cred_store, validate=False)
+
+        assert "/stats" in bodies[0]
+        assert "/healthz" in bodies[0]
+
+    def test_balancing_panel_lists_stats(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A8.1: the balancing bridge panel advertises ``GET /stats`` too."""
+        from types import SimpleNamespace
+
+        import kitty.cli.main as cli_main
+
+        self._skip_catalog_refresh(monkeypatch)
+        _patch_bridge_prerequisites(monkeypatch)
+        _balancing_stubs(monkeypatch, _profile_stub(name="member-1"))
+        self._stub_server(monkeypatch)
+        bodies = self._capture_panel(monkeypatch)
+        cred_store = SimpleNamespace(get=lambda ref: "sk-test-key")
+
+        with pytest.raises(_WiringSentinel):
+            cli_main._run_bridge_balancing(SimpleNamespace(name="ci-pool"), cred_store, validate=False)
+
+        assert "/stats" in bodies[0]
+        assert "/healthz" in bodies[0]

--- a/tests/test_launch_orchestrator.py
+++ b/tests/test_launch_orchestrator.py
@@ -625,3 +625,128 @@ class TestAdaptersWithoutSessionSettings:
 
         assert exit_code == 0
         assert not config_path.exists(), "kitty left a Kilo config holding the real API key"
+
+
+# ── Test: session summary wiring (issue #26, R4) ────────────────────────────
+
+
+class _RecordingServer(BridgeServer):
+    """BridgeServer that records ``session_summary_path`` and aborts the launch."""
+
+    seen: list = []
+
+    def __init__(self, *args, **kwargs):
+        """Record the nominated summary path before construction."""
+        type(self).seen.append(kwargs.get("session_summary_path"))
+        super().__init__(*args, **kwargs)
+
+    async def start_async(self) -> int:
+        """Abort the launch once the constructor has been observed."""
+        raise _Sentinel
+
+
+class TestSessionSummaryWiring:
+    """The nominated summary path reaches the bridge that will write it."""
+
+    @pytest.mark.asyncio
+    async def test_launch_async_passes_the_summary_path_to_the_bridge(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ):
+        """A4.2: the agent-launch path is the one CI actually uses."""
+        from kitty.cli import launcher as launcher_mod
+
+        _RecordingServer.seen = []
+        monkeypatch.setattr(launcher_mod, "BridgeServer", _RecordingServer)
+
+        with pytest.raises(_Sentinel):
+            await launcher_mod.launch_async(
+                adapter=StubLauncher(),
+                provider=StubProvider(),
+                profile=_make_profile(),
+                cred_store=_make_cred_store(),
+                validate=False,
+                session_summary_path=tmp_path / "run.json",
+            )
+
+        assert _RecordingServer.seen == [tmp_path / "run.json"]
+
+    @pytest.mark.asyncio
+    async def test_launch_async_defaults_to_no_summary(self, monkeypatch: pytest.MonkeyPatch):
+        """A4.4: an un-nominated launch leaves the bridge writing nothing."""
+        from kitty.cli import launcher as launcher_mod
+
+        _RecordingServer.seen = []
+        monkeypatch.setattr(launcher_mod, "BridgeServer", _RecordingServer)
+
+        with pytest.raises(_Sentinel):
+            await launcher_mod.launch_async(
+                adapter=StubLauncher(),
+                provider=StubProvider(),
+                profile=_make_profile(),
+                cred_store=_make_cred_store(),
+                validate=False,
+            )
+
+        assert _RecordingServer.seen == [None]
+
+
+# ── Test: profile naming on the attribution surfaces (issue #26, R2/R5) ─────
+
+
+class _NameRecordingServer(BridgeServer):
+    """BridgeServer that records ``profile_name`` and aborts the launch."""
+
+    seen: list = []
+
+    def __init__(self, *args, **kwargs):
+        """Record the profile name the launch path chose."""
+        type(self).seen.append(kwargs.get("profile_name"))
+        super().__init__(*args, **kwargs)
+
+    async def start_async(self) -> int:
+        """Abort the launch once the constructor has been observed."""
+        raise _Sentinel
+
+
+class TestProfileNameWiring:
+    """An attribution record that calls every session "default" names nothing."""
+
+    @pytest.mark.asyncio
+    async def test_launch_names_the_profile_it_launched(self, monkeypatch: pytest.MonkeyPatch):
+        """A5.5: the single-backend header reports the profile, not a placeholder."""
+        from kitty.cli import launcher as launcher_mod
+
+        _NameRecordingServer.seen = []
+        monkeypatch.setattr(launcher_mod, "BridgeServer", _NameRecordingServer)
+
+        with pytest.raises(_Sentinel):
+            await launcher_mod.launch_async(
+                adapter=StubLauncher(),
+                provider=StubProvider(),
+                profile=_make_profile(),
+                cred_store=_make_cred_store(),
+                validate=False,
+            )
+
+        assert _NameRecordingServer.seen == ["test"]
+
+    @pytest.mark.asyncio
+    async def test_a_balancing_launch_names_the_pool_not_its_first_member(self, monkeypatch: pytest.MonkeyPatch):
+        """A2.2: the session ran as a pool; naming one member misdescribes it."""
+        from kitty.cli import launcher as launcher_mod
+
+        _NameRecordingServer.seen = []
+        monkeypatch.setattr(launcher_mod, "BridgeServer", _NameRecordingServer)
+
+        with pytest.raises(_Sentinel):
+            await launcher_mod.launch_async(
+                adapter=StubLauncher(),
+                provider=StubProvider(),
+                profile=_make_profile(),
+                cred_store=_make_cred_store(),
+                validate=False,
+                backends=[(StubProvider(), "key", _make_profile())],
+                profile_name="ci-pool",
+            )
+
+        assert _NameRecordingServer.seen == ["ci-pool"]


### PR DESCRIPTION
Fixes #26. Ships as **1.5.0**.

kitty replaces the model an agent asks for with the one its profile configures — that is the product working as designed. What it never did was tell the consumer, in any form a program can read. The only durable record of which backend and which real model served a session was a `logger.debug` line inside a debug log that was 42 MB on the run that prompted this issue, is off by default, and is deleted by cleanup.

So every downstream record was confidently wrong and nothing anywhere disagreed with it. On one CI run: $2.39 of `MiniMax-M3` spend filed under `deepseek-v4-flash`; a structured-output failure — a statement about the *serving* model's ability to emit a schema-conformant document — investigated against a model that never ran; and 37 upstream calls that all returned 200 narrated as "the model provider was unavailable", a story the next automated reviewer then repeated as established fact.

## What ships

**One accumulator, three surfaces, so no two records of a session can disagree.** `_session_stats()` builds a single document; `GET /stats`, the shutdown summary file and the `X-Kitty-*` headers are three readings of it. The issue offered these as alternatives; implementing them over shared state means they cannot drift, which matters because drift between two records of one session is the defect being fixed.

**Counting happens at the two existing funnels, never at the ~15 failover sites.** `_record_attempt()` is called from `_select_backend()`, the sole entry point for choosing a backend; completion and token totals accumulate inside `_log_usage()`, the sole funnel for finished calls. Instrumenting fifteen call sites would guarantee that a future path is added without instrumentation, silently reintroducing exactly this bug. Token totals are counted regardless of `--logging`; only the `usage.log` *file* stays behind that flag, since attribution is what tells a consumer whose cost this was.

**`GET /stats`**, sibling to `/healthz`: per-backend attempts, the real models served with their token totals, `failovers`, `retries`, `all_backends_unhealthy`, plus `pid`/`port` so two bridges pointed at one path are tellable apart.

**`--session-summary PATH` / `KITTY_SESSION_SUMMARY`** writes that document on shutdown. This is the surface built for CI: the bridge is torn down at job end and a small JSON file uploads as an artifact. The environment fallback covers `bridge_runner.py` and embedded use, which never pass through the CLI parser.

**`X-Kitty-Backend` / `-Model` / `-Tier`** on every proxied response, naming the backend that produced its first byte.

**`profile_name` now reaches the bridge from the launch paths.** `cli/main.py` and `cli/launcher.py` never passed it, so every launched bridge called itself `"default"` — in the usage log, in the access log, and it would have in the new header. A balancing launch passes the *pool* name, which the member profile cannot supply.

## What the numbers deliberately do not mean

Three counters read lower or narrower than an eager consumer would assume, and each is documented in the README, the docstring and the design doc rather than left to be discovered:

- `attempts` counts backend **selections**, not upstream POSTs — `_make_upstream_request` retries the same backend inside one selection. It will not reconcile with `grep -c "Upstream POST"`, which is exactly how this issue was diagnosed.
- `failovers` counts only re-selections that landed on a **different** backend. `_stream_messages` and `_stream_chat_completions` re-select after an *empty but successful* response and the weighted draw can return the same member; those are `retries`. This one is load-bearing: an inflated `failovers` would support the very outage narrative the issue was filed to kill. In `single` mode it is structurally 0 and carries no signal — read `mode` first.
- `all_backends_unhealthy` counts every raise, including ones a failover loop absorbed without the client ever seeing a 503. `0` remains the strong "never happened" flag the issue asks for by name.

## Notes

Three assumptions from the original design were falsified during implementation, each empirically rather than by reading:

**The keep-alive ContextVar leak does not exist.** The plan called for a per-request reset on the belief that aiohttp handles keep-alive requests on one connection within a single task. It creates a new task per request precisely to avoid that — `web_protocol.RequestHandler.start()`, comment *"a new task is used for copy context vars (#3406)"*. No reset was written; a test now pins that third-party guarantee, since the whole failover count rests on it.

**The header sanitiser guarded the wrong failure.** aiohttp passes non-ASCII header values through as UTF-8 without error and raises on CR/LF/NUL — which are ASCII, so `encode("ascii", "replace")` let them through untouched. `Profile.validate_model` checks only non-emptiness, so a newline in a model id is reachable and would have failed *every* response on that backend, with the diagnostic header as the sole cause.

**Middleware order is load-bearing.** `[auth, attribution, access_log]`: inside auth so a 401 discloses no backend details, and outside the access log, whose `except Exception` synthesises the 500 for an unhandled handler error. That 500 is the "why did this model fail?" response this issue is about; an earlier revision left it the one response naming no model.

`/stats` is as exposed as `/healthz` — which on the `kitty claude` path means not protected at all, since that path deliberately starts the bridge with no keys file. It is localhost-bound and discloses the same class of information `/healthz` already does; a test asserts the exposure deliberately rather than leaving it an accident of middleware ordering.

## Tests

69 new tests across four files, each traced to a numbered acceptance criterion. Every criterion whose implementation is a single line was mutation-checked — the two panel `/stats` lines, each `session_summary_path=` kwarg, each `profile_name=` kwarg, and the middleware order were each deleted and the corresponding test confirmed to turn red. A first round of CLI tests passed with the behaviour removed, because they entered at `launch_async` and so proved only that a keyword argument is forwarded; they now enter at `_run_bridge`, `_run_bridge_balancing` and `_launch_target_balancing`, the functions that actually implement the requirement.

Full suite: 2868 passed, 36 skipped. The 22 errors in `test_pypi_packaging.py` are the recorded pre-existing baseline — `python -m build` chokes on the stray untracked `nul` file at the repo root, reproduced independently of this change.

## Release

Second commit bumps 1.4.1 → **1.5.0** (minor: new endpoint, new flag, new response headers). The tag is **not** pushed — `vX.Y.Z` goes on the merge commit after this lands, since a tag push publishes to PyPI and those versions cannot be reused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Te5Fy7XnBfqn5fZsne1B7R
