### PR TITLE
Make response-side tool_use observable, and flag inputs that contradict their schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,12 @@ their token totals, how many times a request switched backend (`failovers`), and
 (`all_backends_unhealthy`). Like `/healthz`, it is readable without credentials unless a keys file is configured — and
 `kitty claude` deliberately runs without one.
 
+`malformed_tool_use` counts responses where an upstream returned `200 OK` with a `tool_use` whose `input` contradicts
+the schema the client declared for that tool — the shape a client-side validator then rejects. It is reported per
+backend and as a session total, so a pool member returning well-formed-looking garbage is visible without re-running
+under `--debug`. It is a diagnostic only: it never marks a backend unhealthy or triggers failover. Run with `--debug`
+and `grep 'tool_use audit:'` for the offending payloads.
+
 **After the run.** `--session-summary PATH` (or `KITTY_SESSION_SUMMARY`) writes the same document to a file when the
 bridge shuts down — a small artifact CI can upload, instead of a multi-megabyte debug log:
 

--- a/src/kitty/bridge/server.py
+++ b/src/kitty/bridge/server.py
@@ -41,6 +41,7 @@ from kitty.bridge.responses.events import (
     format_error_event as responses_format_error,
 )
 from kitty.bridge.responses.translator import ResponsesTranslator
+from kitty.bridge.tool_audit import AUDIT_MARKER, ToolUseAuditor, collect_tool_schemas, report_tool_use
 from kitty.cloudflare import is_cloudflare_block
 from kitty.egress import EgressConfig, should_bypass
 from kitty.providers.base import ProviderAdapter, ProviderError
@@ -978,6 +979,12 @@ class BridgeServer:
         self._stats_retries = 0
         self._stats_all_unhealthy = 0
         self._stats_backend_attempts: dict[int, int] = {}
+        # Malformed tool_use responses per backend index (issue #33).  Counted
+        # rather than only logged because the WARNING reaches a handler only
+        # under --debug, and the point of the ask is to distinguish "200 but
+        # garbage" from "200 and clean" in an ordinary run.  Counting only —
+        # it never influences health, cooldown or routing.
+        self._stats_malformed_tool_use: dict[int, int] = {}
         self._stats_models: dict[str, dict[str, int]] = {}
         self._started_at: str | None = None
 
@@ -1621,6 +1628,7 @@ class BridgeServer:
                         "healthy": health["healthy"],
                         "remaining_cooldown": remaining,
                         "cooldown_events": health.get("failure_count", 0),
+                        "malformed_tool_use": self._stats_malformed_tool_use.get(idx, 0),
                     }
                 )
         else:
@@ -1636,6 +1644,7 @@ class BridgeServer:
                     "healthy": True,
                     "remaining_cooldown": 0,
                     "cooldown_events": 0,
+                    "malformed_tool_use": self._stats_malformed_tool_use.get(-1, 0),
                 }
             )
         return {
@@ -1653,9 +1662,65 @@ class BridgeServer:
             "failovers": self._stats_failovers,
             "retries": self._stats_retries,
             "all_backends_unhealthy": self._stats_all_unhealthy,
+            "malformed_tool_use": sum(self._stats_malformed_tool_use.values()),
             "models_served": {model: dict(record) for model, record in self._stats_models.items()},
             "backends": backends,
         }
+
+    def _record_malformed_tool_use(self) -> None:
+        """Count one malformed ``tool_use`` against the serving backend.
+
+        Surfaced by ``GET /stats`` and the shutdown summary so the signal
+        survives a run without ``--debug``, where the auditor's WARNING reaches
+        no handler. Diagnostics only: never consulted for health or routing.
+        """
+        idx = self._current_backend_idx
+        self._stats_malformed_tool_use[idx] = self._stats_malformed_tool_use.get(idx, 0) + 1
+
+    def _backend_label(self) -> str:
+        """Return a short identifier for the backend currently serving.
+
+        Used to point a diagnostic warning at a specific pool member, which is
+        the difference between "something returned garbage" and "this profile
+        returned garbage" when a balancing pool is in play.
+
+        Returns:
+            The profile name in balancing mode, otherwise the provider type.
+        """
+        idx = self._current_backend_idx
+        if self._backends and 0 <= idx < len(self._backends):
+            return str(self._backends[idx][2].name)
+        return str(getattr(self._active_provider, "provider_type", type(self._active_provider).__name__))
+
+    def _audit_response_tool_use(self, result: object, schemas: dict[str, dict]) -> None:
+        """Report every ``tool_use`` block in a non-streaming Messages response.
+
+        The streaming paths assemble their blocks incrementally; a complete
+        response already carries them, so this only has to walk ``content``.
+
+        Args:
+            result: The Messages API response body being returned to the client.
+            schemas: Declared tool schemas from :func:`collect_tool_schemas`.
+        """
+        try:
+            if not isinstance(result, dict):
+                return
+            content = result.get("content")
+            if not isinstance(content, list):
+                return
+            backend = self._backend_label()
+            for block in content:
+                if isinstance(block, dict) and block.get("type") == "tool_use":
+                    report_tool_use(
+                        block.get("name", ""),
+                        block.get("input"),
+                        schemas,
+                        backend=backend,
+                        on_anomaly=self._record_malformed_tool_use,
+                    )
+        except Exception as exc:
+            # Diagnostics must never break a response that is otherwise fine.
+            logger.debug("%s auditing failed, continuing: %s: %s", AUDIT_MARKER, type(exc).__name__, exc)
 
     def _log_backend_selection(self) -> None:
         """Log diagnostic info about the currently selected backend."""
@@ -2741,6 +2806,7 @@ class BridgeServer:
                 result = cc_response
             else:
                 result = translator.translate_response(cc_response, context=self._empty_response_context())
+            self._audit_response_tool_use(result, collect_tool_schemas(body))
             self._log_usage(cc_response.get("usage"))
             if self._backends and self._current_backend_idx >= 0:
                 self._mark_backend_healthy(self._current_backend_idx)
@@ -2771,6 +2837,9 @@ class BridgeServer:
     ) -> web.StreamResponse:
         message_id = f"msg_{uuid.uuid4().hex[:24]}"
         model = cc_request.get("model", body.get("model", ""))
+        # The client's own tool declarations are the only ground truth for what
+        # shape a returned tool_use should have (issue #33).
+        tool_schemas = collect_tool_schemas(body)
 
         logger.debug("═══ STREAM MESSAGES START ═══ message_id=%s model=%s", message_id, model)
 
@@ -2906,6 +2975,10 @@ class BridgeServer:
                         "Translated Messages API result: %s",
                         json.dumps(result, ensure_ascii=False)[:2000],
                     )
+                    # The custom transport builds its blocks here rather than
+                    # streaming them, so it is audited from the finished result
+                    # instead of at the write boundary (issue #33).
+                    self._audit_response_tool_use(result, tool_schemas)
 
                     msg_id = result.get("id", message_id)
                     model = result.get("model", "")
@@ -3156,11 +3229,26 @@ class BridgeServer:
 
                         # Success path — stream the response
                         if self._active_provider.use_native_messages:
-                            # Native Messages: forward raw SSE bytes to client
-                            async for chunk_bytes in upstream.content:
-                                s = await _ensure_prepared()
-                                await s.write(chunk_bytes)
-                                events_emitted = True
+                            # Native Messages: forward raw SSE bytes to client.
+                            # The auditor reads the same bytes so the forwarded
+                            # tool_use inputs are recoverable from our own log
+                            # (issue #33); it never alters what is written.
+                            auditor = ToolUseAuditor(
+                                tool_schemas,
+                                backend=self._backend_label(),
+                                on_anomaly=self._record_malformed_tool_use,
+                            )
+                            try:
+                                async for chunk_bytes in upstream.content:
+                                    s = await _ensure_prepared()
+                                    await s.write(chunk_bytes)
+                                    auditor.feed(chunk_bytes)
+                                    events_emitted = True
+                            finally:
+                                # Bytes already reached the client even if the
+                                # iteration raised, so the partial tool_use is
+                                # still worth reporting.
+                                auditor.finish()
                             stream_ok = True
                             break
 
@@ -3170,6 +3258,14 @@ class BridgeServer:
                         events_emitted = False
                         chunk_count = 0
                         finish_events: list[str] = []  # buffered finish events
+                        # Fed the Messages-API events we emit, so the translated
+                        # path is audited by the same assembler as the native one
+                        # (issue #33).  Per attempt: a failover resets the stream.
+                        auditor = ToolUseAuditor(
+                            tool_schemas,
+                            backend=self._backend_label(),
+                            on_anomaly=self._record_malformed_tool_use,
+                        )
                         async for chunk_bytes in upstream.content:
                             if done:
                                 break
@@ -3218,7 +3314,9 @@ class BridgeServer:
                                     else:
                                         for event in events:
                                             s = await _ensure_prepared()
-                                            await s.write(event.encode())
+                                            encoded = event.encode()
+                                            await s.write(encoded)
+                                            auditor.feed(encoded)
                                             events_emitted = True
 
                         logger.debug("Upstream stream ended. chunks=%d done=%s", chunk_count, done)
@@ -3238,7 +3336,9 @@ class BridgeServer:
                                         else:
                                             for event in events:
                                                 s = await _ensure_prepared()
-                                                await s.write(event.encode())
+                                                encoded = event.encode()
+                                                await s.write(encoded)
+                                                auditor.feed(encoded)
                                     except json.JSONDecodeError:
                                         logger.warning("Failed to parse flushed SSE data: %s", data_str[:200])
 
@@ -3262,7 +3362,9 @@ class BridgeServer:
                             try:
                                 s = await _ensure_prepared()
                                 for event in translator.finalize_interrupted_stream():
-                                    await s.write(event.encode())
+                                    encoded = event.encode()
+                                    await s.write(encoded)
+                                    auditor.feed(encoded)
                             except (
                                 ConnectionResetError,
                                 BrokenPipeError,
@@ -3272,6 +3374,9 @@ class BridgeServer:
                                     "Client disconnected before interrupted stream finalization for %s",
                                     message_id,
                                 )
+                            # A truncated stream is exactly when a half-delivered
+                            # tool_use is worth seeing, so audit before leaving.
+                            auditor.finish()
                             break
 
                         # Handle in-stream error failover
@@ -3283,7 +3388,9 @@ class BridgeServer:
                                 try:
                                     s = await _ensure_prepared()
                                     for event in translator.finalize_interrupted_stream():
-                                        await s.write(event.encode())
+                                        encoded = event.encode()
+                                        await s.write(encoded)
+                                        auditor.feed(encoded)
                                 except (
                                     ConnectionResetError,
                                     BrokenPipeError,
@@ -3293,6 +3400,7 @@ class BridgeServer:
                                         "Client disconnected before interrupted stream finalization for %s",
                                         message_id,
                                     )
+                                auditor.finish()
                                 break
                             elif attempt < max_attempts - 1:
                                 translator.reset()
@@ -3402,7 +3510,10 @@ class BridgeServer:
                         # Write buffered finish events to client
                         s = await _ensure_prepared()
                         for event in finish_events:
-                            await s.write(event.encode())
+                            encoded = event.encode()
+                            await s.write(encoded)
+                            auditor.feed(encoded)
+                        auditor.finish()
                         self._log_usage(last_usage)
                         stream_ok = True
                         break  # Exit retry loop

