### PR TITLE
Name the cause in the all-unhealthy 503 (rate limit vs network vs credentials)

### DIFF
--- a/src/kitty/bridge/server.py
+++ b/src/kitty/bridge/server.py
@@ -1535,21 +1535,13 @@ class BridgeServer:
         return web.json_response(data, status=status, headers=hdrs)
 
     @staticmethod
-    def _all_unhealthy_response(exc: AllBackendsUnhealthyError) -> web.Response:
-        """Build a 503 response from an AllBackendsUnhealthyError.
+    def _all_unhealthy_payload(exc: AllBackendsUnhealthyError) -> dict:
+        """Compute the protocol-agnostic cause payload for the all-unhealthy 503.
 
-        Includes a ``Retry-After`` header (in seconds) so clients can back off
-        instead of retrying immediately.  The body names the soonest retry
-        window and, per backend, the failure kind that took it down and when it
-        becomes retryable — so a rate limit is distinguishable from a network
-        outage without reading the bridge log.
-
-        The error ``type`` stays in the retryable ``api_error`` class for every
-        cause: Anthropic-style clients treat ``authentication_error`` /
-        ``permission_error`` / ``invalid_request_error`` as non-retryable, and
-        a cause-specific type on a 503 could make a transient outage look
-        fatal.  The cause therefore rides in the message and the structured
-        ``error.backends`` field only.
+        The message names the soonest retry window and, per backend, the
+        failure kind that took it down and when it becomes retryable — so a
+        rate limit is distinguishable from a network outage without reading
+        the bridge log.
 
         Args:
             exc: The selection failure carrying per-backend status dicts.
@@ -1557,13 +1549,9 @@ class BridgeServer:
                 read with a default.
 
         Returns:
-            The 503 JSON response with ``Retry-After`` and an enriched body.
+            A dict with ``message``, ``retry_after`` and a ``backends`` list of
+            ``{name, reason, remaining_cooldown}`` entries.
         """
-        logger.error(
-            "All %d backends unhealthy; returning 503 with Retry-After=%ds",
-            len(exc.backends),
-            exc.retry_after,
-        )
         # Per-backend (name, reason, cooldown) triples; absent keys fall back
         # to unknown so a minimal dict can never raise here.
         entries = [
@@ -1598,22 +1586,87 @@ class BridgeServer:
         message = f"{headline}: {detail}. Retry after {exc.retry_after}s." if detail else (
             f"{headline}. Retry after {exc.retry_after}s."
         )
-        return BridgeServer._error_response(
-            {
+        return {
+            "message": message,
+            "retry_after": exc.retry_after,
+            "backends": [
+                {"name": name, "reason": reason, "remaining_cooldown": cooldown}
+                for name, reason, cooldown in entries
+            ],
+        }
+
+    @staticmethod
+    def _all_unhealthy_response(exc: AllBackendsUnhealthyError, *, style: str = "anthropic") -> web.Response:
+        """Build the 503 response for an AllBackendsUnhealthyError.
+
+        Includes a ``Retry-After`` header (in seconds) so clients can back off
+        instead of retrying immediately.  The envelope is protocol-native — the
+        bridge renders per-protocol shapes for all its other errors, so the
+        shared cause payload is wrapped in whichever dialect the calling
+        endpoint speaks.
+
+        Every type/code/status below is the retryable class of its own
+        protocol: Anthropic ``api_error`` (500-class), OpenAI
+        ``upstream_error`` (clients retry >=500 by status), Google
+        ``UNAVAILABLE``.  Cause-specific types such as ``authentication_error``
+        would be non-retryable classes and could make a transient outage look
+        fatal, so the cause rides in the message and ``backends`` only.
+
+        Args:
+            exc: The selection failure carrying per-backend status dicts.
+            style: Error dialect of the calling endpoint — ``"anthropic"``
+                (``/v1/messages``), ``"openai_chat"`` (``/v1/chat/completions``),
+                ``"openai_responses"`` (``/v1/responses``), or ``"google"``
+                (Gemini ``generateContent``).
+
+        Returns:
+            The 503 JSON response with ``Retry-After`` and an enriched,
+            protocol-native body.
+        """
+        logger.error(
+            "All %d backends unhealthy; returning 503 with Retry-After=%ds",
+            len(exc.backends),
+            exc.retry_after,
+        )
+        payload = BridgeServer._all_unhealthy_payload(exc)
+        if style == "openai_chat":
+            body = {
+                "error": {
+                    "type": "upstream_error",
+                    "message": payload["message"],
+                    "retry_after": payload["retry_after"],
+                    "backends": payload["backends"],
+                }
+            }
+        elif style == "openai_responses":
+            body = {
+                "error": {
+                    "code": "upstream_error",
+                    "message": payload["message"],
+                    "retry_after": payload["retry_after"],
+                    "backends": payload["backends"],
+                }
+            }
+        elif style == "google":
+            body = {
+                "error": {
+                    "code": 503,
+                    "message": payload["message"],
+                    "status": "UNAVAILABLE",
+                    "backends": payload["backends"],
+                }
+            }
+        else:  # anthropic
+            body = {
                 "type": "error",
                 "error": {
                     "type": "api_error",
-                    "message": message,
-                    "retry_after": exc.retry_after,
-                    "backends": [
-                        {"name": name, "reason": reason, "remaining_cooldown": cooldown}
-                        for name, reason, cooldown in entries
-                    ],
+                    "message": payload["message"],
+                    "retry_after": payload["retry_after"],
+                    "backends": payload["backends"],
                 },
-            },
-            status=503,
-            headers={"Retry-After": str(exc.retry_after)},
-        )
+            }
+        return BridgeServer._error_response(body, status=503, headers={"Retry-After": str(exc.retry_after)})
 
     def _empty_response_context(self, upstream_error: str | None = None) -> dict:
         """Build diagnostic context for empty-response fallback text.
