### PR TITLE
Release 1.9.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kitty-bridge"
-version = "1.8.0"
+version = "1.9.0"
 description = "Kitty Bridge — launch coding agents through a local API bridge"
 readme = "README.md"
 license = "MIT"

--- a/src/kitty/__init__.py
+++ b/src/kitty/__init__.py
@@ -4,5 +4,5 @@ import logging
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
-__version__ = "1.8.0"
+__version__ = "1.9.0"
 __all__ = ["__version__"]

--- a/src/kitty/bridge/server.py
+++ b/src/kitty/bridge/server.py
@@ -1629,6 +1629,9 @@ class BridgeServer:
             exc.retry_after,
         )
         payload = BridgeServer._all_unhealthy_payload(exc)
+        # The anthropic branch mixes a top-level string key with nested dicts, so the
+        # union has to be declared up front rather than inferred from the first branch.
+        body: dict
         if style == "openai_chat":
             body = {
                 "error": {


### PR DESCRIPTION
Bumps `pyproject.toml` and `src/kitty/__init__.py` from 1.8.0 to 1.9.0 so the `v1.9.0` tag can publish to PyPI (the publish workflow refuses a tag whose version does not match `pyproject.toml`).

Version-only change — no behaviour is modified by this PR.

## Context for the Product Owner

Release 1.9.0 ships the work merged in #41: when every backend in a balancing profile is unhealthy, Kitty's 503 response now **tells the user why**. Instead of a generic "all backends unhealthy" message, the error names the actual cause — rate limit, network failure, or bad credentials — and is delivered in the error format each agent CLI natively understands (Claude Code, Codex, Gemini CLI, Kilo), so the message shows up properly in the agent's UI rather than as an unparsed blob.

Practically: when a user's providers are all failing, they can now see whether they hit a quota, lost connectivity, or need to re-authenticate, without digging through logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0196rYQi4eUXMtTVwj9NHFmc