--- a/src/kitty/bridge/tool_audit.py
+++ b/src/kitty/bridge/tool_audit.py
@@ -1,0 +1,502 @@
+"""Response-side ``tool_use`` auditing for the Messages API bridge.
+
+Makes visible a defect class the bridge previously forwarded in silence: an
+upstream returns a ``tool_use`` block whose ``input`` is the wrong shape, the
+client's own validator rejects it, and nothing in kitty's log records what was
+forwarded (kitty-bridge#33).  Response payloads were logged only on the custom
+transport, so on every other transport the operator could not tell a bridge
+translation bug from an upstream serialization bug from a client-side schema
+error.
+
+Two pieces:
+
+- :func:`describe_tool_input_anomaly` — a pure detector that compares a
+  returned ``input`` against the tool's **own declared schema** and describes
+  the mismatch.  It names no cause: it reports shape, so it stays correct
+  whatever the underlying reason turns out to be.
+- :class:`ToolUseAuditor` — assembles ``tool_use`` inputs from the Anthropic
+  SSE the bridge writes to the client, and reports each one.
+
+Every log line this module emits is prefixed :data:`AUDIT_MARKER`, so an
+incident report can be answered with a single ``grep`` — the evidence in #33
+was literally a grep that returned zero hits.
+
+Two invariants hold throughout.  **Auditing never alters the response**: it
+observes the bytes being written, rewrites nothing, and cannot influence
+backend health or routing.  **The WARNING carries key names only, never
+values**: it is the one line here that can reach a non-debug handler if an
+embedder configures logging, and tool inputs routinely contain file contents
+and user data.  Full inputs stay at DEBUG, which only ever reaches the opt-in
+debug file.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Callable
+
+__all__ = [
+    "AUDIT_MARKER",
+    "MAX_LOGGED_INPUT_CHARS",
+    "ToolUseAuditor",
+    "collect_tool_schemas",
+    "describe_tool_input_anomaly",
+    "report_tool_use",
+]
+
+logger = logging.getLogger(__name__)
+
+# Fixed, greppable prefix on every line this module emits.
+AUDIT_MARKER = "tool_use audit:"
+
+# Bound on the JSON rendering written to the DEBUG log.  A structured-output
+# payload can be large, and a debug log that is mostly one tool input is
+# unreadable.
+MAX_LOGGED_INPUT_CHARS = 2000
+
+# Bound on accumulated ``input_json_delta`` text per tool call.
+_MAX_BUFFERED_ARG_CHARS = 1_000_000
+
+# Bound on simultaneously open tool_use blocks.  Per-block argument bounds do
+# not bound the total: an upstream emitting `content_block_start` without
+# matching stops would otherwise retain one entry per index for the whole
+# response.  The native path held no per-stream state before this auditor, so
+# every dimension of it has to be capped.
+_MAX_OPEN_BLOCKS = 256
+
+# Bound on the auditor's own line buffer.  The native path has no line buffer
+# today, so this one is introduced here; an upstream that never sends a newline
+# must not be able to grow it without limit.
+_MAX_LINE_BYTES = 10 * 1024 * 1024
+
+# Schema keywords whose presence means the top-level ``properties``/``required``
+# are not the authoritative constraint.  Composition and ``$ref`` put the real
+# schema somewhere this detector does not resolve — and in draft-07, which the
+# Claude Code SDK validates against, the siblings of ``$ref`` are ignored
+# entirely.  Judging such a schema from its root keys would call valid input
+# malformed, so the detector stands down instead.
+_COMPOSITION_KEYWORDS = ("oneOf", "anyOf", "allOf", "not", "if", "$ref")
+
+
+def collect_tool_schemas(messages_request: dict) -> dict[str, dict]:
+    """Map each declared tool name to its input schema.
+
+    The client tells the bridge exactly what shape it expects back, in the
+    ``tools`` array of its own request.  That declaration is the only ground
+    truth available here, and it is what makes the detector schema-driven
+    rather than provider-specific.
+
+    Args:
+        messages_request: The Anthropic Messages request body from the client.
+
+    Returns:
+        Tool name to ``input_schema``. Empty when the request declares no
+        tools, which disables anomaly detection while leaving logging active.
+    """
+    tools = messages_request.get("tools")
+    if not isinstance(tools, list):
+        return {}
+
+    schemas: dict[str, dict] = {}
+    for tool in tools:
+        if not isinstance(tool, dict):
+            continue
+        name = tool.get("name")
+        schema = tool.get("input_schema")
+        if isinstance(name, str) and isinstance(schema, dict):
+            schemas[name] = schema
+    return schemas
+
+
+def _summarize_keys(keys: list[str], limit: int = 10) -> str:
+    """Render a bounded key list for the WARNING line.
+
+    The DEBUG rendering is capped by :data:`MAX_LOGGED_INPUT_CHARS`, but the
+    WARNING is the line that can reach an embedder's handler, and its key lists
+    come straight from upstream bytes — a path-keyed input can carry thousands.
+    Bounding here keeps the one escaping line small.
+
+    Args:
+        keys: Key names to render.
+        limit: How many to show before summarising the remainder.
+
+    Returns:
+        A bracketed list, with a ``(+N more)`` suffix when truncated.
+    """
+    if len(keys) <= limit:
+        return str(keys)
+    return f"{keys[:limit]} (+{len(keys) - limit} more)"
+
+
+def _looks_nested(tool_input: dict, missing: list[str]) -> bool:
+    """Return True when the missing properties all sit one level down.
+
+    The specific fingerprint of a payload wrapped one level too deep: a single
+    root key whose value is an object containing every property the schema
+    required and the root lacks.  Far more precise than "one unexpected key",
+    and it still fires when the wrapper name collides with a declared property
+    — the documented wrapper key rotates, and one of its values is the tool's
+    own name.
+
+    Args:
+        tool_input: The returned input object.
+        missing: Required property names absent from the root.
+
+    Returns:
+        True when every missing name is present inside the single root value.
+    """
+    if len(tool_input) != 1 or not missing:
+        return False
+    inner = next(iter(tool_input.values()))
+    return isinstance(inner, dict) and all(name in inner for name in missing)
+
+
+def describe_tool_input_anomaly(name: str, tool_input: object, schema: dict | None) -> str | None:
+    """Describe how a returned tool input contradicts its declared schema.
+
+    Reports on either of two findings:
+
+    - **both** at least one root key the schema does not declare **and** at
+      least one required property missing.  Either alone is ordinary traffic —
+      a model omitting a field is a commoner failure that belongs to the
+      client's validator, and a harmless extra key is not evidence of anything
+      — so requiring both is what keeps this quiet enough to be worth reading;
+    - the nesting fingerprint of :func:`_looks_nested`, which catches a wrapped
+      payload even when the wrapper key collides with a declared property and
+      the first rule therefore cannot fire.
+
+    A root ``required`` name absent from the input is proof the input violates
+    the declared schema, unconditionally and regardless of
+    ``additionalProperties``.  That is what makes the rule precise rather than
+    merely conservative, and why it must not later be relaxed into an "or".
+
+    Deliberately describes shape and names no cause.  The reported incident is
+    *suspected* to come from an upstream wrapping tool arguments one level too
+    deep, but that was unconfirmed when this was written, and a detector that
+    asserted a cause would be wrong the moment the suspicion was.
+
+    Args:
+        name: The tool's name, for the description.
+        tool_input: The ``input`` value returned by the upstream.
+        schema: The tool's declared ``input_schema``, or None when the client
+            never declared this tool.
+
+    Returns:
+        A description of the mismatch naming **key names only, never values**,
+        or None when the input is consistent with the schema, when there is
+        nothing to check against, or when the schema is composed and its
+        constraints cannot be read directly.
+    """
+    if not isinstance(schema, dict) or not isinstance(tool_input, dict):
+        return None
+
+    # A composed or referencing schema keeps its real constraints somewhere
+    # this detector does not resolve; every valid key would look unexpected.
+    if any(keyword in schema for keyword in _COMPOSITION_KEYWORDS):
+        return None
+
+    properties = schema.get("properties")
+    required = schema.get("required")
+    if not isinstance(properties, dict) or not properties:
+        return None
+    if not isinstance(required, list) or not required:
+        return None
+
+    unexpected = sorted(key for key in tool_input if key not in properties)
+    # `required` comes from the client's request, so a malformed entry (an
+    # unhashable dict, say) must not raise: containment would disable auditing
+    # for the whole session, and the same schema recurs every turn.
+    missing = sorted(key for key in required if isinstance(key, str) and key not in tool_input)
+    nested = _looks_nested(tool_input, missing)
+    if not missing or (not unexpected and not nested):
+        return None
+
+    if unexpected:
+        description = (
+            f"tool_use {name!r} input has unexpected root key(s) {_summarize_keys(unexpected)} "
+            f"and is missing required propert(ies) {_summarize_keys(missing)}"
+        )
+    else:
+        # Only the nesting rule fired: the wrapper key is itself a declared
+        # property, so reporting an empty "unexpected" list would read as a bug.
+        description = f"tool_use {name!r} input is missing required propert(ies) {_summarize_keys(missing)}"
+    if nested:
+        description += " — every missing property is present one level down, so the payload looks wrapped (envelope)"
+    return description
+
+
+def report_tool_use(
+    name: str,
+    tool_input: object,
+    schemas: dict[str, dict],
+    *,
+    backend: str | None = None,
+    on_anomaly: Callable[[], None] | None = None,
+) -> None:
+    """Log one returned ``tool_use`` block, and warn if its shape contradicts its schema.
+
+    Always emits the DEBUG line: the point of kitty-bridge#33's first ask is
+    that the forwarded payload be recoverable from kitty's own log even when
+    nothing looks wrong.
+
+    Args:
+        name: The tool's name.
+        tool_input: The ``input`` value returned by the upstream.
+        schemas: Declared schemas from :func:`collect_tool_schemas`.
+        backend: Identifier of the backend that served the response, so a
+            warning points at a pool member.
+        on_anomaly: Called once when an anomaly is found, so the caller can
+            count it somewhere an operator will see without ``--debug``.
+    """
+    # Full input at DEBUG only — the debug log is opt-in and file-backed.
+    logger.debug("%s name=%s input=%s", AUDIT_MARKER, name, _render(tool_input))
+
+    anomaly = describe_tool_input_anomaly(name, tool_input, schemas.get(name))
+    if anomaly is None:
+        return
+
+    # Key names only. This line can reach an embedder's own handler, and tool
+    # inputs routinely carry file contents and user data.
+    logger.warning(
+        "%s upstream returned a malformed tool_use (backend=%s): %s",
+        AUDIT_MARKER,
+        backend or "unknown",
+        anomaly,
+    )
+    if on_anomaly is not None:
+        on_anomaly()
+
+
+def _render(tool_input: object) -> str:
+    """Render a tool input for the DEBUG log, bounded and never raising.
+
+    Args:
+        tool_input: The value to render.
+
+    Returns:
+        A JSON rendering truncated to :data:`MAX_LOGGED_INPUT_CHARS`, or a
+        repr-based fallback when the value is not JSON-serialisable.
+    """
+    try:
+        text = json.dumps(tool_input, ensure_ascii=False)
+    except (TypeError, ValueError):
+        text = repr(tool_input)
+    if len(text) > MAX_LOGGED_INPUT_CHARS:
+        return f"{text[:MAX_LOGGED_INPUT_CHARS]}… ({len(text)} chars total)"
+    return text
+
+
+class ToolUseAuditor:
+    """Assembles ``tool_use`` inputs from the Anthropic SSE written to the client.
+
+    Every Messages path — native passthrough, CC-translated and custom
+    transport — ends by writing Anthropic SSE to the client, so that write
+    boundary is the one place all of them share.  Observing there means one
+    parser and one state machine, and it means an abandoned upstream attempt is
+    never audited, because its events are never written.
+
+    Chunks arrive on arbitrary byte boundaries, so lines are buffered and split
+    the way the bridge's own SSE handling does.
+
+    Every public method is total.  A leaked exception here would be
+    indistinguishable from an upstream stream failure — it would inject an SSE
+    ``error`` event into a stream that already delivered valid content and
+    leave the serving backend unmarked — so parse failures and unexpected
+    shapes are contained, and after any containment event the auditor disables
+    itself for the rest of the response rather than failing once per chunk.
+    """
+
+    def __init__(
+        self,
+        schemas: dict[str, dict],
+        *,
+        backend: str | None = None,
+        on_anomaly: Callable[[], None] | None = None,
+    ) -> None:
+        """Initialise an auditor for one upstream attempt.
+
+        A new instance is required per attempt: carrying one across a failover
+        would splice the previous attempt's trailing partial line onto the next
+        attempt's first chunk and merge two independent blocks at the same
+        index, fabricating a warning about bytes that never existed together.
+
+        Args:
+            schemas: Declared tool schemas from :func:`collect_tool_schemas`.
+            backend: Identifier of the serving backend, for warnings.
+            on_anomaly: Called once per anomaly found.
+        """
+        self._schemas = schemas
+        self._backend = backend
+        self._on_anomaly = on_anomaly
+        self._line_buffer = bytearray()
+        # Open tool_use blocks by content-block index.
+        self._open: dict[int, dict] = {}
+        self._disabled = False
+
+    def feed(self, chunk: bytes) -> None:
+        """Consume one chunk of the SSE being written to the client.
+
+        Args:
+            chunk: Raw bytes, exactly as written downstream.
+        """
+        if self._disabled:
+            return
+        try:
+            self._feed(chunk)
+        except Exception as exc:
+            self._disable(f"{type(exc).__name__}: {exc}")
+
+    def finish(self) -> None:
+        """Report any ``tool_use`` block left open when the response ended.
+
+        An upstream that truncates mid-tool-call is exactly the case worth
+        seeing in the log, so the partial input is reported rather than
+        dropped.
+        """
+        if self._disabled:
+            return
+        try:
+            for index in list(self._open):
+                self._close(index)
+        except Exception as exc:
+            self._disable(f"{type(exc).__name__}: {exc}")
+
+    def _disable(self, reason: str) -> None:
+        """Stop auditing this response after a containment event.
+
+        Args:
+            reason: What went wrong, for the single DEBUG line.
+        """
+        self._disabled = True
+        self._open.clear()
+        self._line_buffer = bytearray()
+        logger.debug("%s auditing failed, disabled for this response: %s", AUDIT_MARKER, reason)
+
+    def _feed(self, chunk: bytes) -> None:
+        """Buffer bytes and dispatch each complete SSE data line.
+
+        Args:
+            chunk: Raw bytes, exactly as written downstream.
+        """
+        self._line_buffer.extend(chunk)
+        if len(self._line_buffer) > _MAX_LINE_BYTES:
+            self._disable(f"SSE line exceeded {_MAX_LINE_BYTES} bytes")
+            return
+        while b"\n" in self._line_buffer:
+            raw_line, _, rest = bytes(self._line_buffer).partition(b"\n")
+            self._line_buffer = bytearray(rest)
+            line = raw_line.decode("utf-8", errors="replace").strip()
+            # Cheap pre-check: most lines are `event:` or blank, and skipping
+            # them avoids a JSON parse per line.
+            if not line.startswith("data:"):
+                continue
+            payload = line[5:].strip()
+            if not payload or payload == "[DONE]":
+                continue
+            try:
+                event = json.loads(payload)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(event, dict):
+                self._handle(event)
+
+    def _handle(self, event: dict) -> None:
+        """Track one Anthropic SSE event.
+
+        Args:
+            event: The parsed ``data:`` payload.
+        """
+        event_type = event.get("type")
+
+        if event_type == "content_block_start":
+            block = event.get("content_block")
+            index = event.get("index")
+            if isinstance(block, dict) and block.get("type") == "tool_use" and isinstance(index, int):
+                # Anthropic always opens with an empty input and streams
+                # deltas, but a non-Anthropic shim handing back a pre-parsed
+                # tool call typically populates it here and sends no deltas at
+                # all — precisely the traffic this audit exists to see. Seed
+                # from it; any deltas that follow win.
+                if len(self._open) >= _MAX_OPEN_BLOCKS:
+                    self._disable(f"more than {_MAX_OPEN_BLOCKS} open tool_use blocks")
+                    return
+                seeded = block.get("input")
+                self._open[index] = {
+                    "name": block.get("name", ""),
+                    "args": [],
+                    "seeded": seeded if isinstance(seeded, dict) and seeded else None,
+                }
+            return
+
+        if event_type == "content_block_delta":
+            index = event.get("index")
+            delta = event.get("delta")
+            if not isinstance(index, int) or not isinstance(delta, dict):
+                return
+            state = self._open.get(index)
+            if state is None or delta.get("type") != "input_json_delta":
+                return
+            partial = delta.get("partial_json")
+            if isinstance(partial, str):
+                state["args"].append(partial)
+                state["size"] = state.get("size", 0) + len(partial)
+                # Abandon this block rather than the whole audit: a runaway
+                # tool call is still a stream the client is entitled to.
+                if state["size"] > _MAX_BUFFERED_ARG_CHARS:
+                    logger.debug("%s buffer exceeded for index %d, abandoning block", AUDIT_MARKER, index)
+                    del self._open[index]
+            return
+
+        if event_type == "content_block_stop":
+            index = event.get("index")
+            if isinstance(index, int) and index in self._open:
+                self._close(index)
+
+    def _close(self, index: int) -> None:
+        """Finish one ``tool_use`` block and report it.
+
+        Args:
+            index: The content-block index that just closed.
+        """
+        state = self._open.pop(index, None)
+        if state is None:
+            return
+
+        text = "".join(state["args"])
+        if not text:
+            # No deltas: either a shim that populated content_block_start, or
+            # a genuinely argument-less tool call.
+            report_tool_use(
+                state["name"],
+                state["seeded"] if state["seeded"] is not None else {},
+                self._schemas,
+                backend=self._backend,
+                on_anomaly=self._on_anomaly,
+            )
+            return
+
+        try:
+            tool_input = json.loads(text)
+        except json.JSONDecodeError:
+            # Invalid accumulated JSON is itself worth seeing — it is the
+            # serialization defect the issue's corroborating report describes.
+            # Length only, never the bytes: they may be a truncated payload.
+            logger.warning(
+                "%s upstream tool_use %r arguments are not valid JSON (backend=%s, %d chars)",
+                AUDIT_MARKER,
+                state["name"],
+                self._backend or "unknown",
+                len(text),
+            )
+            if self._on_anomaly is not None:
+                self._on_anomaly()
+            return
+
+        report_tool_use(
+            state["name"],
+            tool_input,
+            self._schemas,
+            backend=self._backend,
+            on_anomaly=self._on_anomaly,
+        )

--- a/src/kitty/bridge/tool_audit.py
+++ b/src/kitty/bridge/tool_audit.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 import json
 import logging
 from collections.abc import Callable
+from dataclasses import dataclass, field
 
 __all__ = [
     "AUDIT_MARKER",
@@ -107,6 +108,25 @@ def collect_tool_schemas(messages_request: dict) -> dict[str, dict]:
         if isinstance(name, str) and isinstance(schema, dict):
             schemas[name] = schema
     return schemas
+
+
+@dataclass
+class _OpenBlock:
+    """A ``tool_use`` content block whose input is still being assembled.
+
+    Attributes:
+        name: The tool's name, from ``content_block_start``.
+        fragments: ``input_json_delta`` payloads in arrival order.
+        size: Total characters buffered, kept alongside so the bound check
+            does not re-join the fragments on every delta.
+        seeded: A non-empty ``input`` present on ``content_block_start``, used
+            only when no deltas follow.
+    """
+
+    name: str
+    fragments: list[str] = field(default_factory=list)
+    size: int = 0
+    seeded: dict | None = None
 
 
 def _summarize_keys(keys: list[str], limit: int = 10) -> str:
@@ -250,7 +270,10 @@ def report_tool_use(
             count it somewhere an operator will see without ``--debug``.
     """
     # Full input at DEBUG only — the debug log is opt-in and file-backed.