@@ -2385,7 +2438,7 @@ class BridgeServer:
         try:
             self._select_backend()
         except AllBackendsUnhealthyError as exc:
-            return self._all_unhealthy_response(exc)
+            return self._all_unhealthy_response(exc, style="openai_responses")
         try:
             body = await request.json()
         except web.HTTPRequestEntityTooLarge:
@@ -2939,7 +2992,7 @@ class BridgeServer:
         try:
             self._select_backend()
         except AllBackendsUnhealthyError as exc:
-            return self._all_unhealthy_response(exc)
+            return self._all_unhealthy_response(exc, style="anthropic")
         try:
             body = await request.json()
         except web.HTTPRequestEntityTooLarge:
@@ -3924,7 +3977,7 @@ class BridgeServer:
         try:
             self._select_backend()
         except AllBackendsUnhealthyError as exc:
-            return self._all_unhealthy_response(exc)
+            return self._all_unhealthy_response(exc, style="google")
         model_from_path = request.match_info["model"]
 
         try:
@@ -4653,7 +4706,7 @@ class BridgeServer:
         try:
             self._select_backend()
         except AllBackendsUnhealthyError as exc:
-            return self._all_unhealthy_response(exc)
+            return self._all_unhealthy_response(exc, style="openai_chat")
         try:
             body = await request.json()
         except web.HTTPRequestEntityTooLarge:

--- a/src/kitty/bridge/server.py
+++ b/src/kitty/bridge/server.py
@@ -648,6 +648,21 @@ _SSE_MAX_LINE_BYTES = 10 * 1024 * 1024  # 10 MiB — guards against unbounded li
 _MAX_HEADER_VALUE_CHARS = 256  # cap on X-Kitty-* values — names are config-supplied, so unbounded
 
 
+# Human-readable cause headlines for the all-unhealthy 503, keyed by the
+# failure kinds recorded in the backend health records.  Phrased as verb
+# phrases so they compose as "All N backends <headline>.".
+_CAUSE_HEADLINES: dict[str, str] = {
+    "rate_limit": "rate-limited by the upstream provider (429)",
+    "transport": "unreachable (connection errors) — check network/proxy",
+    "auth": "rejecting the credentials (401/403)",
+    "cloudflare": "blocked by the provider firewall (403)",
+    "entitlement": "requires a plan/subscription upgrade",
+    "oversized": "rejected as too large for the provider context window",
+    "hard": "returning provider errors",
+    "stream": "returning provider errors",
+}
+
+
 class AllBackendsUnhealthyError(Exception):
     """Raised when all backends are unhealthy and the soonest retry exceeds the fast-fail threshold."""
 
@@ -1060,6 +1075,10 @@ class BridgeServer:
                     "failure_count": 0,
                     "transport_error_count": 0,
                     "cloudflare_error_count": 0,
