### PR TITLE
Release 1.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kitty-bridge"
-version = "1.5.0"
+version = "1.6.0"
 description = "Kitty Bridge — launch coding agents through a local API bridge"
 readme = "README.md"
 license = "MIT"

--- a/src/kitty/__init__.py
+++ b/src/kitty/__init__.py
@@ -4,5 +4,5 @@ import logging
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
-__version__ = "1.5.0"
+__version__ = "1.6.0"
 __all__ = ["__version__"]


### PR DESCRIPTION
Version bump only — no behaviour change. Two lines: `pyproject.toml` and
`src/kitty/__init__.py`.

## Context for the Product Owner

Two customer-reported failures are fixed in this release, both of the same
family: a provider misbehaved, and kitty either made it worse or hid it.

**A single provider hiccup no longer throws away a whole session (#32).** When
kitty moved a running session to a backup provider from a different vendor, the
new provider rejected the entire conversation history and kitty gave up — on
the first of eighteen available retries, benching a healthy provider for five
minutes on the way out. One reported incident discarded 48 successful requests
and $4.56 of work, and turned a customer's CI check red with no review
produced. Kitty now recognises that the rejection is about the request it
built, repairs it, and carries on.

**Malformed provider responses are no longer invisible (#33).** When a provider
returned a badly shaped tool payload, the agent rejected it and the run failed —
but kitty logged nothing about what it had passed along, so nobody could tell
whose fault it was. A customer instrumented an entire run to capture it and got
zero matching lines in a 222,551-line log. Kitty now records every tool payload
it returns, names the specific provider when a payload contradicts what the
agent asked for, and counts those in `/stats` so they are visible without
re-running under `--debug`.

## What's in 1.6.0

| PR | Change |
|---|---|
| [#34](https://github.com/Shelpuk-AI-Technology-Consulting/kitty-bridge/pull/34) | Repair the thinking round-trip instead of killing the session (fixes #32) |
| [#35](https://github.com/Shelpuk-AI-Technology-Consulting/kitty-bridge/pull/35) | Make response-side `tool_use` observable, and flag inputs that contradict their schema (addresses #33) |
| [#31](https://github.com/Shelpuk-AI-Technology-Consulting/kitty-bridge/pull/31) | Update OpenRouter model metadata |

## Why minor, not patch

Both merged changes add surface rather than only fixing behaviour, and both are
backward compatible:

- **#34** adds `ProviderAdapter.upstream_wire_is_messages_api`, a new property
  on the adapter ABC that third-party adapters inherit.
- **#35** adds a `malformed_tool_use` field to the `/stats` document and the
  shutdown summary, which consumers parse. Existing fields are unchanged.

Nothing is removed or renamed, so not a major.

## Verification

- `tests/test_pypi_packaging.py` — 26 passed, including
  `test_version_in_init_matches_pyproject`, which is what stops the two files
  drifting.
- `ruff check .` clean; `import kitty` reports `1.6.0`.
- The publish workflow re-runs the full suite before it will push to PyPI, and
  refuses a tag whose version disagrees with `pyproject.toml`.

## Release step

`publish.yml` triggers on a `v*` tag. Once this merges, tag `v1.6.0` on the
merge commit and push it — tell me when and I'll do it.

**One gap worth knowing about:** that workflow verifies the tag against
`pyproject.toml` only, not `src/kitty/__init__.py`. The packaging test covers
the drift today, so this is not urgent, but the guard in the release path
itself is one-sided. Happy to tighten it separately if you want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NJJJmUgnet1Qdh2imTzdSL