-    logger.debug("%s name=%s input=%s", AUDIT_MARKER, name, _render(tool_input))
+    # Guarded because _render serialises the whole input, which is wasted work
+    # on every request when the debug log is off (the common case).
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug("%s name=%s input=%s", AUDIT_MARKER, name, _render(tool_input))
 
     anomaly = describe_tool_input_anomaly(name, tool_input, schemas.get(name))
     if anomaly is None:
@@ -331,7 +354,7 @@ class ToolUseAuditor:
         self._on_anomaly = on_anomaly
         self._line_buffer = bytearray()
         # Open tool_use blocks by content-block index.
-        self._open: dict[int, dict] = {}
+        self._open: dict[int, _OpenBlock] = {}
         self._disabled = False
 
     def feed(self, chunk: bytes) -> None:
@@ -370,7 +393,10 @@ class ToolUseAuditor:
         """
         self._disabled = True
         self._open.clear()
-        self._line_buffer = bytearray()
+        # Cleared in place rather than rebound: `_feed` holds a local alias to
+        # this bytearray while draining, and rebinding would leave it mutating
+        # an orphan.
+        self._line_buffer.clear()
         logger.debug("%s auditing failed, disabled for this response: %s", AUDIT_MARKER, reason)
 
     def _feed(self, chunk: bytes) -> None:
@@ -380,26 +406,51 @@ class ToolUseAuditor:
             chunk: Raw bytes, exactly as written downstream.
         """
         self._line_buffer.extend(chunk)
-        if len(self._line_buffer) > _MAX_LINE_BYTES:
-            self._disable(f"SSE line exceeded {_MAX_LINE_BYTES} bytes")
-            return
-        while b"\n" in self._line_buffer:
-            raw_line, _, rest = bytes(self._line_buffer).partition(b"\n")
-            self._line_buffer = bytearray(rest)
-            line = raw_line.decode("utf-8", errors="replace").strip()
-            # Cheap pre-check: most lines are `event:` or blank, and skipping
-            # them avoids a JSON parse per line.
-            if not line.startswith("data:"):
+
+        start = 0
+        buffer = self._line_buffer
+        while (newline := buffer.find(b"\n", start)) != -1:
+            raw_line = buffer[start:newline]
+            start = newline + 1
+            # Match on bytes before decoding: most lines are `event:` or blank,
+            # and decoding them only to discard them is the bulk of the work on
+            # a path that previously did no parsing at all.
+            if not raw_line.startswith(b"data:"):
                 continue
-            payload = line[5:].strip()
-            if not payload or payload == "[DONE]":
+            payload = raw_line[5:].strip()
+            if not payload or payload == b"[DONE]":
+                continue
+            # With no block open, the only event that can matter is the
+            # `content_block_start` that opens one, and its payload always
+            # carries the literal `tool_use`. A substring scan is far cheaper
+            # than a JSON parse, and it skips every event of a turn that never
+            # calls a tool — which is most of them. Once a block is open every
+            # event is parsed, because deltas and stops both matter and both
+            # need their index read.
+            if not self._open and b"tool_use" not in payload:
                 continue
             try:
-                event = json.loads(payload)
+                event = json.loads(payload.decode("utf-8", errors="replace"))
             except json.JSONDecodeError:
                 continue
             if isinstance(event, dict):
                 self._handle(event)
+                # _handle can disable the auditor (an open-block flood), and
+                # the remaining lines in this chunk must not re-populate the
+                # state it just cleared.  Belt-and-braces: `_disable` also
+                # empties the buffer this loop is scanning, which terminates it
+                # anyway.  Stated explicitly because an earlier version relied
+                # on that coupling alone and broke the moment the drain stopped
+                # re-reading `self._line_buffer` each pass.
+                if self._disabled:
+                    return
+        del buffer[:start]
+
+        # Checked on the residual, after draining: the bound exists for a line
+        # that never terminates, and testing the whole buffer first would
+        # disable the auditor for one large chunk of perfectly good lines.
+        if len(self._line_buffer) > _MAX_LINE_BYTES:
+            self._disable(f"unterminated SSE line exceeded {_MAX_LINE_BYTES} bytes")
 
     def _handle(self, event: dict) -> None:
         """Track one Anthropic SSE event.
@@ -422,11 +473,10 @@ class ToolUseAuditor:
                     self._disable(f"more than {_MAX_OPEN_BLOCKS} open tool_use blocks")
                     return
                 seeded = block.get("input")
-                self._open[index] = {
-                    "name": block.get("name", ""),
-                    "args": [],
-                    "seeded": seeded if isinstance(seeded, dict) and seeded else None,
-                }
+                self._open[index] = _OpenBlock(
+                    name=str(block.get("name", "")),
+                    seeded=seeded if isinstance(seeded, dict) and seeded else None,
+                )
             return
 
         if event_type == "content_block_delta":
@@ -439,11 +489,11 @@ class ToolUseAuditor:
                 return
             partial = delta.get("partial_json")
             if isinstance(partial, str):
-                state["args"].append(partial)
-                state["size"] = state.get("size", 0) + len(partial)
+                state.fragments.append(partial)
+                state.size += len(partial)
                 # Abandon this block rather than the whole audit: a runaway
                 # tool call is still a stream the client is entitled to.
-                if state["size"] > _MAX_BUFFERED_ARG_CHARS:
+                if state.size > _MAX_BUFFERED_ARG_CHARS:
                     logger.debug("%s buffer exceeded for index %d, abandoning block", AUDIT_MARKER, index)
                     del self._open[index]
             return
@@ -463,13 +513,13 @@ class ToolUseAuditor:
         if state is None:
             return
 
-        text = "".join(state["args"])
+        text = "".join(state.fragments)
         if not text:
             # No deltas: either a shim that populated content_block_start, or
             # a genuinely argument-less tool call.
             report_tool_use(
-                state["name"],
-                state["seeded"] if state["seeded"] is not None else {},
+                state.name,
+                state.seeded if state.seeded is not None else {},
                 self._schemas,
                 backend=self._backend,
                 on_anomaly=self._on_anomaly,
@@ -485,7 +535,7 @@ class ToolUseAuditor:
             logger.warning(
                 "%s upstream tool_use %r arguments are not valid JSON (backend=%s, %d chars)",
                 AUDIT_MARKER,
-                state["name"],
+                state.name,
                 self._backend or "unknown",
                 len(text),
             )
@@ -494,7 +544,7 @@ class ToolUseAuditor:
             return
 
         report_tool_use(
-            state["name"],
+            state.name,
             tool_input,
             self._schemas,
             backend=self._backend,

--- a/tests/bridge/test_session_stats.py
+++ b/tests/bridge/test_session_stats.py
@@ -380,6 +380,7 @@ class TestBackendDescription:
                 "healthy": True,
                 "remaining_cooldown": 0,
                 "cooldown_events": 0,
+                "malformed_tool_use": 0,
             }
         ]
 

--- a/tests/bridge/test_tool_use_audit.py
+++ b/tests/bridge/test_tool_use_audit.py
@@ -1,0 +1,230 @@
+"""Unit tests for response-side ``tool_use`` auditing.
+
+Covers kitty-bridge#33: an upstream returns a ``tool_use`` whose ``input`` is
+the wrong shape, the bridge forwards it, and nothing in kitty's log records
+what was forwarded.  The detector here is what makes that visible.
+
+The detector's whole value is precision.  A warning that fires on ordinary
+traffic trains operators to ignore it, so the negative cases below carry as
+much weight as the positive one.
+
+Covers ``.requirements/20260828T210855Z_tool_use_response_audit`` FR-1 and
+FR-5.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kitty.bridge.tool_audit import describe_tool_input_anomaly
+
+# The schema Claude Code compiled into its ajv validator, reduced to the parts
+# the detector reads.  From the incident report.
+STRUCTURED_OUTPUT_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "findings": {"type": "array"},
+        "conversation_notes": {"type": "string"},
+    },
+    "required": ["findings", "conversation_notes"],
+    "additionalProperties": False,
+}
+
+
+class TestReportedFingerprint:
+    """AC-1.1 — the shape the incident actually produced."""
+
+    def test_envelope_wrapped_payload_is_reported(self):
+        """The ajv triple from the issue, reproduced as a shape mismatch."""
+        tool_input = {
+            "result": {
+                "findings": [{"file": "a.py"}],
+                "conversation_notes": "looks fine",
+            }
+        }
+        description = describe_tool_input_anomaly("StructuredOutput", tool_input, STRUCTURED_OUTPUT_SCHEMA)
+
+        assert description is not None
+        assert "result" in description
+        assert "findings" in description
+        assert "conversation_notes" in description
+
+    @pytest.mark.parametrize("wrapper", ["result", "arguments", "StructuredOutput"])
+    def test_every_documented_wrapper_key_is_reported(self, wrapper):
+        """The wrapper key is documented as rotating between three values.
+
+        The detector keys off the schema, not off a list of wrapper names, so
+        all three are caught by the same rule — and so would a fourth.
+        """
+        tool_input = {wrapper: {"findings": [], "conversation_notes": ""}}
+        assert describe_tool_input_anomaly("StructuredOutput", tool_input, STRUCTURED_OUTPUT_SCHEMA) is not None
+
+    def test_envelope_hint_is_offered_for_a_single_object_key(self):
+        """AC-1.6 — a single root key wrapping an object is called out as a hint."""
+        tool_input = {"result": {"findings": [], "conversation_notes": ""}}
+        description = describe_tool_input_anomaly("StructuredOutput", tool_input, STRUCTURED_OUTPUT_SCHEMA)
+
+        assert description is not None
+        assert "envelope" in description.lower()
+
+    def test_no_envelope_hint_for_a_scalar_key(self):
+        """AC-1.6 — a single unexpected scalar is a mismatch but not an envelope.
+
+        Calling it an envelope would send a reader looking for a nesting bug
+        that isn't there.
+        """
+        description = describe_tool_input_anomaly("StructuredOutput", {"oops": "text"}, STRUCTURED_OUTPUT_SCHEMA)
+
+        assert description is not None
+        assert "envelope" not in description.lower()
+
+
+class TestDetectorStaysQuiet:
+    """The negative cases — each one is traffic that must never warn."""
+
+    def test_wellformed_input_is_silent(self):
+        """AC-1.2 — the ordinary case."""
+        tool_input = {"findings": [], "conversation_notes": "ok"}
+        assert describe_tool_input_anomaly("StructuredOutput", tool_input, STRUCTURED_OUTPUT_SCHEMA) is None
+
+    def test_missing_required_alone_is_silent(self):
+        """AC-1.3 — an incomplete payload is not the reported fingerprint.
+
+        The model simply omitting a field is a different, commoner failure and
+        is the client validator's business, not this detector's.
+        """
+        assert describe_tool_input_anomaly("StructuredOutput", {"findings": []}, STRUCTURED_OUTPUT_SCHEMA) is None
+
+    def test_extra_key_alone_is_silent(self):
+        """AC-1.4 — a harmless extra key is not the reported fingerprint."""
+        tool_input = {"findings": [], "conversation_notes": "ok", "extra": 1}
+        assert describe_tool_input_anomaly("StructuredOutput", tool_input, STRUCTURED_OUTPUT_SCHEMA) is None
+
+    def test_unknown_tool_is_silent(self):
+        """AC-1.5 — a tool the client never declared cannot be judged."""
+        assert describe_tool_input_anomaly("SomeServerTool", {"anything": 1}, None) is None
+
+    def test_schema_without_properties_or_required_is_silent(self):
+        """AC-1.5 — nothing to check against.
+
+        Claude Code declares several tools with a bare object schema; those
+        must never produce a warning.
+        """
+        assert describe_tool_input_anomaly("Bare", {"whatever": 1}, {"type": "object"}) is None
+
+    def test_empty_schema_is_silent(self):
+        """AC-1.5 — an empty schema is not evidence of anything."""
+        assert describe_tool_input_anomaly("Bare", {"whatever": 1}, {}) is None
+
+    def test_non_dict_input_is_silent(self):
+        """AC-1.5 — a non-object input is a different defect, not this one."""
+        assert describe_tool_input_anomaly("StructuredOutput", ["findings"], STRUCTURED_OUTPUT_SCHEMA) is None
+        assert describe_tool_input_anomaly("StructuredOutput", "text", STRUCTURED_OUTPUT_SCHEMA) is None
+        assert describe_tool_input_anomaly("StructuredOutput", None, STRUCTURED_OUTPUT_SCHEMA) is None
+
+    def test_empty_input_against_required_schema_is_silent(self):
+        """An empty object has no unexpected key, so it is not the fingerprint."""
+        assert describe_tool_input_anomaly("StructuredOutput", {}, STRUCTURED_OUTPUT_SCHEMA) is None
+
+    def test_schema_with_only_required_and_no_properties_still_works(self):
+        """`required` alone is enough to detect a missing field, but not an extra one.
+
+        With no `properties` there is no way to call any key unexpected, so the
+        both-conditions rule keeps this silent.
+        """
+        schema = {"type": "object", "required": ["findings"]}
+        assert describe_tool_input_anomaly("T", {"result": {}}, schema) is None
+
+
+class TestRulePrecisionIsPinned:
+    """The two rules each have a case only they can catch — pin both.
+
+    Without these, either rule could be deleted and the suite would stay green,
+    which would make the spec's "must never be relaxed into an or" unenforced.
+    """
+
+    def test_fires_under_additional_properties_true(self):
+        """AC-1.7 — a missing root `required` is a violation regardless.
+
+        `additionalProperties: true` permits the extra key, but `required` at
+        the root is unconditional, so the input is provably invalid. This AC
+        exists to stop a future change from suppressing the warning here.
+        """
+        schema = {
+            "type": "object",
+            "properties": {"findings": {"type": "array"}, "conversation_notes": {"type": "string"}},
+            "required": ["findings", "conversation_notes"],
+            "additionalProperties": True,
+        }
+        tool_input = {"result": {"findings": [], "conversation_notes": "x"}}
+        assert describe_tool_input_anomaly("StructuredOutput", tool_input, schema) is not None
+
+    def test_nesting_rule_fires_when_the_wrapper_collides_with_a_declared_property(self):
+        """The case that justifies the nesting rule's existence.
+
+        The documented wrapper key rotates between `result`, `arguments` and
+        the tool's own name. If a tool happens to declare a property called
+        `result`, nothing is "unexpected" and the first rule cannot fire — the
+        wrapped payload would go unreported without the nesting fingerprint.
+        """
+        schema = {
+            "type": "object",
+            "properties": {
+                "result": {"type": "object"},
+                "findings": {"type": "array"},
+                "conversation_notes": {"type": "string"},
+            },
+            "required": ["findings", "conversation_notes"],
+        }
+        tool_input = {"result": {"findings": [], "conversation_notes": "x"}}
+
+        description = describe_tool_input_anomaly("StructuredOutput", tool_input, schema)
+        assert description is not None, "the nesting rule is the only thing that can catch this"
+        assert "envelope" in description.lower()
+        # No key is unexpected here, so the message must not claim otherwise.
+        assert "[]" not in description
+
+    def test_malformed_required_entry_does_not_raise(self):
+        """A schema comes from the client, so a bad entry must not raise.
+
+        Containment would disable auditing for the whole response, and the same
+        schema arrives on every turn — so one malformed tool declaration would
+        silently switch the audit off for the session.
+        """
+        schema = {"type": "object", "properties": {"p": {}}, "required": [{"bad": 1}, "p"]}
+
+        # The malformed entry is skipped rather than poisoning the whole check:
+        # the valid `p` is still judged, so one bad declaration cannot blind the
+        # audit to the rest of the schema.
+        description = describe_tool_input_anomaly("T", {"other": 1}, schema)
+        assert description is not None
+        assert "'p'" in description
+        assert "bad" not in description
+
+
+class TestComposedSchemas:
+    """Schemas whose real property set is not in the top-level `properties`.
+
+    A composed schema hides its properties inside `oneOf`/`anyOf`/`allOf` or
+    behind `$ref`.  Treating the top-level `properties` as complete would make
+    every valid key look unexpected, so the detector must stand down instead.
+    """
+
+    @pytest.mark.parametrize("keyword", ["oneOf", "anyOf", "allOf"])
+    def test_composed_schema_is_silent(self, keyword):
+        schema = {
+            "type": "object",
+            "properties": {"kind": {"type": "string"}},
+            "required": ["kind"],
+            keyword: [{"properties": {"findings": {"type": "array"}}}],
+        }
+        assert describe_tool_input_anomaly("T", {"findings": []}, schema) is None
+
+    def test_ref_schema_is_silent(self):
+        schema = {
+            "type": "object",
+            "properties": {"kind": {"type": "string"}},
+            "required": ["kind"],
+            "$ref": "#/definitions/Other",
+        }
+        assert describe_tool_input_anomaly("T", {"findings": []}, schema) is None