+                    # Kind of the failure that most recently quarantined this
+                    # backend (``None`` while healthy) — the all-unhealthy 503
+                    # reads it to tell the client *why* every backend is down.
+                    "last_failure_kind": None,
                 }
                 for _ in backends
             ]
@@ -1224,6 +1243,7 @@ class BridgeServer:
                         health["healthy"] = True
                         health["failed_at"] = None
                         health["stream_error_count"] = 0
+                        health["last_failure_kind"] = None
                         healthy_indices.append(idx)
 
             if healthy_indices:
@@ -1263,6 +1283,8 @@ class BridgeServer:
                         "name": self._backends[idx][2].name,
                         "healthy": False,
                         "remaining_cooldown": 0,
+                        # Not a failure: these backends simply cannot stream.
+                        "reason": "not_stream_capable",
                     }
                     for idx in range(n)
                 ]
@@ -1288,6 +1310,10 @@ class BridgeServer:
                         "name": self._backends[idx][2].name,
                         "healthy": False,
                         "remaining_cooldown": remaining,
+                        # Why this backend is in cooldown — surfaced in the
+                        # all-unhealthy 503 so clients can tell a rate limit
+                        # from a network outage.
+                        "reason": health.get("last_failure_kind") or "unknown",
                     }
                 )
                 candidates.append((remaining, idx))
@@ -1344,6 +1370,8 @@ class BridgeServer:
         health["healthy"] = False
         health["failed_at"] = time.monotonic()
         health["failure_count"] = health.get("failure_count", 0) + 1
+        # Remember *why* so the all-unhealthy 503 can report the cause.
+        health["last_failure_kind"] = failure_kind
 
         if failure_kind == "cloudflare":
             health["cloudflare_error_count"] = health.get("cloudflare_error_count", 0) + 1
@@ -1434,6 +1462,7 @@ class BridgeServer:
         health["failed_at"] = None
         health["stream_error_count"] = 0
         health["transport_error_count"] = 0
+        health["last_failure_kind"] = None
         # F21: decay cloudflare count instead of resetting — prevents thrash loop
         health["cloudflare_error_count"] = max(0, health.get("cloudflare_error_count", 0) - 1)
 
@@ -1511,22 +1540,75 @@ class BridgeServer:
 
         Includes a ``Retry-After`` header (in seconds) so clients can back off
         instead of retrying immediately.  The body names the soonest retry
