### PR TITLE
Repair the thinking round-trip instead of killing the session

### DIFF
--- a/src/kitty/bridge/server.py
+++ b/src/kitty/bridge/server.py
@@ -314,6 +314,60 @@ def _is_thinking_roundtrip_error(status: int, body: object) -> bool:
     return any(all(token in searchable for token in tokens) for tokens in _THINKING_ROUNDTRIP_PATTERNS)
 
 
+def _with_thinking_carrier(msg: dict, *, native: bool) -> dict | None:
+    """Return a copy of an assistant message carrying the thinking carrier.
+
+    Adds the empty carrier the target's thinking mode requires: a leading
+    ``{"type": "thinking", "thinking": ""}`` content block on the Anthropic
+    wire, a ``reasoning_content`` field on the Chat Completions wire.  The
+    block goes first because the Messages API requires reasoning to precede
+    text in an assistant turn.
+
+    Returns ``None`` — meaning "already satisfied, nothing to do" — for a
+    message that carries a thinking block or a ``reasoning_content`` already,
+    and for one whose ``content`` is neither a list nor a string, which is not
+    a shape the carrier can be attached to.  That is what makes the repair
+    converge: the caller retries only on a change, so a message reported as
+    changed on every pass would retry forever.
+
+    On the Chat Completions side the test is ``is None`` rather than the
+    ``not in`` used by :meth:`ProviderAdapter._inject_empty_reasoning_content`.
+    The two are deliberately different: that helper runs proactively during
+    serialization, while this one runs after it and must treat an explicit
+    ``None`` as still needing repair, yet leave an already-written ``""``
+    alone.  Do not unify them — convergence depends on this asymmetry.
+
+    Args:
+        msg: The assistant message to inspect. Never modified.
+        native: True when the enclosing body is an Anthropic Messages body,
+            False when it is a Chat Completions body.
+
+    Returns:
+        A new message dict with the carrier added, or None when the message
+        already satisfies the contract or cannot carry one.
+    """
+    if not native:
+        if msg.get("reasoning_content") is not None:
+            return None
+        return {**msg, "reasoning_content": ""}
+
+    content = msg.get("content")
+    if isinstance(content, list):
+        if any(isinstance(block, dict) and block.get("type") == "thinking" for block in content):
+            return None
+        return {**msg, "content": [dict(_THINKING_CARRIER_BLOCK), *content]}
+
+    if isinstance(content, str):
+        # A string-content turn needs the block form to carry thinking; the
+        # text survives as an explicit text block.
+        blocks: list[dict] = [dict(_THINKING_CARRIER_BLOCK)]
+        if content:
+            blocks.append({"type": "text", "text": content})
+        return {**msg, "content": blocks}
+
+    return None
+
+
 def _repair_thinking_roundtrip(body: dict, *, native: bool) -> bool:
     """Give every assistant turn the thinking carrier its target requires.
 
@@ -336,12 +390,16 @@ def _repair_thinking_roundtrip(body: dict, *, native: bool) -> bool:
 
     The dialect is passed in rather than inferred, because
     ``{"role": "assistant", "content": "..."}`` is valid in both and guessing
-    would silently write the wrong carrier for one of them.
+    would silently write the wrong carrier for one of them.  It must come from
+    the adapter's :attr:`ProviderAdapter.upstream_wire_is_messages_api`, not
+    from ``_native_messages_request`` — see :meth:`BridgeServer._upstream_body_for`.
 
     Changed messages are **copied**, not edited in place, and ``messages`` is
     replaced with a new list.  ``translate_to_upstream`` returns a shallow copy
     whose ``messages`` list is ``cc_request``'s own, so editing a message would
     reach back into the request that the next attempt re-serializes.
+
+    Per-message rewriting lives in :func:`_with_thinking_carrier`.
 
     Args:
         body: The outgoing upstream body.  Its ``messages`` key is rebound when
@@ -362,39 +420,12 @@ def _repair_thinking_roundtrip(body: dict, *, native: bool) -> bool:
     repaired = messages.copy()
     changed = False
     for index, msg in enumerate(messages):
-        # The contract binds assistant turns only; user, system and tool
-        # messages carry no reasoning to pass back.
+        # The contract binds assistant turns only.
         if not isinstance(msg, dict) or msg.get("role") != "assistant":
             continue
-
-        if not native:
-            # Chat Completions: a missing sibling field is the gap.  Tested for
-            # absence rather than falsiness so an already-repaired ``""`` is not
-            # reported as a change — the caller retries on a change, and a
-            # repair that never converges would retry forever.  Deliberately
-            # `is None` rather than the `not in` used by the sibling helper
-            # ``ProviderAdapter._inject_empty_reasoning_content``, which runs
-            # proactively during serialization: an explicit ``None`` reaches
-            # this path already serialized and still needs repairing.  Do not
-            # "unify" the two — the convergence guarantee depends on this one.
-            if msg.get("reasoning_content") is None:
-                repaired[index] = {**msg, "reasoning_content": ""}
-                changed = True
-            continue
-
-        content = msg.get("content")
-        if isinstance(content, list):
-            if any(isinstance(b, dict) and b.get("type") == "thinking" for b in content):
-                continue
-            repaired[index] = {**msg, "content": [dict(_THINKING_CARRIER_BLOCK), *content]}
-            changed = True
-        elif isinstance(content, str):
-            # A string-content turn still needs the block form to carry
-            # thinking; the text survives as an explicit text block.
-            blocks: list[dict] = [dict(_THINKING_CARRIER_BLOCK)]
-            if content:
-                blocks.append({"type": "text", "text": content})
-            repaired[index] = {**msg, "content": blocks}
+        carrier = _with_thinking_carrier(msg, native=native)
+        if carrier is not None:
+            repaired[index] = carrier
             changed = True
 
     if changed:
@@ -3062,23 +3093,10 @@ class BridgeServer:
                                 upstream_body = self._upstream_body_for(cc_request)
                                 continue
 
-                            # Thinking round-trip mismatch — this backend needs
-                            # every assistant turn of the replayed transcript to
-                            # carry its reasoning, and the turns were authored by
-                            # a provider that emits none (the cross-family
-                            # failover of issue #32).  The request the bridge
-                            # built is at fault, not the backend, so repair it
-                            # and retry the SAME backend: no health penalty, no
-                            # failover slot spent.  The repair is applied to the
-                            # outgoing body, so it binds to this backend only;
-                            # a later failover re-serializes from cc_request and
-                            # the sibling never sees a fabricated carrier.  A
-                            # False means the body already carries the carrier
-                            # (the provider adapter injected it) and retrying
-                            # would re-send identical bytes — fall through
-                            # instead.  The attempt guard comes first to skip a
-                            # pointless repair-and-log on an attempt that will
-                            # not be retried anyway.
+                            # Transcript the bridge malformed, not a sick backend
+                            # (issue #32): repair and retry the same backend.
+                            # A False repair means nothing changed, so retrying
+                            # would re-send identical bytes — fall through.
                             if (
                                 attempt < max_attempts - 1
                                 and _is_thinking_roundtrip_error(upstream.status, error_body)

--- a/src/kitty/bridge/server.py
+++ b/src/kitty/bridge/server.py
@@ -258,6 +258,150 @@ def _is_tool_use_format_error(status: int, body: object) -> bool:
     )
 
 
+# Token pairs that identify a thinking round-trip rejection.  Both tokens of a
+# pair must be present, which keeps the bare words "thinking" and "missing"
+# from matching unrelated 4xx bodies.
+_THINKING_ROUNDTRIP_PATTERNS: tuple[tuple[str, ...], ...] = (
+    # DeepSeek, both dialects: "The `content[].thinking` / `reasoning_content`
+    # in the thinking mode must be passed back to the API."
+    ("thinking mode", "must be passed back"),
+    # Kimi's wording for the same contract: "thinking is enabled but
+    # reasoning_content is missing in assistant tool call message".  The second
+    # token carries "in assistant" because gateways echo the offending request
+    # inside the error body, where a bare "reasoning_content" plus a bare
+    # "missing" ("missing required parameter") would collide.
+    ("reasoning_content", "is missing in assistant"),
+)
+
+# The empty carrier that satisfies a thinking round-trip contract on the
+# Anthropic-shaped wire.  Copied per use so callers cannot alias it.
+_THINKING_CARRIER_BLOCK = {"type": "thinking", "thinking": ""}
+
+
+def _is_thinking_roundtrip_error(status: int, body: object) -> bool:
+    """Return True if the upstream rejected the transcript's thinking round-trip.
+
+    Providers whose thinking mode is stateful across tool calls (DeepSeek,
+    Kimi) require every assistant turn of a replayed transcript to carry the
+    reasoning the model produced — a ``thinking`` content block on an
+    Anthropic-shaped endpoint, a ``reasoning_content`` field on a Chat
+    Completions one.  A transcript whose assistant turns were authored by a
+    provider that emits neither cannot satisfy that contract, which is what a
+    mid-conversation failover across provider families produces.
+
+    This is a rejection of the request the bridge built, not evidence that the
+    backend is unwell, so the caller repairs and retries the same backend
+    rather than failing over.  See
+    :func:`_repair_thinking_roundtrip`.
+
+    Only 4xx statuses match: the same wording arriving with a 5xx is a backend
+    fault and is already covered by the retryable-status path.
+
+    Args:
+        status: The upstream HTTP status code.
+        body: The upstream error body, as text or as a parsed dict.
+
+    Returns:
+        True when the body states that thinking-mode reasoning must be passed
+        back, False otherwise.
+    """
+    if status < 400 or status >= 500:
+        return False
+    if body is None:
+        return False
+
+    searchable = str(body).lower()
+    return any(all(token in searchable for token in tokens) for tokens in _THINKING_ROUNDTRIP_PATTERNS)
+
+
+def _repair_thinking_roundtrip(body: dict, *, native: bool) -> bool:
+    """Give every assistant turn the thinking carrier its target requires.
+
+    Repairs the transcript so a backend enforcing a thinking round-trip
+    contract accepts a history authored by a different provider.  An **empty**
+    carrier is used: the reasoning of the previous provider's turns is not
+    available and inventing one would put words in the model's mouth, whereas
+    an empty carrier satisfies the contract without adding content the model
+    never produced.
+
+    Operates on the **serialized upstream body**, never on ``cc_request``.
+    That placement is what makes the repair per-backend: a later failover
+    re-serializes ``cc_request`` from scratch, so the carrier does not travel
+    to a sibling backend that never asked for it (and would reject a
+    fabricated, signature-less ``thinking`` block).  It also lets the repair
+    see carriers the provider adapter injected during serialization — Kimi,
+    Z.AI and custom-OpenAI already add ``reasoning_content`` in
+    :meth:`translate_to_upstream` — so it reports "no change" instead of
+    retrying a byte-identical request.
+
+    The dialect is passed in rather than inferred, because
+    ``{"role": "assistant", "content": "..."}`` is valid in both and guessing
+    would silently write the wrong carrier for one of them.
+
+    Changed messages are **copied**, not edited in place, and ``messages`` is
+    replaced with a new list.  ``translate_to_upstream`` returns a shallow copy
+    whose ``messages`` list is ``cc_request``'s own, so editing a message would
+    reach back into the request that the next attempt re-serializes.
+
+    Args:
+        body: The outgoing upstream body.  Its ``messages`` key is rebound when
+            anything changes; the original list and its messages are untouched.
+        native: True when ``body`` is an Anthropic Messages body (the carrier
+            is a ``thinking`` content block), False when it is a Chat
+            Completions body (the carrier is a ``reasoning_content`` field).
+
+    Returns:
+        True if at least one assistant message was changed.  The caller must
+        only retry when this is True — a False means the transcript already
+        satisfies the contract and the rejection has another cause.
+    """
+    messages = body.get("messages")
+    if not isinstance(messages, list):
+        return False
+
+    repaired = messages.copy()
+    changed = False
+    for index, msg in enumerate(messages):
+        # The contract binds assistant turns only; user, system and tool
+        # messages carry no reasoning to pass back.
+        if not isinstance(msg, dict) or msg.get("role") != "assistant":
+            continue
+
+        if not native:
+            # Chat Completions: a missing sibling field is the gap.  Tested for
+            # absence rather than falsiness so an already-repaired ``""`` is not
+            # reported as a change — the caller retries on a change, and a
+            # repair that never converges would retry forever.  Deliberately
+            # `is None` rather than the `not in` used by the sibling helper
+            # ``ProviderAdapter._inject_empty_reasoning_content``, which runs
+            # proactively during serialization: an explicit ``None`` reaches
+            # this path already serialized and still needs repairing.  Do not
+            # "unify" the two — the convergence guarantee depends on this one.
+            if msg.get("reasoning_content") is None:
+                repaired[index] = {**msg, "reasoning_content": ""}
+                changed = True
+            continue
+
+        content = msg.get("content")
+        if isinstance(content, list):
+            if any(isinstance(b, dict) and b.get("type") == "thinking" for b in content):
+                continue
+            repaired[index] = {**msg, "content": [dict(_THINKING_CARRIER_BLOCK), *content]}
+            changed = True
+        elif isinstance(content, str):
+            # A string-content turn still needs the block form to carry
+            # thinking; the text survives as an explicit text block.
+            blocks: list[dict] = [dict(_THINKING_CARRIER_BLOCK)]
+            if content:
+                blocks.append({"type": "text", "text": content})
+            repaired[index] = {**msg, "content": blocks}
+            changed = True
+
+    if changed:
+        body["messages"] = repaired
+    return changed
+
+
 def _convert_native_to_cc_format(body: dict) -> dict:
     """Convert an Anthropic Messages body to Chat Completions format.
 