--- a/tests/bridge/test_tool_use_audit_streaming.py
+++ b/tests/bridge/test_tool_use_audit_streaming.py
@@ -1,0 +1,535 @@
+"""Subsystem tests for response-side ``tool_use`` auditing in the Messages bridge.
+
+kitty-bridge#33: response payloads were logged only on the custom transport, so
+a malformed ``tool_use`` was forwarded to the client with nothing in kitty's own
+log recording what went out.  These tests prove the audit fires on the paths the
+reporter actually uses, and — the point that matters most — that it changes
+nothing about what the client receives.
+
+Covers ``.requirements/20260828T210855Z_tool_use_response_audit`` FR-3 … FR-6.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+
+import aiohttp
+import pytest
+from aioresponses import CallbackResult, aioresponses
+
+from kitty.bridge.server import BridgeServer
+from kitty.launchers.base import LauncherAdapter, SpawnConfig
+from kitty.profiles.schema import Profile
+from kitty.providers.custom_anthropic import CustomAnthropicAdapter
+from kitty.providers.custom_openai import CustomOpenAIAdapter
+from kitty.types import BridgeProtocol
+
+NATIVE_URL = "https://api.native.test/anthropic/v1/messages"
+CC_URL = "https://api.cc.test/v1/chat/completions"
+AUDIT_LOGGER = "kitty.bridge.tool_audit"
+
+STRUCTURED_OUTPUT_SCHEMA = {
+    "type": "object",
+    "properties": {"findings": {"type": "array"}, "conversation_notes": {"type": "string"}},
+    "required": ["findings", "conversation_notes"],
+    "additionalProperties": False,
+}
+
+
+class _StubLauncher(LauncherAdapter):
+    """Minimal launcher that selects the Messages API bridge protocol."""
+
+    @property
+    def name(self) -> str:
+        return "stub"
+
+    @property
+    def binary_name(self) -> str:
+        return "stub"
+
+    @property
+    def bridge_protocol(self) -> BridgeProtocol:
+        return BridgeProtocol.MESSAGES_API
+
+    def build_spawn_config(self, profile, bridge_port: int, resolved_key: str) -> SpawnConfig:
+        return SpawnConfig(env_overrides={}, env_clear=[], cli_args=[])
+
+
+def _sse(event_type: str, payload: dict) -> str:
+    """Render one Anthropic SSE event."""
+    return f"event: {event_type}\ndata: {json.dumps(payload)}\n\n"
+
+
+def _native_tool_use_sse(tool_input: dict, name: str = "StructuredOutput") -> bytes:
+    """A well-formed native Anthropic stream whose assistant turn calls one tool."""
+    return "".join(
+        [
+            _sse(
+                "message_start",
+                {
+                    "type": "message_start",
+                    "message": {
+                        "id": "msg_1",
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [],
+                        "model": "MiniMax-M3",
+                        "usage": {"input_tokens": 5, "output_tokens": 0},
+                    },
+                },
+            ),
+            _sse(
+                "content_block_start",
+                {
+                    "type": "content_block_start",
+                    "index": 0,
+                    "content_block": {"type": "tool_use", "id": "toolu_1", "name": name, "input": {}},
+                },
+            ),
+            _sse(
+                "content_block_delta",
+                {
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": {"type": "input_json_delta", "partial_json": json.dumps(tool_input)},
+                },
+            ),
+            _sse("content_block_stop", {"type": "content_block_stop", "index": 0}),
+            _sse("message_delta", {"type": "message_delta", "delta": {"stop_reason": "tool_use"}}),
+            _sse("message_stop", {"type": "message_stop"}),
+        ]
+    ).encode()
+
+
+def _cc_tool_call_sse(tool_input: dict, name: str = "StructuredOutput") -> bytes:
+    """A Chat Completions stream whose assistant turn calls one tool."""
+    chunks = [
+        {
+            "id": "chatcmpl-1",
+            "object": "chat.completion.chunk",
+            "model": "MiniMax-M3",
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "id": "call_1",
+                                "type": "function",
+                                "function": {"name": name, "arguments": json.dumps(tool_input)},
+                            }
+                        ]
+                    },
+                }
+            ],
+        },
+        {
+            "id": "chatcmpl-1",
+            "object": "chat.completion.chunk",
+            "model": "MiniMax-M3",
+            "choices": [{"index": 0, "delta": {}, "finish_reason": "tool_calls"}],
+        },
+    ]
+    body = "".join(f"data: {json.dumps(c)}\n\n" for c in chunks)
+    return (body + "data: [DONE]\n\n").encode()
+
+
+def _client_request(*, stream: bool = True, with_tools: bool = True) -> dict:
+    """A Claude Code request declaring the StructuredOutput tool."""
+    request: dict = {
+        "model": "claude-sonnet-4-6",
+        "max_tokens": 4096,
+        "stream": stream,
+        "messages": [{"role": "user", "content": [{"type": "text", "text": "review"}]}],
+    }
+    if with_tools:
+        request["tools"] = [
+            {
+                "name": "StructuredOutput",
+                "description": "Emit the structured review",
+                "input_schema": STRUCTURED_OUTPUT_SCHEMA,
+            }
+        ]
+    return request
+
+
+def _make_server(*, native: bool) -> BridgeServer:
+    """Build a single-backend Messages server on the requested wire shape."""
+    if native:
+        provider: object = CustomAnthropicAdapter()
+        base_url = "https://api.native.test/anthropic"
+    else:
+        provider = CustomOpenAIAdapter()
+        base_url = "https://api.cc.test/v1"
+
+    profile = Profile(
+        name="pool-member-1",
+        provider="custom_anthropic" if native else "custom_openai",
+        model="MiniMax-M3",
+        auth_ref=str(uuid.uuid4()),
+        provider_config={"base_url": base_url},
+    )
+    return BridgeServer(
+        adapter=_StubLauncher(),
+        provider=provider,
+        resolved_key="key-1",
+        model="MiniMax-M3",
+        provider_config=profile.provider_config,
+        host="127.0.0.1",
+        port=0,
+    )
+
+
+def _make_balancing_server() -> BridgeServer:
+    """Build a two-member native pool, the shape the incident report describes.
+
+    The backend label only carries a profile name in balancing mode, and
+    naming the pool member is the difference between "something returned
+    garbage" and "this member returned garbage".
+    """
+    backends = []
+    for name in ("pool-member-1", "pool-member-2"):
+        profile = Profile(
+            name=name,
+            provider="custom_anthropic",
+            model="MiniMax-M3",
+            auth_ref=str(uuid.uuid4()),
+            provider_config={"base_url": "https://api.native.test/anthropic"},
+        )
+        backends.append((CustomAnthropicAdapter(), f"key-{name}", profile))
+
+    return BridgeServer(
+        adapter=_StubLauncher(),
+        provider=backends[0][0],
+        resolved_key=backends[0][1],
+        model="MiniMax-M3",
+        provider_config=backends[0][2].provider_config,
+        backends=backends,
+        host="127.0.0.1",
+        port=0,
+    )
+
+
+async def _post(server: BridgeServer, request: dict) -> tuple[int, bytes]:
+    async with (
+        aiohttp.ClientSession() as session,
+        session.post(f"http://127.0.0.1:{server.port}/v1/messages", json=request) as resp,
+    ):
+        return resp.status, await resp.read()
+
+
+async def _run(server: BridgeServer, url: str, upstream_body: bytes, request: dict) -> tuple[int, bytes]:
+    """Serve one scripted upstream response through the bridge."""
+    with aioresponses(passthrough=["http://127.0.0.1"]) as m:
+        m.post(
+            url,
+            callback=lambda u, **kw: CallbackResult(
+                status=200, headers={"Content-Type": "text/event-stream"}, body=upstream_body
+            ),
+            repeat=True,
+        )
+        await server.start_async()
+        try:
+            return await _post(server, request)
+        finally:
+            await server.stop_async()
+
+
+class TestNativePassthrough:
+    """AC-3.1 / AC-4.1 — the path the reporter's MiniMax pool actually uses."""
+
+    @pytest.mark.asyncio
+    async def test_tool_use_input_is_logged(self, caplog):
+        server = _make_server(native=True)
+        clean = {"findings": [], "conversation_notes": "ok"}
+
+        with caplog.at_level(logging.DEBUG, logger=AUDIT_LOGGER):
+            status, _ = await _run(server, NATIVE_URL, _native_tool_use_sse(clean), _client_request())
+
+        assert status == 200
+        assert any(
+            "StructuredOutput" in r.getMessage() and "conversation_notes" in r.getMessage()
+            for r in caplog.records
+        ), [r.getMessage() for r in caplog.records]
+
+    @pytest.mark.asyncio
+    async def test_envelope_wrapped_input_warns_naming_the_backend(self, caplog):
+        """The whole point of the issue: make this visible instead of silent.
+
+        Uses a balancing pool because that is the reported setup, and because
+        the profile name is what lets an operator act on the warning.
+        """
+        server = _make_balancing_server()
+        wrapped = {"result": {"findings": [], "conversation_notes": "ok"}}
+
+        with caplog.at_level(logging.WARNING, logger=AUDIT_LOGGER):
+            status, _ = await _run(server, NATIVE_URL, _native_tool_use_sse(wrapped), _client_request())
+
+        assert status == 200
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING and r.name == AUDIT_LOGGER]
+        assert len(warnings) == 1, [r.getMessage() for r in warnings]
+        message = warnings[0].getMessage()
+        # Pool selection is random, so pin the property that matters: the
+        # warning names a profile, not the provider type shared by every member.
+        assert "pool-member-1" in message or "pool-member-2" in message, message
+        assert "result" in message
+        assert "findings" in message
+
+    @pytest.mark.asyncio
+    async def test_clean_input_does_not_warn(self, caplog):
+        """AC-4.2 — ordinary traffic must stay quiet or the warning is worthless."""
+        server = _make_server(native=True)
+        clean = {"findings": [{"file": "a.py"}], "conversation_notes": "ok"}
+
+        with caplog.at_level(logging.WARNING, logger=AUDIT_LOGGER):
+            await _run(server, NATIVE_URL, _native_tool_use_sse(clean), _client_request())
+
+        assert [r for r in caplog.records if r.levelno == logging.WARNING and r.name == AUDIT_LOGGER] == []
+
+    @pytest.mark.asyncio
+    async def test_client_bytes_are_unchanged_by_auditing(self):
+        """AC-5.1 — the client receives exactly the upstream stream.
+
+        Auditing reads the same bytes it forwards; if it ever altered or
+        withheld one, this is what would catch it.
+        """
+        # AC-5.1 asks for thinking and text alongside the tool_use, so the
+        # comparison covers every block type the auditor walks past.
+        upstream_body = (
+            _sse(
+                "message_start",
+                {
+                    "type": "message_start",
+                    "message": {
+                        "id": "msg_1",
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [],
+                        "model": "MiniMax-M3",
+                        "usage": {"input_tokens": 5, "output_tokens": 0},
+                    },
+                },
+            )
+            + _sse(
+                "content_block_start",
+                {
+                    "type": "content_block_start",
+                    "index": 0,
+                    "content_block": {"type": "thinking", "thinking": ""},
+                },
+            )
+            + _sse(
+                "content_block_delta",
+                {
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": {"type": "thinking_delta", "thinking": "considering"},
+                },
+            )
+            + _sse("content_block_stop", {"type": "content_block_stop", "index": 0})
+            + _sse(
+                "content_block_start",
+                {"type": "content_block_start", "index": 1, "content_block": {"type": "text", "text": ""}},
+            )
+            + _sse(
+                "content_block_delta",
+                {"type": "content_block_delta", "index": 1, "delta": {"type": "text_delta", "text": "hi"}},
+            )
+            + _sse("content_block_stop", {"type": "content_block_stop", "index": 1})
+        ).encode() + _native_tool_use_sse({"result": {"findings": []}})
+        server = _make_server(native=True)
+
+        status, received = await _run(server, NATIVE_URL, upstream_body, _client_request())
+
+        assert status == 200
+        assert received == upstream_body
+
+
+class TestTranslatedPath:
+    """AC-3.2 — a Chat Completions upstream, audited via the events we emit."""
+
+    @pytest.mark.asyncio
+    async def test_tool_use_input_is_logged(self, caplog):
+        server = _make_server(native=False)
+        clean = {"findings": [], "conversation_notes": "ok"}
+
+        with caplog.at_level(logging.DEBUG, logger=AUDIT_LOGGER):
+            status, _ = await _run(server, CC_URL, _cc_tool_call_sse(clean), _client_request())
+
+        assert status == 200
+        assert any("StructuredOutput" in r.getMessage() for r in caplog.records), [
+            r.getMessage() for r in caplog.records
+        ]
+
+    @pytest.mark.asyncio
+    async def test_envelope_wrapped_input_warns(self, caplog):
+        server = _make_server(native=False)
+        wrapped = {"result": {"findings": [], "conversation_notes": "ok"}}
+
+        with caplog.at_level(logging.WARNING, logger=AUDIT_LOGGER):
+            await _run(server, CC_URL, _cc_tool_call_sse(wrapped), _client_request())
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING and r.name == AUDIT_LOGGER]
+        assert len(warnings) == 1, [r.getMessage() for r in warnings]
+        assert "result" in warnings[0].getMessage()
+
+
+class TestNonStreaming:
+    """AC-3.3 — a non-streaming response carries its tool_use complete."""
+
+    @pytest.mark.asyncio
+    async def test_envelope_wrapped_input_warns(self, caplog):
+        server = _make_server(native=True)
+        body = {
+            "id": "msg_1",
+            "type": "message",
+            "role": "assistant",
+            "model": "MiniMax-M3",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "toolu_1",
+                    "name": "StructuredOutput",
+                    "input": {"result": {"findings": [], "conversation_notes": "ok"}},
+                }
+            ],
+            "usage": {"input_tokens": 5, "output_tokens": 3},
+        }
+
+        with (
+            aioresponses(passthrough=["http://127.0.0.1"]) as m,
+            caplog.at_level(logging.WARNING, logger=AUDIT_LOGGER),
+        ):
+            m.post(NATIVE_URL, payload=body, repeat=True)
+            await server.start_async()
+            try:
+                status, _ = await _post(server, _client_request(stream=False))
+            finally:
+                await server.stop_async()
+
+        assert status == 200
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING and r.name == AUDIT_LOGGER]
+        assert len(warnings) == 1, [r.getMessage() for r in warnings]
+        assert "result" in warnings[0].getMessage()
+
+
+class TestNoToolsDeclared:
+    """AC-2.2 — logging without schemas still works, and never warns."""
+
+    @pytest.mark.asyncio
+    async def test_logs_but_does_not_warn(self, caplog):
+        server = _make_server(native=True)
+        wrapped = {"result": {"findings": []}}
+
+        with caplog.at_level(logging.DEBUG, logger=AUDIT_LOGGER):
+            await _run(server, NATIVE_URL, _native_tool_use_sse(wrapped), _client_request(with_tools=False))
+
+        assert any("StructuredOutput" in r.getMessage() for r in caplog.records)
+        assert [r for r in caplog.records if r.levelno == logging.WARNING and r.name == AUDIT_LOGGER] == []
+
+
+class TestTruncatedStream:
+    """A stream that dies mid-response still delivered bytes to the client.
+
+    The interrupted-stream finalization paths write Anthropic SSE downstream,
+    so they must be audited like any other write — and this is not a corner
+    case: #33 reports the failure as *intermittent on identical input*, and an
+    upstream that truncates after emitting the tool call is the archetype. It
+    is exactly when the counter must not stay at zero.
+    """
+
+    @pytest.mark.asyncio
+    async def test_tool_use_on_a_truncated_stream_is_audited(self, caplog):
+        server = _make_server(native=False)
+        wrapped = {"result": {"findings": [], "conversation_notes": "ok"}}
+        # A tool call, then the stream simply stops: no finish_reason, no [DONE].
+        truncated = json.dumps(
+            {
+                "id": "chatcmpl-1",
+                "object": "chat.completion.chunk",
+                "model": "MiniMax-M3",
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {
+                            "tool_calls": [
+                                {
+                                    "index": 0,
+                                    "id": "call_1",
+                                    "type": "function",
+                                    "function": {
+                                        "name": "StructuredOutput",
+                                        "arguments": json.dumps(wrapped),
+                                    },
+                                }
+                            ]
+                        },
+                    }
+                ],
+            }
+        )
+        body = f"data: {truncated}\n\n".encode()
+
+        with caplog.at_level(logging.DEBUG, logger=AUDIT_LOGGER):
+            status, received = await _run(server, CC_URL, body, _client_request())
+
+        assert status == 200
+        assert b"tool_use" in received, "the client did receive the tool call"
+
+        audit_records = [r for r in caplog.records if r.name == AUDIT_LOGGER]
+        assert any("StructuredOutput" in r.getMessage() for r in audit_records), [
+            r.getMessage() for r in audit_records
+        ]
+        assert server._session_stats()["malformed_tool_use"] == 1
+
+
+class TestStatsCounter:
+    """The signal has to survive a run without ``--debug``.
+
+    ``kitty/__init__.py`` attaches only a NullHandler, and the sole real
+    handler is the DEBUG file handler created when ``--debug`` is passed. A
+    WARNING alone would therefore reach nobody in an ordinary run — which is
+    the situation the issue is complaining about. The counter is surfaced by
+    ``GET /stats`` and the shutdown summary instead.
+    """
+
+    @pytest.mark.asyncio
+    async def test_malformed_tool_use_is_counted(self):
+        server = _make_server(native=True)
+        wrapped = {"result": {"findings": [], "conversation_notes": "ok"}}
+
+        await _run(server, NATIVE_URL, _native_tool_use_sse(wrapped), _client_request())
+
+        stats = server._session_stats()
+        assert stats["malformed_tool_use"] == 1
+        assert stats["backends"][0]["malformed_tool_use"] == 1
+
+    @pytest.mark.asyncio
+    async def test_clean_traffic_counts_zero(self):
+        server = _make_server(native=True)
+        clean = {"findings": [], "conversation_notes": "ok"}
+
+        await _run(server, NATIVE_URL, _native_tool_use_sse(clean), _client_request())
+
+        stats = server._session_stats()
+        assert stats["malformed_tool_use"] == 0
+        assert stats["backends"][0]["malformed_tool_use"] == 0
+
+
+class TestHealthUntouched:
+    """AC-6.1 — a shape mismatch is diagnostics, not a routing signal."""
+
+    @pytest.mark.asyncio
+    async def test_backend_health_is_not_affected(self):
+        server = _make_server(native=True)
+        wrapped = {"result": {"findings": [], "conversation_notes": "ok"}}
+
+        status, _ = await _run(server, NATIVE_URL, _native_tool_use_sse(wrapped), _client_request())
+
+        assert status == 200
+        # Single-backend mode keeps no health entries; the assertion that
+        # matters is that the request succeeded and nothing was marked.
+        assert server._backend_health == []