-        window and the count of exhausted backends.
+        window and, per backend, the failure kind that took it down and when it
+        becomes retryable — so a rate limit is distinguishable from a network
+        outage without reading the bridge log.
+
+        The error ``type`` stays in the retryable ``api_error`` class for every
+        cause: Anthropic-style clients treat ``authentication_error`` /
+        ``permission_error`` / ``invalid_request_error`` as non-retryable, and
+        a cause-specific type on a 503 could make a transient outage look
+        fatal.  The cause therefore rides in the message and the structured
+        ``error.backends`` field only.
+
+        Args:
+            exc: The selection failure carrying per-backend status dicts.
+                Legacy callers pass dicts with only ``name``, so every key is
+                read with a default.
+
+        Returns:
+            The 503 JSON response with ``Retry-After`` and an enriched body.
         """
         logger.error(
             "All %d backends unhealthy; returning 503 with Retry-After=%ds",
             len(exc.backends),
             exc.retry_after,
         )
+        # Per-backend (name, reason, cooldown) triples; absent keys fall back
+        # to unknown so a minimal dict can never raise here.
+        entries = [
+            (
+                backend.get("name") or "backend",
+                backend.get("reason") or "unknown",
+                backend.get("remaining_cooldown"),
+            )
+            for backend in exc.backends
+        ]
+
+        # Unanimous known causes get a cause-specific headline; a pool of
+        # non-stream-capable backends is not a failure at all and says so;
+        # anything else keeps the neutral headline with the detail inline.
+        reasons = [reason for _name, reason, _cooldown in entries]
+        if reasons and all(reason == "not_stream_capable" for reason in reasons):
+            headline = (
+                f"No stream-capable backend is available ({len(entries)} backends cannot stream)"
+            )
+        elif reasons and len(set(reasons)) == 1 and reasons[0] in _CAUSE_HEADLINES:
+            headline = f"All {len(entries)} backends {_CAUSE_HEADLINES[reasons[0]]}"
+        else:
+            headline = f"All {len(entries)} backends are currently unavailable"
+
+        def _describe(name: str, reason: str, cooldown: int | None) -> str:
+            """Render one backend as ``name (reason[, ready in Ns])``."""
+            if cooldown is None:
+                return f"{name} ({reason})"
+            return f"{name} ({reason}, ready in {cooldown}s)"
+
+        detail = "; ".join(_describe(*entry) for entry in entries)
+        message = f"{headline}: {detail}. Retry after {exc.retry_after}s." if detail else (
+            f"{headline}. Retry after {exc.retry_after}s."
+        )
         return BridgeServer._error_response(
             {
                 "type": "error",
                 "error": {
-                    "type": "service_unavailable",
-                    "message": (
-                        f"All {len(exc.backends)} backends are currently unavailable. Retry after {exc.retry_after}s."
-                    ),
+                    "type": "api_error",
+                    "message": message,
                     "retry_after": exc.retry_after,
+                    "backends": [
+                        {"name": name, "reason": reason, "remaining_cooldown": cooldown}
+                        for name, reason, cooldown in entries
+                    ],
                 },
             },
             status=503,

--- a/tests/bridge/test_all_backends_unhealthy.py
+++ b/tests/bridge/test_all_backends_unhealthy.py
@@ -322,6 +322,217 @@ class TestGeminiHandlerReturns503:
             await server.stop_async()
 
 
+# ── last_failure_kind persistence ─────────────────────────────────────────
+
+
+class TestLastFailureKindPersistence:
+    """The health record remembers the failure kind that quarantined a backend,
+    so the all-unhealthy 503 can name the cause.  The memory is cleared
+    wherever the backend returns to health."""
+
+    def _make_server_with_backends(self) -> BridgeServer:
+        """Build a BridgeServer with a real backends list — health tracking
+        (and therefore ``last_failure_kind``) only exists in that mode."""
+        import uuid
+
+        from kitty.profiles.schema import Profile
+
+        provider = _StubProvider()
+        profile = Profile(name="kind-test", provider="openai", model="m", auth_ref=str(uuid.uuid4()))
+        return BridgeServer(
+            _StubLauncher(),
+            provider,
+            "test-key",
+            backends=[(provider, "test-key", profile)],
+            backend_cooldown=300,
+        )
+
+    def test_initial_value_is_none(self):
+        server = self._make_server_with_backends()
+        assert server._backend_health[0]["last_failure_kind"] is None
+
+    def test_set_by_mark_unhealthy(self):
+        server = self._make_server_with_backends()
+        server._mark_backend_unhealthy(0, failure_kind="rate_limit")
+        assert server._backend_health[0]["last_failure_kind"] == "rate_limit"
+
+    def test_cleared_by_mark_healthy(self):
+        server = self._make_server_with_backends()
+        server._mark_backend_unhealthy(0, failure_kind="rate_limit")
+        server._mark_backend_healthy(0)
+        assert server._backend_health[0]["last_failure_kind"] is None
+
+    def test_cleared_by_cooldown_expiry(self):
+        import time
+
+        server = self._make_server_with_backends()
+        server._mark_backend_unhealthy(0, failure_kind="rate_limit")
+        # Rewind failed_at past the cooldown so _select_backend sees expiry.
+        server._backend_health[0]["failed_at"] = time.monotonic() - 100_000
+        server._select_backend()
+        assert server._backend_health[0]["last_failure_kind"] is None
+
+
+# ── Enriched 503 body names the cause ─────────────────────────────────────
+
+
+def _parse(resp):
+    return json.loads(resp.text)
+
+
+class TestAllUnhealthyResponseNamesCause:
+    """The all-unhealthy 503 body must tell the user *why*: which failure kind
+    each backend hit and when it becomes retryable.  The error ``type`` stays
+    in the retryable ``api_error`` class for every cause — Anthropic clients
+    treat ``authentication_error`` / ``permission_error`` /
+    ``invalid_request_error`` as non-retryable, and a cause-specific type on a
+    503 could make Claude Code abort a transient outage.  The cause rides in
+    the message and a structured ``error.backends`` field instead."""
+
+    def _exc(self, backends, retry_after=196):
+        return AllBackendsUnhealthyError(backends, retry_after=retry_after)
+
+    def test_unanimous_rate_limit(self):
+        resp = BridgeServer._all_unhealthy_response(
+            self._exc(
+                [
+                    {"name": "secondary", "reason": "rate_limit", "remaining_cooldown": 196},
+                    {"name": "zai_coding", "reason": "rate_limit", "remaining_cooldown": 180},
+                ]
+            )
+        )
+        assert resp.status == 503
+        assert resp.headers["Retry-After"] == "196"
+        body = _parse(resp)
+        assert body["error"]["type"] == "api_error"
+        assert "rate-limited by the upstream provider" in body["error"]["message"]
+        assert "secondary" in body["error"]["message"]
+        assert "zai_coding" in body["error"]["message"]
+        assert body["error"]["backends"] == [
+            {"name": "secondary", "reason": "rate_limit", "remaining_cooldown": 196},
+            {"name": "zai_coding", "reason": "rate_limit", "remaining_cooldown": 180},
+        ]
+
+    def test_mixed_reasons_neutral_headline(self):
+        resp = BridgeServer._all_unhealthy_response(
+            self._exc(
+                [
+                    {"name": "a", "reason": "rate_limit", "remaining_cooldown": 100},
+                    {"name": "b", "reason": "transport", "remaining_cooldown": 50},
+                ]
+            )
+        )
+        body = _parse(resp)
+        assert body["error"]["type"] == "api_error"
+        assert "All 2 backends are currently unavailable" in body["error"]["message"]
+        # Both causes still visible in the per-backend list.
+        assert "a (rate_limit, ready in 100s)" in body["error"]["message"]
+        assert "b (transport, ready in 50s)" in body["error"]["message"]
+
+    def test_minimal_dict_still_503(self):
+        """Existing callers pass only ``name`` — no KeyError, no 500, no leak."""
+        resp = BridgeServer._all_unhealthy_response(self._exc([{"name": "stub"}]))
+        body = _parse(resp)
+        assert resp.status == 503
+        assert body["error"]["type"] == "api_error"
+        assert "All 1 backends are currently unavailable" in body["error"]["message"]
+        assert "stub (unknown)" in body["error"]["message"]
+        assert body["error"]["backends"] == [
+            {"name": "stub", "reason": "unknown", "remaining_cooldown": None}
+        ]
+        assert "Traceback" not in resp.text
+        assert "AllBackendsUnhealthyError" not in resp.text
+
+    def test_not_stream_capable_headline(self):
+        resp = BridgeServer._all_unhealthy_response(
+            self._exc(
+                [
+                    {"name": "a", "reason": "not_stream_capable", "remaining_cooldown": 0},
+                    {"name": "b", "reason": "not_stream_capable", "remaining_cooldown": 0},
+                ]
+            )
+        )
+        body = _parse(resp)
+        assert "No stream-capable backend is available" in body["error"]["message"]
+
+    @pytest.mark.parametrize(
+        ("reason", "headline"),
+        [
+            ("transport", "unreachable (connection errors)"),
+            ("auth", "rejecting the credentials"),
+            ("cloudflare", "blocked by the provider firewall"),
+            ("entitlement", "requires a plan/subscription upgrade"),
+            ("oversized", "too large for the provider context window"),
+            ("hard", "returning provider errors"),
+            ("stream", "returning provider errors"),
+        ],
+    )
+    def test_cause_headlines(self, reason, headline):
+        resp = BridgeServer._all_unhealthy_response(
+            self._exc([{"name": "a", "reason": reason, "remaining_cooldown": 10}])
+        )
+        assert headline in _parse(resp)["error"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_messages_503_names_cause_over_http(self):
+        server = _make_server()
+        port = await server.start_async()
+        try:
+            with patch.object(
+                server,
+                "_select_backend",
+                side_effect=AllBackendsUnhealthyError(
+                    [
+                        {"name": "secondary", "reason": "rate_limit", "remaining_cooldown": 196},
+                        {"name": "zai_coding", "reason": "rate_limit", "remaining_cooldown": 180},
+                    ],
+                    retry_after=196,
+                ),
+            ):
+                async with (
+                    aiohttp.ClientSession() as session,
+                    session.post(
+                        f"http://127.0.0.1:{port}/v1/messages",
+                        json=_messages_request(),
+                        headers={"content-type": "application/json"},
+                    ) as resp,
+                ):
+                    assert resp.status == 503
+                    assert resp.headers["Retry-After"] == "196"
+                    body = await resp.json()
+                    assert body["error"]["type"] == "api_error"
+                    assert "rate-limited by the upstream provider" in body["error"]["message"]
+        finally:
+            await server.stop_async()
+
+    @pytest.mark.asyncio
+    async def test_chat_completions_503_names_cause_over_http(self):
+        server = _make_bridge_mode_server()
+        port = await server.start_async()
+        try:
+            with patch.object(
+                server,
+                "_select_backend",
+                side_effect=AllBackendsUnhealthyError(
+                    [{"name": "stub", "reason": "transport", "remaining_cooldown": 90}],
+                    retry_after=90,
+                ),
+            ):
+                async with (
+                    aiohttp.ClientSession() as session,
+                    session.post(
+                        f"http://127.0.0.1:{port}/v1/chat/completions",
+                        json=_cc_request(),
+                        headers={"content-type": "application/json"},
+                    ) as resp,
+                ):
+                    assert resp.status == 503
+                    body = await resp.json()
+                    assert "unreachable (connection errors)" in body["error"]["message"]
+        finally:
+            await server.stop_async()
+
+
 # ── Negative: success path still works ────────────────────────────────────
 
 

--- a/tests/bridge/test_all_backends_unhealthy.py
+++ b/tests/bridge/test_all_backends_unhealthy.py
@@ -473,6 +473,66 @@ class TestAllUnhealthyResponseNamesCause:
         )
         assert headline in _parse(resp)["error"]["message"]
 
+    @pytest.mark.parametrize(
+        "style",
+        ["anthropic", "openai_chat", "openai_responses", "google"],
+    )
+    def test_per_protocol_envelopes(self, style):
+        """Each protocol gets its native error envelope (the bridge renders
+        per-protocol shapes for all its other errors) with the shared cause
+        message and backends payload inside."""
+        resp = BridgeServer._all_unhealthy_response(
+            self._exc([{"name": "a", "reason": "rate_limit", "remaining_cooldown": 100}]),
+            style=style,
+        )
+        body = _parse(resp)
+        assert resp.status == 503
+        err = body["error"]
+        if style == "anthropic":
+            assert body["type"] == "error"
+            assert err["type"] == "api_error"
+        elif style == "google":
+            assert err["code"] == 503
+            assert err["status"] == "UNAVAILABLE"
+        elif style == "openai_responses":
+            assert err["code"] == "upstream_error"
+        else:
+            assert err["type"] == "upstream_error"
+        assert "rate-limited by the upstream provider" in err["message"]
+        assert err["backends"] == [
+            {"name": "a", "reason": "rate_limit", "remaining_cooldown": 100}
+        ]
+
+    @pytest.mark.asyncio
+    async def test_gemini_503_native_envelope_over_http(self):
+        server = _make_bridge_mode_server()
+        port = await server.start_async()
+        try:
+            with patch.object(
+                server,
+                "_select_backend",
+                side_effect=AllBackendsUnhealthyError(
+                    [{"name": "stub", "reason": "rate_limit", "remaining_cooldown": 300}],
+                    retry_after=300,
+                ),
+            ):
+                async with (
+                    aiohttp.ClientSession() as session,
+                    session.post(
+                        f"http://127.0.0.1:{port}/v1beta/models/test:generateContent",
+                        json={"contents": [{"parts": [{"text": "hi"}]}]},
+                        headers={"content-type": "application/json"},
+                    ) as resp,
+                ):
+                    assert resp.status == 503
+                    assert resp.headers.get("Retry-After") is not None
+                    body = await resp.json()
+                    assert body["error"]["code"] == 503
+                    assert body["error"]["status"] == "UNAVAILABLE"
+                    assert "rate-limited by the upstream provider" in body["error"]["message"]
+        finally:
+            await server.stop_async()
+
     @pytest.mark.asyncio
     async def test_messages_503_names_cause_over_http(self):
         server = _make_server()
@@ -528,6 +588,9 @@ class TestAllUnhealthyResponseNamesCause:
                 ):
                     assert resp.status == 503
                     body = await resp.json()
+                    # OpenAI envelope — no Anthropic "type": "error" wrapper.
+                    assert "type" not in body
+                    assert body["error"]["type"] == "upstream_error"
                     assert "unreachable (connection errors)" in body["error"]["message"]
         finally:
             await server.stop_async()


### PR DESCRIPTION
## Problem

When every backend is down, the bridge returns the same Anthropic-shaped body
regardless of why:

```json
{"type": "error", "error": {"type": "service_unavailable",
 "message": "All 2 backends are currently unavailable. Retry after 196s."}}
```

The bridge already knows the cause — `_provider_error_failure_kind()` classifies
every failure as `rate_limit` / `transport` / `auth` / `cloudflare` / … — but the
kind is discarded at the health record, so a provider rate limit (429), a dead
network and rejected credentials are indistinguishable to the client. Hit this
live: both configured backends (same upstream, different keys) were 429-throttled,
Claude Code showed a bare "503", and the only way to learn it was rate limiting was
to grep a 750 MB debug log.

## The change

**1. Remember why.** `_mark_backend_unhealthy()` records `last_failure_kind` in
the health record (initialised `None`); cleared wherever the backend returns to
health (cooldown expiry in `_select_backend`, `_mark_backend_healthy`).

**2. Carry it.** Both `backend_status` constructions in `_select_backend` add
`"reason"` — the recorded kind, `"unknown"` for minimal dicts,
`"not_stream_capable"` on the no-stream-capable raise (those backends are not
unhealthy, they just can't stream, and the body now says so instead of
"unavailable").

**3. Show it, in each protocol's native envelope.** The all-unhealthy 503 has
always returned the Anthropic `{"type": "error", …}` wrapper on **all four**
protocol endpoints — a pre-existing mismatch this PR fixes, since every other
error path in the bridge already renders per-protocol shapes. The shared cause
payload (headline + per-backend list + `backends`) is now wrapped in the
calling endpoint's dialect, mirroring the vocabulary each handler already uses
for its own upstream errors:

| Endpoint | Envelope (type/code = retryable class of that protocol) |
|---|---|
| `/v1/messages` (Claude Code) | `{"type": "error", "error": {"type": "api_error", …}}` |
| `/v1/chat/completions` (Codex etc.) | `{"error": {"type": "upstream_error", …}}` |
| `/v1/responses` | `{"error": {"code": "upstream_error", …}}` |
| Gemini `generateContent` | `{"error": {"code": 503, "status": "UNAVAILABLE", …}}` |

Cause message example (same text inside every envelope):

```
All 2 backends rate-limited by the upstream provider (429):
secondary (rate_limit, ready in 196s); zai_coding (rate_limit, ready in 180s).
Retry after 196s.
```

A structured `error.backends: [{name, reason, remaining_cooldown}]` field rides
along for machine-readable consumption (same pattern as the existing envelope
`retry_after`). All per-backend keys are read with `.get()` defaults, so
legacy minimal dicts keep producing a valid 503.

## Retry behaviour is untouched

HTTP status (503) and `Retry-After` are unchanged. Every envelope's type/code
is the retryable class of its own protocol: Anthropic `api_error` (500-class —
deliberately *not* cause-specific, since `authentication_error` /
`permission_error` / `invalid_request_error` are documented non-retryable and
could make Claude Code treat a transient outage as fatal); OpenAI SDKs retry
≥500 by status alone; Google `UNAVAILABLE` is the canonical retryable status.
The cause travels in prose and structured data only.

## Context (for the product owner)

When the bridge has no healthy backend left, the user's coding agent — Claude
Code, Codex, Gemini CLI, whatever speaks to the bridge — now tells them *why*
("rate-limited by the upstream provider, ready in 3 minutes" vs "connection
errors, check your network"), in the error format their agent already
understands, instead of an opaque 503. No change to when retries happen or how
the bridge picks backends.

## Testing

- 22 new tests in `tests/bridge/test_all_backends_unhealthy.py` (TDD, written
  first): cause persistence set/cleared on all three return-to-health paths,
  headline matrix per cause, per-protocol envelope matrix, mixed /
  minimal-dict / not-stream-capable bodies, `Retry-After` intact, no traceback
  leakage, and over-HTTP integration tests on `/v1/messages`,
  `/v1/chat/completions` (OpenAI envelope asserted) and Gemini (Google
  envelope asserted).
- Full existing file passes unmodified (10 tests).
- Repo-wide unit suite green on Windows/Py3.10 except one pre-existing,
  unrelated failure (`TestBridgeReachable` IPv6-mapped loopback param — fails
  on clean `main` too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6DkHDV12hGG3KTMdTMvYP
