### PR TITLE
Never charge a network interruption to a healthy backend (fixes #38); release 1.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,13 @@ automatically without restarting anything.
 Anything that makes a member unavailable counts: rate limits, exhausted quotas, expired credentials, upstream 5xx, and
 connection failures.
 
+A dropped connection is given the benefit of the doubt first. For up to 30 seconds kitty retries the *same* member
+instead of cooling it down, so a brief network interruption between kitty and a provider costs a short pause rather
+than five minutes of that plan. Only a connection that keeps failing past that window counts as a failure. The same
+applies in the other direction: if your agent disconnects mid-answer — you close the terminal, hit Ctrl+C, or your
+network blips — that is charged to the agent, never to the provider, so the next request still finds every plan
+healthy.
+
 One caveat: a member that cannot handle streaming is skipped for streaming requests regardless of tier, so a streaming
 request can reach a backup member while a non-streaming primary is still healthy. This only affects providers without
 streaming support, and matches how balanced profiles already behaved.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kitty-bridge"
-version = "1.7.0"
+version = "1.8.0"
 description = "Kitty Bridge — launch coding agents through a local API bridge"
 readme = "README.md"
 license = "MIT"

--- a/src/kitty/__init__.py
+++ b/src/kitty/__init__.py
@@ -4,5 +4,5 @@ import logging
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
-__version__ = "1.7.0"
+__version__ = "1.8.0"
 __all__ = ["__version__"]

--- a/src/kitty/bridge/server.py
+++ b/src/kitty/bridge/server.py
@@ -636,6 +636,14 @@ _STREAM_READ_TIMEOUT = 120  # seconds — upstream must respond with first byte 
 _SINGLE_BACKEND_COOLDOWN_CAP = 30  # seconds — cap cooldown for single-backend profiles
 _CLOUDFLARE_FIRST_HIT_COOLDOWN = 15  # seconds — short cooldown for first Cloudflare block
 _ALL_UNHEALTHY_FAST_FAIL_THRESHOLD = 60  # seconds — fast-fail if soonest retry exceeds this
+# A blip on the wire between kitty and the provider is not a provider outage.
+# Before this window existed, the first connection reset cost the backend a full
+# cooldown, and the failover spread the damage to its siblings until every
+# provider sat in quarantine and healthy upstreams answered 503 (issue #38).
+# Inside the window the same backend is simply retried, so a few seconds of bad
+# Wi-Fi or a dropped keep-alive costs a short pause instead of five minutes.
+_TRANSPORT_GRACE_PERIOD = 30.0  # seconds of connection trouble tolerated per request
+_TRANSPORT_GRACE_DELAYS = (2.0, 4.0, 8.0, 16.0)  # backoff between grace retries; sums to the window
 _SSE_MAX_LINE_BYTES = 10 * 1024 * 1024  # 10 MiB — guards against unbounded line_buffer growth
 _MAX_HEADER_VALUE_CHARS = 256  # cap on X-Kitty-* values — names are config-supplied, so unbounded
 
@@ -698,9 +706,103 @@ def _token_count(value: object) -> int:
     return value if isinstance(value, int) else 0
 
 
+class ClientDisconnectedError(Exception):
+    """Raised when writing to the *client* connection fails.
+
+    aiohttp reports a dead client with the same ``ConnectionResetError``
+    family it uses for a dead upstream — a client that closes its terminal
+    mid-stream surfaces as ``ClientConnectionResetError("Cannot write to
+    closing transport")``.  Attributing that to the backend quarantined
+    healthy providers for the full cooldown, and the failover then wrote to
+    the same dead client and quarantined the next one too, so live clients
+    got ``503 All backends unhealthy`` for five minutes (issue #38).  This
+    distinct type keeps the two sides of the proxy apart.
+    """
+
+
+class TransportGrace:
+    """Per-request budget for riding out upstream connection trouble.
+
+    Tracks how long the current request has been fighting connection errors on
+    the way to the provider. While the budget lasts the caller retries the
+    **same** backend without touching its health; once it is spent the caller
+    falls back to the normal mark-unhealthy-and-fail-over path.
+
+    The window is per request, not per backend: a request that has already
+    spent 30 seconds on retries has taken long enough, whichever upstream it
+    was talking to.
+    """
+
+    def __init__(self, budget: float | None = None) -> None:
+        """Initialise an unstarted grace period.
+
+        Args:
+            budget: Seconds of connection trouble to tolerate; defaults to
+                :data:`_TRANSPORT_GRACE_PERIOD`, read here rather than as a
+                default argument so the window stays adjustable. The clock
+                starts at the first :meth:`next_delay` call, not at
+                construction.
+        """
+        self._budget = _TRANSPORT_GRACE_PERIOD if budget is None else budget
+        self._started_at: float | None = None
+        self._retries = 0
+
+    @property
+    def retries(self) -> int:
+        """Number of grace retries already spent on this request."""
+        return self._retries
+
+    def next_delay(self) -> float | None:
+        """Consume one grace retry and return how long to wait before it.
+
+        Returns:
+            Seconds to sleep before retrying the same backend, or ``None`` when
+            the grace period is exhausted and the caller should mark the
+            backend unhealthy and fail over.
+        """
+        # Bounded by count as well as by the clock, so a run of instant
+        # failures cannot spend the whole retry budget before the window
+        # closes and leave nothing for the failover that follows it.
+        if self._retries >= len(_TRANSPORT_GRACE_DELAYS):
+            return None
+        now = time.monotonic()
+        if self._started_at is None:
+            self._started_at = now
+        remaining = self._budget - (now - self._started_at)
+        if remaining <= 0:
+            return None
+        # Never sleep past the end of the window: the last retry lands on time.
+        delay = min(_TRANSPORT_GRACE_DELAYS[self._retries], remaining)
+        self._retries += 1
+        return delay
+
+
+async def _write_client(stream: web.StreamResponse, data: bytes) -> None:
+    """Write bytes to the client, tagging a client-side failure as such.
+
+    Args:
+        stream: The prepared SSE response to the agent.
+        data: The encoded bytes to send.
+
+    Raises:
+        ClientDisconnectedError: When the client connection is gone.
+    """
+    try:
+        await stream.write(data)
+    except (ConnectionResetError, BrokenPipeError, OSError) as exc:
+        raise ClientDisconnectedError(str(exc) or type(exc).__name__) from exc
+
+
 def _is_retryable_exception(exc: Exception) -> bool:
     """Return True for transient network exceptions that should be retried."""
+    # A gone client is not an upstream fault: retrying has nobody to serve.
+    if isinstance(exc, ClientDisconnectedError):
+        return False
     if isinstance(exc, (asyncio.TimeoutError, ConnectionResetError, BrokenPipeError, aiohttp.ClientConnectionError)):
+        return True
+    # An upstream body that stops short of its declared length is a dropped
+    # connection wearing a different exception class.
+    if isinstance(exc, aiohttp.ClientPayloadError):
         return True
     if isinstance(exc, OSError):
         return exc.errno in {32, 104, 110, 111, 113}
@@ -709,7 +811,20 @@ def _is_retryable_exception(exc: Exception) -> bool:
 
 def _is_transport_error(exc: Exception) -> bool:
     """Return True for connection-reset / transport errors (not timeouts)."""
+    # Guard the substring check below: the wrapped client-side message can
+    # read like an upstream reset, and only the type says where it came from.
+    if isinstance(exc, ClientDisconnectedError):
+        return False
+    # aiohttp files its timeouts under ClientConnectionError
+    # (ServerTimeoutError -> ServerConnectionError -> ClientConnectionError), so
+    # without this the check below would contradict its own docstring and hand a
+    # 120s sock_read timeout the connection-blip grace on top of the wait.
+    if isinstance(exc, asyncio.TimeoutError):
+        return False
     if isinstance(exc, (ConnectionResetError, BrokenPipeError, aiohttp.ClientConnectionError)):
+        return True
+    # A truncated upstream body is a dropped connection, not a bad response.
+    if isinstance(exc, aiohttp.ClientPayloadError):
         return True
     if isinstance(exc, OSError):
         return exc.errno in {32, 104}  # EPIPE, ECONNRESET
@@ -2415,6 +2530,7 @@ class BridgeServer:
             n_backends = len(self._backends) if self._backends else 1
             _original_max_attempts = (_MAX_RETRIES + 1) * n_backends
             max_attempts = _original_max_attempts + len(_EMPTY_FINAL_DELAYS)
+            transport_grace = TransportGrace()
             for attempt in range(max_attempts):
                 if attempt >= _original_max_attempts:
                     delay = _EMPTY_FINAL_DELAYS[attempt - _original_max_attempts]
@@ -2425,8 +2541,10 @@ class BridgeServer:
                         max_attempts,
                     )
                     await asyncio.sleep(delay)
-                session = await self._session_for(url)
-                async with session.post(url, json=upstream_body, headers=headers, timeout=stream_timeout) as upstream:
+                upstream = await self._open_upstream_stream(
+                    url, upstream_body, headers, stream_timeout, transport_grace
+                )
+                async with upstream:
                     upstream_status = upstream.status
                     logger.debug("Upstream response status: %d", upstream.status)
                     logger.debug("Upstream response headers: %s", dict(upstream.headers))
@@ -2852,10 +2970,23 @@ class BridgeServer:
         _last_error_status: int = 502  # default error status for pre-stream failures
 
         async def _ensure_prepared() -> web.StreamResponse:
-            """Lazily prepare the SSE StreamResponse on first content write."""
+            """Lazily prepare the SSE StreamResponse on first content write.
+
+            ``sr`` is assigned only once the headers are actually on the wire,
+            so ``sr is not None`` means exactly "the client has received
+            something".  Both the grace gate and the finalize gate below read
+            it that way.  Preparing writes to the client, so a client that dies
+            here is reported as a client disconnect, not an upstream fault.
+
+            Returns:
+                The prepared SSE response.
+
+            Raises:
+                ClientDisconnectedError: When the client is already gone.
+            """
             nonlocal sr
             if sr is None:
-                sr = web.StreamResponse(
+                prepared = web.StreamResponse(
                     status=200,
                     headers={
                         "Content-Type": "text/event-stream",
@@ -2863,7 +2994,11 @@ class BridgeServer:
                         **self._attribution_headers(),
                     },
                 )
-                await sr.prepare(request)
+                try:
+                    await prepared.prepare(request)
+                except (ConnectionResetError, BrokenPipeError, OSError) as exc:
+                    raise ClientDisconnectedError(str(exc) or type(exc).__name__) from exc
+                sr = prepared
             return sr
 
         def _make_error_response(error_data: dict, status: int) -> web.Response:
@@ -3097,7 +3232,13 @@ class BridgeServer:
             n_backends = len(self._backends) if self._backends else 1
             _original_max_attempts = (_MAX_RETRIES + 1) * n_backends
             max_attempts = _original_max_attempts + len(_EMPTY_FINAL_DELAYS)
-            for attempt in range(max_attempts):
+            transport_grace = TransportGrace()
+            # A grace retry re-sends to the *same* backend after a connection
+            # blip, so it must not spend a failover attempt or pull the
+            # empty-response schedule forward — the loop is extended by the most
+            # grace can use, and `attempt` counts only real backend attempts.
+            for raw_attempt in range(max_attempts + len(_TRANSPORT_GRACE_DELAYS)):
+                attempt = raw_attempt - transport_grace.retries
                 if attempt >= _original_max_attempts:
                     delay = _EMPTY_FINAL_DELAYS[attempt - _original_max_attempts]
                     logger.warning(
@@ -3143,7 +3284,7 @@ class BridgeServer:
                                 if sr is None:
                                     _last_error_status = upstream.status
                                     return _make_error_response(error_data, status=upstream.status)
-                                await sr.write(messages_format_error(error_data).encode())
+                                await _write_client(sr, messages_format_error(error_data).encode())
                                 break
 
                             # Native-passthrough tool_use format mismatch — convert
@@ -3224,7 +3365,7 @@ class BridgeServer:
                             if sr is None:
                                 _last_error_status = upstream.status
                                 return _make_error_response(error_data, status=upstream.status)
-                            await sr.write(messages_format_error(error_data).encode())
+                            await _write_client(sr, messages_format_error(error_data).encode())
                             break
 
                         # Success path — stream the response
@@ -3241,7 +3382,7 @@ class BridgeServer:
                             try:
                                 async for chunk_bytes in upstream.content:
                                     s = await _ensure_prepared()
-                                    await s.write(chunk_bytes)
+                                    await _write_client(s, chunk_bytes)
                                     auditor.feed(chunk_bytes)
                                     events_emitted = True
                             finally:
@@ -3315,7 +3456,7 @@ class BridgeServer:
                                         for event in events:
                                             s = await _ensure_prepared()
                                             encoded = event.encode()
-                                            await s.write(encoded)
+                                            await _write_client(s, encoded)
                                             auditor.feed(encoded)
                                             events_emitted = True
 
@@ -3337,7 +3478,7 @@ class BridgeServer:
                                             for event in events:
                                                 s = await _ensure_prepared()
                                                 encoded = event.encode()
-                                                await s.write(encoded)
+                                                await _write_client(s, encoded)
                                                 auditor.feed(encoded)
                                     except json.JSONDecodeError:
                                         logger.warning("Failed to parse flushed SSE data: %s", data_str[:200])
@@ -3511,14 +3652,78 @@ class BridgeServer:
                         s = await _ensure_prepared()
                         for event in finish_events:
                             encoded = event.encode()
-                            await s.write(encoded)
+                            await _write_client(s, encoded)
                             auditor.feed(encoded)
                         auditor.finish()
                         self._log_usage(last_usage)
                         stream_ok = True
                         break  # Exit retry loop
+                except ClientDisconnectedError as exc:
+                    # The agent went away, not the provider (issue #38). Leave
+                    # backend health alone and stop: a failover would only write
+                    # to the same dead socket and quarantine the next backend.
+                    logger.info("Client disconnected mid-stream for %s (%s)", message_id, exc)
+                    break
                 except Exception as exc:
                     if _is_retryable_exception(exc):
+                        # Ride out a connection blip on the same backend before
+                        # spending its health on it (issue #38).  Only while
+                        # nothing has reached the client yet: once bytes are on
+                        # the wire a restart would duplicate them.
+                        if (
+                            _is_transport_error(exc)
+                            and sr is None
+                            and (grace_delay := transport_grace.next_delay()) is not None
+                        ):
+                            logger.warning(
+                                "Upstream connection blip (%s) on %s; retrying the same backend in %.1fs",
+                                type(exc).__name__,
+                                self._backend_label(),
+                                grace_delay,
+                            )
+                            await asyncio.sleep(grace_delay)
+                            translator.reset()
+                            continue
+                        # Bytes already reached the client, so a restart on any
+                        # backend would duplicate them.  Close the message off
+                        # instead — the same choice FI-8.3 makes for a clean
+                        # truncation, and it spares the backend a cooldown it
+                        # would only spread to its siblings.
+                        if _is_transport_error(exc) and sr is not None:
+                            logger.warning(
+                                "Upstream connection dropped mid-stream (%s); finalizing partial response for %s",
+                                type(exc).__name__,
+                                message_id,
+                            )
+                            # The native-passthrough path never drives the
+                            # translator, so it has no half-open message to
+                            # close and would otherwise leave the client on an
+                            # SSE stream that just stops.  Those get the error
+                            # event they got before this branch existed.
+                            closing = [e.encode() for e in translator.finalize_interrupted_stream()] or [
+                                messages_format_error(
+                                    {
+                                        "type": "error",
+                                        "error": {
+                                            "type": "api_error",
+                                            "message": "Upstream connection dropped mid-stream",
+                                        },
+                                    }
+                                ).encode()
+                            ]
+                            try:
+                                for encoded in closing:
+                                    await _write_client(sr, encoded)
+                                    auditor.feed(encoded)
+                            except ClientDisconnectedError:
+                                logger.debug(
+                                    "Client disconnected before interrupted stream finalization for %s",
+                                    message_id,
+                                )
+                            # A truncated stream is exactly when a half-delivered
+                            # tool_use is worth seeing, as FI-8.3 notes.
+                            auditor.finish()
+                            break
                         if attempt < max_attempts - 1:
                             # In balancing mode: mark unhealthy, try next backend
                             if self._backends and self._current_backend_idx >= 0:
@@ -3839,6 +4044,7 @@ class BridgeServer:
             n_backends = len(self._backends) if self._backends else 1
             _original_max_attempts = (_MAX_RETRIES + 1) * n_backends
             max_attempts = _original_max_attempts + len(_EMPTY_FINAL_DELAYS)
+            transport_grace = TransportGrace()
             for attempt in range(max_attempts):
                 if attempt >= _original_max_attempts:
                     delay = _EMPTY_FINAL_DELAYS[attempt - _original_max_attempts]
@@ -3849,8 +4055,10 @@ class BridgeServer:
                         max_attempts,
                     )
                     await asyncio.sleep(delay)
-                session = await self._session_for(url)
-                async with session.post(url, json=upstream_body, headers=headers, timeout=stream_timeout) as upstream:
+                upstream = await self._open_upstream_stream(
+                    url, upstream_body, headers, stream_timeout, transport_grace
+                )
+                async with upstream:
                     logger.debug("Upstream response status: %d", upstream.status)
 
                     if upstream.status not in (200, 201):
@@ -4599,6 +4807,7 @@ class BridgeServer:
             n_backends = len(self._backends) if self._backends else 1
             _original_max_attempts = (_MAX_RETRIES + 1) * n_backends
             max_attempts = _original_max_attempts + len(_EMPTY_FINAL_DELAYS)
+            transport_grace = TransportGrace()
             for attempt in range(max_attempts):
                 if attempt >= _original_max_attempts:
                     delay = _EMPTY_FINAL_DELAYS[attempt - _original_max_attempts]
@@ -4615,8 +4824,10 @@ class BridgeServer:
                 stream_error = False
                 has_content = False
                 chunk_count = 0
-                session = await self._session_for(url)
-                async with session.post(url, json=upstream_body, headers=headers, timeout=stream_timeout) as upstream:
+                upstream = await self._open_upstream_stream(
+                    url, upstream_body, headers, stream_timeout, transport_grace
+                )
+                async with upstream:
                     upstream_status = upstream.status
                     logger.debug("Upstream response status: %d", upstream.status)
 
@@ -5936,6 +6147,50 @@ class BridgeServer:
             return cast("dict[str, str]", provider.build_upstream_headers_for_model(self._active_key, model))  # type: ignore[attr-defined]  # optional provider hook
         return provider.build_upstream_headers(self._active_key)
 
+    async def _open_upstream_stream(
+        self,
+        url: str,
+        upstream_body: dict,
+        headers: dict[str, str],
+        timeout: aiohttp.ClientTimeout,
+        grace: TransportGrace,
+    ) -> aiohttp.ClientResponse:
+        """Open an upstream SSE response, riding out connection blips.
+
+        Connecting is the one part of a streamed request that can be retried
+        with no risk of duplicating output, because nothing has been read from
+        the provider yet.  A reset here is charged to ``grace`` and retried on
+        the same backend instead of being surfaced as a failure (issue #38).
+
+        Args:
+            url: The upstream endpoint.
+            upstream_body: The JSON body to POST.
+            headers: The upstream request headers.
+            timeout: The streaming timeout policy.
+            grace: The request's remaining tolerance for connection trouble.
+
+        Returns:
+            The open :class:`aiohttp.ClientResponse`; the caller owns closing it.
+
+        Raises:
+            Exception: The last connection error, once the grace period is spent.
+        """
+        while True:
+            session = await self._session_for(url)
+            try:
+                return await session.post(url, json=upstream_body, headers=headers, timeout=timeout)
+            except Exception as exc:
+                grace_delay = grace.next_delay() if _is_transport_error(exc) else None
+                if grace_delay is None:
+                    raise
+                logger.warning(
+                    "Upstream connection blip (%s) on %s; retrying the same backend in %.1fs",
+                    type(exc).__name__,
+                    self._backend_label(),
+                    grace_delay,
+                )
+                await asyncio.sleep(grace_delay)
+
     async def _make_upstream_request(self, cc_request: dict, *, retry_rate_limit: bool = True) -> dict:
         """Send a non-streaming request upstream.
 
@@ -5965,44 +6220,64 @@ class BridgeServer:
 
         last_status = 0
         last_body: object = {}
-        for attempt in range(_MAX_RETRIES + 1):
+        # Connection blips get their own budget so they cannot eat the
+        # status-retry attempts, and vice versa (issue #38).
+        attempt = 0
+        transport_grace = TransportGrace()
+        while True:
             session = await self._session_for(url)
-            async with session.post(url, json=upstream_body, headers=headers, timeout=request_timeout) as resp:
-                last_status = resp.status
-                try:
-                    last_body = await resp.json()
-                except Exception:
-                    last_body = await resp.text()
+            try:
+                async with session.post(url, json=upstream_body, headers=headers, timeout=request_timeout) as resp:
+                    last_status = resp.status
+                    try:
+                        last_body = await resp.json()
+                    except Exception:
+                        last_body = await resp.text()
 
-                if last_status < 400:
-                    if (
-                        self._active_provider.use_native_messages
-                        and isinstance(last_body, dict)
-                        and last_body.get("type") == "message"
-                    ):
-                        return last_body
-                    return self._active_provider.translate_from_upstream(cast(dict, last_body))
+                    if last_status < 400:
+                        if (
+                            self._active_provider.use_native_messages
+                            and isinstance(last_body, dict)
+                            and last_body.get("type") == "message"
+                        ):
+                            return last_body
+                        return self._active_provider.translate_from_upstream(cast(dict, last_body))
 
-                # In balancing mode (retry_rate_limit=False), raise 429 immediately
-                # so the caller can fail over to another backend.
-                if last_status == 429 and not retry_rate_limit:
+                    # In balancing mode (retry_rate_limit=False), raise 429 immediately
+                    # so the caller can fail over to another backend.
+                    if last_status == 429 and not retry_rate_limit:
+                        raise UpstreamError(last_status, last_body)
+
+                    if self._is_non_retryable_error_code(last_status, last_body):
+                        raise UpstreamError(last_status, last_body)
+
+                    if last_status in _RETRYABLE_STATUSES and attempt < _MAX_RETRIES:
+                        delay = _BACKOFF_BASE * (2**attempt)
+                        logger.debug(
+                            "Upstream %d, retrying in %.1fs (%d/%d)",
+                            last_status,
+                            delay,
+                            attempt + 1,
+                            _MAX_RETRIES,
+                        )
+                        await asyncio.sleep(delay)
+                        attempt += 1
+                        continue
+
                     raise UpstreamError(last_status, last_body)
-
-                if self._is_non_retryable_error_code(last_status, last_body):
-                    raise UpstreamError(last_status, last_body)
-
-                if last_status in _RETRYABLE_STATUSES and attempt < _MAX_RETRIES:
-                    delay = _BACKOFF_BASE * (2**attempt)
-                    logger.debug(
-                        "Upstream %d, retrying in %.1fs (%d/%d)",
-                        last_status,
-                        delay,
-                        attempt + 1,
-                        _MAX_RETRIES,
-                    )
-                    await asyncio.sleep(delay)
-                    continue
-
-                raise UpstreamError(last_status, last_body)
-
-        raise UpstreamError(last_status, last_body)
+            except UpstreamError:
+                raise
+            except Exception as exc:
+                # A dropped connection to the provider is not yet a provider
+                # fault: retry it here rather than let the caller quarantine
+                # the backend on the strength of one blip.
+                grace_delay = transport_grace.next_delay() if _is_transport_error(exc) else None
+                if grace_delay is None:
+                    raise
+                logger.warning(
+                    "Upstream connection blip (%s) on %s; retrying the same backend in %.1fs",
+                    type(exc).__name__,
+                    self._backend_label(),
+                    grace_delay,
+                )
+                await asyncio.sleep(grace_delay)

--- a/src/kitty/bridge/server.py
+++ b/src/kitty/bridge/server.py
@@ -737,13 +737,13 @@ class TransportGrace:
         """Initialise an unstarted grace period.
 
         Args:
-            budget: Seconds of connection trouble to tolerate; defaults to
-                :data:`_TRANSPORT_GRACE_PERIOD`, read here rather than as a
-                default argument so the window stays adjustable. The clock
-                starts at the first :meth:`next_delay` call, not at
-                construction.
+            budget: Seconds of connection trouble to tolerate. ``None`` means
+                :data:`_TRANSPORT_GRACE_PERIOD`, read at first use like
+                :data:`_TRANSPORT_GRACE_DELAYS` so both knobs resolve at the
+                same moment. The clock starts at the first :meth:`next_delay`
+                call, not at construction.
         """
-        self._budget = _TRANSPORT_GRACE_PERIOD if budget is None else budget
+        self._budget = budget
         self._started_at: float | None = None
         self._retries = 0
 
@@ -768,7 +768,8 @@ class TransportGrace:
         now = time.monotonic()
         if self._started_at is None:
             self._started_at = now
-        remaining = self._budget - (now - self._started_at)
+        budget = _TRANSPORT_GRACE_PERIOD if self._budget is None else self._budget
+        remaining = budget - (now - self._started_at)
         if remaining <= 0:
             return None
         # Never sleep past the end of the window: the last retry lands on time.
@@ -3239,6 +3240,14 @@ class BridgeServer:
             # grace can use, and `attempt` counts only real backend attempts.
             for raw_attempt in range(max_attempts + len(_TRANSPORT_GRACE_DELAYS)):
                 attempt = raw_attempt - transport_grace.retries
+                # The extra iterations exist only to give grace retries back.
+                # Without this the loop could run past the last real attempt —
+                # a `continue` that does not check `attempt` (the tool_use
+                # format fallback) would then index off the end of
+                # _EMPTY_FINAL_DELAYS. Ending here keeps the pre-grace
+                # invariant: at most `max_attempts` real attempts.
+                if attempt >= max_attempts:
+                    break
                 if attempt >= _original_max_attempts:
                     delay = _EMPTY_FINAL_DELAYS[attempt - _original_max_attempts]
                     logger.warning(
@@ -3667,21 +3676,11 @@ class BridgeServer:
                 except Exception as exc:
                     if _is_retryable_exception(exc):
                         # Ride out a connection blip on the same backend before
-                        # spending its health on it (issue #38).  Only while
-                        # nothing has reached the client yet: once bytes are on
-                        # the wire a restart would duplicate them.
-                        if (
-                            _is_transport_error(exc)
-                            and sr is None
-                            and (grace_delay := transport_grace.next_delay()) is not None
-                        ):
-                            logger.warning(
-                                "Upstream connection blip (%s) on %s; retrying the same backend in %.1fs",
-                                type(exc).__name__,
-                                self._backend_label(),
-                                grace_delay,
-                            )
-                            await asyncio.sleep(grace_delay)
+                        # spending its health on it (issue #38).  `sr is None`
+                        # comes first so a drop that happened after the client
+                        # saw bytes does not spend grace it cannot use: once
+                        # bytes are on the wire a restart would duplicate them.
+                        if sr is None and await self._wait_out_transport_blip(exc, transport_grace):
                             translator.reset()
                             continue
                         # Bytes already reached the client, so a restart on any
@@ -4328,15 +4327,28 @@ class BridgeServer:
         marking failed backends as unhealthy.  Also retries empty responses
         across backends.
         """
+        # One window for the whole request, not one per upstream call: these
+        # helpers call _make_upstream_request once per backend, and a fresh
+        # grace each time would let a request spend 30s per backend.
+        grace = TransportGrace()
         if self._backends:
-            return await self._request_with_retry_balancing(cc_request)
-        return await self._request_with_retry_single(cc_request)
+            return await self._request_with_retry_balancing(cc_request, grace)
+        return await self._request_with_retry_single(cc_request, grace)
 
-    async def _request_with_retry_single(self, cc_request: dict) -> dict:
-        """Non-balancing retry: retry empty responses with backoff."""
+    async def _request_with_retry_single(self, cc_request: dict, grace: TransportGrace) -> dict:
+        """Non-balancing retry: retry empty responses with backoff.
+
+        Args:
+            cc_request: The request payload in CC format.
+            grace: The request's tolerance for upstream connection trouble,
+                opened once per request by :meth:`_request_with_retry`.
+
+        Returns:
+            The upstream response dict in CC format.
+        """
         max_attempts = len(_EMPTY_RETRY_DELAYS) + len(_EMPTY_FINAL_DELAYS) + 1
         for attempt in range(max_attempts):
-            cc_response = await self._make_upstream_request(cc_request)
+            cc_response = await self._make_upstream_request(cc_request, grace=grace)
             if not self._is_empty_cc_response(cc_response):
                 return cc_response
             if attempt < len(_EMPTY_RETRY_DELAYS):
@@ -4362,8 +4374,17 @@ class BridgeServer:
         logger.warning("Empty upstream response after %d attempts, returning fallback", max_attempts)
         return cc_response
 
-    async def _request_with_retry_balancing(self, cc_request: dict) -> dict:
-        """Balancing retry: failover across backends on errors or empty responses."""
+    async def _request_with_retry_balancing(self, cc_request: dict, grace: TransportGrace) -> dict:
+        """Balancing retry: failover across backends on errors or empty responses.
+
+        Args:
+            cc_request: The request payload in CC format.
+            grace: The request's tolerance for upstream connection trouble,
+                shared across every backend this request tries.
+
+        Returns:
+            The upstream response dict in CC format.
+        """
         assert self._backends is not None  # balancing mode only
         n_backends = len(self._backends)
         last_exc: UpstreamError | Exception | None = None
@@ -4391,7 +4412,7 @@ class BridgeServer:
                 self._active_provider.normalize_request(cc_request)
 
             try:
-                cc_response = await self._make_upstream_request(cc_request, retry_rate_limit=False)
+                cc_response = await self._make_upstream_request(cc_request, retry_rate_limit=False, grace=grace)
                 if not self._is_empty_cc_response(cc_response):
                     return cc_response
                 # Empty response — try next backend
@@ -4427,7 +4448,7 @@ class BridgeServer:
                     )
                     self._compact_with_tighter_budget(cc_request, factor=0.5)
                     try:
-                        cc_response = await self._make_upstream_request(cc_request, retry_rate_limit=False)
+                        cc_response = await self._make_upstream_request(cc_request, retry_rate_limit=False, grace=grace)
                         if not self._is_empty_cc_response(cc_response):
                             return cc_response
                         last_response = cc_response
@@ -4498,7 +4519,7 @@ class BridgeServer:
             self._normalize_model(cc_request)
             self._active_provider.normalize_request(cc_request)
             try:
-                cc_response = await self._make_upstream_request(cc_request, retry_rate_limit=False)
+                cc_response = await self._make_upstream_request(cc_request, retry_rate_limit=False, grace=grace)
             except UpstreamError as exc:
                 last_exc = exc
                 idx = self._current_backend_idx
@@ -6147,6 +6168,37 @@ class BridgeServer:
             return cast("dict[str, str]", provider.build_upstream_headers_for_model(self._active_key, model))  # type: ignore[attr-defined]  # optional provider hook
         return provider.build_upstream_headers(self._active_key)
 
+    async def _wait_out_transport_blip(self, exc: Exception, grace: TransportGrace) -> bool:
+        """Sleep out a connection blip, or report that the grace period is over.
+
+        The single place that decides whether a failure on the wire to the
+        provider is still worth another try on the same backend (issue #38).
+        Callers use the answer to choose between retrying and treating the
+        failure as a provider fault; they must not consult ``grace``
+        themselves, so the budget is spent in exactly one place.
+
+        Args:
+            exc: The failure being considered.
+            grace: The request's remaining tolerance for connection trouble.
+
+        Returns:
+            True when the caller should retry the same backend, False when the
+            failure has to be surfaced or charged to the backend's health.
+        """
+        if not _is_transport_error(exc):
+            return False
+        delay = grace.next_delay()
+        if delay is None:
+            return False
+        logger.warning(
+            "Upstream connection blip (%s) on %s; retrying the same backend in %.1fs",
+            type(exc).__name__,
+            self._backend_label(),
+            delay,
+        )
+        await asyncio.sleep(delay)
+        return True
+
     async def _open_upstream_stream(
         self,
         url: str,
@@ -6180,18 +6232,12 @@ class BridgeServer:
             try:
                 return await session.post(url, json=upstream_body, headers=headers, timeout=timeout)
             except Exception as exc:
-                grace_delay = grace.next_delay() if _is_transport_error(exc) else None
-                if grace_delay is None:
+                if not await self._wait_out_transport_blip(exc, grace):
                     raise
-                logger.warning(
-                    "Upstream connection blip (%s) on %s; retrying the same backend in %.1fs",
-                    type(exc).__name__,
-                    self._backend_label(),
-                    grace_delay,
-                )
-                await asyncio.sleep(grace_delay)
 
-    async def _make_upstream_request(self, cc_request: dict, *, retry_rate_limit: bool = True) -> dict:
+    async def _make_upstream_request(
+        self, cc_request: dict, *, retry_rate_limit: bool = True, grace: TransportGrace | None = None
+    ) -> dict:
         """Send a non-streaming request upstream.
 
         For providers with ``use_custom_transport=True``, delegates to the
@@ -6202,6 +6248,10 @@ class BridgeServer:
             cc_request: The request payload in CC format.
             retry_rate_limit: When False, 429 is not retried on this backend
                 (the caller handles failover instead).
+            grace: The request's tolerance for upstream connection trouble,
+                supplied by the caller so a request that tries several backends
+                shares one window instead of opening a fresh one per backend.
+                A new window is opened when omitted.
 
         Returns the upstream response dict (in CC format) on success.
         Raises UpstreamError(status, body) on non-retryable or exhausted failures.
@@ -6223,7 +6273,7 @@ class BridgeServer:
         # Connection blips get their own budget so they cannot eat the
         # status-retry attempts, and vice versa (issue #38).
         attempt = 0
-        transport_grace = TransportGrace()
+        transport_grace = TransportGrace() if grace is None else grace
         while True:
             session = await self._session_for(url)
             try:
@@ -6271,13 +6321,5 @@ class BridgeServer:
                 # A dropped connection to the provider is not yet a provider
                 # fault: retry it here rather than let the caller quarantine
                 # the backend on the strength of one blip.
-                grace_delay = transport_grace.next_delay() if _is_transport_error(exc) else None
-                if grace_delay is None:
+                if not await self._wait_out_transport_blip(exc, transport_grace):
                     raise
-                logger.warning(
-                    "Upstream connection blip (%s) on %s; retrying the same backend in %.1fs",
-                    type(exc).__name__,
-                    self._backend_label(),
-                    grace_delay,
-                )
-                await asyncio.sleep(grace_delay)

--- a/tests/bridge/test_client_disconnect_health.py
+++ b/tests/bridge/test_client_disconnect_health.py
@@ -1,0 +1,611 @@
+"""Tolerance for network interruptions on both sides of the bridge (issue #38).
+
+Two distinct failures used to be conflated, because aiohttp reports a dead
+*client* with the same ``ConnectionResetError`` family it uses for a dead
+*upstream*:
+
+* An agent that goes away mid-stream was charged to the provider. The Messages
+  streaming loop marked the backend unhealthy for 300s, failed over, wrote to
+  the same dead client again, and quarantined every remaining backend — so live
+  clients got ``503 All backends unhealthy`` for five minutes while both
+  providers were fine.
+* A momentary blip on the wire to the provider was treated as an outage on the
+  first occurrence, with no tolerance window at all.
+
+The client disconnect is forced by patching
+:meth:`aiohttp.web.StreamResponse.write` rather than by racing a real socket
+close, so the failure lands at exactly the boundary that broke and the test is
+deterministic. The upstream mid-stream abort needs a real socket, so those
+tests run against a local aiohttp server instead of ``aioresponses``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+import uuid
+from unittest.mock import patch
+
+import aiohttp
+import pytest
+from aiohttp import web
+from aioresponses import aioresponses
+
+from kitty.bridge import server as server_module
+from kitty.bridge.server import (
+    _TRANSPORT_GRACE_DELAYS,
+    BridgeServer,
+    ClientDisconnectedError,
+    TransportGrace,
+    _is_retryable_exception,
+    _is_transport_error,
+)
+from kitty.launchers.base import LauncherAdapter, SpawnConfig
+from kitty.profiles.schema import Profile
+from kitty.providers.base import ProviderAdapter
+from kitty.types import BridgeProtocol
+
+# ── Test infrastructure ──────────────────────────────────────────────────
+
+
+class _StubLauncher(LauncherAdapter):
+    """Minimal launcher exposing the Messages API bridge protocol."""
+
+    @property
+    def name(self) -> str:
+        return "stub"
+
+    @property
+    def binary_name(self) -> str:
+        return "stub"
+
+    @property
+    def bridge_protocol(self) -> BridgeProtocol:
+        return BridgeProtocol.MESSAGES_API
+
+    def build_spawn_config(self, profile: Profile, bridge_port: int, resolved_key: str) -> SpawnConfig:
+        return SpawnConfig()
+
+
+class _StubProvider(ProviderAdapter):
+    """Chat Completions upstream stub pinned to a per-backend base URL."""
+
+    def __init__(self, base_url: str, native: bool = False) -> None:
+        self._base_url = base_url
+        self._native = native
+
+    @property
+    def provider_type(self) -> str:
+        return "stub"
+
+    @property
+    def default_base_url(self) -> str:
+        return self._base_url
+
+    @property
+    def use_native_messages(self) -> bool:
+        return self._native
+
+    @property
+    def upstream_wire_is_messages_api(self) -> bool:
+        return self._native
+
+    @property
+    def upstream_path(self) -> str:
+        return "/messages" if self._native else "/chat/completions"
+
+    def build_request(self, model: str, messages: list[dict], **kwargs) -> dict:
+        return {"model": model, "messages": messages, "stream": kwargs.get("stream", False)}
+
+    def parse_response(self, response_data: dict) -> dict:
+        return response_data
+
+    def map_error(self, status_code: int, body: dict) -> Exception:
+        return Exception(f"Upstream error {status_code}: {body}")
+
+
+# Chat Completions SSE: one content delta, one finish chunk, then [DONE].
+_CC_CONTENT_CHUNK = (
+    b'data: {"id":"c1","choices":[{"index":0,"delta":{"content":"Hi"},'
+    b'"finish_reason":null}],"model":"test-model"}\n\n'
+)
+_CC_STREAM = (
+    _CC_CONTENT_CHUNK + b'data: {"id":"c1","choices":[{"index":0,"delta":{},'
+    b'"finish_reason":"stop"}],"model":"test-model","usage":null}\n\n'
+    b"data: [DONE]\n\n"
+)
+
+# Non-streaming Chat Completions response.
+_CC_JSON_RESPONSE = {
+    "id": "c1",
+    "model": "test-model",
+    "choices": [{"index": 0, "message": {"role": "assistant", "content": "Hi"}, "finish_reason": "stop"}],
+    "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+}
+
+# Anthropic Messages SSE, forwarded verbatim by the native-passthrough path.
+_NATIVE_STREAM = (
+    b'event: message_start\ndata: {"type":"message_start","message":{"id":"msg_1",'
+    b'"type":"message","role":"assistant","content":[],"model":"test-model",'
+    b'"stop_reason":null,"usage":{"input_tokens":1,"output_tokens":1}}}\n\n'
+    b'event: message_stop\ndata: {"type":"message_stop"}\n\n'
+)
+
+
+@pytest.fixture
+def short_grace(monkeypatch):
+    """Shrink every retry delay so these tests don't sleep for a minute."""
+    monkeypatch.setattr(server_module, "_TRANSPORT_GRACE_PERIOD", 0.3)
+    monkeypatch.setattr(server_module, "_TRANSPORT_GRACE_DELAYS", (0.01, 0.02))
+    monkeypatch.setattr(server_module, "_EMPTY_FINAL_DELAYS", [0.01, 0.01])
+
+
+def _make_server(n_backends: int = 2, native: bool = False, base_urls: list[str] | None = None) -> BridgeServer:
+    """Build a balancing BridgeServer with ``n_backends`` distinct upstreams."""
+    backends = []
+    for i in range(n_backends):
+        base_url = base_urls[i] if base_urls else f"https://api{i}.example.com/v1"
+        provider = _StubProvider(base_url, native=native)
+        profile = Profile(name=f"profile-{i}", provider="openai", model="test-model", auth_ref=str(uuid.uuid4()))
+        backends.append((provider, f"key-{i}", profile))
+    return BridgeServer(
+        adapter=_StubLauncher(),
+        provider=backends[0][0],
+        resolved_key=backends[0][1],
+        model="test-model",
+        backends=backends,
+        backend_cooldown=300,
+    )
+
+
+class _WriteFailer:
+    """Replacement for ``StreamResponse.write`` that dies like a gone client.
+
+    Args:
+        fail_after: Number of writes to let through before failing. 0 kills the
+            very first write; a larger value exercises a disconnect that only
+            shows up on the buffered finish events.
+    """
+
+    def __init__(self, fail_after: int = 0) -> None:
+        self.fail_after = fail_after
+        self.calls = 0
+
+    async def __call__(self, _self: web.StreamResponse, data: bytes = b"", *args, **kwargs) -> None:
+        self.calls += 1
+        if self.calls > self.fail_after:
+            raise aiohttp.ClientConnectionResetError("Cannot write to closing transport")
+
+
+async def _post_stream(port: int) -> bytes:
+    """Issue a streaming /v1/messages request and return whatever comes back."""
+    async with (
+        aiohttp.ClientSession() as session,
+        session.post(
+            f"http://127.0.0.1:{port}/v1/messages",
+            json={
+                "model": "test-model",
+                "messages": [{"role": "user", "content": "hi"}],
+                "max_tokens": 1024,
+                "stream": True,
+            },
+            timeout=aiohttp.ClientTimeout(total=60),
+        ) as resp,
+    ):
+        return await resp.read()
+
+
+def _count_posts(mocked: aioresponses) -> int:
+    """Count upstream POSTs recorded by an ``aioresponses`` context."""
+    return sum(len(calls) for key, calls in mocked.requests.items() if key[0] == "POST")
+
+
+def _assert_all_backends_untouched(server: BridgeServer) -> None:
+    """Assert no backend was marked unhealthy or charged a failure."""
+    for idx, health in enumerate(server._backend_health):
+        assert health["healthy"] is True, f"backend {idx} was quarantined"
+        assert health["failure_count"] == 0, f"backend {idx} was charged a failure"
+
+
+# ── Exception classification ─────────────────────────────────────────────
+
+
+class TestClientDisconnectedErrorClassification:
+    """A client disconnect is never an upstream transport failure."""
+
+    def test_not_retryable(self):
+        assert _is_retryable_exception(ClientDisconnectedError("Cannot write to closing transport")) is False
+
+    def test_not_a_transport_error(self):
+        assert _is_transport_error(ClientDisconnectedError("Cannot write to closing transport")) is False
+
+    def test_not_a_transport_error_for_connection_reset_wording(self):
+        """The message is the client's, so its wording must not leak through."""
+        assert _is_transport_error(ClientDisconnectedError("Connection reset by peer")) is False
+
+    def test_upstream_connection_reset_is_still_a_transport_error(self):
+        assert _is_transport_error(aiohttp.ClientConnectionResetError("boom")) is True
+
+    def test_truncated_upstream_body_is_a_transport_error(self):
+        assert _is_transport_error(aiohttp.ClientPayloadError("short body")) is True
+        assert _is_retryable_exception(aiohttp.ClientPayloadError("short body")) is True
+
+    @pytest.mark.parametrize(
+        "exc_type",
+        [aiohttp.ServerTimeoutError, aiohttp.SocketTimeoutError, aiohttp.ConnectionTimeoutError],
+    )
+    def test_timeouts_are_not_transport_errors(self, exc_type):
+        """aiohttp files its timeouts under ClientConnectionError, but a
+        provider that answered too slowly is not a connection blip and must
+        not be handed the grace window on top of its own timeout."""
+        assert issubclass(exc_type, aiohttp.ClientConnectionError)
+        assert _is_transport_error(exc_type("slow")) is False
+        assert _is_retryable_exception(exc_type("slow")) is True
+
+
+# ── Agent → kitty: a dead client must not cost a backend ──────────────────
+
+
+class TestClientDisconnectLeavesBackendsHealthy:
+    """A dead client must not put healthy providers into cooldown."""
+
+    @pytest.mark.asyncio
+    async def test_disconnect_mid_stream_keeps_backends_healthy(self):
+        """Every write fails; both backends stay healthy."""
+        server = _make_server(2)
+        port = await server.start_async()
+        try:
+            with aioresponses(passthrough=["http://127.0.0.1"]) as m:
+                for i in range(2):
+                    m.post(
+                        f"https://api{i}.example.com/v1/chat/completions",
+                        body=_CC_STREAM,
+                        headers={"Content-Type": "text/event-stream"},
+                        repeat=True,
+                    )
+                with patch.object(web.StreamResponse, "write", _WriteFailer(fail_after=0)):
+                    await _post_stream(port)
+            _assert_all_backends_untouched(server)
+        finally:
+            await server.stop_async()
+
+    @pytest.mark.asyncio
+    async def test_disconnect_mid_stream_does_not_retry_upstream(self):
+        """There is nobody left to serve, so no failover POST is made."""
+        server = _make_server(2)
+        port = await server.start_async()
+        try:
+            with aioresponses(passthrough=["http://127.0.0.1"]) as m:
+                for i in range(2):
+                    m.post(
+                        f"https://api{i}.example.com/v1/chat/completions",
+                        body=_CC_STREAM,
+                        headers={"Content-Type": "text/event-stream"},
+                        repeat=True,
+                    )
+                with patch.object(web.StreamResponse, "write", _WriteFailer(fail_after=0)):
+                    await _post_stream(port)
+                posts = _count_posts(m)
+            assert posts == 1
+        finally:
+            await server.stop_async()
+
+    @pytest.mark.asyncio
+    async def test_disconnect_on_native_passthrough_keeps_backends_healthy(self):
+        """The raw-chunk forwarding path is a separate write site."""
+        server = _make_server(2, native=True)
+        port = await server.start_async()
+        try:
+            with aioresponses(passthrough=["http://127.0.0.1"]) as m:
+                for i in range(2):
+                    m.post(
+                        f"https://api{i}.example.com/v1/messages",
+                        body=_NATIVE_STREAM,
+                        headers={"Content-Type": "text/event-stream"},
+                        repeat=True,
+                    )
+                with patch.object(web.StreamResponse, "write", _WriteFailer(fail_after=0)):
+                    await _post_stream(port)
+            _assert_all_backends_untouched(server)
+        finally:
+            await server.stop_async()
+
+    @pytest.mark.asyncio
+    async def test_disconnect_on_finish_events_keeps_backends_healthy(self):
+        """The upstream completed cleanly; only the last write fails."""
+        server = _make_server(2)
+        port = await server.start_async()
+        try:
+            with aioresponses(passthrough=["http://127.0.0.1"]) as m:
+                for i in range(2):
+                    m.post(
+                        f"https://api{i}.example.com/v1/chat/completions",
+                        body=_CC_STREAM,
+                        headers={"Content-Type": "text/event-stream"},
+                        repeat=True,
+                    )
+                # Let the message_start / content_block deltas through, then die
+                # on the buffered finish events written after the upstream EOF.
+                with patch.object(web.StreamResponse, "write", _WriteFailer(fail_after=4)):
+                    await _post_stream(port)
+            _assert_all_backends_untouched(server)
+        finally:
+            await server.stop_async()
+
+
+# ── kitty → provider: the grace window ───────────────────────────────────
+
+
+class TestTransportGrace:
+    """The per-request budget for riding out upstream connection trouble."""
+
+    def test_first_call_returns_the_first_backoff(self):
+        grace = TransportGrace(budget=30.0)
+        assert grace.next_delay() == _TRANSPORT_GRACE_DELAYS[0]
+        assert grace.retries == 1
+
+    def test_backoff_escalates_then_stops(self):
+        """Capped by count too, so instant failures cannot eat every attempt."""
+        grace = TransportGrace(budget=1000.0)
+        delays = [grace.next_delay() for _ in range(len(_TRANSPORT_GRACE_DELAYS) + 1)]
+        assert delays[: len(_TRANSPORT_GRACE_DELAYS)] == list(_TRANSPORT_GRACE_DELAYS)
+        assert delays[-1] is None
+
+    def test_delay_never_runs_past_the_end_of_the_window(self):
+        grace = TransportGrace(budget=0.5)
+        assert grace.next_delay() == pytest.approx(0.5, abs=0.05)
+
+    def test_exhausted_budget_returns_none(self):
+        assert TransportGrace(budget=0.0).next_delay() is None
+
+    def test_budget_is_spent_by_elapsed_time_not_retry_count(self):
+        """The window is wall-clock, so a slow retry can end it on its own."""
+        grace = TransportGrace(budget=0.05)
+        assert grace.next_delay() is not None
+        time.sleep(0.06)
+        assert grace.next_delay() is None
+
+    def test_default_budget_follows_the_module_setting(self, monkeypatch):
+        monkeypatch.setattr(server_module, "_TRANSPORT_GRACE_PERIOD", 0.0)
+        assert TransportGrace().next_delay() is None
+
+
+class TestUpstreamConnectionTolerance:
+    """A connection blip to the provider is retried, not charged to health."""
+
+    @pytest.mark.asyncio
+    async def test_upstream_blip_is_retried_on_the_same_backend(self, short_grace):
+        """The reset is invisible to the agent and costs no backend health."""
+        server = _make_server(1)
+        port = await server.start_async()
+        try:
+            with aioresponses(passthrough=["http://127.0.0.1"]) as m:
+                m.post(
+                    "https://api0.example.com/v1/chat/completions",
+                    exception=aiohttp.ClientConnectionResetError("blip"),
+                )
+                m.post(
+                    "https://api0.example.com/v1/chat/completions",
+                    body=_CC_STREAM,
+                    headers={"Content-Type": "text/event-stream"},
+                )
+                body = await _post_stream(port)
+                posts = _count_posts(m)
+            assert posts == 2, "the blip should have been retried"
+            assert b"message_stop" in body, "the agent should still get a complete stream"
+            _assert_all_backends_untouched(server)
+        finally:
+            await server.stop_async()
+
+    @pytest.mark.asyncio
+    async def test_sustained_upstream_failure_still_quarantines(self, short_grace):
+        """Past the window it is an outage, not a blip: mark it unhealthy."""
+        server = _make_server(1)
+        port = await server.start_async()
+        try:
+            with aioresponses(passthrough=["http://127.0.0.1"]) as m:
+                m.post(
+                    "https://api0.example.com/v1/chat/completions",
+                    exception=aiohttp.ClientConnectionResetError("upstream went away"),
+                    repeat=True,
+                )
+                await _post_stream(port)
+            assert server._backend_health[0]["healthy"] is False
+            assert server._backend_health[0]["transport_error_count"] >= 1
+        finally:
+            await server.stop_async()
+
+    @pytest.mark.asyncio
+    async def test_grace_does_not_delay_a_non_connection_failure(self, short_grace):
+        """An HTTP 500 is an answer, not a blip — fail over without waiting."""
+        server = _make_server(2)
+        port = await server.start_async()
+        try:
+            with aioresponses(passthrough=["http://127.0.0.1"]) as m:
+                m.post("https://api0.example.com/v1/chat/completions", status=500, body="boom", repeat=True)
+                m.post("https://api1.example.com/v1/chat/completions", status=500, body="boom", repeat=True)
+                await _post_stream(port)
+            for health in server._backend_health:
+                assert health["transport_error_count"] == 0
+                assert health["healthy"] is False
+        finally:
+            await server.stop_async()
+
+
+class TestUpstreamToleranceAcrossProtocols:
+    """Connecting to the provider is retried on every protocol, streamed or
+    not — that is the one point in a request where a retry cannot duplicate
+    output, because nothing has been read from the upstream yet."""
+
+    def _bridge_server(self) -> BridgeServer:
+        """A bridge-mode server, which registers every protocol route."""
+        provider = _StubProvider("https://api0.example.com/v1")
+        profile = Profile(name="profile-0", provider="openai", model="test-model", auth_ref=str(uuid.uuid4()))
+        return BridgeServer(
+            adapter=None,  # type: ignore[arg-type]
+            provider=provider,
+            resolved_key="key-0",
+            model="test-model",
+            backends=[(provider, "key-0", profile)],
+            backend_cooldown=300,
+        )
+
+    @pytest.mark.parametrize(
+        ("path", "payload", "stream"),
+        [
+            ("/v1/responses", {"model": "test-model", "input": [{"role": "user", "content": "hi"}]}, True),
+            (
+                "/v1/chat/completions",
+                {"model": "test-model", "messages": [{"role": "user", "content": "hi"}]},
+                True,
+            ),
+            (
+                "/v1/chat/completions",
+                {"model": "test-model", "messages": [{"role": "user", "content": "hi"}]},
+                False,
+            ),
+            (
+                "/v1beta/models/test-model:streamGenerateContent",
+                {"contents": [{"role": "user", "parts": [{"text": "hi"}]}]},
+                True,
+            ),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_connection_blip_is_retried(self, short_grace, path, payload, stream):
+        server = self._bridge_server()
+        port = await server.start_async()
+        try:
+            with aioresponses(passthrough=["http://127.0.0.1"]) as m:
+                m.post(
+                    "https://api0.example.com/v1/chat/completions",
+                    exception=aiohttp.ClientConnectionResetError("blip"),
+                )
+                if stream:
+                    m.post(
+                        "https://api0.example.com/v1/chat/completions",
+                        body=_CC_STREAM,
+                        headers={"Content-Type": "text/event-stream"},
+                    )
+                else:
+                    m.post("https://api0.example.com/v1/chat/completions", payload=_CC_JSON_RESPONSE)
+                async with (
+                    aiohttp.ClientSession() as session,
+                    session.post(
+                        f"http://127.0.0.1:{port}{path}",
+                        json={**payload, "stream": stream},
+                        timeout=aiohttp.ClientTimeout(total=60),
+                    ) as resp,
+                ):
+                    assert resp.status == 200
+                    await resp.read()
+                assert _count_posts(m) == 2, "the blip should have been retried"
+            _assert_all_backends_untouched(server)
+        finally:
+            await server.stop_async()
+
+
+class TestUpstreamAbortAfterBytesReachedTheClient:
+    """Once bytes are on the wire a restart would duplicate them, so the
+    partial message is closed off rather than retried or failed over — and the
+    client is always left with a terminated stream, never one that just stops."""
+
+    @staticmethod
+    async def _serve_abort(path: str, chunk: bytes, counter: list[int]) -> tuple[web.AppRunner, str]:
+        """Start a local upstream that sends ``chunk`` then aborts the socket."""
+
+        async def _handler(request: web.Request) -> web.StreamResponse:
+            counter.append(1)
+            resp = web.StreamResponse(headers={"Content-Type": "text/event-stream"})
+            await resp.prepare(request)
+            await resp.write(chunk)
+            await asyncio.sleep(0)
+            request.transport.abort()  # type: ignore[union-attr]
+            return resp
+
+        app = web.Application()
+        app.router.add_post(path, _handler)
+        runner = web.AppRunner(app)
+        await runner.setup()
+        await web.TCPSite(runner, "127.0.0.1", 0).start()
+        return runner, f"http://127.0.0.1:{runner.addresses[0][1]}/v1"
+
+    @pytest.mark.asyncio
+    async def test_mid_stream_abort_finalizes_instead_of_erroring(self, short_grace):
+        calls: list[int] = []
+        runner, base = await self._serve_abort("/v1/chat/completions", _CC_CONTENT_CHUNK, calls)
+        server = _make_server(2, base_urls=[base, base])
+        port = await server.start_async()
+        try:
+            body = await _post_stream(port)
+            assert len(calls) == 1, "a stream with bytes already delivered must not be restarted"
+            assert b"message_stop" in body, "the partial message should be closed off cleanly"
+            assert b"internal_error" not in body and b"api_error" not in body
+            _assert_all_backends_untouched(server)
+        finally:
+            await server.stop_async()
+            await runner.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_native_passthrough_abort_still_terminates_the_stream(self, short_grace):
+        """The native path never drives the translator, so it has no half-open
+        message to close — it must still get a terminal event rather than an
+        SSE stream that simply stops."""
+        calls: list[int] = []
+        native_chunk = (
+            b'event: message_start\ndata: {"type":"message_start","message":{"id":"msg_1",'
+            b'"type":"message","role":"assistant","content":[],"model":"test-model",'
+            b'"stop_reason":null,"usage":{"input_tokens":1,"output_tokens":1}}}\n\n'
+        )
+        runner, base = await self._serve_abort("/v1/messages", native_chunk, calls)
+        server = _make_server(2, native=True, base_urls=[base, base])
+        port = await server.start_async()
+        try:
+            body = await _post_stream(port)
+            assert len(calls) == 1, "a stream with bytes already delivered must not be restarted"
+            assert b"message_start" in body
+            assert b'"type": "error"' in body or b'"type":"error"' in body, (
+                "the client must be told the stream ended, not left hanging"
+            )
+            _assert_all_backends_untouched(server)
+        finally:
+            await server.stop_async()
+            await runner.cleanup()
+
+
+class TestGraceDoesNotSpendTheFailoverBudget:
+    """A grace retry re-sends to the same backend, so it must not pull the
+    empty-response schedule forward or consume a failover attempt."""
+
+    @pytest.mark.asyncio
+    async def test_persistent_blip_does_not_reach_the_empty_response_retries(self, monkeypatch):
+        """A single-backend profile hitting a dead upstream should spend its
+        grace and then fail — not also sit through the empty-response delays."""
+        monkeypatch.setattr(server_module, "_TRANSPORT_GRACE_PERIOD", 0.05)
+        monkeypatch.setattr(server_module, "_TRANSPORT_GRACE_DELAYS", (0.001, 0.001, 0.001, 0.001))
+        empty_delays_used: list[float] = []
+        real_sleep = asyncio.sleep
+
+        async def _record_sleep(delay, *args, **kwargs):
+            if delay >= 1.0:
+                empty_delays_used.append(delay)
+            return await real_sleep(0)
+
+        monkeypatch.setattr(server_module.asyncio, "sleep", _record_sleep)
+
+        server = _make_server(1)
+        port = await server.start_async()
+        try:
+            with aioresponses(passthrough=["http://127.0.0.1"]) as m:
+                m.post(
+                    "https://api0.example.com/v1/chat/completions",
+                    exception=aiohttp.ClientConnectionResetError("blip"),
+                    repeat=True,
+                )
+                await _post_stream(port)
+            assert empty_delays_used == [], (
+                f"grace retries pulled the empty-response schedule forward: {empty_delays_used}"
+            )
+            assert server._backend_health[0]["healthy"] is False
+        finally:
+            await server.stop_async()

--- a/tests/bridge/test_client_disconnect_health.py
+++ b/tests/bridge/test_client_disconnect_health.py
@@ -22,6 +22,7 @@ tests run against a local aiohttp server instead of ``aioresponses``.
 from __future__ import annotations
 
 import asyncio
+import logging
 import time
 import uuid
 from unittest.mock import patch
@@ -171,7 +172,10 @@ class _WriteFailer:
         self.fail_after = fail_after
         self.calls = 0
 
-    async def __call__(self, _self: web.StreamResponse, data: bytes = b"", *args, **kwargs) -> None:
+    async def __call__(self, *args, **kwargs) -> None:
+        # Patched onto the class as a plain instance, which is not a
+        # descriptor, so no `self` is bound and the arguments are whatever the
+        # caller passed. They are not needed: this only ever fails.
         self.calls += 1
         if self.calls > self.fail_after:
             raise aiohttp.ClientConnectionResetError("Cannot write to closing transport")
@@ -326,8 +330,13 @@ class TestClientDisconnectLeavesBackendsHealthy:
                     )
                 # Let the message_start / content_block deltas through, then die
                 # on the buffered finish events written after the upstream EOF.
-                with patch.object(web.StreamResponse, "write", _WriteFailer(fail_after=4)):
+                failer = _WriteFailer(fail_after=4)
+                with patch.object(web.StreamResponse, "write", failer):
                     await _post_stream(port)
+            assert failer.calls > failer.fail_after, (
+                "the stream produced too few events to reach the buffered finish events — "
+                "this test would otherwise silently degrade into the fail-on-first-write case"
+            )
             _assert_all_backends_untouched(server)
         finally:
             await server.stop_async()
@@ -573,39 +582,109 @@ class TestUpstreamAbortAfterBytesReachedTheClient:
             await runner.cleanup()
 
 
+class TestRetryLoopStaysBounded:
+    """Extending the Messages loop to hand grace retries back must not let it
+    run past its last real attempt — the empty-response schedule is indexed by
+    `attempt`, so an over-running loop indexes off the end of it."""
+
+    @pytest.mark.asyncio
+    async def test_upstream_errors_never_exceed_the_attempt_budget(self, short_grace):
+        server = _make_server(3)
+        port = await server.start_async()
+        max_attempts = (server_module._MAX_RETRIES + 1) * 3 + len(server_module._EMPTY_FINAL_DELAYS)
+        try:
+            with aioresponses(passthrough=["http://127.0.0.1"]) as m:
+                for i in range(3):
+                    m.post(f"https://api{i}.example.com/v1/chat/completions", status=500, body="boom", repeat=True)
+                body = await _post_stream(port)
+                posts = _count_posts(m)
+            assert posts <= max_attempts, f"{posts} upstream calls exceeds the {max_attempts}-attempt budget"
+            assert b"error" in body, "the agent should be told the request failed"
+        finally:
+            await server.stop_async()
+
+
+class TestGraceIsPerRequestNotPerBackend:
+    """The window covers a request, however many backends it touches."""
+
+    @pytest.mark.asyncio
+    async def test_non_streaming_shares_one_window_across_backends(self, short_grace, monkeypatch):
+        """`_request_with_retry` calls `_make_upstream_request` once per
+        backend; a fresh window per call would let one request spend the whole
+        tolerance three times over."""
+        windows: list[server_module.TransportGrace] = []
+        real_init = server_module.TransportGrace.__init__
+
+        def _track(self, *args, **kwargs):
+            real_init(self, *args, **kwargs)
+            windows.append(self)
+
+        monkeypatch.setattr(server_module.TransportGrace, "__init__", _track)
+
+        server = _make_server(3)
+        port = await server.start_async()
+        try:
+            with aioresponses(passthrough=["http://127.0.0.1"]) as m:
+                for i in range(3):
+                    m.post(
+                        f"https://api{i}.example.com/v1/chat/completions",
+                        exception=aiohttp.ClientConnectionResetError("blip"),
+                        repeat=True,
+                    )
+                async with (
+                    aiohttp.ClientSession() as session,
+                    session.post(
+                        f"http://127.0.0.1:{port}/v1/messages",
+                        json={
+                            "model": "test-model",
+                            "messages": [{"role": "user", "content": "hi"}],
+                            "max_tokens": 1024,
+                            "stream": False,
+                        },
+                        timeout=aiohttp.ClientTimeout(total=60),
+                    ) as resp,
+                ):
+                    await resp.read()
+            assert len(windows) == 1, f"expected one grace window for the request, got {len(windows)}"
+            assert windows[0].retries <= len(server_module._TRANSPORT_GRACE_DELAYS)
+        finally:
+            await server.stop_async()
+
+
 class TestGraceDoesNotSpendTheFailoverBudget:
     """A grace retry re-sends to the same backend, so it must not pull the
     empty-response schedule forward or consume a failover attempt."""
 
     @pytest.mark.asyncio
-    async def test_persistent_blip_does_not_reach_the_empty_response_retries(self, monkeypatch):
+    async def test_persistent_blip_does_not_reach_the_empty_response_retries(self, monkeypatch, caplog):
         """A single-backend profile hitting a dead upstream should spend its
-        grace and then fail — not also sit through the empty-response delays."""
+        grace and then fail — not also sit through the empty-response delays,
+        which are for a backend that answered with nothing, not one that never
+        answered at all.
+
+        Asserted on the log rather than on elapsed time: the delays are
+        shortened so the test stays fast, which would hide the bug from a
+        timing assertion.
+        """
         monkeypatch.setattr(server_module, "_TRANSPORT_GRACE_PERIOD", 0.05)
         monkeypatch.setattr(server_module, "_TRANSPORT_GRACE_DELAYS", (0.001, 0.001, 0.001, 0.001))
-        empty_delays_used: list[float] = []
-        real_sleep = asyncio.sleep
-
-        async def _record_sleep(delay, *args, **kwargs):
-            if delay >= 1.0:
-                empty_delays_used.append(delay)
-            return await real_sleep(0)
-
-        monkeypatch.setattr(server_module.asyncio, "sleep", _record_sleep)
+        monkeypatch.setattr(server_module, "_EMPTY_FINAL_DELAYS", [0.001, 0.001])
 
         server = _make_server(1)
         port = await server.start_async()
         try:
-            with aioresponses(passthrough=["http://127.0.0.1"]) as m:
+            with (
+                caplog.at_level(logging.WARNING, logger="kitty.bridge.server"),
+                aioresponses(passthrough=["http://127.0.0.1"]) as m,
+            ):
                 m.post(
                     "https://api0.example.com/v1/chat/completions",
                     exception=aiohttp.ClientConnectionResetError("blip"),
                     repeat=True,
                 )
                 await _post_stream(port)
-            assert empty_delays_used == [], (
-                f"grace retries pulled the empty-response schedule forward: {empty_delays_used}"
-            )
+            empty_retries = [r.getMessage() for r in caplog.records if "Empty upstream response" in r.getMessage()]
+            assert empty_retries == [], f"grace retries pulled the empty-response schedule forward: {empty_retries}"
             assert server._backend_health[0]["healthy"] is False
         finally:
             await server.stop_async()

--- a/tests/bridge/test_concurrent_backend_selection.py
+++ b/tests/bridge/test_concurrent_backend_selection.py
@@ -176,8 +176,16 @@ class TestProviderConfigContextIsolation:
         assert "CORRUPTED" not in cfg.get("base_url", "")
 
     @pytest.mark.asyncio
-    async def test_concurrent_tasks_have_isolated_provider_config(self):
-        """Two tasks selecting different backends see different provider_configs."""
+    async def test_concurrent_tasks_have_isolated_provider_config(self, monkeypatch):
+        """Two tasks selecting different backends see different provider_configs.
+
+        The selection is pinned instead of left to ``_get_next_backend``, which
+        chooses at random: with two equally-weighted backends both tasks landed
+        on the same one about half the time, and the assertion below then failed
+        on the coin flip rather than on the isolation it is named for. Which
+        backend each task gets is incidental here — that the two do not leak
+        into each other across an ``await`` is the point.
+        """
         import uuid
 
         from kitty.profiles.schema import Profile
@@ -208,6 +216,17 @@ class TestProviderConfigContextIsolation:
             model="m",
         )
 
+        # Hand the first caller backend "a" and the second backend "b". The
+        # interleave below makes that call order deterministic, so each task
+        # knows which config it must still be seeing after its await.
+        selection_order = iter([0, 1])
+
+        def _pinned_backend(self, *, require_streaming: bool = False):
+            provider, key, profile = self._backends[next(selection_order)]
+            return provider, key, profile.model, profile.provider_config, 0
+
+        monkeypatch.setattr(BridgeServer, "_get_next_backend", _pinned_backend)
+
         results: dict = {}
 
         async def task(idx: int) -> None:
@@ -221,8 +240,6 @@ class TestProviderConfigContextIsolation:
         t2 = asyncio.create_task(task(1))
         await asyncio.gather(t1, t2)
 
-        # Both must have valid configs from the context var
-        assert results[0]
-        assert results[1]
-        # The two URLs must differ (proves each task saw its own selection)
-        assert results[0].get("base_url") != results[1].get("base_url")
+        # Each task must still see the backend it selected, not its sibling's
+        assert results[0].get("base_url") == "https://backend-a.example.com"
+        assert results[1].get("base_url") == "https://backend-b.example.com"


### PR DESCRIPTION
Fixes #38.

## Context for the Product Owner

Two things could make kitty stop serving even though every provider behind it was healthy.

**Your agent hanging up was blamed on the provider.** If you closed the terminal, hit Ctrl+C, or your laptop's network blipped while an answer was streaming, kitty read that as "the provider dropped the connection". It put that plan in a five-minute cooldown, switched to the next plan, tried to write the same answer to the same dead terminal, and cooled that one down too. Within seconds every plan was quarantined and the next thing you typed got `503 All backends unhealthy` for five minutes — with nothing actually wrong upstream. That is exactly the incident in #38: two healthy z.ai plans knocked out at 16:48 by one disconnect, back to normal at 17:06 only because the cooldowns expired.

**A one-second network hiccup cost you a plan for five minutes.** kitty had no tolerance at all for a transient connection failure to a provider: the first dropped connection was treated as an outage.

After this change:

- A disconnect on your side is charged to your side. The stream ends, every plan stays healthy, and your next message is served normally.
- A dropped connection to a provider gets 30 seconds of benefit of the doubt. kitty quietly retries the *same* plan with escalating backoff; you never see an error for a blip that clears. Only a connection that keeps failing past 30 seconds counts as a real failure and moves you to another plan.
- If a provider drops the connection *after* it has already sent you part of an answer, kitty now closes that answer off cleanly instead of showing an internal error — and does not restart it on another plan, which would have duplicated text you had already seen.

The 30-second tolerance applies on every protocol kitty speaks: Claude Code (Messages), Codex (Responses), Gemini, and OpenAI-compatible chat, streaming and non-streaming.

Released as **1.8.0**.

## What changed technically

Root cause: aiohttp reports a dead *client* with the same `ConnectionResetError` family it uses for a dead *upstream*. `_stream_messages` wrote to the client inside its per-attempt `try`, so a client disconnect landed in the failover handler, `_is_transport_error` said "transport", and `_mark_backend_unhealthy(..., failure_kind="transport")` gave it a 300 s cooldown. The failover repeated the write on the next backend and quarantined that too.

- `_write_client()` wraps every previously-unguarded client write in the Messages retry loop and re-raises as `ClientDisconnectedError`; a dedicated `except` clause ends the stream without touching backend health. `_is_retryable_exception` / `_is_transport_error` both reject the new type, so its message cannot be mistaken for an upstream reset.
- `_ensure_prepared()` assigns `sr` only after `prepare()` returns. `prepare()` writes headers to the client and can fail, so this makes `sr is not None` mean exactly "the client has received something" — the invariant the two new gates below depend on.
- `TransportGrace` is a per-request budget: up to `_TRANSPORT_GRACE_PERIOD` (30 s) across `_TRANSPORT_GRACE_DELAYS` (2/4/8/16 s), bounded by both count and wall clock. Used in the Messages loop, in the new `_open_upstream_stream()` that the Responses / Gemini / Chat Completions handlers open through, and in `_make_upstream_request` (rebuilt as a `while` loop so connection blips and status retries have separate budgets).
- Grace retries are free: the Messages loop iterates `raw_attempt` and derives `attempt = raw_attempt - transport_grace.retries`. Without this a single-backend profile spent its whole allowance on grace and then sat through `_EMPTY_FINAL_DELAYS` (20 s + 40 s) mislabelled as empty-response retries.
- `aiohttp.ClientPayloadError` (truncated upstream body) is now classified as a connection failure, and `asyncio.TimeoutError` is now excluded from `_is_transport_error` — aiohttp files `ServerTimeoutError` under `ClientConnectionError`, so the function had been contradicting its own docstring and would have added 30 s of grace on top of a 120 s `sock_read` timeout.
- An upstream drop after bytes reached the client finalizes the partial message rather than restarting it, matching the existing FI-8.3 truncation policy. The native-passthrough path has no half-open translator message, so it gets a terminal `error` event instead of a stream that simply stops.

## Testing

New `tests/bridge/test_client_disconnect_health.py` — 28 tests, ~1 s. Unit tests for the classification and the grace arithmetic; subsystem tests driving a real `BridgeServer` with `aioresponses` upstreams, plus a local aiohttp server that aborts a socket mid-body for the cases that need a real disconnect.

Each behaviour was verified to fail before its fix, not just to pass after:

- against the pre-fix `server.py`, the four client-disconnect tests fail with the same `Upstream POST failed after 10 attempts: Cannot write to closing transport` line as the production log in #38;
- with the grace delays emptied, all five tolerance tests fail;
- with the `raw_attempt` accounting reverted, the budget test fails on `Empty upstream response: final retry in 20.0s (5/6)`;
- with the native terminal-event fallback removed, the native abort test fails.

Full suite: **3029 passed, 1 failed, 34 skipped**. The failure is `test_bridge_management.py::TestBridgeReachable::test_connect_target_table[::ffff:0.0.0.0-127.0.0.1]`, which is pre-existing — verified failing on the base commit `ffd5d45` and untouched by this branch. `ruff`, `mypy`, and `lint-imports` are clean.

## Known gap

The Responses, Gemini and Chat Completions *streaming* handlers still conflate a dead client and a dead upstream in a single handler-level `except (ConnectionResetError, BrokenPipeError, OSError)` that ends the stream silently. That pre-dates this change; those handlers gain the connect-time grace but not the attribution fix, because giving them one means wrapping three ~250-line loop bodies in a per-attempt handler. Happy to do that as a follow-up if you want it in this release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015uiTmSTM2JRCizCEEF9DSf