@@ -746,6 +890,15 @@ class BridgeServer:
 
         self._backend_cooldown = backend_cooldown
         self._family_cooldown: dict[str, dict] = {}
+
+        # Backends that have rejected this session's transcript for a thinking
+        # round-trip mismatch (issue #32).  A backend that rejected the
+        # transcript once will reject every later turn of it, so the repair is
+        # applied before the first attempt instead of being rediscovered at the
+        # cost of a round-trip per turn.  Indices, so -1 covers non-balancing
+        # mode.  Mutated only by `set.add` with no await in between, which is
+        # atomic across the concurrent request tasks sharing this loop.
+        self._thinking_repair_backends: set[int] = set()
 
         # Backend health tracking (parallel to _backends)
         self._backend_health: list[dict] = []
@@ -2831,7 +2984,7 @@ class BridgeServer:
         try:
             url = self._build_upstream_url()
             headers = self._build_upstream_headers()
-            upstream_body = self._active_provider.translate_to_upstream(cc_request)
+            upstream_body = self._upstream_body_for(cc_request)
             logger.debug("Upstream POST → %s", url)
 
             stream_timeout = aiohttp.ClientTimeout(total=None, sock_connect=30, sock_read=_STREAM_READ_TIMEOUT)
@@ -2874,7 +3027,7 @@ class BridgeServer:
                                         self._active_provider.normalize_request(cc_request)
                                         url = self._build_upstream_url()
                                         headers = self._build_upstream_headers()