--- a/tests/bridge/test_tool_use_auditor.py
+++ b/tests/bridge/test_tool_use_auditor.py
@@ -326,6 +326,50 @@ class TestAuditorIsTotal:
         warnings = [r for r in caplog.records if r.levelno == logging.WARNING and r.name == AUDIT_LOGGER]
         assert len(warnings) == 2, [r.getMessage() for r in warnings]
 
+    def test_a_large_chunk_of_complete_lines_does_not_disable(self):
+        """The line bound is for an *unterminated* line, not for volume.
+
+        Checking the whole buffer before draining would disable the auditor on
+        one big chunk of perfectly good SSE — and then silently miss every tool
+        call in the rest of the response.
+        """
+        auditor = ToolUseAuditor({}, backend="b")
+        filler = b"".join(
+            _sse("content_block_delta", {"type": "content_block_delta", "index": 9, "delta": {}})
+            for _ in range(20000)
+        )
+        assert len(filler) > _MAX_LINE_BYTES // 8, "filler should be substantial"
+
+        auditor.feed(filler * 8)
+        auditor.feed(_tool_use_stream("Read", '{"path":"a.py"}'))
+        auditor.finish()
+
+        assert auditor._disabled is False
+
+    def test_tool_use_after_a_long_text_stream_is_still_detected(self, caplog):
+        """The cheap pre-filter must not hide a tool call that comes later.
+
+        Events are skipped without parsing only while no block is open, so a
+        turn that talks for a long time and then calls a tool must still be
+        caught.
+        """
+        auditor = ToolUseAuditor({"StructuredOutput": STRUCTURED_OUTPUT_SCHEMA}, backend="b")
+        chatter = b"".join(
+            _sse(
+                "content_block_delta",
+                {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "hello "}},
+            )
+            for _ in range(500)
+        )
+
+        with caplog.at_level(logging.WARNING, logger=AUDIT_LOGGER):
+            auditor.feed(chatter)
+            auditor.feed(_tool_use_stream("StructuredOutput", '{"result":{"findings":[],"conversation_notes":"x"}}', 1))
+            auditor.finish()
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING and r.name == AUDIT_LOGGER]
+        assert len(warnings) == 1, [r.getMessage() for r in warnings]
+
     def test_line_buffer_bound_disables_the_auditor(self, caplog):
         """FR-5 — an upstream that never sends a newline must not grow it forever."""
         auditor = ToolUseAuditor({}, backend="b")