-                                        upstream_body = self._active_provider.translate_to_upstream(cc_request)
+                                        upstream_body = self._upstream_body_for(cc_request)
                                         logger.info(
                                             "Messages stream Cloudflare failover: attempt %d/%d, switching backend",
                                             attempt + 1,
@@ -2906,7 +3059,42 @@ class BridgeServer:
                                 self._active_provider.normalize_request(cc_request)
                                 url = self._build_upstream_url()
                                 headers = self._build_upstream_headers()
-                                upstream_body = self._active_provider.translate_to_upstream(cc_request)
+                                upstream_body = self._upstream_body_for(cc_request)
+                                continue
+
+                            # Thinking round-trip mismatch — this backend needs
+                            # every assistant turn of the replayed transcript to
+                            # carry its reasoning, and the turns were authored by
+                            # a provider that emits none (the cross-family
+                            # failover of issue #32).  The request the bridge
+                            # built is at fault, not the backend, so repair it
+                            # and retry the SAME backend: no health penalty, no
+                            # failover slot spent.  The repair is applied to the
+                            # outgoing body, so it binds to this backend only;
+                            # a later failover re-serializes from cc_request and
+                            # the sibling never sees a fabricated carrier.  A
+                            # False means the body already carries the carrier
+                            # (the provider adapter injected it) and retrying
+                            # would re-send identical bytes — fall through
+                            # instead.  The attempt guard comes first to skip a
+                            # pointless repair-and-log on an attempt that will
+                            # not be retried anyway.
+                            if (
+                                attempt < max_attempts - 1
+                                and _is_thinking_roundtrip_error(upstream.status, error_body)
+                                and _repair_thinking_roundtrip(
+                                    upstream_body,
+                                    native=self._active_provider.upstream_wire_is_messages_api,
+                                )
+                            ):
+                                self._thinking_repair_backends.add(self._current_backend_idx)
+                                logger.warning(
+                                    "Backend rejected the transcript's thinking round-trip (status %d) "
+                                    "— repaired and retrying the same backend (attempt %d/%d)",
+                                    upstream.status,
+                                    attempt + 1,
+                                    max_attempts,
+                                )
                                 continue
 
                             retryable = self._should_retry_stream(upstream.status, error_body)
@@ -2924,7 +3112,7 @@ class BridgeServer:
                                     self._active_provider.normalize_request(cc_request)
                                     url = self._build_upstream_url()
                                     headers = self._build_upstream_headers()
-                                    upstream_body = self._active_provider.translate_to_upstream(cc_request)
+                                    upstream_body = self._upstream_body_for(cc_request)
                                     logger.info(
                                         "Messages stream failover: attempt %d/%d (status %d), switching backend",
                                         attempt + 1,
@@ -3096,7 +3284,7 @@ class BridgeServer:
                                 self._active_provider.normalize_request(cc_request)
                                 url = self._build_upstream_url()
                                 headers = self._build_upstream_headers()
-                                upstream_body = self._active_provider.translate_to_upstream(cc_request)
+                                upstream_body = self._upstream_body_for(cc_request)
                                 logger.info(
                                     "Messages stream in-stream error (no output yet): attempt %d/%d, switching backend",
                                     attempt + 1,
@@ -3140,7 +3328,7 @@ class BridgeServer:
                                     self._active_provider.normalize_request(cc_request)
                                     url = self._build_upstream_url()
                                     headers = self._build_upstream_headers()
-                                    upstream_body = self._active_provider.translate_to_upstream(cc_request)
+                                    upstream_body = self._upstream_body_for(cc_request)
                                     logger.info(
                                         "Messages stream empty response: attempt %d/%d, switching backend",
                                         attempt + 1,
@@ -3165,7 +3353,7 @@ class BridgeServer:
                                         self._active_provider.normalize_request(cc_request)
                                         url = self._build_upstream_url()
                                         headers = self._build_upstream_headers()
-                                        upstream_body = self._active_provider.translate_to_upstream(cc_request)
+                                        upstream_body = self._upstream_body_for(cc_request)
                                         retried = True
                                 else:
                                     logger.warning(
@@ -3223,7 +3411,7 @@ class BridgeServer:
                                     self._active_provider.normalize_request(cc_request)
                                     url = self._build_upstream_url()
                                     headers = self._build_upstream_headers()
-                                    upstream_body = self._active_provider.translate_to_upstream(cc_request)
+                                    upstream_body = self._upstream_body_for(cc_request)
                                     logger.info(
                                         "Streaming failover: backend attempt %d/%d failed (%s), switching backend",
                                         attempt + 1,
@@ -5583,6 +5771,33 @@ class BridgeServer:
         path = self._active_provider.get_upstream_path(model)
         return f"{base}{path}"
 
+    def _upstream_body_for(self, cc_request: dict) -> dict:
+        """Serialize ``cc_request`` for the backend currently selected.
+
+        Wraps :meth:`ProviderAdapter.translate_to_upstream` with the one piece
+        of per-backend shaping the bridge owns: a backend that has already
+        rejected this session's transcript for a thinking round-trip mismatch
+        gets the carrier added before the request goes out, instead of
+        rediscovering the mismatch at the cost of one rejected round-trip per
+        turn (issue #32).
+
+        Every re-serialization inside a handler must go through here, because
+        the shaping is a property of the *selected backend*: a failover that
+        re-serializes with ``translate_to_upstream`` directly would carry the
+        previous backend's carrier to a sibling that never asked for it.
+
+        Args:
+            cc_request: The normalized request. Never modified — the carrier is
+                written to the returned body only.
+
+        Returns:
+            The dict to send as the upstream JSON body.
+        """
+        upstream_body = self._active_provider.translate_to_upstream(cc_request)
+        if self._current_backend_idx in self._thinking_repair_backends:
+            _repair_thinking_roundtrip(upstream_body, native=self._active_provider.upstream_wire_is_messages_api)
+        return upstream_body
+
     def _build_upstream_headers(self) -> dict[str, str]:
         provider = self._active_provider
         # Providers that route to different endpoints per model may need
@@ -5615,7 +5830,7 @@ class BridgeServer:
 
         url = self._build_upstream_url()
         headers = self._build_upstream_headers()
-        upstream_body = self._active_provider.translate_to_upstream(cc_request)
+        upstream_body = self._upstream_body_for(cc_request)
 
         request_timeout = aiohttp.ClientTimeout(total=None, sock_connect=30, sock_read=_STREAM_READ_TIMEOUT)
 

--- a/src/kitty/providers/anthropic.py
+++ b/src/kitty/providers/anthropic.py
@@ -70,6 +70,16 @@ class AnthropicAdapter(ProviderAdapter):
     def upstream_path(self) -> str:
         return "/v1/messages"
 
+    @property
+    def upstream_wire_is_messages_api(self) -> bool:
+        """Always True — every path through ``translate_to_upstream`` emits Messages API.
+
+        Subclasses either forward a native Messages body unchanged or fall back
+        to this class's Chat Completions → Messages translation, so the wire
+        shape does not depend on ``_native_messages_request``.
+        """
+        return True
+
     # ── Auth headers ─────────────────────────────────────────────────────
 
     def build_upstream_headers(self, api_key: str) -> dict[str, str]:

--- a/src/kitty/providers/base.py
+++ b/src/kitty/providers/base.py
@@ -255,6 +255,22 @@ class ProviderAdapter(ABC):
         return False
 
     @property
+    def upstream_wire_is_messages_api(self) -> bool:
+        """Whether ``translate_to_upstream`` emits an Anthropic Messages body.
+
+        Distinct from :attr:`use_native_messages`, which says whether the
+        bridge may skip its own translation layer.  This one describes the
+        shape that actually goes on the wire, and the two can disagree: an
+        Anthropic-wire adapter whose ``_native_messages_request`` flag was
+        cleared (by the bridge's ``tool_use`` format fallback) still emits an
+        Anthropic body, built from the Chat Completions request.
+
+        Anything shaping the serialized body — notably the bridge's thinking
+        round-trip repair — must branch on this, never on the request flag.
+        """
+        return False
+
+    @property
     def use_custom_transport(self) -> bool:
         """Whether this provider handles its own HTTP transport.
 

--- a/tests/bridge/test_thinking_roundtrip_failover.py
+++ b/tests/bridge/test_thinking_roundtrip_failover.py
@@ -1,0 +1,551 @@
+"""Subsystem tests for the thinking round-trip repair inside ``_stream_messages``.
+
+Reproduces kitty-bridge#32: a mid-conversation failover lands on a backend
+whose thinking mode requires every assistant turn of the replayed transcript to
+carry its reasoning.  The transcript was authored by the previous provider and
+carries none, so the receiving backend answers 400.  The bridge must repair and
+retry that backend instead of surfacing the error and taking the backend out of
+rotation.
+
+Covers ``.requirements/20260828T153428Z_thinking_roundtrip_failover_repair``
+FR-3 … FR-7.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import uuid
+
+import aiohttp
+import pytest
+from aioresponses import CallbackResult, aioresponses
+
+from kitty.bridge.server import BridgeServer
+from kitty.launchers.base import LauncherAdapter, SpawnConfig
+from kitty.profiles.schema import Profile
+from kitty.providers.custom_anthropic import CustomAnthropicAdapter
+from kitty.types import BridgeProtocol
+
+PRIMARY_URL = "https://api.primary.test/anthropic/v1/messages"
+SIBLING_URL = "https://api.sibling.test/anthropic/v1/messages"
+
+THINKING_ROUNDTRIP_400 = (
+    '{"error":{"message":"The `content[].thinking` in the thinking mode must be '
+    'passed back to the API.","type":"invalid_request_error","param":null,'
+    '"code":"invalid_request_error"}}'
+)
+
+
+class _StubLauncher(LauncherAdapter):
+    """Minimal launcher that selects the Messages API bridge protocol."""
+
+    @property
+    def name(self) -> str:
+        return "stub"
+
+    @property
+    def binary_name(self) -> str:
+        return "stub"
+
+    @property
+    def bridge_protocol(self) -> BridgeProtocol:
+        return BridgeProtocol.MESSAGES_API
+
+    def build_spawn_config(self, profile, bridge_port: int, resolved_key: str) -> SpawnConfig:
+        return SpawnConfig(env_overrides={}, env_clear=[], cli_args=[])
+
+
+def _anthropic_sse() -> bytes:
+    """A minimal, well-formed Anthropic Messages SSE stream."""
+    events = [
+        (
+            "message_start",
+            {
+                "type": "message_start",
+                "message": {
+                    "id": "msg_ok",
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [],
+                    "model": "deepseek-v4-flash",
+                    "usage": {"input_tokens": 10, "output_tokens": 0},
+                },
+            },
+        ),
+        (
+            "content_block_start",
+            {"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}},
+        ),
+        (
+            "content_block_delta",
+            {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "Recovered"}},
+        ),
+        ("content_block_stop", {"type": "content_block_stop", "index": 0}),
+        (
+            "message_delta",
+            {"type": "message_delta", "delta": {"stop_reason": "end_turn"}, "usage": {"output_tokens": 3}},
+        ),
+        ("message_stop", {"type": "message_stop"}),
+    ]
+    return b"".join(f"event: {name}\ndata: {json.dumps(payload)}\n\n".encode() for name, payload in events)
+
+
+def _client_request() -> dict:
+    """A Claude Code transcript whose assistant turns carry no thinking block."""
+    return {
+        "model": "claude-sonnet-4-6",
+        "max_tokens": 4096,
+        "stream": True,
+        "thinking": {"type": "enabled", "budget_tokens": 2048},
+        "system": [{"type": "text", "text": "You are a reviewer."}],
+        "messages": [
+            {"role": "user", "content": [{"type": "text", "text": "Review this diff"}]},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "Reading the file."},
+                    {"type": "tool_use", "id": "call_1", "name": "Read", "input": {"path": "a.py"}},
+                ],
+            },
+            {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "call_1", "content": "print(1)"}]},
+        ],
+        "tools": [{"name": "Read", "description": "Read a file", "input_schema": {"type": "object"}}],
+    }
+
+
+def _make_server() -> BridgeServer:
+    """Build a two-backend balancing server of native-passthrough providers.
+
+    Both members speak the Anthropic Messages API, which is the reported
+    pool's shape: the family boundary the incident crosses is invisible to
+    ``provider_type``.
+    """
+    backends = []
+    for name, base_url in (
+        ("primary", "https://api.primary.test/anthropic"),
+        ("sibling", "https://api.sibling.test/anthropic"),
+    ):
+        provider = CustomAnthropicAdapter()
+        profile = Profile(
+            name=name,
+            provider="custom_anthropic",
+            model="deepseek-v4-flash",
+            auth_ref=str(uuid.uuid4()),
+            provider_config={"base_url": base_url},
+        )
+        backends.append((provider, f"key-{name}", profile))
+
+    return BridgeServer(
+        adapter=_StubLauncher(),
+        provider=backends[0][0],
+        resolved_key=backends[0][1],
+        model="deepseek-v4-flash",
+        provider_config=backends[0][2].provider_config,
+        backends=backends,
+        host="127.0.0.1",
+        port=0,
+    )
+
+
+@pytest.fixture
+def prefer_first_backend(monkeypatch: pytest.MonkeyPatch):
+    """Make backend selection deterministic: always take the first candidate.
+
+    Selection is uniform-random over the healthy tier, so a test could not
+    otherwise tell a same-backend retry from a failover.  Taking the first
+    candidate means the sibling is chosen if and only if the primary was
+    actually marked unhealthy.
+    """
+    import kitty.bridge.server as server_module
+
+    monkeypatch.setattr(server_module.random, "choices", lambda population, weights=None, k=1: [population[0]])
+    monkeypatch.setattr(server_module.random, "choice", lambda population: population[0])
+
+
+class _ScriptedUpstream:
+    """Records every request body and replies from a scripted sequence.
+
+    The body is deep-copied on arrival.  The repair rewrites the outgoing body
+    in place after it has been sent, so recording the reference would let a
+    later attempt retroactively rewrite what an earlier attempt is recorded as
+    having sent — and every "attempt 1 was unrepaired" assertion would pass or
+    fail for the wrong reason.
+    """
+
+    def __init__(self, *responses: CallbackResult) -> None:
+        self._responses = list(responses)
+        self.bodies: list[dict] = []
+        self.urls: list[str] = []
+
+    def __call__(self, url, **kwargs) -> CallbackResult:
+        self.bodies.append(copy.deepcopy(kwargs.get("json", {})))
+        self.urls.append(str(url))
+        if len(self._responses) > 1:
+            return self._responses.pop(0)
+        return self._responses[0]
+
+
+def _rejection() -> CallbackResult:
+    return CallbackResult(status=400, content_type="application/json", body=THINKING_ROUNDTRIP_400)
+
+
+def _stream_ok() -> CallbackResult:
+    return CallbackResult(status=200, headers={"Content-Type": "text/event-stream"}, body=_anthropic_sse())
+
+
+async def _post(server: BridgeServer, request: dict) -> tuple[int, str]:
+    async with (
+        aiohttp.ClientSession() as session,
+        session.post(f"http://127.0.0.1:{server.port}/v1/messages", json=request) as resp,
+    ):
+        return resp.status, (await resp.read()).decode("utf-8")
+
+
+class TestRepairAndRetrySameBackend:
+    """FR-3 / FR-4 — the session survives and the backend keeps its health."""
+
+    @pytest.mark.asyncio
+    async def test_client_receives_the_stream_not_the_400(self, prefer_first_backend):
+        """AC-3.1 — one rejection no longer kills the session.
+
+        The sibling is scripted to reject too, so a 200 can only come from the
+        repaired retry on the primary.  Sharing one scripted upstream between
+        both backends would let a plain failover satisfy this test.
+        """
+        server = _make_server()
+        upstream = _ScriptedUpstream(_rejection(), _stream_ok())
+        sibling = _ScriptedUpstream(_rejection())
+
+        with aioresponses(passthrough=["http://127.0.0.1"]) as m:
+            m.post(PRIMARY_URL, callback=upstream, repeat=True)
+            m.post(SIBLING_URL, callback=sibling, repeat=True)
+
+            await server.start_async()
+            try:
+                status, body = await _post(server, _client_request())
+            finally:
+                await server.stop_async()
+
+        assert status == 200, body
+        assert "Recovered" in body
+        assert "invalid_request_error" not in body
+
+    @pytest.mark.asyncio
+    async def test_retry_body_carries_the_thinking_carrier(self, prefer_first_backend):
+        """AC-3.2 — the retried transcript satisfies the contract."""
+        server = _make_server()
+        upstream = _ScriptedUpstream(_rejection(), _stream_ok())
+
+        with aioresponses(passthrough=["http://127.0.0.1"]) as m:
+            m.post(PRIMARY_URL, callback=upstream, repeat=True)
+            m.post(SIBLING_URL, callback=upstream, repeat=True)
+
+            await server.start_async()
+            try:
+                await _post(server, _client_request())
+            finally:
+                await server.stop_async()
+
+        assert len(upstream.bodies) == 2
+        first_assistants = [m for m in upstream.bodies[0]["messages"] if m["role"] == "assistant"]
+        assert all(
+            not any(b.get("type") == "thinking" for b in msg["content"]) for msg in first_assistants
+        ), "the first attempt must reproduce the unrepaired transcript"
+
+        retry_assistants = [m for m in upstream.bodies[1]["messages"] if m["role"] == "assistant"]
+        assert retry_assistants
+        for msg in retry_assistants:
+            assert msg["content"][0] == {"type": "thinking", "thinking": ""}
+
+    @pytest.mark.asyncio
+    async def test_retry_goes_to_the_same_backend(self, prefer_first_backend):
+        """AC-3.3 / AC-4.2 — a repair is not a failover."""
+        server = _make_server()
+        upstream = _ScriptedUpstream(_rejection(), _stream_ok())
+
+        with aioresponses(passthrough=["http://127.0.0.1"]) as m:
+            m.post(PRIMARY_URL, callback=upstream, repeat=True)
+            m.post(SIBLING_URL, callback=upstream, repeat=True)
+
+            await server.start_async()
+            try:
+                await _post(server, _client_request())
+            finally:
+                await server.stop_async()
+
+        assert upstream.urls == [PRIMARY_URL, PRIMARY_URL]
+
+    @pytest.mark.asyncio
+    async def test_backend_health_is_untouched(self, prefer_first_backend):
+        """AC-4.1 — a request the bridge malformed must not cost the backend 300s."""
+        server = _make_server()
+        upstream = _ScriptedUpstream(_rejection(), _stream_ok())
+
+        with aioresponses(passthrough=["http://127.0.0.1"]) as m:
+            m.post(PRIMARY_URL, callback=upstream, repeat=True)
+            m.post(SIBLING_URL, callback=upstream, repeat=True)
+
+            await server.start_async()
+            try:
+                await _post(server, _client_request())
+            finally:
+                await server.stop_async()
+
+        health = server._backend_health[0]
+        assert health["healthy"] is True
+        assert health["failed_at"] is None
+        assert health["failure_count"] == 0
+
+    @pytest.mark.asyncio
+    async def test_repair_is_logged_once(self, prefer_first_backend, caplog):
+        """AC-3.4 — the compatibility miss is visible to an operator."""
+        import logging
+
+        server = _make_server()
+        upstream = _ScriptedUpstream(_rejection(), _stream_ok())
+
+        with aioresponses(passthrough=["http://127.0.0.1"]) as m:
+            m.post(PRIMARY_URL, callback=upstream, repeat=True)
+            m.post(SIBLING_URL, callback=upstream, repeat=True)
+
+            await server.start_async()
+            try:
+                with caplog.at_level(logging.WARNING, logger="kitty.bridge.server"):
+                    await _post(server, _client_request())
+            finally:
+                await server.stop_async()
+
+        matches = [r for r in caplog.records if "thinking round-trip" in r.getMessage()]
+        assert len(matches) == 1, [r.getMessage() for r in caplog.records]
+
+
+class TestStickyRepair:
+    """FR-5 — later turns do not pay for the same discovery again."""
+
+    @pytest.mark.asyncio
+    async def test_second_request_is_repaired_before_the_first_attempt(self, prefer_first_backend):
+        """AC-5.1 — the backend is remembered for the session."""
+        server = _make_server()
+        upstream = _ScriptedUpstream(_rejection(), _stream_ok())
+
+        with aioresponses(passthrough=["http://127.0.0.1"]) as m:
+            m.post(PRIMARY_URL, callback=upstream, repeat=True)
+            m.post(SIBLING_URL, callback=upstream, repeat=True)
+
+            await server.start_async()
+            try:
+                await _post(server, _client_request())
+                before = len(upstream.bodies)
+                status, body = await _post(server, _client_request())
+            finally:
+                await server.stop_async()
+
+        assert status == 200, body
+        assert len(upstream.bodies) == before + 1, "the second turn must not need a rejected attempt"
+
+        assistants = [m for m in upstream.bodies[-1]["messages"] if m["role"] == "assistant"]
+        for msg in assistants:
+            assert msg["content"][0] == {"type": "thinking", "thinking": ""}
+
+
+class TestRepairIsPerBackend:
+    """The carrier binds to the backend that asked for it, and nothing else."""
+
+    @pytest.mark.asyncio
+    async def test_repair_does_not_travel_to_the_sibling_on_failover(self, prefer_first_backend):
+        """A fabricated carrier must not be handed to a backend that never asked.
+
+        The repair is written to the outgoing body, not to ``cc_request``, so a
+        later failover re-serializes a clean transcript.  Anthropic's contract
+        is that a passed-back ``thinking`` block is complete, unmodified and
+        signature-verified, so shipping an empty one to a sibling risks turning
+        a recoverable failover into a second 400 — charged to that sibling's
+        health.
+        """
+        server = _make_server()
+        # Primary: thinking-400, then a hard 500 on the repaired retry, which
+        # is a genuine backend fault and does fail over.
+        primary = _ScriptedUpstream(
+            _rejection(),
+            CallbackResult(status=500, content_type="application/json", body='{"error":"boom"}'),
+        )
+        sibling = _ScriptedUpstream(_stream_ok())
+
+        with aioresponses(passthrough=["http://127.0.0.1"]) as m:
+            m.post(PRIMARY_URL, callback=primary, repeat=True)
+            m.post(SIBLING_URL, callback=sibling, repeat=True)
+
+            await server.start_async()
+            try:
+                status, body = await _post(server, _client_request())
+            finally:
+                await server.stop_async()
+
+        assert status == 200, body
+        assert len(primary.bodies) == 2, "primary should see the original and the repaired transcript"
+        assert primary.bodies[1]["messages"][1]["content"][0] == {"type": "thinking", "thinking": ""}
+
+        assert len(sibling.bodies) == 1
+        sibling_assistants = [m for m in sibling.bodies[0]["messages"] if m["role"] == "assistant"]
+        assert sibling_assistants
+        for msg in sibling_assistants:
+            assert not any(b.get("type") == "thinking" for b in msg["content"]), (
+                "the sibling must receive the client's own transcript, not the carrier "
+                "fabricated for the primary"
+            )
+
+    @pytest.mark.asyncio
+    async def test_sticky_repair_does_not_leak_to_the_sibling(self, prefer_first_backend):
+        """AC-5.2 — the sticky set is keyed by backend, not by server.
+
+        The primary rejects and is repaired; the sibling, which never rejected,
+        must still receive the client's own transcript on a later turn.
+        """
+        server = _make_server()
+        primary = _ScriptedUpstream(_rejection(), _stream_ok())
+        sibling = _ScriptedUpstream(_stream_ok())
+
+        with aioresponses(passthrough=["http://127.0.0.1"]) as m:
+            m.post(PRIMARY_URL, callback=primary, repeat=True)
+            m.post(SIBLING_URL, callback=sibling, repeat=True)
+
+            await server.start_async()
+            try:
+                await _post(server, _client_request())
+                # Take the primary out of rotation so the next turn lands on
+                # the sibling, which is not in the sticky set.
+                server._mark_backend_unhealthy(0, failure_kind="hard")
+                status, body = await _post(server, _client_request())
+            finally:
+                await server.stop_async()
+
+        assert status == 200, body
+        assert len(sibling.bodies) == 1
+        sibling_assistants = [m for m in sibling.bodies[0]["messages"] if m["role"] == "assistant"]
+        assert sibling_assistants
+        for msg in sibling_assistants:
+            assert not any(b.get("type") == "thinking" for b in msg["content"]), (
+                "a backend that never rejected must not inherit the primary's carrier"
+            )
+
+    def test_repair_uses_the_wire_dialect_not_the_request_flag(self):
+        """The carrier must match the body the adapter actually emits.
+
+        ``CustomAnthropicAdapter`` emits an Anthropic Messages body on **both**
+        branches of ``translate_to_upstream`` — natively when
+        ``_native_messages_request`` is set, and via the inherited
+        CC → Messages translation when the ``tool_use`` format fallback has
+        cleared it (``server.py`` sets the flag to False and re-serializes).
+        Deriving the dialect from the request flag would write the Chat
+        Completions carrier onto an Anthropic-shaped message, so the sticky
+        repair would silently malform every later turn on that path.
+        """
+        server = _make_server()
+        server._thinking_repair_backends.add(server._current_backend_idx)
+
+        # Exactly the state the tool_use fallback leaves behind: an
+        # Anthropic-wire adapter with the native flag cleared, carrying a
+        # Chat-Completions-shaped transcript.
+        cc_request = {
+            "model": "deepseek-v4-flash",
+            "max_tokens": 4096,
+            "_native_messages_request": False,
+            "messages": [
+                {"role": "user", "content": "Review this diff"},
+                {"role": "assistant", "content": "Reading the file."},
+            ],
+        }
+        upstream_body = server._upstream_body_for(cc_request)
+
+        assistants = [m for m in upstream_body["messages"] if m["role"] == "assistant"]
+        assert assistants, upstream_body
+        for msg in assistants:
+            assert "reasoning_content" not in msg, (
+                "an Anthropic-shaped body must never carry the Chat Completions carrier"
+            )
+            assert any(b.get("type") == "thinking" for b in msg["content"])
+
+    @pytest.mark.asyncio
+    async def test_single_backend_mode_is_covered(self):
+        """FR-5 — non-balancing mode is keyed by index -1, not skipped."""
+        provider = CustomAnthropicAdapter()
+        server = BridgeServer(
+            adapter=_StubLauncher(),
+            provider=provider,
+            resolved_key="key-solo",
+            model="deepseek-v4-flash",
+            provider_config={"base_url": "https://api.primary.test/anthropic"},
+            host="127.0.0.1",
+            port=0,
+        )
+        upstream = _ScriptedUpstream(_rejection(), _stream_ok())
+
+        with aioresponses(passthrough=["http://127.0.0.1"]) as m:
+            m.post(PRIMARY_URL, callback=upstream, repeat=True)
+
+            await server.start_async()
+            try:
+                await _post(server, _client_request())
+                before = len(upstream.bodies)
+                status, body = await _post(server, _client_request())
+            finally:
+                await server.stop_async()
+
+        assert status == 200, body
+        assert len(upstream.bodies) == before + 1, "the second turn must not need a rejected attempt"
+        assistants = [m for m in upstream.bodies[-1]["messages"] if m["role"] == "assistant"]
+        assert assistants
+        for msg in assistants:
+            assert msg["content"][0] == {"type": "thinking", "thinking": ""}
+
+
+class TestUnaffectedPaths:
+    """FR-6 / FR-7 — everything else behaves exactly as before."""
+
+    @pytest.mark.asyncio
+    async def test_success_path_body_is_unchanged(self, prefer_first_backend):
+        """AC-7.2 — a backend that never rejects receives the client's own body."""
+        server = _make_server()
+        upstream = _ScriptedUpstream(_stream_ok())
+        request = _client_request()
+
+        with aioresponses(passthrough=["http://127.0.0.1"]) as m:
+            m.post(PRIMARY_URL, callback=upstream, repeat=True)
+
+            await server.start_async()
+            try:
+                status, _ = await _post(server, request)
+            finally:
+                await server.stop_async()
+
+        assert status == 200
+        assert len(upstream.bodies) == 1
+        assert upstream.bodies[0]["messages"] == request["messages"]
+
+    @pytest.mark.asyncio
+    async def test_already_repaired_rejection_falls_back_to_failover(self, prefer_first_backend):
+        """AC-6.1 — when the repair cannot help, today's behaviour is unchanged."""
+        server = _make_server()
+        primary = _ScriptedUpstream(_rejection())
+        sibling = _ScriptedUpstream(_stream_ok())
+
+        request = _client_request()
+        for msg in request["messages"]:
+            if msg["role"] == "assistant":
+                msg["content"].insert(0, {"type": "thinking", "thinking": "already reasoned"})
+
+        with aioresponses(passthrough=["http://127.0.0.1"]) as m:
+            m.post(PRIMARY_URL, callback=primary, repeat=True)
+            m.post(SIBLING_URL, callback=sibling, repeat=True)
+
+            await server.start_async()
+            try:
+                status, body = await _post(server, request)
+            finally:
+                await server.stop_async()
+
+        assert status == 200, body
+        assert "Recovered" in body
+        assert server._backend_health[0]["healthy"] is False
+        assert len(sibling.bodies) == 1

--- a/tests/bridge/test_thinking_roundtrip_repair.py
+++ b/tests/bridge/test_thinking_roundtrip_repair.py
@@ -1,0 +1,310 @@
+"""Tests for the thinking round-trip repair on cross-backend transcript replay.
+
+A backend that enforces a thinking-mode round-trip contract (DeepSeek, Kimi)
+rejects a transcript whose assistant turns were authored by a provider that
+emits no thinking blocks.  The bridge must recognise that rejection as a
+request-shape problem of its own making, repair the transcript, and retry the
+same backend without charging the failure to that backend's health.
+
+Covers ``.requirements/20260828T153428Z_thinking_roundtrip_failover_repair``.
+"""
+
+from __future__ import annotations
+
+import copy
+
+from kitty.bridge.server import (
+    _is_thinking_roundtrip_error,
+    _repair_thinking_roundtrip,
+)
+
+# ── Real upstream error bodies ─────────────────────────────────────────────
+# Verbatim from the incident report (kitty-bridge#32) and from DeepSeek's and
+# Kimi's documented wording for the same contract.
+
+DEEPSEEK_ANTHROPIC_400 = (
+    '{"error":{"message":"The `content[].thinking` in the thinking mode must be '
+    'passed back to the API.","type":"invalid_request_error","param":null,'
+    '"code":"invalid_request_error"}}'
+)
+
+DEEPSEEK_CHAT_COMPLETIONS_400 = (
+    '{"error":{"message":"The `reasoning_content` in the thinking mode must be '
+    'passed back to the API.","type":"invalid_request_error"}}'
+)
+
+KIMI_400 = (
+    '{"error":{"message":"thinking is enabled but reasoning_content is missing '
+    'in assistant tool call message at index 63","type":"invalid_request_error"}}'
+)
+
+
+def _native_transcript() -> dict:
+    """Anthropic Messages body whose assistant turns carry no thinking block."""
+    return {
+        "model": "deepseek-v4-flash",
+        "stream": True,
+        "system": [{"type": "text", "text": "You are helpful."}],
+        "messages": [
+            {"role": "user", "content": [{"type": "text", "text": "Please run ls"}]},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "Running it now."},
+                    {"type": "tool_use", "id": "call_1", "name": "Bash", "input": {"command": "ls"}},
+                ],
+            },
+            {
+                "role": "user",
+                "content": [{"type": "tool_result", "tool_use_id": "call_1", "content": "a.txt"}],
+            },
+            {"role": "assistant", "content": [{"type": "text", "text": "There is one file."}]},
+        ],
+        "tools": [{"name": "Bash", "description": "Run a command", "input_schema": {"type": "object"}}],
+    }
+
+
+def _cc_transcript() -> dict:
+    """Chat Completions body whose assistant turns carry no reasoning_content."""
+    return {
+        "model": "deepseek-v4-flash",
+        "messages": [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "Please run ls"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "Bash", "arguments": '{"command": "ls"}'},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "a.txt"},
+            {"role": "assistant", "content": "There is one file."},
+        ],
+    }
+
+
+# ── FR-1: recognising the rejection ────────────────────────────────────────
+
+
+class TestIsThinkingRoundtripError:
+    """AC-1.1 … AC-1.4 — the predicate that classifies the upstream 400."""
+
+    def test_deepseek_anthropic_wording_matches(self):
+        """AC-1.1 — the exact body from the incident report."""
+        assert _is_thinking_roundtrip_error(400, DEEPSEEK_ANTHROPIC_400) is True
+
+    def test_deepseek_chat_completions_wording_matches(self):
+        """AC-1.1 — same contract, OpenAI-shaped field name."""
+        assert _is_thinking_roundtrip_error(400, DEEPSEEK_CHAT_COMPLETIONS_400) is True
+
+    def test_kimi_wording_matches(self):
+        """AC-1.1 — Kimi states the same contract in different words."""
+        assert _is_thinking_roundtrip_error(400, KIMI_400) is True
+
+    def test_dict_body_matches(self):
+        """AC-1.4 — the body may arrive already parsed."""
+        body = {
+            "error": {
+                "message": "The `content[].thinking` in the thinking mode must be passed back to the API.",
+            }
+        }
+        assert _is_thinking_roundtrip_error(400, body) is True
+
+    def test_matching_is_case_insensitive(self):
+        """AC-1.4 — providers are inconsistent about capitalisation."""
+        assert _is_thinking_roundtrip_error(400, DEEPSEEK_ANTHROPIC_400.upper()) is True
+
+    def test_500_does_not_match(self):
+        """AC-1.2 — a 5xx is a backend fault and is already retried elsewhere."""
+        assert _is_thinking_roundtrip_error(500, DEEPSEEK_ANTHROPIC_400) is False
+
+    def test_502_does_not_match(self):
+        """AC-1.2 — the failure that starts the incident must not be reclassified."""
+        assert _is_thinking_roundtrip_error(502, DEEPSEEK_ANTHROPIC_400) is False
+
+    def test_tool_use_format_error_does_not_match(self):
+        """AC-1.3 — the other request-shape 400 keeps its own repair path."""
+        body = '{"error":{"message":"invalid params, tool result\'s tool id(call_x) not found (2013)"}}'
+        assert _is_thinking_roundtrip_error(400, body) is False
+
+    def test_rate_limit_body_does_not_match(self):
+        """AC-1.3 — no overlap with the quota classification."""
+        assert _is_thinking_roundtrip_error(429, '{"error":{"message":"rate limit exceeded"}}') is False
+
+    def test_context_too_large_does_not_match(self):
+        """AC-1.3 — a genuinely oversized request must stay non-retryable."""
+        body = '{"error":{"code":"1261","message":"Prompt exceeds max length"}}'
+        assert _is_thinking_roundtrip_error(400, body) is False
+
+    def test_unrelated_mention_of_thinking_does_not_match(self):
+        """AC-1.3 — naming `thinking` is not enough; the contract phrase is required."""
+        body = '{"error":{"message":"thinking blocks are not supported by this model"}}'
+        assert _is_thinking_roundtrip_error(400, body) is False
+
+    def test_none_body_does_not_match(self):
+        """AC-1.4 — an absent body must not crash the classifier."""
+        assert _is_thinking_roundtrip_error(400, None) is False
+
+    def test_echoed_request_with_unrelated_missing_field_does_not_match(self):
+        """AC-1.3 — the Kimi token pair must survive a gateway echoing the request.
+
+        Some gateways include the offending request in the error body.  A
+        transcript that legitimately carries ``reasoning_content`` would then
+        put that word in the body, and "missing" is common in unrelated
+        validation text — so the Kimi pattern requires the fuller phrase
+        ``is missing in assistant``.  A false positive here would suppress the
+        health penalty for a genuinely bad backend.
+        """
+        body = (
+            '{"error":{"message":"missing required parameter: model"},'
+            '"request":{"messages":[{"role":"assistant","reasoning_content":"real reasoning"}]}}'
+        )
+        assert _is_thinking_roundtrip_error(400, body) is False
+
+
+# ── FR-2: repairing the transcript ─────────────────────────────────────────
+
+
+class TestRepairThinkingRoundtripNative:
+    """AC-2.1 … AC-2.6 on Anthropic-shaped bodies."""
+
+    def test_assistant_content_list_gains_leading_thinking_block(self):
+        """AC-2.1 — the carrier the target asks for is prepended."""
+        body = _native_transcript()
+        assert _repair_thinking_roundtrip(body, native=True) is True
+
+        for msg in body["messages"]:
+            if msg["role"] == "assistant":
+                assert msg["content"][0] == {"type": "thinking", "thinking": ""}
+
+    def test_existing_blocks_keep_order_and_values(self):
+        """AC-2.1 — the repair adds, it never rewrites what is already there."""
+        body = _native_transcript()
+        original = copy.deepcopy(body["messages"][1]["content"])
+        _repair_thinking_roundtrip(body, native=True)
+
+        assert body["messages"][1]["content"][1:] == original
+
+    def test_assistant_with_thinking_block_is_untouched(self):
+        """AC-2.2 — no second carrier is added to a turn that already has one."""
+        body = {
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "thinking", "thinking": "already here", "signature": "sig"},
+                        {"type": "text", "text": "Done"},
+                    ],
+                }
+            ]
+        }
+        before = copy.deepcopy(body)
+        assert _repair_thinking_roundtrip(body, native=True) is False
+        assert body == before
+
+    def test_assistant_string_content_becomes_thinking_plus_text(self):
+        """AC-2.1 — a string-content assistant turn still needs the carrier."""
+        body = {"messages": [{"role": "assistant", "content": "Hi there!"}]}
+        assert _repair_thinking_roundtrip(body, native=True) is True
+
+        assert body["messages"][0]["content"] == [
+            {"type": "thinking", "thinking": ""},
+            {"type": "text", "text": "Hi there!"},
+        ]
+
+    def test_non_assistant_messages_are_untouched(self):
+        """AC-2.4 — the contract binds assistant turns only."""
+        body = _native_transcript()
+        before_users = copy.deepcopy([m for m in body["messages"] if m["role"] != "assistant"])
+        _repair_thinking_roundtrip(body, native=True)
+
+        assert [m for m in body["messages"] if m["role"] != "assistant"] == before_users
+
+    def test_system_field_is_untouched(self):
+        """AC-2.4 — the top-level Anthropic system block is not a message."""
+        body = _native_transcript()
+        _repair_thinking_roundtrip(body, native=True)
+
+        assert body["system"] == [{"type": "text", "text": "You are helpful."}]
+
+    def test_repair_is_idempotent(self):
+        """AC-2.6 — a repaired body reports no further change."""
+        body = _native_transcript()
+        assert _repair_thinking_roundtrip(body, native=True) is True
+
+        after_first = copy.deepcopy(body)
+        assert _repair_thinking_roundtrip(body, native=True) is False
+        assert body == after_first
+
+    def test_original_messages_are_not_mutated(self):
+        """AC-2.7 — the client's parsed request must survive the repair intact.
+
+        The Messages handler forwards ``dict(body)``, a shallow copy sharing the
+        client's ``messages`` list, and re-reads that list on later attempts.
+        """
+        body = _native_transcript()
+        original_list = body["messages"]
+        original_snapshot = copy.deepcopy(original_list)
+
+        assert _repair_thinking_roundtrip(body, native=True) is True
+
+        assert original_list == original_snapshot
+        assert body["messages"] is not original_list
+
+    def test_no_assistant_messages_reports_no_change(self):
+        """AC-2.5 — nothing to repair means the caller must not retry."""
+        body = {"messages": [{"role": "user", "content": [{"type": "text", "text": "hi"}]}]}
+        assert _repair_thinking_roundtrip(body, native=True) is False
+
+    def test_body_without_messages_reports_no_change(self):
+        """AC-2.5 — a malformed body must not crash the repair."""
+        assert _repair_thinking_roundtrip({"model": "x"}, native=True) is False
+
+
+class TestRepairThinkingRoundtripChatCompletions:
+    """AC-2.3 on Chat-Completions-shaped bodies."""
+
+    def test_assistant_gains_empty_reasoning_content(self):
+        """AC-2.3 — the OpenAI-shaped carrier is a sibling field, not a block."""
+        body = _cc_transcript()
+        assert _repair_thinking_roundtrip(body, native=False) is True
+
+        for msg in body["messages"]:
+            if msg["role"] == "assistant":
+                assert msg["reasoning_content"] == ""
+
+    def test_existing_reasoning_content_is_preserved(self):
+        """AC-2.3 — a real chain of thought is never overwritten with an empty one."""
+        body = {"messages": [{"role": "assistant", "content": "hi", "reasoning_content": "real reasoning"}]}
+        assert _repair_thinking_roundtrip(body, native=False) is False
+        assert body["messages"][0]["reasoning_content"] == "real reasoning"
+
+    def test_tool_calls_are_preserved(self):
+        """AC-2.3 — the repair must not disturb the tool-call round-trip."""
+        body = _cc_transcript()
+        before = copy.deepcopy(body["messages"][2]["tool_calls"])
+        _repair_thinking_roundtrip(body, native=False)
+
+        assert body["messages"][2]["tool_calls"] == before
+
+    def test_tool_and_system_messages_are_untouched(self):
+        """AC-2.4 — only assistant turns carry the contract."""
+        body = _cc_transcript()
+        _repair_thinking_roundtrip(body, native=False)
+
+        assert body["messages"][0] == {"role": "system", "content": "You are helpful."}
+        assert body["messages"][3] == {"role": "tool", "tool_call_id": "call_1", "content": "a.txt"}
+
+    def test_repair_is_idempotent(self):
+        """AC-2.6 — a repaired CC body reports no further change."""
+        body = _cc_transcript()
+        assert _repair_thinking_roundtrip(body, native=False) is True
+
+        after_first = copy.deepcopy(body)
+        assert _repair_thinking_roundtrip(body, native=False) is False
+        assert body == after_first

--- a/tests/bridge/test_thinking_roundtrip_repair.py
+++ b/tests/bridge/test_thinking_roundtrip_repair.py
@@ -266,6 +266,45 @@ class TestRepairThinkingRoundtripNative:
         assert _repair_thinking_roundtrip({"model": "x"}, native=True) is False
 
 
+class TestRepairLeavesUnrepairableBodiesAlone:
+    """Convergence guards — anything the carrier cannot attach to reports no change."""
+
+    def test_assistant_without_usable_content_reports_no_change(self):
+        """A message the carrier cannot attach to must not be reported as changed.
+
+        The caller retries only on a change, so a message reported as changed
+        on every pass would retry forever.  Falling through to the normal
+        failover path is the correct outcome here.
+        """
+        body = {"messages": [{"role": "assistant", "content": None}]}
+        assert _repair_thinking_roundtrip(body, native=True) is False
+        assert body["messages"] == [{"role": "assistant", "content": None}]
+
+    def test_body_without_messages_reports_no_change(self):
+        """A Gemini-shaped body must pass through untouched.
+
+        One bridge server can register all four protocol routes, so a backend
+        in the sticky set may serialize a Gemini body, which has ``contents``
+        rather than ``messages``.
+        """
+        body = {"contents": [{"role": "model", "parts": [{"text": "hi"}]}]}
+        before = copy.deepcopy(body)
+        assert _repair_thinking_roundtrip(body, native=True) is False
+        assert body == before
+
+    def test_partial_repair_still_reports_change(self):
+        """One repairable turn beside an unrepairable one still earns a retry."""
+        body = {
+            "messages": [
+                {"role": "assistant", "content": None},
+                {"role": "assistant", "content": [{"type": "text", "text": "hi"}]},
+            ]
+        }
+        assert _repair_thinking_roundtrip(body, native=True) is True
+        assert body["messages"][0] == {"role": "assistant", "content": None}
+        assert body["messages"][1]["content"][0] == {"type": "thinking", "thinking": ""}
+
+
 class TestRepairThinkingRoundtripChatCompletions:
     """AC-2.3 on Chat-Completions-shaped bodies."""
 