--- a/tests/bridge/test_tool_use_auditor.py
+++ b/tests/bridge/test_tool_use_auditor.py
@@ -1,0 +1,378 @@
+"""Unit tests for the SSE-side ``tool_use`` assembler.
+
+The native-passthrough path forwards upstream bytes to the client without
+parsing them, so the only way to record what was forwarded is to read the
+stream alongside it.  These tests pin that reconstruction, and — just as
+importantly — pin that it can never break the stream it observes.
+
+Covers ``.requirements/20260828T210855Z_tool_use_response_audit`` FR-3, FR-4
+and FR-5.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import pytest
+
+from kitty.bridge.tool_audit import (
+    _MAX_BUFFERED_ARG_CHARS,
+    _MAX_LINE_BYTES,
+    _MAX_OPEN_BLOCKS,
+    ToolUseAuditor,
+)
+
+from .test_tool_use_audit import STRUCTURED_OUTPUT_SCHEMA
+
+AUDIT_LOGGER = "kitty.bridge.tool_audit"
+
+
+def _sse(event_type: str, payload: dict) -> bytes:
+    """Render one Anthropic SSE event exactly as an upstream would."""
+    return f"event: {event_type}\ndata: {json.dumps(payload)}\n\n".encode()
+
+
+def _start(name: str, index: int = 0) -> bytes:
+    """A ``content_block_start`` opening a tool_use block."""
+    return _sse(
+        "content_block_start",
+        {
+            "type": "content_block_start",
+            "index": index,
+            "content_block": {"type": "tool_use", "id": "toolu_1", "name": name, "input": {}},
+        },
+    )
+
+
+def _delta(partial: str, index: int = 0) -> bytes:
+    """An ``input_json_delta`` carrying a fragment of the argument JSON."""
+    return _sse(
+        "content_block_delta",
+        {
+            "type": "content_block_delta",
+            "index": index,
+            "delta": {"type": "input_json_delta", "partial_json": partial},
+        },
+    )
+
+
+def _stop(index: int = 0) -> bytes:
+    """A ``content_block_stop`` closing a block."""
+    return _sse("content_block_stop", {"type": "content_block_stop", "index": index})
+
+
+def _tool_use_stream(name: str, argument_json: str, index: int = 0) -> bytes:
+    """A minimal SSE stream carrying one complete tool_use block."""
+    return _start(name, index) + _delta(argument_json, index) + _stop(index)
+
+
+class TestAssembly:
+    """AC-3.1 — the assembler reconstructs the input that was forwarded."""
+
+    def test_tool_use_input_is_logged(self, caplog):
+        auditor = ToolUseAuditor({}, backend="minimax-large")
+        with caplog.at_level(logging.DEBUG, logger=AUDIT_LOGGER):
+            auditor.feed(_tool_use_stream("Read", '{"path":"a.py"}'))
+            auditor.finish()
+
+        messages = [r.getMessage() for r in caplog.records]
+        assert any("Read" in m and "a.py" in m for m in messages), messages
+
+    @pytest.mark.parametrize("size", [1, 3, 7, 64])
+    def test_assembly_is_independent_of_chunk_boundaries(self, size, caplog):
+        """Upstream chunks are arbitrary TCP bytes — not lines, not events.
+
+        Size 1 splits every multi-byte UTF-8 sequence and every JSON token.
+        """
+        stream = _tool_use_stream("Read", '{"path":"café.py"}')
+        auditor = ToolUseAuditor({}, backend="b")
+        with caplog.at_level(logging.DEBUG, logger=AUDIT_LOGGER):
+            for start in range(0, len(stream), size):
+                auditor.feed(stream[start : start + size])
+            auditor.finish()
+
+        assert any("café.py" in r.getMessage() for r in caplog.records), f"chunk size {size}"
+
+    def test_arguments_split_across_deltas_are_joined(self, caplog):
+        """Real upstreams deliver argument JSON one fragment at a time."""
+        auditor = ToolUseAuditor({}, backend="b")
+        stream = _start("Read") + b"".join(_delta(f) for f in ('{"pa', 'th":"', 'a.py"}')) + _stop()
+
+        with caplog.at_level(logging.DEBUG, logger=AUDIT_LOGGER):
+            auditor.feed(stream)
+            auditor.finish()
+
+        assert any("a.py" in r.getMessage() for r in caplog.records)
+
+    def test_text_only_stream_reports_no_tool_use(self, caplog):
+        """A stream with no tool_use must not invent one."""
+        auditor = ToolUseAuditor({}, backend="b")
+        stream = (
+            _sse(
+                "content_block_start",
+                {"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}},
+            )
+            + _stop()
+        )
+        with caplog.at_level(logging.DEBUG, logger=AUDIT_LOGGER):
+            auditor.feed(stream)
+            auditor.finish()
+
+        assert not any("tool_use" in r.getMessage() for r in caplog.records)
+
+    def test_parallel_tool_calls_are_reported_separately(self, caplog):
+        """AC-4.3 — two blocks, two reports, correctly de-interleaved by index."""
+        auditor = ToolUseAuditor({}, backend="b")
+        stream = (
+            _start("Read", 0)
+            + _start("Write", 1)
+            + _delta('{"path":"a.py"}', 0)
+            + _delta('{"path":"b.py"}', 1)
+            + _stop(0)
+            + _stop(1)
+        )
+        with caplog.at_level(logging.DEBUG, logger=AUDIT_LOGGER):
+            auditor.feed(stream)
+            auditor.finish()
+
+        messages = [r.getMessage() for r in caplog.records]
+        assert any("Read" in m and "a.py" in m for m in messages), messages
+        assert any("Write" in m and "b.py" in m for m in messages), messages
+
+
+class TestWarnsOnAnomaly:
+    """AC-4.1 / AC-4.2 — the warning fires exactly when the shape contradicts the schema."""
+
+    def test_envelope_wrapped_input_warns_once(self, caplog):
+        auditor = ToolUseAuditor({"StructuredOutput": STRUCTURED_OUTPUT_SCHEMA}, backend="minimax-large")
+        payload = '{"result":{"findings":[],"conversation_notes":"x"}}'
+
+        with caplog.at_level(logging.WARNING, logger=AUDIT_LOGGER):
+            auditor.feed(_tool_use_stream("StructuredOutput", payload))
+            auditor.finish()
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) == 1, [r.getMessage() for r in warnings]
+        message = warnings[0].getMessage()
+        assert "minimax-large" in message
+        assert "result" in message
+        assert "findings" in message
+
+    def test_clean_input_does_not_warn(self, caplog):
+        auditor = ToolUseAuditor({"StructuredOutput": STRUCTURED_OUTPUT_SCHEMA}, backend="b")
+
+        with caplog.at_level(logging.WARNING, logger=AUDIT_LOGGER):
+            auditor.feed(_tool_use_stream("StructuredOutput", '{"findings":[],"conversation_notes":"x"}'))
+            auditor.finish()
+
+        assert [r for r in caplog.records if r.levelno == logging.WARNING] == []
+
+    def test_undeclared_tool_is_logged_but_not_warned(self, caplog):
+        """A tool the client never declared cannot be judged."""
+        auditor = ToolUseAuditor({}, backend="b")
+        with caplog.at_level(logging.DEBUG, logger=AUDIT_LOGGER):
+            auditor.feed(_tool_use_stream("ServerSideThing", '{"anything":1}'))
+            auditor.finish()
+
+        assert any("ServerSideThing" in r.getMessage() for r in caplog.records)
+        assert [r for r in caplog.records if r.levelno == logging.WARNING] == []
+
+
+class TestRedaction:
+    """The WARNING is the one line that can reach an embedder's own handler.
+
+    Tool inputs routinely carry file contents and user data, so the warning
+    must name keys and never values.  A maintainer "helpfully" appending the
+    input to it would break this quietly, which is why it is pinned.
+    """
+
+    def test_warning_names_keys_but_never_values(self, caplog):
+        secret = "s3cret-api-token-do-not-log"
+        auditor = ToolUseAuditor({"StructuredOutput": STRUCTURED_OUTPUT_SCHEMA}, backend="b")
+        payload = json.dumps({"result": {"findings": [secret], "conversation_notes": secret}})
+
+        with caplog.at_level(logging.WARNING, logger=AUDIT_LOGGER):
+            auditor.feed(_tool_use_stream("StructuredOutput", payload))
+            auditor.finish()
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) == 1
+        message = warnings[0].getMessage()
+        assert "result" in message, "key names are the point of the warning"
+        assert secret not in message, "the warning must never carry tool input values"
+
+    def test_invalid_json_warning_reports_length_not_bytes(self, caplog):
+        """A truncated payload's bytes are still payload — report only its size."""
+        secret = "s3cret-in-a-truncated-payload"
+        auditor = ToolUseAuditor({}, backend="b")
+
+        with caplog.at_level(logging.WARNING, logger=AUDIT_LOGGER):
+            auditor.feed(_tool_use_stream("Read", '{"path":"' + secret))
+            auditor.finish()
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert warnings
+        assert secret not in warnings[0].getMessage()
+
+
+class TestPreParsedToolCall:
+    """A shim that hands back a parsed tool call sends no deltas at all.
+
+    Anthropic always opens with ``input: {}`` and streams fragments, but the
+    suspected cause in #33 is a non-Anthropic shim — and a shim that already
+    parsed the arguments typically populates ``content_block_start`` instead.
+    Ignoring that field would make the audit blind to the very shape it exists
+    to catch.
+    """
+
+    def test_input_on_content_block_start_is_audited(self, caplog):
+        auditor = ToolUseAuditor({"StructuredOutput": STRUCTURED_OUTPUT_SCHEMA}, backend="b")
+        stream = (
+            _sse(
+                "content_block_start",
+                {
+                    "type": "content_block_start",
+                    "index": 0,
+                    "content_block": {
+                        "type": "tool_use",
+                        "id": "t",
+                        "name": "StructuredOutput",
+                        "input": {"result": {"findings": [], "conversation_notes": "x"}},
+                    },
+                },
+            )
+            + _stop()
+        )
+
+        with caplog.at_level(logging.WARNING, logger=AUDIT_LOGGER):
+            auditor.feed(stream)
+            auditor.finish()
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) == 1, [r.getMessage() for r in warnings]
+        assert "result" in warnings[0].getMessage()
+
+    def test_deltas_win_over_a_seeded_input(self, caplog):
+        """Anthropic sends an empty seed then deltas; the deltas are the truth."""
+        auditor = ToolUseAuditor({}, backend="b")
+        stream = _start("Read") + _delta('{"path":"from-delta.py"}') + _stop()
+
+        with caplog.at_level(logging.DEBUG, logger=AUDIT_LOGGER):
+            auditor.feed(stream)
+            auditor.finish()
+
+        assert any("from-delta.py" in r.getMessage() for r in caplog.records)
+
+
+class TestAuditorIsTotal:
+    """FR-5 — auditing is diagnostics and must never break the stream."""
+
+    def test_invalid_argument_json_warns_but_does_not_raise(self, caplog):
+        """AC-5.2 — malformed serialization is itself a signal worth having.
+
+        The literal boundary-token leak from MiniMax-M3#31.
+        """
+        auditor = ToolUseAuditor({}, backend="b")
+        with caplog.at_level(logging.WARNING, logger=AUDIT_LOGGER):
+            auditor.feed(_tool_use_stream("Read", '{"path": ]<]minimax[>['))
+            auditor.finish()
+
+        assert any("not valid JSON" in r.getMessage() for r in caplog.records)
+
+    def test_oversized_arguments_are_abandoned_without_raising(self):
+        """AC-5.3 — a runaway upstream must not exhaust memory through the auditor."""
+        auditor = ToolUseAuditor({}, backend="b")
+        auditor.feed(_start("Read"))
+        auditor.feed(_delta("x" * (_MAX_BUFFERED_ARG_CHARS + 1)))
+        auditor.finish()
+
+        assert auditor._open == {}
+
+    def test_detector_exception_is_contained(self, monkeypatch, caplog):
+        """AC-5.4 — a bug in the detector must not surface as a broken response."""
+        import kitty.bridge.tool_audit as module
+
+        def boom(*args, **kwargs):
+            raise RuntimeError("detector bug")
+
+        monkeypatch.setattr(module, "describe_tool_input_anomaly", boom)
+        auditor = ToolUseAuditor({"Read": STRUCTURED_OUTPUT_SCHEMA}, backend="b")
+
+        with caplog.at_level(logging.DEBUG, logger=AUDIT_LOGGER):
+            auditor.feed(_tool_use_stream("Read", '{"path":"a.py"}'))
+            auditor.finish()
+
+        assert any("auditing failed" in r.getMessage() for r in caplog.records)
+
+    def test_non_sse_noise_is_ignored(self):
+        """Bytes that are not SSE at all must not raise."""
+        auditor = ToolUseAuditor({}, backend="b")
+        auditor.feed(b"\x00\xff not sse at all\n\ndata: {broken\n\nevent: ping\n\n")
+        auditor.finish()
+
+    def test_two_anomalous_blocks_produce_two_warnings(self, caplog):
+        """AC-4.3 — the composition, not just the two halves separately."""
+        auditor = ToolUseAuditor({"StructuredOutput": STRUCTURED_OUTPUT_SCHEMA}, backend="b")
+        payload = '{"result":{"findings":[],"conversation_notes":"x"}}'
+        stream = _tool_use_stream("StructuredOutput", payload, 0) + _tool_use_stream(
+            "StructuredOutput", payload, 1
+        )
+
+        with caplog.at_level(logging.WARNING, logger=AUDIT_LOGGER):
+            auditor.feed(stream)
+            auditor.finish()
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING and r.name == AUDIT_LOGGER]
+        assert len(warnings) == 2, [r.getMessage() for r in warnings]
+
+    def test_line_buffer_bound_disables_the_auditor(self, caplog):
+        """FR-5 — an upstream that never sends a newline must not grow it forever."""
+        auditor = ToolUseAuditor({}, backend="b")
+
+        with caplog.at_level(logging.DEBUG, logger=AUDIT_LOGGER):
+            auditor.feed(b"data: " + b"x" * (_MAX_LINE_BYTES + 1))
+
+        assert auditor._disabled is True
+        assert auditor._line_buffer == bytearray()
+        assert any("disabled for this response" in r.getMessage() for r in caplog.records)
+
+    def test_open_block_bound_disables_the_auditor(self, caplog):
+        """Per-block argument bounds do not bound the number of blocks."""
+        auditor = ToolUseAuditor({}, backend="b")
+
+        with caplog.at_level(logging.DEBUG, logger=AUDIT_LOGGER):
+            # Open far more blocks than the cap, never closing any.
+            auditor.feed(b"".join(_start("Read", i) for i in range(_MAX_OPEN_BLOCKS + 5)))
+
+        assert auditor._disabled is True
+        assert auditor._open == {}
+
+    def test_containment_logs_once_not_once_per_chunk(self, monkeypatch, caplog):
+        """A poisoned auditor must not spend a DEBUG line on every later chunk."""
+        import kitty.bridge.tool_audit as module
+
+        def boom(*args, **kwargs):
+            raise RuntimeError("detector bug")
+
+        monkeypatch.setattr(module, "describe_tool_input_anomaly", boom)
+        auditor = ToolUseAuditor({"Read": STRUCTURED_OUTPUT_SCHEMA}, backend="b")
+
+        with caplog.at_level(logging.DEBUG, logger=AUDIT_LOGGER):
+            auditor.feed(_tool_use_stream("Read", '{"path":"a.py"}'))
+            for _ in range(20):
+                auditor.feed(_tool_use_stream("Read", '{"path":"b.py"}'))
+            auditor.finish()
+
+        failures = [r for r in caplog.records if "auditing failed" in r.getMessage()]
+        assert len(failures) == 1, [r.getMessage() for r in failures]
+
+    def test_truncated_stream_reports_the_partial_block(self, caplog):
+        """An upstream dying mid-tool-call is exactly what we want to see."""
+        auditor = ToolUseAuditor({}, backend="b")
+        auditor.feed(_start("Read") + _delta('{"path":'))
+
+        with caplog.at_level(logging.WARNING, logger=AUDIT_LOGGER):
+            auditor.finish()
+
+        assert any("not valid JSON" in r.getMessage() for r in caplog.records)