### PR DESCRIPTION
Fixes #32.

## Context for the Product Owner

A user's CI job died mid-run and lost $4.56 of work for no good reason.

Kitty can be configured with a pool of model providers, so that if one has a
hiccup the session quietly moves to another. That worked — except when the
replacement came from a *different vendor*.

Every turn, the coding agent re-sends the whole conversation so far. Some
vendors (DeepSeek, Kimi) require the model's own reasoning to be handed back
with that history. A conversation that started on MiniMax has no such reasoning
attached, so the moment Kitty moved the session to DeepSeek, DeepSeek rejected
the whole conversation as malformed.

Kitty treated that rejection as "this provider is broken": it gave up on the
session, showed the user a raw API error, and benched a perfectly healthy
provider for five minutes. In the reported incident that threw away 48
successful requests and 125 seconds of work **on the first of eighteen
available retries**, and the customer's pull request went red with no review.

After this change, Kitty recognises that the rejection is about the *request it
built*, not the provider. It fixes up the conversation, retries the same
provider, and the session carries on. The user sees nothing but a line in the
log. One vendor hiccup no longer costs a session.

## What changed

When an upstream returns a 4xx saying thinking-mode reasoning must be passed
back, the bridge now:

1. recognises it as a **request-shape rejection**, not a backend fault;
2. gives every assistant turn the empty carrier its target requires — a
   `thinking` block on the Anthropic wire, `reasoning_content` on the Chat
   Completions wire;
3. retries the **same backend**: no health penalty, no failover slot spent;
4. remembers the backend for the session, so later turns are repaired before
   their first attempt instead of paying a rejected round-trip each time.

If the repair changes nothing, today's mark-unhealthy/failover path runs
unchanged — the change can't make any existing case worse.

## Two design points worth a reviewer's attention

**The repair targets the serialized upstream body, never `cc_request`.** This is
load-bearing twice:

- A later failover re-serializes a clean transcript, so a sibling backend never
  receives a carrier fabricated for a different provider. Anthropic requires
  passed-back `thinking` blocks to be complete, unmodified and
  signature-verified, and to be *stripped* when switching models — shipping an
  empty one to a sibling could turn a recoverable failover into a second 400,
  charged to that sibling's health.
- The repair sees carriers the provider adapter already injected during
  serialization (`kimi`, `zai`, `custom_openai` add `reasoning_content` inside
  `translate_to_upstream`), so it reports "no change" rather than retrying
  byte-identical bytes.

**The dialect comes from the adapter, not the request flag.** New
`ProviderAdapter.upstream_wire_is_messages_api` (True on `AnthropicAdapter` and
its subclasses). The `tool_use` format fallback clears
`_native_messages_request` while an Anthropic-wire adapter still emits an
Anthropic body via the inherited CC → Messages translation — branching on the
flag would write `reasoning_content` onto an Anthropic-shaped message.