### PR DESCRIPTION
Addresses #33 — asks 1 and 2. **Not** ask 3 (the defensive unwrap); see below.

## Context for the Product Owner

A customer's CI review job kept failing, and nobody could tell whose fault it was.

Kitty sits between the coding agent and the model provider. When the model
calls a tool, it hands back a small structured payload. Sometimes a provider
returns that payload in the wrong shape — the agent rejects it and the run
fails. Everything still looks healthy from the outside: the provider answered
"200 OK", so kitty counted it as a success.

The customer could not investigate, because kitty wrote nothing about what it
had passed along. They instrumented an entire run to capture it and got **zero
matching lines in a 222,551-line debug log** — the logging existed on only one
of five internal code paths, and not the one they were using.

Now every tool payload kitty returns is recorded, on every path. When a payload
contradicts the shape the agent itself asked for, kitty says so by name — which
tool, which fields, and which provider in the pool produced it — and counts it
where an operator will see it without re-running anything.

Kitty does **not** try to repair the payload. We do not yet know for certain
what is malformed about it, and a wrong guess would quietly corrupt a correct
answer instead of loudly failing. This change is what will tell us.

## What changed

- Every `tool_use` returned to a Messages client is logged at DEBUG with its
  name and a truncated input — on **all five** routes: native passthrough,
  CC-translated and custom-transport streaming, plus both non-streaming paths.
- When an input contradicts that tool's own declared `input_schema`, a WARNING
  names the tool, the offending keys and the serving backend.
- A per-backend `malformed_tool_use` counter in `GET /stats` and the shutdown
  summary.
- Every line carries the prefix `tool_use audit:`, so the next incident is one
  `grep` away.

## Three decisions worth a reviewer's attention

**Observed at the write boundary.** All streaming paths end by writing
Anthropic SSE downstream, so watching there gives one parser and one state
machine, needs no translator changes, and never audits an abandoned upstream
attempt — those events are never written. The interrupted-stream finalizations
write downstream too, so they are audited and `finish()`ed like any other exit.
That one is not a corner case: #33 reports the failure as *intermittent on
identical input*, and an upstream truncating after emitting the tool call is
the archetype — exactly when the counter must not read zero.

**The rule is narrow on purpose.** It fires on both an unexpected root key AND
a missing required property, or on a single root key whose value holds every
missing required name. A root `required` absent from the input is *proof* of a
violation regardless of `additionalProperties` — that half cannot
false-positive. A model merely omitting a field, or adding a harmless extra
key, stays silent. It stands down entirely for composed schemas: draft-07,
which the Claude Code SDK validates with, ignores `$ref` siblings, so a valid
input would otherwise trip both conditions. A detector that fires on ordinary
traffic trains people to ignore it, which costs more than it gives.

**It counts as well as logs.** `kitty/__init__.py` attaches only a
`NullHandler`, and the only real handler is the `--debug` file handler — so a
WARNING alone would reach nobody in a normal run, which is precisely the
complaint the issue makes.

## Safety

Diagnostics only. Nothing rewrites a payload or touches health, cooldown or
routing. A leaked exception would be severe — `_is_retryable_exception` returns
False for `ValueError`/`TypeError`/`KeyError`, so it would escape the attempt
loop, inject an SSE `error` into a stream that had already delivered valid
content, and leave the backend unmarked. So assembler and detector are both
contained, the auditor disables itself after any containment event rather than
failing once per chunk, all three of its buffers are bounded, and a fresh
auditor is built per upstream attempt so a failover cannot splice two attempts
into one fabricated block.

**The WARNING carries key names and lengths, never values.** It is the only
line that can reach an embedder's own handler, and tool inputs routinely carry
file contents and user data. Pinned by a test asserting a secret value never
appears.

## Why no unwrap (ask 3)

The issue gates it on a capture the reporter states they have **not** made, and
notes it "has a chance of refuting the envelope hypothesis entirely". An unwrap
is not a safe bet on that: a tool whose input legitimately is a single `result`
key — plausible for one named `StructuredOutput` — would be silently corrupted,
turning a loud validator rejection into quiet data loss. A missed detection
costs one more failing run; a wrong unwrap costs a wrong answer nobody sees.

The detector is deliberately schema-driven and names no cause, so it stays
correct and useful whichever way the capture lands — and it is what will settle
it. If the wrapper key is confirmed, the unwrap becomes a small, evidenced
follow-up.

I also verified the Langertha citation in the issue is accurate verbatim, and
established by experiment that `api.minimax.io/anthropic` traffic can only run
the **native passthrough** path (the translated path yields zero events for
Anthropic-shaped SSE) — so the native-streaming test is the acceptance test for
this incident.

## Testing

58 new tests across three files — L1 detector, L1 SSE assembler, L3 subsystem.
The precision rule, the detector, and the truncated-stream fix were each
mutation-checked: reverting them turns the relevant tests red.

| Gate | Result |
|---|---|
| `tests/bridge/` | 1132 passed, 1 skipped |
| `tests/` minus bridge & egress-proxy | 1854 passed, 35 skipped |
| `ruff` / `mypy` / `lint-imports` | clean |

`tests/test_egress_https_proxy.py` has 5 pre-existing fixture errors, unrelated
(they need a local TLS proxy). One existing contract test in
`test_session_stats.py` needed the new key added — it pins the exact stats
shape, which is it doing its job.

## Scope

Messages protocol only. The Responses, Gemini and Chat Completions paths carry
tool calls too; widening is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NJJJmUgnet1Qdh2imTzdSL