## Why the issue's "fix 1" is not implemented

The issue proposed preferring a same-provider backend on failover, and asked
whether the MiniMax siblings were healthy but simply not preferred. They were
not: the session died at attempt 1 of 18, so the budget was not exhausted, which
means no backend was healthy after DeepSeek was marked.

More durably, `_get_backend_family` derives family from `provider_type`, which
is `custom_anthropic` for **both** MiniMax and DeepSeek in an Anthropic-shaped
pool. The boundary that matters is the upstream *host*, which nothing models.
Recorded in `SYSTEM_DESIGN.md` §8.B.9 so it doesn't read as an oversight.

## Testing

40 new tests in `tests/bridge/test_thinking_roundtrip_{repair,failover}.py` —
L1 for the predicate and the rewriter, L3 against a scripted fake upstream for
the retry, health, stickiness, per-backend binding and fall-through behaviour.

Each regression test was falsified: reverting the corresponding fix turns it red
with a legible message, including the headline test, which fails with the
issue's own 400-vs-200 symptom.

| Gate | Result |
|---|---|
| `tests/bridge/` | 1071 passed, 1 skipped |
| `tests/` minus bridge & egress-proxy | 1854 passed, 35 skipped |
| `ruff check .` | clean |
| `mypy src/kitty` | clean |
| `lint-imports` | 3 contracts kept |

`tests/test_egress_https_proxy.py` has 5 fixture errors that are pre-existing —
confirmed by reproducing them on a clean tree. They need a local TLS proxy.

## One open assumption

That an **empty** carrier satisfies these providers is supported by DeepSeek's
docs and by third-party repro (claude-code-router#1378 reports a direct curl
with `reasoning_content: ""` succeeding), but is **not verified by us against a
live key** — the incident isn't reproducible without one. For Kimi the external
fixes use `" "` instead, while this repo's own
`ProviderAdapter._inject_empty_reasoning_content` has shipped `""` in
production; the repair uses `""` to match the helper it sits beside.

The design degrades safely either way: a still-rejected repaired request falls
through to today's behaviour, so a wrong assumption costs one attempt and cannot
make the session worse than it is now. Symptom to watch for is a backend that
never converges — the same rejection every turn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NJJJmUgnet1Qdh2imTzdSL
