### PR TITLE
Add a four-layer test suite design (KBR-2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 /.import_linter_cache/
 /.requirements/
 /.serena/
-/.system_design/
 /.venv/
 /debug/
 /.codex

--- a/.system_design/TEST_SUITE.md
+++ b/.system_design/TEST_SUITE.md
@@ -186,86 +186,176 @@ trigger no test can fail — so each material mutation gets its own row.
 | P9a | Set `User-Agent` to `claude-code/1.0` | `KimiCodeAdapter`, `BytePlusAdapter`, `MimoAdapter` `.build_upstream_headers` | Always, on those three | Those providers 403 without a recognised coding-agent user-agent. Central to I2 — F1. |
 | P9b | Remove `Authorization`, add `api-key` | `MimoAdapter.build_upstream_headers` | Always | MiMo does not use Bearer auth. An auth-**scheme** change §4.3 C1's exact-set assertion must encode. |
 | P9c | Synthesise a Codex CLI `User-Agent` and a `version` header | `OpenAISubscriptionAdapter` | Always | Impersonation required by the subscription endpoint. **The two disagree — see F1.** |
-| P10 | Set `reasoning_split = True` | `MiniMaxAdapter.normalize_request` | **Unconditionally** | Makes MiniMax return thinking in `reasoning_details` instead of inline tags. Unconditional, so exempt from §3.3 assertion 2. |
-| P11 | Translate CC → Bedrock Converse | `BedrockAdapter.translate_to_upstream` | Always, on `bedrock` | A third upstream wire format M2 does not name. Custom transport — see §3.3.2. |
+| P10 | Set `reasoning_split = True` | `MiniMaxAdapter.normalize_request` | **Unconditionally** | Makes MiniMax return thinking in `reasoning_details` instead of inline tags. Unconditional, so exempt from §3.3.2 assertion 2. |
+| P11 | Translate CC → Bedrock Converse | `BedrockAdapter.translate_to_upstream` | Always, on `bedrock` | A third upstream wire format M2 does not name. Custom transport — see §3.3.4. |
 | P12 | Translate CC → Ollama `/api/chat` | `OllamaCloudAdapter.translate_to_upstream` | Always, on `ollama_cloud` | A fourth wire format. Custom transport. |
+| P13 | **Drop fourteen Chat-Completions-only parameters** — `temperature`, `top_p`, `max_tokens`, `max_completion_tokens`, `frequency_penalty`, `presence_penalty`, `logprobs`, `top_logprobs`, `response_format`, `stop`, `n`, `stream_options`, `seed`, `logit_bias` | `OpenAISubscriptionAdapter._cc_to_responses` | Always, on the **CC-origin** path | The Codex backend applies strict allowlist validation and rejects them with 400. **User-visible**: `max_tokens` and `temperature` silently do nothing on this provider. Logged at DEBUG. |
+| P14 | **Drop every parameter outside the Codex allowlist**, notably `max_output_tokens` | `OpenAISubscriptionAdapter._prepare_responses_body` | Always, on the **Responses-origin** path | Same backend restriction, different input shape — this path receives a Responses body, so the parameter is spelled `max_output_tokens`, not `max_tokens`. A single row cannot cover both paths; the sets differ. |
+| P15 | **Strip `strict` from every tool declaration** | `_prepare_responses_body` | Always, on the Responses-origin path | The Codex backend rejects it. A change to the **tool schema** the agent declared, not to a sampling parameter — a different kind of fidelity mutation and worth its own row. |
+| P16 | Rewrite content types `input_text` → `output_text` | `_convert_content_types`, called from `_prepare_responses_body` | Always, on the Responses-origin path | The Codex backend validates content types strictly. **Message-content mutation.** |
+| P17 | Inject `stream: True` and `store: False` | `_cc_to_responses` and the Responses-origin body builder | **Unconditionally**, both subscription paths | The Codex backend is streaming-only; kitty reassembles a non-streaming reply from the SSE. Note `stream: True` **overrides a non-streaming client request** — the subscription-path analogue of M11. |
+| P18 | Remove `modelId` and `stream` from the Converse payload | ``BedrockAdapter` transport (`make_request` / `stream_request`)` | Always, on `bedrock` | boto3 takes the model id as a call argument and selects streaming by choosing `converse` vs `converse_stream`, so both must leave the body. Applied **in the transport, after `translate_to_upstream`**. |
+| P19 | Overwrite `stream` | `OllamaCloudAdapter` transport (`make_request` sets `False`, `stream_request` sets `True`) | Always, on `ollama_cloud` | The transport, not the caller, decides which Ollama endpoint mode is used. Applied **after `translate_to_upstream`** has already set it from the request. |
 
 **Conditional rows are the point.** Every row whose trigger is a condition must be provably
 *inert* when that condition is absent — the sharpest form of "unless absolutely necessary", and
-what §3.3 assertion 2 tests. M1, M2, M10, P1, P6, P9a–c, P10, P11 and P12 are unconditional by
-design and are exempt from that assertion.
+what §3.3.2 assertion 2 tests, with the trigger complements §3.3.4 requires. M1, M2, M10, P1,
+P6, P9a–c, P10, P11, P12, P13, P14, P15, P16, P17, P18 and P19 are unconditional by design and
+are exempt from that assertion.
 
 **Register maintenance.** The register is the specification. A pull request that adds a mutation
 site without adding a row fails the L2 register guards (§6.2.3).
+
+#### 3.2.3 Serialization paths — where the register must actually be checked
+
+The register is only enforceable at the point where bytes are handed to a transport. That point
+is **not** `translate_to_upstream` for any of the three custom-transport providers, and assuming
+it is hid seven rows in the first draft: on `openai_subscription` the hook returns a Chat
+Completions shape and the real body is built afterwards (P13–P17), while on `bedrock` and
+`ollama_cloud` the hook builds the body and the transport then **mutates it** (P18, P19).
+
+| Path | Adapters | Where the final bytes are decided |
+|---|---|---|
+| Bridge aiohttp | the 20 default-transport adapters | The `json=` body passed to `session.post` in `_make_upstream_request` / `_open_upstream_stream` |
+| curl_cffi | `openai_subscription` | Built **inside the transport**: `_cc_to_responses` (CC-origin) or `_prepare_responses_body` (Responses-origin). The adapter hook's output is not what ships. |
+| botocore | `bedrock` | Built by `translate_to_upstream`, then **mutated** in `make_request` / `stream_request` (P18). Capture after the mutation. |
+| provider aiohttp | `ollama_cloud` | Built by `translate_to_upstream`, then **mutated** in `make_request` / `stream_request` (P19). Capture after the mutation. |
+
+Every guard and every oracle run in this document targets the right-hand column, never the hook
+that precedes it. Where the body is built in the hook and mutated in the transport, "after the
+mutation" is the boundary — capturing the hook's return value would miss P18 and P19 exactly as
+it missed P13.
 
 ### 3.3 The transparency oracle
 
 The single piece of new infrastructure that makes I1 testable.
 
 **What it is.** A test harness that runs a request through the real `BridgeServer` into a
-recording fake upstream, then diffs the captured upstream body against the inbound agent body
-and classifies every difference against the register.
+recording upstream, projects both the inbound agent body and the captured upstream body into a
+**wire-independent semantic form**, and classifies every difference against the register.
 
 ```
-inbound agent body ──► BridgeServer ──► recording upstream
-        │                                      │
-        └───────── structural diff ────────────┘
-                          │
-                classify each delta
-                          │
-     ┌────────────────────┴────────────────────┐
-claimed by a register row              unclaimed  ──► FAIL
-whose trigger was present                    │
-            │                          unclaimed delta is the
-    assert the row's                   whole point of the oracle
-    stated shape held
+inbound agent body ─────► BridgeServer ─────► recording upstream (final wire bytes)
+        │                                                 │
+   project()                                         project()
+        │                                                 │
+        ▼                                                 ▼
+  Conversation                                      Conversation
+        └──────────────── structural diff ────────────────┘
+                              │
+                    classify each delta
+                              │
+         ┌────────────────────┴────────────────────┐
+   claimed by a register row              unclaimed  ──► FAIL
+   whose trigger was present                    │
+                │                          unclaimed delta is the
+        assert the row's                   whole point of the oracle
+        stated shape held
 ```
 
-**The two assertions, in priority order.**
+#### 3.3.1 The comparison is an independent projection, never a round-trip
 
-1. **No unclaimed delta.** Any difference between inbound and upstream bodies must map to a
-   register row. This is the invariant.
-2. **No mutation without its trigger.** For each conditional row, a corpus entry that does not
-   meet the trigger must show that row's mutation *absent*. This is what stops M3/M5 quietly
-   becoming unconditional.
+An earlier draft of this design specified comparing the inbound body against a **round-trip**
+through the production translators — `translate_request` then `translate_response`. That is
+wrong twice over, and the reason is worth recording so nobody proposes it again.
 
-#### 3.3.1 The oracle is scoped by wire shape — and why
+**It is a category error.** `MessagesTranslator.translate_request` maps a Messages *request* to a
+Chat Completions *request*. `MessagesTranslator.translate_response` maps a Chat Completions
+*response* — a body whose payload is `choices` — back to a Messages *response*. They are not
+inverses and never were: composing them takes a conversation in and returns an assistant reply,
+so the input history cannot survive the trip. The same objection applies to any "inverse pair"
+assembled from the provider adapters.
 
-A direct inbound-vs-upstream diff is only meaningful where the two bodies are in the same
-protocol. On a Chat-Completions-wire provider the upstream body is CC while the inbound body is
-Anthropic Messages: *every* field differs, every delta is claimed by M2, and assertion 1 passes
-trivially while proving nothing. A test that cannot fail is worse than no test.
+**Even a real inverse would prove the wrong thing.** Using the production translator to check the
+production translator establishes self-consistency, not fidelity. A translator that drops the
+same field in both directions round-trips perfectly. The oracle must not be written in terms of
+the code under test.
 
-| Path | Adapters | Comparison | Why |
-|---|---|---|---|
-| **Native Messages wire** | `anthropic`, `zai_coding`, `custom_anthropic`, `minimax_token`, and `opencode_go` **for its Messages models only** | Inbound body vs. upstream body, directly | Same protocol both sides. "Unchanged" is literally meaningful, and this is the path the Jira premise names. |
-| **Chat Completions wire** | the remaining adapters | Inbound vs. **round-trip** (`translate_request` → `translate_response` back to the agent's protocol) | The claim that survives translation is semantic preservation, not byte equality. |
-| **Other wire** | `bedrock` (Converse), `ollama_cloud` (`/api/chat`) | Round-trip through that adapter's own pair | Neither Messages nor CC. Round-trip mode needs the adapter's own inverse, not the shared one (P11, P12). |
+**The projection.** Define one **`Conversation`** value type in the test tree:
 
-**The scoping predicate is per-request, not per-adapter.** `upstream_wire_is_messages_api` is the
-natural selector, but it cannot be trusted as an adapter-level constant: `OpenCodeGoAdapter`
-inherits `True` from `AnthropicAdapter` while its `translate_to_upstream` returns a **Chat
-Completions** body for every model outside `_MESSAGES_MODELS`. See finding F5. Until that is
-fixed, the oracle must select on the observed body shape, and an L2 guard must assert the
-property agrees with the actual output shape for every adapter × representative model.
+```
+Conversation
+  system:    ordered text parts
+  turns:     ordered [ Turn(role, parts) ]
+  tools:     ordered [ ToolDecl(name, schema) ]
+  sampling:  { max_tokens, temperature, top_p, stop, … }   # declared, may be absent
 
-#### 3.3.2 The oracle must be parametrised over transport
+Part = Text(str)
+     | ToolUse(id, name, arguments)
+     | ToolResult(tool_use_id, content, is_error)
+     | Thinking(text)
+     | Image(digest)
+```
 
-`openai_subscription`, `bedrock` and `ollama_cloud` set `use_custom_transport = True` and never
-go through `_make_upstream_request`, so §7.2's aiohttp recording upstream never sees their
-bodies. The oracle is parametrised over transport exactly as §5.5's containment harness is:
-an aiohttp recording server for the default path, a `curl_cffi`-reachable one for the
-subscription provider, and a botocore endpoint override for Bedrock. Without this, §3.4's "every
-provider" rows are false for three adapters.
+Then write one **hand-written projection per wire format** — Anthropic Messages, Chat
+Completions, OpenAI Responses, Gemini, Bedrock Converse, Ollama `/api/chat` — each written
+directly against that format's published shape and **importing nothing from `src/kitty/bridge`**.
+Six small readers, each independent of whatever kitty code produces that format. The oracle compares
+`project(inbound)` with `project(captured_upstream_bytes)`.
 
-**Diffing semantics.** Structural, not byte-level. JSON key order and whitespace are not part of
-the agent's meaning and vary with serialisation; a byte diff would fail constantly and teach
-people to ignore it. The oracle compares parsed JSON with a canonical ordering, and reports
-deltas as JSON-pointer paths so a failure names the exact field. The one exception is key
-ordering on the native path, which §4.3 C2 asserts for I2 reasons.
+This is the independent-oracle rule, and it is what makes the check meaningful across a protocol
+boundary: a Messages body and a Chat Completions body are not comparable as JSON, but their
+projections are directly comparable, because a conversation is a conversation.
 
-**What it does not do.** It does not judge whether a translation is *semantically* correct — that
-a `tool_use` block became the right `tool_calls` entry is an L1 translator claim. The oracle
+**Response translation is tested separately**, with its own projection (`Reply(parts, stop_reason,
+usage)`) over the response direction. It is a different claim and it gets a different test.
+
+#### 3.3.2 The two assertions
+
+1. **No unclaimed delta.** Every difference between the two projections must map to a register
+   row whose trigger the input met. This is the invariant.
+2. **No mutation without its trigger.** For each conditional row, an input that does *not* meet
+   the trigger must show that row's mutation **absent**. This is what stops M3/M5 quietly
+   becoming unconditional, and it is why §3.3.4 insists on trigger complements.
+
+#### 3.3.3 Bridge-introduced content is what gets the vendor-token check
+
+The projection also settles a problem a naive I2 check cannot (§4.3 C2). "The upstream body must
+not contain the string `kitty`" is **wrong** — a user may legitimately ask Claude Code to explain
+kitty-bridge, a repository path may contain the word, or a tool result may quote this very
+document. All of that must reach the provider **unchanged**, or I1 is broken in the act of
+defending I2. The two invariants would be in direct conflict.
+
+Diffing projections separates the two cases cleanly:
+
+- A part present in the upstream projection with a counterpart in the inbound projection is
+  **agent-supplied**. It is never inspected for vendor tokens, whatever it contains.
+- A part with no inbound counterpart is **bridge-introduced**. Only that set is scanned.
+
+The regression case is explicit, and belongs in the corpus (§7.1): an inbound turn whose text is
+`Please explain how kitty-bridge works` must survive byte-identically, **and** an injected vendor
+message (M13) must still be caught in the same run. A harness that cannot do both at once has
+not solved the problem.
+
+#### 3.3.4 Scoping, triggers and transports
+
+**Scoped by observed wire shape, per request.** `upstream_wire_is_messages_api` is the natural
+selector but cannot be trusted as an adapter-level constant: `OpenCodeGoAdapter` inherits `True`
+from `AnthropicAdapter` while emitting Chat Completions for every model outside
+`_MESSAGES_MODELS` (F5, KBR-7). The oracle selects the projection by the shape actually observed
+on the wire, and an L2 guard asserts the property agrees with that shape for every adapter ×
+representative model.
+
+**Triggers and their complements, across representative models.** A single fixed request cannot
+establish register completeness. For every conditional row the corpus must contain a case that
+meets the trigger and a case that does not, and both must run against every adapter for which
+the row is reachable — including each adapter's distinct model classes where routing differs
+(`opencode_go` Messages vs. CC models; `fireworks` streaming vs. non-streaming for P7).
+
+**Parametrised over transport.** `openai_subscription`, `bedrock` and `ollama_cloud` set
+`use_custom_transport = True` and never reach `_make_upstream_request`, so an aiohttp recording
+upstream never sees their bodies. The oracle runs against the recorder appropriate to each
+transport (§7.2). Without this, "every provider" is false for three adapters — and those three
+are where the least-inspected serialization code lives (§3.2.3).
+
+**Diffing semantics.** Structural, over projections. JSON key order and whitespace are not part
+of the agent's meaning and vary with serialisation; a byte diff would fail constantly and teach
+people to ignore it. Deltas are reported as paths into the `Conversation` so a failure names the
+exact turn and part. The one byte-level exception is key ordering on the native passthrough
+path, which §4.3 C2 asserts for I2 reasons.
+
+**What it does not do.** It does not judge whether a translation is *semantically apt* — that a
+`tool_use` block became the right `tool_calls` entry is an L1 translator claim. The oracle
 answers a narrower question: was anything changed that nobody declared.
 
 ### 3.4 Where I1 is proven
@@ -273,18 +363,16 @@ answers a narrower question: was anything changed that nobody declared.
 | Claim | Layer | Test |
 |---|---|---|
 | Compaction preserves `tool_use`/`tool_result` atomicity, in both CC and native shapes | L1 property | `compact(m)` contains no orphan |
-| Compaction output fits the budget **unless the system block alone exceeds it** | L1 property | The guaranteed-fit loop breaks out while still over budget when it cannot shrink further; the honest property must say so |
-| The last turn survives **unless pairing validation drops it**, in which case M13 fires | L1 property | Stated with the exception, or it fails on day one and gets weakened |
+| Compaction output fits the budget **unless the surviving set is irreducible** | L1 property | See §6.1 — the honest exception is wider than an oversized system block |
+| The last turn survives **unless it is itself truncated (M3/M4) or dropped by pairing validation (M7), in which case M13 fires** | L1 property | Stated with all three exceptions, or it fails on day one |
 | Compaction is identity below the budget | L1 property | Short-circuit at the `original_size <= compaction_threshold` guard — M5's trigger, tested directly |
 | Truncation is identity below `_TOOL_RESULT_TRUNCATION_LIMIT` | L1 property | Same shape, for M3 and M4 |
-| Protocol round-trip preserves semantic content | L1 property | Text, tool calls, tool results and their ids survive translation both ways |
-| A **below-threshold** corpus entry on a native-wire provider shows only M1 and P1 | L2 | Scoped to below-threshold deliberately: above it, M3/M5/M7 and any triggered `normalize_request` row apply to the native path too |
-| No unclaimed delta, over the whole corpus, on every native-wire provider and model | **L3** | Transparency oracle (§3.3.1), parametrised per transport (§3.3.2) |
-| Round-trip fidelity over the whole corpus, on every CC-wire and other-wire provider | **L3** | Oracle, round-trip mode |
+| Each wire projection reads its format correctly | L1 | The projections are test code and get their own tests — against published format examples, not against kitty's output |
+| A **below-threshold** corpus entry on a native-wire provider shows only M1 and P1 | L2 | Scoped to below-threshold deliberately: above it, M3/M5/M7 and any triggered provider row apply to the native path too |
+| No unclaimed delta, over the whole corpus, on every adapter × representative model × transport | **L3** | Transparency oracle (§3.3) |
+| An inbound `kitty` string survives while an injected vendor message is caught | **L3** | §3.3.3 regression case |
 | A real Claude Code session's tool calls execute correctly through kitty | L4 | Real-agent E2E (§6.4.2) |
 | Compaction has not degraded answer quality | L4 eval | §6.4.3 |
-
----
 
 ## 4. Invariant I2 — Bridge Indistinguishability
 
@@ -303,7 +391,7 @@ list of headers we happened to think of. That posture is what surfaced F3 and F4
 
 | Channel | What it exposes today | Verdict |
 |---|---|---|
-| **C1 — Request headers** | `build_upstream_headers()` constructs the set from scratch; no inbound agent header is forwarded. Four adapters supply a coding-agent `User-Agent` (P9); every other provider — including `zai_coding`, whose set is exactly `Authorization`, `anthropic-version`, `content-type` — sends aiohttp's default. | **Gap, and inconsistent.** F1. |
+| **C1 — Request headers** | `build_upstream_headers()` constructs the set from scratch; no inbound agent header is forwarded. Four adapters supply a coding-agent `User-Agent` (P9a, P9c); every other provider — including `zai_coding`, whose set is exactly `Authorization`, `anthropic-version`, `content-type` — sends aiohttp's default. | **Gap, and inconsistent.** F1. |
 | **C2 — Request body** | The register's mutations (§3.2), JSON key ordering produced by kitty's serialisation, **the literal string `[Kitty Bridge: …]` (M13)**, and **`_effort` / `_thinking_adaptive`, which are kitty-internal and reach the wire**. | **Breached.** F3 and F4. |
 | **C3 — Cross-attempt content and cadence** | Retries (`_MAX_RETRIES = 3`), failover, transport-blip re-connects, the empty-response ladder — and **four** paths that send a *different body* on a later attempt (M6, M8, M9, and failover re-normalisation). | §4.3 C3. Four declared exceptions. |
 | **C4 — Transport fingerprint** | TLS/ALPN/HTTP-2 signature of aiohttp, unlike the agent's own client. `curl_cffi` is already used for the OpenAI subscription provider precisely because that provider fingerprints TLS. | **Accepted residual risk.** §4.5. |
@@ -338,14 +426,18 @@ the difference is large; the test's job is to make it visible and stop it growin
 the build on day one — a reported baseline with a ratchet, becoming a gate once G3 closes.
 
 **C2 — Body shape (L3).** Covered by the transparency oracle (§3.3), plus two assertions the
-oracle does not give for free:
+oracle's projection makes possible and a flat scan cannot:
 
-- **No forbidden token in the body.** The same `kitty` token check C1 applies to headers, applied
-  to the serialized upstream body. This is what M13 breaches, and what nothing currently checks —
-  C1's forbidden set covers headers only, and M13's string is in a message.
+- **No vendor token in *bridge-introduced* content.** The check is emphatically **not** "the
+  serialized body must not contain `kitty`". A user may ask Claude Code to explain kitty-bridge;
+  a path may contain the word; a tool result may quote this document. All of that must reach the
+  provider unchanged — stripping it to satisfy I2 would breach I1, and the two invariants would
+  be in direct conflict. The oracle's projection diff already separates agent-supplied parts
+  from bridge-introduced ones (§3.3.3); only the latter are scanned. M13 is caught because it
+  has no inbound counterpart, while the user's sentence is not, because it does.
 - **Key order preservation on the native path.** A provider can fingerprint the JSON serialiser
-  from key ordering alone. This is the one place the oracle compares bytes rather than structure,
-  and it applies only where kitty claims to be forwarding rather than translating.
+  from key ordering alone. This is the one place the comparison is byte-level rather than
+  projected, and it applies only where kitty claims to be forwarding rather than translating.
 
 **C3 — Cross-attempt content and cadence (L3).** The design must not overstate this: kitty sends
 a different body on a later attempt in **four** distinct situations, not one.
@@ -383,7 +475,7 @@ its own ticket. F3, F4 and F5 are live breaches of invariants defined above.
 
 - **F1 — Agent identity is handled per-provider, not by policy.** *(KBR-8.)* Upstream headers are built from
   scratch, so Claude Code's `user-agent`, `x-app`, `anthropic-beta` and `x-stainless-*` never
-  reach the provider. Four adapters compensate ad hoc (P9): `KimiCodeAdapter`, `BytePlusAdapter`
+  reach the provider. Four adapters compensate ad hoc (P9a, P9c): `KimiCodeAdapter`, `BytePlusAdapter`
   and `MimoAdapter` hard-code `User-Agent: claude-code/1.0` — Kimi's carries a comment recording
   the string was on the provider's allowlist as of 2026-04-18 — and `OpenAISubscriptionAdapter`
   synthesises a Codex CLI identity. Everywhere else, including `zai_coding`, aiohttp's default
@@ -425,7 +517,7 @@ its own ticket. F3, F4 and F5 are live breaches of invariants defined above.
   says the property "describes the shape that actually goes on the wire" and that anything
   shaping the serialized body must branch on it — so a `True` that is false for most models is a
   latent defect in the thinking-repair path (M8) as well as a trap for the oracle's scoping
-  (§3.3.1). Tracked as G16 and KBR-7.
+  (§3.3.4). Tracked as G16 and KBR-7.
 
 ### 4.5 Accepted residual risk
 
@@ -490,39 +582,72 @@ records CONNECT attempts, which is the observation the harness needs.
        │   proxy  session ──────────┐               │
        └────────────────────────────┼───────────────┘
                                     ▼
-                     recording CONNECT proxy  ── CONNECT log
+                     recording CONNECT proxy  ── tunnel log
                                     │
                                     ▼
-                     recording fake upstream  ── request log
+                     recording fake upstream  ── connection + request log
 ```
 
-**The assertions.**
+#### 5.2.1 Correlate connections to tunnels, not requests to CONNECTs
 
-1. **Correlation, not peer address.** Every request the fake upstream records must correlate to
-   a `CONNECT` in the proxy's log for the same target and connection, and the two counts must be
-   equal. *Peer address cannot carry this*: with bridge, proxy and upstream all on loopback in
-   one test process, a proxied and a direct connection both present `127.0.0.1`, and both source
-   ports are ephemeral. Correlating on the proxy's own log discriminates; peer address does not.
-   (Binding the proxy's outbound socket to `127.0.0.2` is an alternative, but it needs an `lo0`
-   alias on macOS — a platform constraint the correlation approach avoids.)
-2. **Negative — traffic stops rather than leaks.** With the proxy stopped and egress configured,
-   the upstream accepts **zero** connections and the request fails. This is the assertion that
-   proves containment; assertion 1 alone is satisfied by a bridge that proxies *sometimes*.
-3. **Local bypass still works.** A loopback or `localhost` provider (a local Ollama) connects
-   directly and is not tunnelled — a rented proxy cannot reach the caller's LAN. **Applies to
-   the bridge's own sessions only**; see §5.5.
-4. **Fail-closed.** A profile whose adapter returns `supports_egress() == False` (Bedrock in SSO
-   mode) prevents startup, and the message names the profile.
+An earlier draft asserted that the count of upstream requests must equal the count of `CONNECT`
+attempts. That is wrong in both directions and would reject correct behaviour:
 
-### 5.3 The addressing trap — and why the harness uses a hostname
+- **One tunnel can carry many requests.** A transport with connection reuse issues a single
+  `CONNECT` and then sends N HTTP requests through it. The bridge's own aiohttp sessions use
+  `force_close=True` so they happen to be 1:1 today, but curl_cffi and botocore need not be —
+  and a test must not silently depend on `force_close`, which C5 and Q7 may well change.
+- **One CONNECT can carry no requests.** A rejected proxy authentication (407) or a failed TLS
+  negotiation produces a `CONNECT` attempt and no HTTP request at all.
 
-**This is the constraint that makes or breaks the harness, and it is not obvious.**
+The correct assertion is at the **connection** level: every TCP connection the upstream accepts
+must be attributable to a successful tunnel through the proxy, with any number of requests
+riding on it, and failed tunnels contributing no upstream connections.
 
-`egress.should_bypass()` returns `True` for loopback, private and link-local destinations, so
-those connect directly. The naive harness binds a fake upstream on `127.0.0.1` — which
-`should_bypass` sends *direct*, so the test proxies nothing and passes vacuously while proving
-the opposite of what it claims. Binding on a Docker network does not help: `172.16.0.0/12` is
-private and is also bypassed.
+**The join.** `ConnectAttempt` records target and authentication status only, which is not enough
+to identify a connection at both ends. Extend it to record the **proxy's outbound source port**
+for each tunnel it opens; the recording upstream already records the peer port of each accepted
+connection. Joining on that port identifies each upstream connection with the tunnel that
+created it. An upstream connection with no matching tunnel port is a bypass, and it is the only
+thing this assertion needs to catch.
+
+(Peer *address* cannot do this job: with bridge, proxy and upstream on loopback in one process,
+proxied and direct connections both present `127.0.0.1`.)
+
+#### 5.2.2 The three phases, per transport
+
+The negative assertion is the one that matters, and on its own it is dangerously easy to satisfy
+for the wrong reason — see §5.3. It must be bracketed by a positive control before it and a
+falsification control after it. All three run for **every** transport in §5.5, not just the
+bridge's own aiohttp session.
+
+| Phase | Setup | Assertion | What it rules out |
+|---|---|---|---|
+| **1. Positive control** | Egress **disabled** | The upstream is reachable **directly**, and records the connection | That the destination is unreachable for some unrelated reason — name resolution, firewall, a mis-scripted fake. Without this, phase 2 proves nothing. |
+| **2. Containment** | Egress enabled, proxy **stopped** | The upstream accepts **zero** connections, and the request fails | A direct fallback on proxy failure |
+| **2b. Containment, healthy** | Egress enabled, proxy running | Every upstream connection joins to a tunnel (§5.2.1) | A partial bypass under normal operation |
+| **3. Falsification control** | Egress enabled, proxy running, **a bypass deliberately introduced** (a patched `should_bypass` returning `True`, or a session built without the proxy) | The harness **fails** | That the harness is incapable of detecting a bypass at all |
+
+Phase 3 is not optional decoration. A containment harness that has never been shown to fail is
+indistinguishable from one that cannot fail, and §5.3 is a worked example of exactly that trap.
+
+**Two further assertions**, unchanged in substance:
+
+- **Local bypass still works.** A loopback or `localhost` provider (a local Ollama) connects
+  directly and is not tunnelled — a rented proxy cannot reach the caller's LAN. **Bridge sessions
+  only**; §5.5 explains why this is false for the custom transports.
+- **Fail-closed.** A profile whose adapter returns `supports_egress() == False` (Bedrock in SSO
+  mode) prevents startup, and the message names the profile.
+
+### 5.3 The addressing trap — and why the harness needs a positive control
+
+**Two traps live here, and the second is created by the fix for the first.**
+
+**Trap 1 — a loopback destination is bypassed.** `egress.should_bypass()` returns `True` for
+loopback, private and link-local destinations, so those connect directly. A harness that binds
+its fake upstream on `127.0.0.1` is sent *direct*, proxies nothing, and passes vacuously while
+proving the opposite of its claim. A Docker network does not help: `172.16.0.0/12` is private and
+also bypassed.
 
 The escape is in `should_bypass`'s own design. It reads `urlsplit(url).hostname` and:
 
@@ -531,19 +656,34 @@ The escape is in `should_bypass`'s own design. It reads `urlsplit(url).hostname`
 3. for anything else, returns `False` **without resolving it** — deliberately, to avoid a DNS
    round trip per request.
 
-So the harness must address the fake upstream by a **hostname outside the `localhost` family**.
-`upstream.kitty-test.invalid` is a good choice: RFC 2606 guarantees `.invalid` never resolves
-publicly, which is precisely why the harness must supply the mapping itself.
+So the harness addresses the fake upstream by a **hostname outside the `localhost` family**.
+`upstream.kitty-test.invalid` is a reasonable choice: RFC 2606 guarantees `.invalid` never
+resolves publicly, so the name cannot escape the test environment.
 
-**Name resolution, per leg.** The two legs differ, and only one needs work:
+**Trap 2 — an unresolvable name satisfies the negative test for the wrong reason.** That same
+guarantee is the problem. If the harness supplies name resolution only for the aiohttp leg, then
+on curl_cffi or botocore a genuinely broken implementation could attempt a direct connection,
+fail at DNS, and the upstream would still record **zero connections**. The negative assertion
+passes; containment was never demonstrated. The test would be green on a product that leaks on
+every other transport.
 
-- *Proxied leg* — **no resolution needed.** aiohttp's `_create_proxy_connection` resolves the
-  *proxy* and then issues `CONNECT upstream.kitty-test.invalid:443`; the test's own proxy
+This is why §5.2.2 phase 1 exists and why it is mandatory per transport: **before** asserting
+that nothing arrives, the harness must have shown that something *can* arrive directly for that
+exact transport and destination. A negative result is only evidence when the positive is
+possible.
+
+**Name resolution, per leg.**
+
+- *Proxied leg* — **no resolution needed by the client.** aiohttp's `_create_proxy_connection`
+  resolves the *proxy* and issues `CONNECT upstream.kitty-test.invalid:443`; the test's own proxy
   resolves the target. The harness owns the resolver because the harness is the proxy.
-- *Direct/bypass leg* — needs a local override. Use a monkeypatched aiohttp resolver, **not** an
-  `/etc/hosts` entry: hosts edits need administrator rights and are unavailable on most CI
-  runners, and `_build_client_session` constructs its own `TCPConnector` with no resolver
-  injection point.
+- *Direct leg* — needs a local override, **for every transport, not only aiohttp**. aiohttp takes
+  a monkeypatched resolver (`/etc/hosts` needs administrator rights and is unavailable on most CI
+  runners, and `_build_client_session` builds its own `TCPConnector` with no injection point).
+  curl_cffi and botocore need their own equivalents — curl's `resolve` mapping and a botocore
+  `endpoint_url` override respectively. If a transport cannot be given a working direct route,
+  its phase-1 control cannot pass, and its negative assertion must be reported as **unproven**
+  rather than counted as a pass.
 
 **The property that keeps the harness honest.** An L1 property test pins the premise so a future
 change to `should_bypass` cannot silently make the harness vacuous:
@@ -567,13 +707,15 @@ whether to change it is Q3.
 |---|---|---|
 | `should_bypass` classifies loopback / private / link-local / `localhost` family / public / hostname correctly | L1 + property | Enumerate IPv4 and IPv6 private ranges via `ipaddress`; assert the §5.3 hostname property |
 | `parse_proxy_url` round-trips credentials, including percent-encoded `@` and `:` | L1 property | `parse(url_with_credentials(cfg)) == cfg` |
-| No `EgressConfig` representation leaks the password | L1 property | `password not in repr(cfg) + str(cfg) + cfg.masked()` for all generated passwords |
+| No `EgressConfig` representation leaks the password | L1 property | Structural: the password component of `masked()` is exactly the mask. **Not** a substring test — see §6.1 |
 | Every outbound HTTP client is egress-aware; no source assigns `HTTP_PROXY`; no session trusts the environment | L2 structural | **Exists:** `tests/test_egress_coverage.py` |
 | **Every** `BridgeServer` construction is dominated by an `egress_block_reason` call | L2 structural | **Must be strengthened** — the existing guard is file-granular (§5.1 gap 3) |
 | An `https://` proxy carries real traffic on all three transport stacks | L2/L3 | **Exists:** `tests/test_egress_https_proxy.py` |
 | Proxy semantics under each dependency's version range | L2 | §6.2.4 |
-| Nothing reaches upstream except via the proxy, **from the bridge's own serving path** | **L3** | Sealed-network harness (§5.2) |
-| Stopping the proxy stops the traffic — no direct fallback | **L3** | §5.2 assertion 2 |
+| The destination is reachable directly with egress **disabled**, on every transport | **L3** | §5.2.2 phase 1 — the positive control. Without it the row below proves nothing (§5.3) |
+| Nothing reaches upstream except via the proxy, **from the bridge's own serving path** | **L3** | Sealed-network harness (§5.2.2 phase 2b) |
+| The harness detects a deliberately injected bypass | **L3** | §5.2.2 phase 3 — the falsification control. A containment harness never shown to fail is indistinguishable from one that cannot |
+| Stopping the proxy stops the traffic — no direct fallback | **L3** | §5.2.2 phase 2 |
 | Containment holds for each custom transport | **L3** | §5.5 |
 | kitty refuses to start when a backend cannot be proxied | L2 + L4 | Guard unit test + scenario EG-3 |
 | A developer's whole session presents one IP | L4 | Scenario EG-1 |
@@ -593,9 +735,9 @@ other outbound paths exist, and each applies the proxy **unconditionally, withou
 
 Three consequences the rest of §5 must not paper over:
 
-1. **§5.2 assertion 3 is false for these paths.** They have no bypass, so a loopback or private
-   destination *is* tunnelled. Arguably safer, but different — the design must say so rather than
-   imply uniformity.
+1. **The local-bypass assertion in §5.2.2 is false for these paths.** They have no bypass, so a
+   loopback or private destination *is* tunnelled. Arguably safer, but different — the design
+   must say so rather than imply uniformity.
 2. **The sealed-network harness proves nothing about them** unless parametrised over the
    transport. It must run over `{bridge aiohttp session, provider aiohttp session, curl_cffi
    session, botocore client}` — the shape `tests/test_egress_https_proxy.py` already uses, which
@@ -617,29 +759,51 @@ the configured egress on the two stacks that read the environment. §6.2.4 pins 
 
 **Scope.** Pure logic: the three translators, the translation engine, compaction and tool-call
 pairing, model normalisation, `should_bypass` and `parse_proxy_url`, profile schema and
-resolver, the tool-use anomaly detector, and every `ProviderAdapter` payload builder.
+resolver, the tool-use anomaly detector, every `ProviderAdapter` payload builder, and the wire
+projections the oracle depends on (§3.3.1 — test code, but code the whole of I1 rests on).
 
 **Tools.** `pytest` (present) + `hypothesis` (**to add**, dev extra only).
 
-**Command.** `pytest tests/ -q`
+**Command.** `pytest -m l1 -q` — a marker, not `pytest tests/ -q`, which runs every layer and so
+cannot be the L1 selection (§8).
 
-**Validation.** Mutation testing (below). This is the layer whose strength is actually measured.
+**Validation.** Mutation testing (below).
 
-**Property tests to add.** Example-based tests sample; these translators and the compactor are
-exactly the kind of total function where properties pay.
+**Property tests to add.**
 
 | Unit | Property |
 |---|---|
-| `MessagesTranslator` | Semantic round-trip: text, tool ids, tool names and tool results survive Messages → CC → Messages |
-| `_compact_messages` | Identity below budget · output ≤ budget **unless the system block alone exceeds it** · no orphaned pair · last block preserved **unless pairing validation drops it (then M13 fires)** · idempotent |
+| `MessagesTranslator` | Semantic round-trip **through the projections, not through the translator pair**: `project_messages(inbound)` equals `project_cc(translate_request(inbound))`. See §3.3.1 for why the translator pair cannot serve as its own oracle. |
+| `_compact_messages` | Identity below budget · no orphaned pair · idempotent · **output ≤ budget unless the surviving set is irreducible** (below) |
 | `_validate_tool_call_pairing` | Output contains no `tool_result` without a `tool_use`, in both message shapes |
 | `_truncate_oversized_tool_results` | Identity below the limit · output ≤ limit · non-tool-result content untouched |
 | `should_bypass` | Every address in a private range is bypassed · the §5.3 hostname property |
-| `parse_proxy_url` / `EgressConfig` | Credential round-trip · password never in any string form |
+| `parse_proxy_url` / `EgressConfig` | Credential round-trip · the redaction property below |
 | `describe_tool_input_anomaly` | Never reports an anomaly for input that validates against the declared schema |
+| Wire projections (§3.3.1) | Each reads its format correctly, tested against published format examples — never against kitty's own output |
 
-The two weakened properties are stated with their exceptions on purpose. A property that fails on
-day one gets weakened by whoever is on the rota, and a weakened property guards nothing.
+**The compaction budget property, stated honestly.** "Output ≤ budget" is false, and the
+exception is wider than an earlier draft claimed. The guaranteed-fit loop drops head blocks, then
+tail blocks, and `break`s while still over budget once it can shrink no further — when only the
+system message and a single tail block remain. So it exceeds the budget whenever the **surviving
+set is irreducible**, which includes a small system message plus one oversized final user turn,
+not only an oversized system block. The property must be stated that way or it fails on the first
+run and gets weakened by whoever is on the rota.
+
+**This is a product question, not just a test-wording question.** What *should* happen when the
+final turn alone will not fit? Today the request goes upstream over budget and is rejected there,
+or M13 replaces it. Neither is obviously right, and neither has been decided. The register,
+the properties and the Gherkin must agree on one answer — see Q10. Until it is decided, the
+document records current behaviour as *observed*, explicitly not as *approved*.
+
+**The redaction property, stated so it cannot false-fail.**
+`password not in repr(cfg) + str(cfg) + cfg.masked()` is wrong: `masked()` returns
+`scheme://user:****@host`, so a password that happens to equal a substring of the host or
+username fails the assertion despite correct masking. Password `proxy` with host `proxy.example`
+reproduces it. Assert the **structure** instead — parse `masked()` and assert its password
+component is exactly the mask — and test percent-encoded and URL-embedded forms as separate
+cases. For the broader "does the password reach a log" sweep, generate a distinctive sentinel
+that cannot collide with any other field.
 
 **Mutation testing.** Line coverage cannot tell a real assertion from `assert result is not
 None`. `mutmut` closes that gap.
@@ -647,29 +811,43 @@ None`. `mutmut` closes that gap.
 - **Tool:** `mutmut` (3.x; requires `fork`, so it runs on Linux CI — on Windows it needs WSL).
   Configured in `pyproject.toml` under `[tool.mutmut]`, where `source_paths` and
   `pytest_add_cli_args_test_selection` take **arrays**.
-- **Command:** `mutmut run`, then `mutmut browse` to triage and `mutmut export-cicd-stats` for
-  the CI score.
-- **In scope — not the whole codebase:** `src/kitty/bridge/messages/`,
-  `src/kitty/bridge/responses/`, `src/kitty/bridge/gemini/`, `src/kitty/bridge/engine.py`,
-  `src/kitty/bridge/tool_audit.py`, `src/kitty/egress.py`, `src/kitty/profiles/`,
-  `src/kitty/validation.py`.
-- **Why a subset.** Mutation testing on 22,700 lines would take hours and produce a survivor list
-  nobody reads. The subset is chosen by one rule: **modules whose silent misbehaviour breaches an
-  invariant**. A mutation surviving in the compactor means the suite would not notice kitty
-  eating a tool result — an I1 breach. A mutation surviving in the TUI menu means a cosmetic
-  defect. Expand when the first list is clean.
-- **Budget:** ≥ 85% killed on the in-scope set. Below that, the layer is not trusted.
+- **Test selection:** `pytest_add_cli_args_test_selection = ["-m", "l1"]`. Mutation testing
+  measures the L1 suite; letting it run L3 subsystem tests would make each mutant minutes long
+  and attribute kills to the wrong layer.
+- **Scope — narrow, but it must include the code the rationale is about.** An earlier draft
+  justified the subset by "a mutation surviving in the compactor means the suite would not notice
+  kitty eating a tool result", then excluded `server.py`, where the compactor lives. Corrected
+  scope, using `mutmut`'s function wildcards rather than whole modules:
+
+  | Target | Why |
+  |---|---|
+  | `kitty.bridge.messages.*`, `kitty.bridge.responses.*`, `kitty.bridge.gemini.*`, `kitty.bridge.engine` | Translation — I1 |
+  | `kitty.bridge.server._compact_messages*`, `_compact_with_tighter_budget*`, `_validate_tool_call_pairing*`, `_truncate_oversized_tool_results*`, `_apply_compaction*`, `_normalize_model*`, `_get_max_context_chars*` | Compaction and pairing — the I1 core, and the thing the rationale was always about |
+  | `kitty.providers.*` `translate_to_upstream` / `normalize_request` / `build_upstream_headers` | The register's provider half — I1 and I2 |
+  | `kitty.egress`, `kitty.egress_guard` | I3, including the startup guard |
+  | `kitty.bridge.tool_audit`, `kitty.profiles.*`, `kitty.validation` | Supporting correctness |
+
+  Still excluded: the TUI, the CLI wiring, the retry/health state machine. A mutation surviving
+  in a menu is a cosmetic defect; one surviving in the compactor is a silent invariant breach.
+
+- **Per-component thresholds, not one aggregate.** ≥ 85% killed **per target group** above. A
+  single aggregate over a large surface lets a weak component hide behind a strong one — and the
+  weak components here are exactly the invariant-critical ones.
 - **Triage rule:** (a) a survivor revealing a missing assertion → strengthen the test; (b)
   revealing untested behaviour → add a test; (c) genuinely equivalent → suppress at the site with
   `# pragma: no mutate` **and a comment saying why**. Never dismiss a survivor silently.
-- **Cadence:** nightly and pre-release. Per-PR would add tens of minutes to a gate that must stay
-  fast.
+- **Cadence — to be set by measurement, not assertion.** The full scoped run is nightly. Whether
+  a **changed-code** mutation run also fits the per-PR gate is an open question with a numeric
+  answer: measure the wall-clock of `mutmut run` restricted to functions touched by a
+  representative PR, and adopt it per-PR if it lands inside the budget the fast gate can absorb.
+  Rejecting per-PR mutation testing without that measurement is an assumption, not a decision.
+  Tracked as Q11.
 
 ### 6.2 L2 — Contract
 
 **Scope.** Any two artifacts that must agree but are deployed, edited or upgraded separately.
 
-**Command.** `pytest tests/contract -q`
+**Command.** `pytest -m l2 -q`
 
 **Validation.** Every structural guard must assert that its own scan finds known positives, so it
 cannot rot into a no-op. `tests/test_egress_coverage.py` already does this
@@ -715,17 +893,27 @@ sentence in that grammar. Applies to all three streaming protocols.
 
 Structural guards in the style of `tests/test_egress_coverage.py`.
 
+**The register guard runs at the serialization boundary (§3.2.3), not at `translate_to_upstream`.**
+An earlier draft specified feeding a request through `normalize_request` + `translate_to_upstream`
+and diffing the result. That misses every transformation inside a custom transport — and P13 is
+exactly that case: on `openai_subscription` those two hooks return a Chat Completions shape, and
+`_cc_to_responses` drops fourteen parameters afterwards. A guard checking the hook would have
+reported the adapter clean.
+
 | Guard | Asserts |
 |---|---|
-| **Register completeness — shape diff, not write scan** | For every registered adapter, feed a fixed CC request through `normalize_request` + `translate_to_upstream` and assert the resulting key-set and value deltas are **exactly** the union of that adapter's §3.2.2 rows. A write-scan cannot do this job: every provider mutation except P7 and the `normalize_request` overrides happens by *building and returning* a new dict, so a scan for writes to `cc_request` sees none of them — and would have missed F4 entirely. |
-| **Internal-key completeness** | AST-scan `bridge/**` for every `_`-prefixed key written into a request dict, and assert each is a member of `_INTERNAL_KEYS`. **This is the guard that catches F4.** The complementary check — that each `translate_to_upstream` override delegates to `super()` or excludes `_INTERNAL_KEYS` — is necessary but not sufficient: every override *does* strip the set today; the set is what is wrong. |
-| **Wire-shape honesty** | For every adapter × representative model, assert `upstream_wire_is_messages_api` agrees with the shape `translate_to_upstream` actually returns. Catches F5. |
-| **Forbidden vendor token** | No string literal reachable into a request body or upstream header contains `kitty` in any casing. Catches F3. |
-| **Start-path domination** | Every `BridgeServer(` construction is dominated by an `egress_block_reason(` call **at AST level**, not merely co-located in the same file. `cli/main.py` already holds two start paths (§5.1 gap 3). |
+| **Register completeness — shape diff at the wire** | For every adapter × representative model × transport, capture the body at the §3.2.3 boundary and assert the projected delta from the input is exactly the union of that adapter's register rows whose triggers the input met. **One fixed request is not sufficient** — each conditional row needs a trigger case and a complement case (§3.3.4), and adapters that route by model need one input per route. |
+| **Internal-key completeness** | AST-scan `bridge/**` for every `_`-prefixed key written into a request dict, and assert each is a member of `_INTERNAL_KEYS`. **This is the guard that catches F4 (KBR-6).** The complementary check — that each `translate_to_upstream` override delegates or excludes the set — is necessary but not sufficient: every override strips it correctly today; the set itself is what is wrong. |
+| **Wire-shape honesty** | For every adapter × representative model, assert `upstream_wire_is_messages_api` agrees with the shape observed at the serialization boundary. Catches F5 (KBR-7). |
+| **Bridge-introduced vendor token** | No content the bridge *introduces* into a request body or header contains `kitty` in any casing. Scoped by the projection diff (§3.3.3), never a flat scan of the serialized body — a flat scan would fail on a user legitimately writing the word, and "fixing" that would breach I1. Catches F3 (KBR-5). |
+| **Start-path domination** | Every `BridgeServer(` construction is dominated by an `egress_block_reason(` call **at AST level**, not merely co-located in the same file. `cli/main.py` already holds two of the five start paths (§5.1 gap 3). |
 | **Env-var register** | `_SETTINGS_ENV_OVERRIDE_KEYS` and `_CONFLICTING_ENV_VARS` (`launchers/claude.py`) match what `build_spawn_config` emits and what the README documents. |
-| **Endpoint table** | The README endpoint table matches `_register_routes`. Catches F2. |
-| **Attribution-header table** | The README's `X-Kitty-*` table matches `_attribution_headers()`, and none of those names can reach `build_upstream_headers()`. |
+| **Endpoint table** | The README endpoint table matches `_register_routes`. Catches F2 (KBR-9). |
+| **Attribution-header table** | The README's `X-Kitty-*` table matches `_attribution_headers()`, and none of those names can reach any `build_upstream_headers()`. |
 | **Flag table** | The README logging-flag table matches the CLI parser. |
+
+Every guard asserts its own scan finds known positives, so none can rot into a no-op —
+`tests/test_egress_coverage.py` already does this and is the pattern to copy.
 
 **Why guard the README specifically.** For a CLI tool the README *is* the interface
 specification — it is what a user configures against. A drifted README is a defect with the same
@@ -756,7 +944,7 @@ and the CLI with the real filesystem and real child processes.
 `tests/test_egress_https_proxy.py`. `testcontainers` only if a scenario genuinely needs process
 isolation; a local proxy and upstream do not.
 
-**Command.** `pytest tests/subsystem -q`
+**Command.** `pytest -m l3 -q`
 
 **Validation.** Each harness must carry a **negative** case proving it can fail — the sealed
 network's proxy-down assertion, the oracle's "mutation present without its trigger" case. A
@@ -765,17 +953,44 @@ each show how easily one goes vacuous.
 
 #### 6.3.1 Bridge with real sockets
 
+**Command.** `pytest -m l3 -q`
+
 | Scenario | Assertion |
 |---|---|
-| Transparency oracle over the corpus (§3.3), per wire shape and per transport | No unclaimed delta; no conditional mutation without its trigger |
-| Sealed network (§5.2), parametrised per transport (§5.5) | Everything correlates to a CONNECT; nothing when the proxy is down |
+| Transparency oracle over the corpus (§3.3), per adapter × model × transport | No unclaimed delta; every conditional row exercised with trigger **and** complement |
+| Bridge-introduced vendor token (§4.3 C2) | An inbound `kitty` string survives byte-identically; an injected vendor message is caught |
+| Sealed network (§5.2), all three phases, per transport (§5.5) | Positive control passes; zero connections with the proxy down; the falsification control fails the harness |
 | Cross-attempt content (§4.3 C3) | Transport-blip and empty-response retries byte-identical; each of M6, M8, M9 and failover re-normalisation fires only under its own trigger |
 | Connection lifecycle (§4.3 C5) | Distinct-connection count per session, against the native baseline |
-| Forbidden vendor token (§4.3 C2) | No `kitty` token in any upstream header or body, including the M13 path |
-| Streaming failover mid-response | The client sees one well-formed stream; `/stats` is authoritative for attribution, per the README's own caveat about first-byte headers |
+| **Streaming recovery — content, not just grammar** (below) | Four injection points; no duplication, no replayed tool calls, no spliced arguments |
 | Client disconnect during a stream | Upstream connection released; the backend not marked unhealthy for a client-side fault |
 | All backends unhealthy | The 503 arrives in each protocol's native error envelope |
 | Oversized request | Rejected with the protocol's own error shape, not a raw 413 |
+| `_backend_context` isolation | Concurrent requests never observe each other's backend selection. **Deterministic, so it belongs here, not in the load profile.** |
+
+**Streaming recovery needs content guarantees, not only a well-formed stream.** "The client sees
+one well-formed stream" is necessary and nowhere near sufficient: a failover that replays text
+the client already received, re-emits a `tool_use` block under a fresh id, or splices tool-call
+arguments assembled from two different attempts produces a stream in which **every SSE event is
+syntactically valid** and the conversation is corrupt. Claude Code will act on a duplicated tool
+call.
+
+Inject the failure at four points, forced deterministically with barriers or a scripted event
+sequence rather than timing:
+
+| Injection point | Assertion |
+|---|---|
+| Before any downstream byte | Clean failover; the client sees one complete stream from the second backend |
+| After text has been emitted | No text the client already received is repeated; the transcript reads as one message |
+| Mid `input_json_delta`, tool arguments partly sent | Arguments are never a splice of two attempts. Either the partial block is properly abandoned and re-opened under a new id, or the turn fails — whichever the agreed semantics say, but never a silent merge |
+| After content, before the terminal event | Exactly one terminal outcome reaches the client; `message_stop` is not duplicated or omitted |
+
+Each case asserts tool-call **identity** (ids stable within an attempt, never reused across
+attempts) and a single terminal outcome. The agreed retry semantics are a prerequisite: if they
+have not been decided, that is the finding, not a test to write around.
+
+`/stats` remains authoritative for attribution after a mid-stream failover, per the README's own
+caveat that the headers name whoever produced the first byte.
 
 #### 6.3.2 CLI with real filesystem and processes
 
@@ -796,14 +1011,13 @@ under suspicion in the KBR-1 investigation. Only a real spawn tests it.
 ### 6.4 L4 — Product
 
 **Tools.** `pytest-bdd` for the Gherkin layer (**to add**, dev extra only — no BDD runner is
-currently a dependency); `pytest` for the real-agent E2E; separate runners for evals and load.
+currently a dependency); `pytest` for the agent tests; separate runners for evals and load.
 
-**Command.** `pytest tests/acceptance -q` · `pytest tests/integration -v --runslow` · the eval
-and load runners are separate entry points.
+**Commands.** `pytest -m acceptance -q` · `pytest -m agent_smoke -q` · `pytest -m agent_live -q`
+· the eval and load runners are separate entry points (§8).
 
-**Validation.** The paired-delta band (§6.4.3), and the requirement that every scenario binds to
-an L3 harness rather than re-implementing one — an acceptance test that grows its own assertions
-has drifted into L3 and should be moved down.
+**Validation.** Every scenario binds to an L3 harness rather than re-implementing one — an
+acceptance test that grows its own assertions has drifted into L3 and should be moved down.
 
 #### 6.4.1 Gherkin acceptance
 
@@ -812,35 +1026,58 @@ The invariants written as scenarios a product owner can read and sign.
 ```gherkin
 Feature: The upstream provider cannot tell Kitty Bridge is there
 
-  Scenario: TR-1  Kitty leaves no fingerprint in the request
+  Scenario: TR-1  Kitty introduces no fingerprint of itself
     Given a profile using the Z.AI coding plan
     When Claude Code sends a turn through kitty
-    Then the request the provider receives contains no header, field or value
-         naming kitty
-    And the header set is a subset of what Claude Code sends natively
+    Then no content the bridge added to the request names kitty
 
-  Scenario: TR-2  A short turn reaches the provider unchanged
-    Given a conversation well inside the model's context window
+  @ratchet  # not gating until G3 (KBR-8) closes — see the note below
+  Scenario: TR-1c  Kitty's headers are a subset of the agent's own
+    Given a profile using the Z.AI coding plan
+    When Claude Code sends a turn through kitty
+    Then the header set is a subset of what Claude Code sends natively
+
+  Scenario: TR-1b  The agent may talk about kitty freely
+    Given a profile using the Z.AI coding plan
+    And a prompt whose text is "Please explain how kitty-bridge works"
+    When Claude Code sends that turn through kitty
+    Then the provider receives that text unchanged
+
+  Scenario: TR-2  A turn needing no adaptation reaches the provider unchanged
+    Given a native-wire provider and no thinking signal in the request
+    And a conversation inside the model's context window
+    And no tool result larger than the truncation limit
     When Claude Code sends a turn through kitty
     Then the provider receives the agent's messages with no content altered
     And the only difference from the agent's own request is the model name
+    # Preconditions matter: on a translated wire M2 rewrites everything, and a
+    # thinking signal triggers P2a, P5c-e and P8 content injection. Cf. 3.4.
 
   Scenario: TR-3  A long turn is altered only as far as necessary
     Given a conversation that exceeds the model's context window
     When Claude Code sends a turn through kitty
     Then history is compacted only as far as the budget requires
     And no tool result is separated from the call that produced it
-    And the most recent turn is preserved in full
+    And the most recent turn is preserved, unless its own tool result exceeds
+         the 50,000-char truncation limit, or it is dropped because its
+         tool_result lost the tool_use that produced it
 
+  @ratchet  # currently fails by design — this is F3/G14 (KBR-5)
   Scenario: TR-4  An unrecoverable conversation fails without naming kitty upstream
     Given a system prompt larger than the model's context window
     When Claude Code sends a turn through kitty
     Then the user is told the conversation cannot be compacted
-    And the provider receives no message naming kitty
+    And the provider receives no content naming kitty
 
 Feature: Configured egress cannot be bypassed
 
-  Scenario: EG-1  Every request presents the gateway's address
+  Scenario: EG-0  The destination is reachable directly when egress is off
+    Given no egress gateway configured
+    When kitty sends a request on each supported transport
+    Then the provider records the connection
+    # Control. Without it, EG-2 can pass because nothing could ever arrive.
+
+  Scenario: EG-1  Every request arrives through the gateway
     Given a configured egress gateway
     When Claude Code runs a session through kitty
     Then every connection the provider accepts arrived through the gateway
@@ -858,45 +1095,112 @@ Feature: Configured egress cannot be bypassed
     Then kitty refuses to start and names the profile
 ```
 
-TR-4 is the acceptance form of F3: it states the outcome the user needs (a legible error) and the
-one they must not pay for it with (the vendor name upstream), without prescribing the fix.
+**Two scenarios are `@ratchet`, and the distinction matters.** The Acceptance job gates every PR
+(§8), so a scenario asserting behaviour the product does not yet have would make `main` red on
+day one — and a permanently red gate gets disabled, taking the working scenarios with it. TR-1c
+(header parity) and TR-4 (the vendor string) both assert the *target* state of open defects: G3
+(KBR-8) and G14 (KBR-5) respectively. They run on every PR and are reported, but they do not
+gate until their defect closes, at which point the marker is removed and they become ordinary
+gating scenarios. This is the same ratchet §4.3 C1b describes for the header baseline; the
+marker exists so the promotion is a deliberate one-line change, not something anyone has to
+remember.
 
-Step definitions bind to the L3 harnesses, so the acceptance layer stays thin: it composes, it
-does not re-implement.
+**Three scenarios were corrected against the implementation, not the other way round.**
 
-#### 6.4.2 Real-agent end-to-end
+- **TR-1 / TR-1b** — the original TR-1 said the request "contains no header, field or value
+  naming kitty", which forbids a user from asking about the product. TR-1 now constrains only
+  content the bridge introduced; TR-1b pins the complement, so the pair cannot be satisfied by
+  stripping user text.
+- **TR-2** — "a short turn reaches the provider unchanged" was false: M3 tool-result truncation
+  is unconditional pre-processing and fires on a short conversation containing one 50,000-char
+  tool result. The precondition is now explicit.
+- **TR-3** — "the most recent turn is preserved in full" was false: the last turn is subject to
+  truncation and to pairing validation. It now states what the code does.
 
-`tests/integration/test_agent_e2e.py` exists and spawns real agent binaries. Keep it out of the
-default `pytest` run — it requires four agent CLIs, live credentials and live network, and a
-suite that cannot run on a laptop or in CI stops being trusted. Promote it to a **nightly** job
-with credentials in CI secrets, and extend it from two cases to cover, for Claude Code
-specifically: a plain turn, a tool-using turn, a multi-turn session with tool results, an
-extended-thinking turn, and a session that crosses the compaction threshold.
+**TR-3 and the compaction properties still depend on an undecided product question** (Q10): what
+*should* happen when the final turn alone exceeds the budget. This Gherkin records current
+behaviour; it does not ratify it. When Q10 is answered, TR-3, register rows M3–M7/M13 and the
+§6.1 properties change together or not at all.
+
+#### 6.4.2 Agent-boundary tests
+
+Two distinct things, currently conflated, with different costs and different cadences.
+
+**Agent smoke — per PR, hermetic.** The claim that kitty configures Claude Code correctly is a
+claim about *Claude Code's* settings precedence between `--settings`, the process environment and
+`~/.claude/settings.json`. Spawning an arbitrary child process does not test that; it tests
+kitty's belief about it, which is precisely the assumption under suspicion in the KBR-1
+investigation. This needs a **pinned real Claude Code binary** run against the scripted fake
+upstream (§7.2) — no live provider, no credentials, no network. One non-interactive turn is
+enough to prove the wiring: the binary starts, resolves the bridge URL from the session settings
+file, sends a request that arrives at the recorder, and exits cleanly.
+
+Pinning it in CI has real questions attached — which distribution, how tightly version-pinned, licensing for
+redistribution in a CI image — recorded as Q12 rather than assumed away.
+
+**Agent live — nightly.** `tests/integration/test_agent_e2e.py` as it exists: real binaries, real
+credentials, real providers. Keep it out of the default run — it needs four agent CLIs and live
+network, and a suite that cannot run on a laptop stops being trusted. Nightly with CI secrets,
+extended from two cases to cover, for Claude Code: a plain turn, a tool-using turn, a multi-turn
+session with tool results, an extended-thinking turn, and a session crossing the compaction
+threshold.
+
+**Neither job may skip silently.** A required job whose prerequisite is missing must **fail**,
+not pass-by-skipping. A green tick that means "we did not test this" is worse than a red one.
 
 #### 6.4.3 Answer-quality evals
 
-Compaction (M5, M6, M13) and truncation (M3, M4, P7) are the mutations that can degrade an answer
-without breaking any structural assertion. Nothing below L4 can detect that.
+Compaction (M5, M6, M13) and truncation (M3, M4, P7, P13) can degrade an answer without breaking
+any structural assertion. Nothing below L4 can detect that. But the method has to be honest about
+what it can establish.
 
-Design: a fixed set of coding tasks with objective pass criteria (the produced code compiles; the
-test it was asked to write passes). Run each through kitty and directly against the same
-provider, and compare pass rates. The metric is the **delta**, not the absolute rate — the
-absolute rate is a property of the model and moves for reasons unrelated to kitty. Sample size
-fixed in advance, run nightly, alert on a delta beyond the band (Q4).
+**What pairing does and does not buy.** Running the same task through kitty and directly against
+the same provider removes *task* variance — task difficulty is held constant. It does **not**
+cancel the model's independent sampling on each call. Two samples of the same prompt differ. So
+the design needs repetition and an interval, not a single paired run and a single number.
 
-**Why a delta rather than a threshold.** An absolute threshold on a nondeterministic system
-produces a flaky gate, and a flaky gate at L4 is worse than none: it trains people to re-run. The
-paired comparison cancels the model's own variance.
+| Element | Specification |
+|---|---|
+| **Tasks** | A fixed set with **independently authored** acceptance tests. A model-generated test that the model's own code passes establishes nothing — the same misunderstanding can be present in both. |
+| **Repetition** | N samples per task per arm, N fixed in advance and large enough for the interval below to be narrower than the margin. |
+| **Pinning** | Model id, provider, dataset revision, temperature and all sampling settings pinned and recorded with each run. An unpinned model makes the series meaningless. |
+| **Statistic** | Difference in pass rate between arms, with a confidence interval — not a point estimate. |
+| **Decision rule** | A **pre-registered regression margin**: the alert fires when the interval excludes a delta smaller than the margin. Chosen before the data, not after. |
+| **Failure attribution** | Provider outage, rate limiting and refusals are classified and excluded from the pass-rate denominator, or a bad afternoon at the provider reads as a product regression. |
+
+**The compaction arm needs a different baseline.** For an input that exceeds the model's context
+window, the direct-provider arm does not produce a worse answer — it produces a 400. There is
+nothing to compare. The baseline for compaction cases must be something that can actually answer:
+kitty against a larger-context model, or kitty with compaction thresholds relaxed. Which one is
+Q13.
+
+Q4 asks for the margin. It is one input to this design, not a substitute for it.
 
 #### 6.4.4 Load
 
-A concurrency and duration profile — many parallel sessions against one bridge, a long streaming
-response, and a sustained session — asserting the connection-pool limit
-(`KITTY_BRIDGE_CONN_LIMIT`, default 500) and `force_close=True` behave as intended, that memory
-does not grow across a long stream, and that the per-request `_backend_context` ContextVar does
-not leak between concurrent requests. Pre-release, not per-PR.
+The earlier draft said "many parallel sessions", "sustained", and "behave as intended". None of
+that is a gate — it is the "as appropriate" this document forbids elsewhere. Specified properly:
 
----
+| Element | Specification |
+|---|---|
+| **Workload** | C concurrent sessions × R requests, Poisson arrivals at rate λ, duration D, response sizes drawn from the corpus. C, R, λ and D fixed in the profile and versioned with it. |
+| **Hardware** | Named runner class and core/memory count recorded with every result. A latency number without a machine is not a number. |
+| **Streaming vs. buffered** | Measured separately. The bridge streams incrementally on the SSE paths but **buffers whole responses** on others (non-streaming `_make_upstream_request`, the subscription provider's SSE-to-response parse). "Memory does not grow across a long stream" is false as a blanket claim and must be scoped to the incremental paths. |
+
+**Metrics and gates:**
+
+- **Bridge-added latency** — p50 and p95 of (through-kitty − direct-to-fake-upstream), against a
+  fixed ceiling.
+- **Time to first output byte** on streaming paths, against a fixed ceiling.
+- **Completion rate** and **error rate** by class, against fixed floors.
+- **Bounded memory** — peak RSS stays within a fixed multiple of the largest single buffered
+  response on buffered paths; flat within a fixed band on incremental paths.
+- **Resource recovery** — open sockets and file descriptors return to baseline within a fixed
+  window after the run, proving `force_close` and the connection-limit behave under saturation.
+
+The ceilings and floors are numbers this document does not invent: they come from a first
+baseline run, recorded and then ratcheted. **`_backend_context` isolation moved to L3** (§6.3.1)
+— it is deterministic and does not need a load rig to prove.
 
 ## 7. Shared test infrastructure
 
@@ -910,12 +1214,25 @@ alongside them (the baselines C1b and C5 compare against).
 Code sends. That belief is the thing most likely to be wrong, and it drifts every time Anthropic
 ships a release. Captured bodies are evidence.
 
-**Required entries, at minimum:** plain text turn · turn with `tools` declared · assistant
-`tool_use` · user `tool_result` · extended thinking · image content block · `system` with
-`cache_control` · a transcript above the compaction budget · a single tool result above 50,000
-chars · a transcript that provokes the 400/413 recovery path (**must run against a balancing
-profile** — M6 exists only in `_request_with_retry_balancing`) · a system prompt alone larger
-than the window, to reach M13 · a malformed body for the fuzz path.
+**Coverage is driven by the register, not by intuition.** Every conditional row in §3.2 needs a
+corpus entry that meets its trigger **and** one that does not (§3.3.4); a corpus that only
+contains trigger cases cannot support assertion 2. At minimum:
+
+| Entry | Exercises |
+|---|---|
+| Plain text turn | Baseline; complement for every conditional row |
+| Turn with `tools` declared | Tool-declaration projection |
+| Assistant `tool_use` / user `tool_result` | Pairing, M7 |
+| Extended thinking | P2a/P2b, P5c, P5d, P8, M8 |
+| Image content block · `system` with `cache_control` | Projection fidelity on non-text parts |
+| Tool result just under and just over 50,000 chars | M3/M4 trigger **and** complement |
+| Transcript just under and just over the compaction budget | M5 trigger and complement |
+| Transcript provoking the upstream 400/413 recovery | M6 — **must run against a balancing profile**; `_request_with_retry` has no compaction recovery |
+| System prompt alone larger than the window | M13, and the Q10 behaviour |
+| A single final turn larger than the budget | The irreducible-set case (§6.1) |
+| **A turn whose text is `Please explain how kitty-bridge works`** | The §3.3.3 regression case — must survive byte-identically while M13 is still caught |
+| `max_tokens` above and below 4096, streaming and non-streaming | P7 trigger and complement; P13 |
+| Malformed body | The L2 fuzz path |
 
 **Traps.** Captured transcripts contain prompts, file contents and API keys. The capture
 procedure must scrub credentials and the corpus must be reviewed before commit; a fixture file is
@@ -923,56 +1240,109 @@ as public as the repository. The corpus needs a refresh cadence tied to Claude C
 a recorded capture procedure — an un-refreshable corpus becomes a museum of a protocol nobody
 speaks any more.
 
-### 7.2 Recording fake upstream
+### 7.2 Recording upstreams — one per transport
 
-An `aiohttp` server that speaks the Anthropic Messages API and the Chat Completions API, records
-every request in full (method, path, **headers with original casing and order**, raw body bytes,
-arrival timestamp, and a connection identifier), and replays scripted responses including SSE
-streams, error statuses, Cloudflare blocks, empty responses, context-too-large rejections and
-mid-stream disconnects.
+The bridge reaches upstream through **five** distinct client configurations (§3.2.3, §5.5), and
+an aiohttp recorder observes only one of them. One recorder per configuration, all presenting the
+same interface to the tests:
 
-It is the substrate for I1 (§3.3), I2 (§4.3) and I3 (§5.2). **Casing** is asserted by C1; **order**
-is recorded for the C1b baseline report only, not asserted — what reaches the wire is aiohttp's
-ordering, not the agent's. The connection identifier supports C5's distinct-connection count and
-§5.2's CONNECT correlation. Peer address is deliberately **not** used for containment (§5.2
-assertion 1).
+| Recorder | Serves | Observes |
+|---|---|---|
+| aiohttp server — bridge sessions | the 20 default-transport adapters | The primary; speaks Anthropic Messages and Chat Completions |
+| aiohttp server — provider sessions | `ollama_cloud`, and the `openai_subscription` **OAuth token legs** | Those adapters build their own sessions and never touch `_session_for`, so the bridge recorder never sees them. The OAuth leg runs at startup, before anything else has been proven (§5.5) |
+| curl_cffi-reachable server | `openai_subscription` serving path | Must terminate TLS with the harness certificate; the only place `_cc_to_responses` output (P13, P17) can be seen |
+| botocore endpoint override | `bedrock` | Points the client at the local recorder rather than AWS; observes the Converse payload **after** the transport's `modelId`/`stream` pops (P18) |
 
-Per §3.3.2 and §5.5, equivalents are needed for the non-aiohttp transports: a `curl_cffi`-reachable
-recorder and a botocore endpoint override.
+Each records every request in full: method, path, **headers with original casing and order**,
+raw body bytes, arrival timestamp, and — for containment — **the peer port of the accepted
+connection**, which is the join key against the proxy's tunnel log (§5.2.1). Each replays
+scripted responses: SSE streams, error statuses, Cloudflare blocks, empty responses,
+context-too-large rejections, and disconnects at each of §6.3.1's four injection points.
+
+**Casing** is asserted by C1; **order** is recorded for the C1b baseline report only, not
+asserted — what reaches the wire is the client library's ordering, not the agent's. Peer
+*address* is deliberately not used for containment (§5.2.1).
 
 ### 7.3 Recording CONNECT proxy
 
 **Already exists.** `tests/test_egress_https_proxy.py` contains `_ConnectProxy` (enforces Basic
 auth, records every `CONNECT` as a `ConnectAttempt`) and `_TlsTarget`, with throwaway
-certificates on ephemeral ports. Extend it rather than build a second: expose it as a shared
-fixture, add the ability to stop it mid-test for §5.2's negative assertion, and keep the CONNECT
-log addressable for correlation.
+certificates on ephemeral ports. Extend it rather than build a second:
 
-### 7.4 Transparency oracle
+- expose it as a shared fixture;
+- add the ability to stop it mid-test, for §5.2.2 phase 2;
+- **record the outbound source port** of each tunnel it opens, so §5.2.1 can join tunnels to the
+  connections the recorders accept — `ConnectAttempt` carries target and auth status only today,
+  which is not enough to identify a connection at both ends;
+- resolve the harness hostname itself on the proxied leg, and expose a per-transport direct-route
+  override for §5.2.2 phase 1.
 
-Specified in §3.3. Implemented as a pytest fixture wrapping the recording upstream, exposing one
-assertion — `assert_no_unclaimed_mutation(inbound, recorded, register, mode)` where `mode` is
-`native`, `round_trip_cc` or `round_trip_other` per §3.3.1 — so a new corpus entry, provider or
+### 7.4 Wire projections and the transparency oracle
+
+**The projections (§3.3.1)** are the load-bearing piece: one hand-written reader per wire format —
+Anthropic Messages, Chat Completions, OpenAI Responses, Gemini, Bedrock Converse, Ollama
+`/api/chat` — each mapping a serialized body to the common `Conversation` form and **importing
+nothing from `src/kitty/bridge`**. They are test code that the whole of I1 rests on, so they get
+their own L1 tests, written against each format's published examples rather than against kitty's
+output.
+
+**The oracle** is a pytest fixture wrapping the recorders, exposing one assertion:
+
+```
+assert_no_unclaimed_mutation(inbound_body, inbound_format,
+                             captured_body, captured_format,
+                             register, triggers_met)
+```
+
+Both formats are supplied by the harness from the observed wire shape (§3.3.4), never read from
+the adapter's own property — that property is unreliable (F5, KBR-7) and, more fundamentally, an
+oracle must not ask the code under test what it did. A new corpus entry, adapter, model route or
 transport costs one parametrisation, not a new test.
 
 ---
 
 ## 8. CI cadence
 
-| Job | Contents | Trigger | Gate? |
-|---|---|---|---|
-| **Fast** | `ruff`, `lint-imports`, `mypy src/kitty`, L1 + L2 across Python 3.10–3.13 | every push and PR | **Yes** |
-| **Subsystem** | L3: oracle, sealed network, settings lifecycle, concurrency | every PR | **Yes** |
-| **Deep** | mutation testing, schemathesis at high `--max-examples`, extended property runs | nightly | Report + ratchet |
-| **Product** | real-agent E2E, answer-quality evals | nightly | Alert, not gate |
-| **Release** | everything above plus load | tag push, via the existing reusable `tests.yml` | **Yes** |
+One executable selection matrix. Every test carries exactly one layer marker
+(`l1`, `l2`, `l3`, `acceptance`, `agent_smoke`, `agent_live`, `eval`, `load`), so a job is
+defined by its marker expression and no test can fall between two jobs or into both.
+
+| Job | Selection | Trigger | Gates a PR? | Gates a release? |
+|---|---|---|---|---|
+| **Fast** | `ruff`, `lint-imports`, `mypy src/kitty`, then `pytest -m "l1 or l2" -q` on Python 3.10–3.13 | push, PR | **Yes** | **Yes** |
+| **Subsystem** | `pytest -m l3 -q` | PR | **Yes** | **Yes** |
+| **Acceptance** | `pytest -m "acceptance or agent_smoke" -q` | PR | **Yes** | **Yes** |
+| **Deep** | mutation testing (§6.1), schemathesis at high `--max-examples`, extended property runs | nightly | No | No |
+| **Agent live** | `pytest -m agent_live -q`, credentials from CI secrets | nightly | No | No |
+| **Eval** | answer-quality runner (§6.4.3) | nightly | No | **No** — alerts only |
+| **Load** | load runner (§6.4.4) | pre-release | No | **Yes** |
+
+**The release gate is the union of the four "gates a release" rows, and nothing else.** An
+earlier draft said Release runs "everything above plus load" and then, a paragraph later, that a
+release must not wait on an LLM eval. Both cannot hold. Evals and the live-agent job are
+**alerting**, not gating: they are nondeterministic and depend on a third party's availability,
+and a release that can be blocked by someone else's rate limiter is not a release process.
+
+**`@ratchet` scenarios report but do not gate.** Two acceptance scenarios assert the target state
+of currently-open defects (§6.4.1). The Acceptance job runs them, records the result, and fails
+only on the non-ratchet set. When G3 and G14 close, the markers come off and they gate like
+everything else. A gate that is red for a known reason on the day it is introduced does not
+survive contact with a release.
+
+**Skips are failures in a gating job.** If `agent_smoke` cannot find its pinned binary, or `l3`
+cannot start its proxy, the job fails. A gating job that goes green because it ran nothing is the
+most expensive kind of false confidence.
 
 The existing arrangement — `publish.yml` and `ci.yml` both calling one reusable `tests.yml` so a
-release runs exactly the checks a PR ran — is correct and is extended rather than replaced. The
-new L3 job joins the same reusable workflow; the nightly jobs get their own, because a release
-must not wait on an LLM eval.
+release runs exactly the checks a PR ran — is correct in shape and extended rather than replaced:
+the reusable workflow gains the Subsystem and Acceptance jobs, and the nightly and pre-release
+jobs live in their own workflows.
 
----
+**A note on the existing runtime.** The suite already takes ~18.5 minutes per Python version, ×4
+versions. The new L3 work adds real sockets to that gate. If the fast gate stops being fast,
+people route around it, so the marker split above is also the mechanism for keeping the per-PR
+path bounded — and the mutation-cadence measurement (Q11) has to be taken against that budget,
+not against an empty one.
 
 ## 9. Gap register
 
@@ -998,10 +1368,12 @@ Four Python versions in CI, with `mypy` and `import-linter` as gates rather than
 | **G14** | **F3 — the vendor name goes upstream in the body (M13)** — KBR-5 | Live I2 breach | Fix the message; forbidden-token guard (§6.2.3) + TR-4 | **0** |
 | **G15** | **F4 — `_effort` / `_thinking_adaptive` reach the wire** — KBR-6 | Live I1+I2 breach on every CC-wire provider | Add both to `_INTERNAL_KEYS`; internal-key completeness guard (§6.2.3) | **0** |
 | **G16** | **F5 — `OpenCodeGoAdapter` misdeclares its wire shape** — KBR-7 | Latent defect in the M8 path; trap for the oracle | Make the property per-model; wire-shape honesty guard | **1** |
+| **G17** | Undecided behaviour for an irreducible final turn | Compaction emits an over-budget request, or M13 replaces the conversation; neither was designed | Answer Q10, then align M3-M7/M13, the 6.1 properties and TR-3 together | **2** |
+| **G18** | P13-P19 - seven transport-level mutations, unregistered in the first draft | Necessary (the Codex backend and boto3 require them) but invisible above DEBUG, and unreachable by a guard placed at `translate_to_upstream` | Rows P13-P19; boundary corrected in 3.2.3; Q5 decides user visibility | **3** |
 | **G1** | I1 is unstated and untested | No definition of "unchanged"; mutation sites discoverable only by reading 6,463 lines | Register (§3.2) + oracle (§3.3) | **1** |
 | **G2** | No-bypass unproven **for the bridge's serving path**; no negative assertion; start-path guard is file-granular | `test_egress_https_proxy.py` proves the transports and drives `egress_cmd._probe` | Sealed-network harness (§5.2) per transport (§5.5) + AST start-path guard | **1** |
 | **G3** | I2 partially breached (F1) — KBR-8 | Identity ad hoc per adapter; the subscription adapter reports two different versions in one request | Header contract + parity baseline, then a policy and a code fix | **2** |
-| **G4** | L1 strength unmeasured | Line coverage only | `mutmut` ≥ 85% on the in-scope set | **2** |
+| **G4** | L1 strength unmeasured | Line coverage only | `mutmut` ≥ 85% **per target group** on the §6.1 scope | **2** |
 | **G8** | No corpus of real agent traffic | Synthetic fixtures encode our assumptions | Golden corpus (§7.1) | **2** |
 | **G10** | Custom-transport containment untested | Proven at transport level, never through the bridge; ambient `HTTP_PROXY`/`NO_PROXY` untested; the OAuth leg untested | §5.5 + §6.2.4 | **2** |
 | **G5** | No contract layer | No published schema; SSE grammar unchecked | OpenAPI + `schemathesis` + grammar state machine | **3** |
@@ -1044,7 +1416,7 @@ none of them. Feeding a fixed request through each adapter and diffing the outpu
 adapter's rows is falsifiable and catches added-and-returned mutations. A source scan would have
 missed F4.
 
-**The oracle is scoped by observed wire shape, not by the adapter's own property (§3.3.1).** On a
+**The oracle is scoped by observed wire shape, not by the adapter's own property (§3.3.4).** On a
 CC-wire provider every field differs and every delta is claimed by the translation row, so a
 direct diff passes without proving anything. And the natural selector cannot be trusted:
 `OpenCodeGoAdapter` declares a Messages wire while emitting Chat Completions for most models
@@ -1055,11 +1427,6 @@ JSON fails on serialisation noise and trains people to ignore red. But key *orde
 a provider fingerprints, so where kitty claims to be forwarding rather than translating, order is
 part of the contract. The asymmetry is deliberate — and it stops at the body: header order is
 aiohttp's, not the agent's, so pinning it would pin a dependency's internals.
-
-**CONNECT-log correlation instead of peer address (§5.2).** With bridge, proxy and upstream on
-loopback in one process, a proxied and a direct connection both present `127.0.0.1` and both
-source ports are ephemeral — peer address cannot discriminate. Correlating each recorded request
-to a recorded `CONNECT` can, and it avoids the `127.0.0.2` alias macOS needs configured.
 
 **A hostname outside the `localhost` family, never an IP literal, for the fake upstream (§5.3).**
 `should_bypass` bypasses loopback, private and `localhost`-suffixed destinations, so the obvious
@@ -1097,13 +1464,67 @@ and stops it growing while the fix is done properly.
 every provider through `curl_cffi`, a large change to the serving path for a threat no provider is
 currently known to apply here. Recording it means a future incident is a known gap, not a surprise.
 
+**The oracle compares independent projections, never a translator round-trip (§3.3.1).** The
+production translators are not inverses — one maps request to request, the other response to
+response — so the round-trip an earlier draft specified could not have run at all. And even a
+genuine inverse would only demonstrate self-consistency: a translator that drops a field in both
+directions round-trips perfectly. Hand-written projections, importing nothing from the bridge,
+are the only form of this check that can fail for the right reason.
+
+**The vendor-token check is scoped to bridge-introduced content (§3.3.3, §4.3 C2).** A flat scan
+of the serialized body for `kitty` puts I1 and I2 in direct conflict: a user asking Claude Code
+to explain kitty-bridge would fail the I2 check, and satisfying it by stripping their words would
+breach I1. Scoping by the projection diff dissolves the conflict — the user's sentence has an
+inbound counterpart, M13's message does not.
+
+**The register is enforced at the serialization boundary, not at `translate_to_upstream`
+(§3.2.3).** On the subscription provider those hooks return a Chat Completions shape and
+`_cc_to_responses` drops fourteen parameters afterwards, inside the custom transport. A guard
+placed at the hook would have called that adapter clean — which is how P13 went unregistered in
+the first draft.
+
+**Containment gets a positive control and a falsification control (§5.2.2).** The `.invalid`
+hostname that solves the loopback-bypass trap creates a second one: an unresolvable destination
+makes "zero upstream connections" true for a broken implementation too. Proving direct
+reachability first, and then proving the harness can detect a deliberately injected bypass, is
+what turns a green result into evidence.
+
+**Connections are joined to tunnels, not counted against requests (§5.2.1).** Connection reuse
+puts many requests on one tunnel and a failed CONNECT puts none on any, so equal counts would
+reject correct behaviour — and would quietly encode today's `force_close=True` into a test, which
+Q7 may change.
+
+**Two compaction claims and three Gherkin scenarios were corrected against the code (§6.1,
+§6.4.1).** "Output ≤ budget except for an oversized system block", "a short turn is unchanged"
+and "the latest turn survives in full" were all false. Where the correction exposed an undesigned
+behaviour rather than a wording slip it became Q10, instead of being written up as intended
+behaviour. A design document that ratifies whatever the code happens to do is not a specification.
+
+**Mutation scope now contains the code its own rationale is about (§6.1).** The subset was
+justified by "a mutation surviving in the compactor", and then excluded `server.py`, where the
+compactor lives. Function-level wildcards bring it in without dragging in the retry state
+machine, and per-component thresholds stop a weak invariant-critical component hiding behind a
+strong one in an aggregate.
+
+**Evals are specified as a measurement, not a comparison (§6.4.3).** Pairing removes task
+variance; it does not remove the model's independent sampling variance, so a single paired run
+and a single delta cannot support a decision. Repetition, a pinned configuration, a confidence
+interval and a pre-registered margin are the minimum that makes a nightly signal actionable —
+and independently authored acceptance tests, because a model-generated test passing the model's
+own code shares the model's misunderstandings.
+
+**Load has numbers or it is not a gate (§6.4.4).** "Behave as intended" is the "as appropriate"
+this document forbids elsewhere. The ceilings come from a recorded baseline run and are then
+ratcheted; streaming and buffered paths are measured separately, because the blanket claim that
+memory does not grow is false on the paths that buffer a whole response.
+
 ---
 
 ## 11. Open questions for the product owner
 
 Answers belong in this document. They are not invented here.
 
-**Q1 — How faithful should the agent's identity be (F1, G3)?** Three options, materially
+**Q1 — How faithful should the agent's identity be (F1, G3, KBR-8)?** Three options, materially
 different: (a) forward a curated allowlist of the agent's real headers, uniformly, so every
 provider sees a genuine coding agent; (b) send a neutral, stable identity that is neither kitty
 nor Claude Code; (c) leave it ad hoc and treat I2 as "no kitty fingerprint" rather than "looks
@@ -1113,21 +1534,25 @@ hard-coded strings with a general mechanism. Whichever is chosen, the current st
 policy — it is four independent workarounds, one of which reports two different client versions
 in the same request. This decides both the I2 target and the C1b gate.
 
-**Q2 — Is pre-flight credential validation an acceptable I2 exception?** It is an upstream request
-the agent never made, and `--no-validate` already exists to suppress it. Declared exception, or
-suppressed by default when egress is configured?
+**Q2 — Is pre-flight credential validation an acceptable I2 exception?** It is an upstream
+request the agent never made, and `--no-validate` already exists to suppress it. Declared
+exception, or suppressed by default when egress is configured?
 
-**Q3 — Should `should_bypass` resolve hostnames (§5.3)?** Not resolving saves a DNS round trip per
-request but means a LAN-hostname-configured local model server gets tunnelled to a proxy that
+**Q3 — Should `should_bypass` resolve hostnames (§5.3)?** Not resolving saves a DNS round trip
+per request but means a LAN-hostname-configured local model server gets tunnelled to a proxy that
 cannot reach it. `localhost` is already handled by name. Keep the trade-off, or resolve-and-cache?
 
-**Q4 — What is the acceptable answer-quality delta (§6.4.3)?** A number is needed for the alert
-band. Zero is not achievable on a nondeterministic system.
+**Q4 — What regression margin for answer quality (§6.4.3)?** A pre-registered number, chosen
+before the data. This is one input to the eval design, not a substitute for it — Q13 and the
+repetition and interval choices in §6.4.3 have to be settled alongside it.
 
-**Q5 — Should the Fireworks `max_tokens` cap (P7) be visible to the user?** It silently shortens
-the model's output. P5c raises `max_tokens` in the other direction. A one-line warning would make
-both visible at the cost of noise. A product call, not a test-design one, but the register
-surfaced it.
+**Q5 — Should silently dropped or overridden request parameters be visible to the user (P5c, P7, P13–P19)?**
+Fireworks caps `max_tokens` down, Anthropic raises it up, the Codex backend drops fourteen
+parameters including `max_tokens` and `temperature` outright and strips `strict` from every tool
+declaration, and both custom transports overwrite `stream`. Every one is necessary — the
+upstream rejects the request otherwise — and every one means a setting the agent sent silently
+does nothing. Today each logs at DEBUG. A one-line warning at launch would make it visible at
+the cost of noise.
 
 **Q6 — Which of the four body-changing retry paths are acceptable (§4.3 C3)?** M6, M8, M9 and
 failover re-normalisation each send a different payload on a later attempt, and a provider that
@@ -1135,17 +1560,43 @@ hashes bodies sees all four. The alternative in each case is to fail the turn, w
 the user. Declare all four as exceptions, or close some?
 
 **Q7 — Should `force_close=True` stay (C5, §4.5)?** It prevents port exhaustion but produces a
-connection pattern unlike the agent's own. Keep, or trade for keep-alive parity?
+connection pattern unlike the agent's own. Keep, or trade for keep-alive parity? §5.2.1 is
+deliberately written not to depend on the answer.
 
 **Q8 — What is the repo's policy on tracking `.system_design/`?** `.gitignore` ignored both
-`.system_design/` and `.requirements/`. KBR-2 asks for this document at a tracked path *and* for a
-PR, which cannot both hold while the directory is ignored; this change therefore un-ignores
+`.system_design/` and `.requirements/`. KBR-2 asks for this document at a tracked path *and* for
+a PR, which cannot both hold while the directory is ignored; this change therefore un-ignores
 `.system_design/` and leaves `.requirements/` ignored as per-task working material. If that is
 wrong, say so — and note the repo has no `SYSTEM_DESIGN.md` at all, so the request path, provider
 registry and failover state machine are undocumented. A separate ticket seems right.
 
-**Q9 — What should the unrecoverable-compaction message say (F3, G14)?** It must stay legible to
-the user and stop naming the product upstream. Options: a vendor-neutral string; routing the
-error to the agent as an HTTP error instead of a synthetic assistant turn; or keeping the text but
-returning it downstream only. The third is probably right — the message is for the user, and it
-currently reaches the one audience it was never meant for.
+**Q9 — What should the unrecoverable-compaction message say (F3, G14, KBR-5)?** It must stay
+legible to the user and stop naming the product upstream. Options: a vendor-neutral string;
+routing the error to the agent as an HTTP error instead of a synthetic assistant turn; or keeping
+the text but returning it downstream only. The third is probably right — the message is for the
+user, and it currently reaches the one audience it was never meant for.
+
+**Q10 — What should happen when the final turn alone exceeds the budget (§6.1, TR-3)?** Today
+compaction gives up and emits an over-budget request, which the provider rejects, or M13 replaces
+the conversation entirely. Neither was designed; both are what the loop happens to do when it can
+shrink no further. Options: truncate the final turn's content, fail fast with a clear local
+error, or keep current behaviour and document it deliberately. **Whatever is chosen, register
+rows M3–M7 and M13, the §6.1 compaction properties and TR-3 move together.** The design records
+current behaviour as observed, explicitly not as approved, until this is answered.
+
+**Q11 — Does changed-code mutation testing fit the per-PR gate (§6.1)?** Answerable by
+measurement, not opinion: time `mutmut run` restricted to the functions a representative PR
+touches, against the budget the fast gate can absorb given it already runs ~18.5 minutes per
+Python version. Adopt per-PR if it fits, nightly-only otherwise. The current nightly-only choice
+is provisional pending that number.
+
+**Q12 — How is a pinned Claude Code binary supplied to CI (§6.4.2)?** The per-PR agent smoke
+needs a real Claude Code, not an arbitrary child process, because the claim under test is Claude
+Code's own settings precedence. Which distribution, pinned how, and is redistribution inside a CI
+image acceptable? If it is not, the settings-precedence claim has no per-PR proof, and that
+limitation should be stated rather than papered over.
+
+**Q13 — What is the baseline for the compaction arm of the evals (§6.4.3)?** For an over-context
+input the direct-provider arm returns a 400, so there is no answer to compare against.
+Candidates: kitty against a larger-context model, or kitty with compaction relaxed. The choice
+determines what a regression in that arm actually means.

--- a/.system_design/TEST_SUITE.md
+++ b/.system_design/TEST_SUITE.md
@@ -271,14 +271,28 @@ production translator establishes self-consistency, not fidelity. A translator t
 same field in both directions round-trips perfectly. The oracle must not be written in terms of
 the code under test.
 
-**The projection.** Define one **`Conversation`** value type in the test tree:
+**The projection must be total, or it hides exactly what it is looking for.** A projection that
+keeps only the semantic conversation cannot see a changed model, a dropped `stream`, a stripped
+tool `description`, or an injected metadata field — both sides project identically and the "no
+unclaimed delta" assertion passes. That blind spot would swallow **M1**, the model override that
+is the product's entire purpose, along with P6, P15, P17, P18 and P19. So the projection covers
+the whole request and accounts for every field:
 
 ```
+Request                          -- the complete request; nothing is dropped silently
+  envelope:     Envelope         -- routing and control
+  conversation: Conversation     -- semantic content
+  residual:     {key: value}     -- anything the reader did not account for
+
+Envelope
+  model, stream, store, and every other control field the format defines
+  (Bedrock's modelId and Responses' store live here too)
+
 Conversation
-  system:    ordered text parts
-  turns:     ordered [ Turn(role, parts) ]
-  tools:     ordered [ ToolDecl(name, schema) ]
-  sampling:  { max_tokens, temperature, top_p, stop, … }   # declared, may be absent
+  system:   ordered text parts
+  turns:    ordered [ Turn(role, parts) ]
+  tools:    ordered [ ToolDecl(name, description, schema, strict) ]
+  sampling: { max_tokens, temperature, top_p, stop, seed, ... } -- declared, may be absent
 
 Part = Text(str)
      | ToolUse(id, name, arguments)
@@ -287,17 +301,46 @@ Part = Text(str)
      | Image(digest)
 ```
 
-Then write one **hand-written projection per wire format** — Anthropic Messages, Chat
-Completions, OpenAI Responses, Gemini, Bedrock Converse, Ollama `/api/chat` — each written
-directly against that format's published shape and **importing nothing from `src/kitty/bridge`**.
-Six small readers, each independent of whatever kitty code produces that format. The oracle compares
-`project(inbound)` with `project(captured_upstream_bytes)`.
+**Unknown fields fail closed.** Each reader must classify **every** key in the body into exactly
+one of: mapped to the envelope, mapped to the conversation, or residual. A non-empty `residual`
+on either side **fails the run** — it is not reported as a diff and it is not ignored. An
+unaccounted field is precisely where an unregistered mutation hides, and a reader that quietly
+skips what it does not recognise is a reader that cannot prove completeness. Adding a field to a
+wire format therefore forces a deliberate decision: map it, or declare it ignored with a reason.
+
+**Every register row names the field it touches.** M1 is `envelope.model`; P17 is
+`envelope.stream` and `envelope.store`; P15 is `conversation.tools[].strict`; P13 is
+`conversation.sampling`. Without that, "claimed by a register row" is a judgement call rather
+than a lookup.
+
+Then write one **hand-written reader per wire format** — Anthropic Messages, Chat Completions,
+OpenAI Responses, Gemini, Bedrock Converse, Ollama `/api/chat` — each written directly against
+that format's published shape and **importing nothing from `src/kitty/bridge`**. Six small
+readers, each independent of whatever kitty code produces that format. The oracle compares
+`project(inbound)` with `project(captured_upstream_bytes)`, field by field, across all three
+parts.
 
 This is the independent-oracle rule, and it is what makes the check meaningful across a protocol
 boundary: a Messages body and a Chat Completions body are not comparable as JSON, but their
 projections are directly comparable, because a conversation is a conversation.
 
-**Response translation is tested separately**, with its own projection (`Reply(parts, stop_reason,
+**The oracle gets its own falsification control.** The same discipline §5.2.2 phase 3 applies to
+the containment harness applies here: a fidelity oracle never shown to fail is indistinguishable
+from one that cannot fail. Five injected mutations must each produce a failure, and they run as
+part of the suite, not once by hand:
+
+| Injected | Must be caught as |
+|---|---|
+| Change the model sent upstream to a value no profile set | unclaimed `envelope.model` delta |
+| Flip `stream` on an otherwise unchanged request | unclaimed `envelope.stream` delta |
+| Delete one tool's `description` | unclaimed `conversation.tools[].description` delta |
+| Strip `strict` from a tool where no register row applies | unclaimed `conversation.tools[].strict` delta |
+| Inject an unrecognised `x-kitty-trace` field into the body | non-empty `residual` — fails closed |
+
+The last of these is also what keeps the vendor-token check (§3.3.3) honest: bridge-added
+metadata that the projection discarded could never have been scanned for a vendor string.
+
+**Response translation is tested separately**, with its own projection (`Reply(parts, stop_reason,**Response translation is tested separately**, with its own projection (`Reply(parts, stop_reason,
 usage)`) over the response direction. It is a different claim and it gets a different test.
 
 #### 3.3.2 The two assertions
@@ -824,11 +867,20 @@ None`. `mutmut` closes that gap.
   | `kitty.bridge.messages.*`, `kitty.bridge.responses.*`, `kitty.bridge.gemini.*`, `kitty.bridge.engine` | Translation — I1 |
   | `kitty.bridge.server._compact_messages*`, `_compact_with_tighter_budget*`, `_validate_tool_call_pairing*`, `_truncate_oversized_tool_results*`, `_apply_compaction*`, `_normalize_model*`, `_get_max_context_chars*` | Compaction and pairing — the I1 core, and the thing the rationale was always about |
   | `kitty.providers.*` `translate_to_upstream` / `normalize_request` / `build_upstream_headers` | The register's provider half — I1 and I2 |
+  | `kitty.providers.openai_subscription._cc_to_responses*`, `_prepare_responses_body*`, `_convert_content_types*`, `_build_user_agent*` | P13–P17 and the F1 user-agent. These are where the subscription path's real body is built; omitting them lets the score stay healthy while nothing detects a regression in the mutations this design only just registered |
   | `kitty.egress`, `kitty.egress_guard` | I3, including the startup guard |
   | `kitty.bridge.tool_audit`, `kitty.profiles.*`, `kitty.validation` | Supporting correctness |
 
   Still excluded: the TUI, the CLI wiring, the retry/health state machine. A mutation surviving
   in a menu is a cosmetic defect; one surviving in the compactor is a silent invariant breach.
+
+- **P18 and P19 need a refactor before they can be mutation-tested.** Both live inside
+  `make_request` / `stream_request`, which open network connections, so `mutmut` cannot reach them
+  from an L1 selection. Extract the payload shaping into a pure builder — `_bedrock_body(...)`,
+  `_ollama_body(...)` — leaving the network method to call it. The builder is then unit-testable
+  and mutation-testable at L1, while the wire-capture test at L3 continues to prove the real bytes.
+  This is the "design for testability" rule applied where the current factoring is what blocks the
+  test, not the test that is hard to write.
 
 - **Per-component thresholds, not one aggregate.** ≥ 85% killed **per target group** above. A
   single aggregate over a large surface lets a weak component hide behind a strong one — and the
@@ -982,12 +1034,18 @@ sequence rather than timing:
 |---|---|
 | Before any downstream byte | Clean failover; the client sees one complete stream from the second backend |
 | After text has been emitted | No text the client already received is repeated; the transcript reads as one message |
-| Mid `input_json_delta`, tool arguments partly sent | Arguments are never a splice of two attempts. Either the partial block is properly abandoned and re-opened under a new id, or the turn fails — whichever the agreed semantics say, but never a silent merge |
+| Mid `input_json_delta`, tool arguments partly sent | Arguments are never a splice of two attempts. **The acceptance oracle here is undecided — Q14.** Until it is answered this row asserts only the negative (no silent merge, no reused id across attempts), which is weaker than the row needs to be |
 | After content, before the terminal event | Exactly one terminal outcome reaches the client; `message_stop` is not duplicated or omitted |
 
 Each case asserts tool-call **identity** (ids stable within an attempt, never reused across
-attempts) and a single terminal outcome. The agreed retry semantics are a prerequisite: if they
-have not been decided, that is the finding, not a test to write around.
+attempts) and a single terminal outcome.
+
+**The post-emission semantics are a prerequisite, and they are not decided.** Once bytes have
+reached the client, what a correct recovery even *looks like* is a product decision, not a test
+detail: abandon and re-open, fail the turn, or something else. Writing "whichever the agreed
+semantics say" into a test specification leaves it without an acceptance oracle — the same defect
+this document objects to elsewhere. It is tracked as **Q14** rather than left as prose, so the
+gap is visible in the question list where decisions are collected, not buried in a table.
 
 `/stats` remains authoritative for attribution after a mid-stream failover, per the README's own
 caveat that the headers name whoever produced the first byte.
@@ -1126,14 +1184,34 @@ behaviour; it does not ratify it. When Q10 is answered, TR-3, register rows M3�
 
 Two distinct things, currently conflated, with different costs and different cadences.
 
-**Agent smoke — per PR, hermetic.** The claim that kitty configures Claude Code correctly is a
-claim about *Claude Code's* settings precedence between `--settings`, the process environment and
-`~/.claude/settings.json`. Spawning an arbitrary child process does not test that; it tests
-kitty's belief about it, which is precisely the assumption under suspicion in the KBR-1
-investigation. This needs a **pinned real Claude Code binary** run against the scripted fake
-upstream (§7.2) — no live provider, no credentials, no network. One non-interactive turn is
-enough to prove the wiring: the binary starts, resolves the bridge URL from the session settings
-file, sends a request that arrives at the recorder, and exits cleanly.
+**Agent smoke — per PR, hermetic.** Two distinct cases, and only the second proves the claim.
+
+*Startup smoke.* A **pinned real Claude Code binary** runs one non-interactive turn against the
+scripted recorder (§7.2) — no live provider, no credentials, no network. The binary starts,
+resolves the bridge URL, its request arrives, it exits cleanly. This proves connectivity.
+
+*Precedence.* Connectivity is **not** the claim. The claim is that kitty's `--settings` file wins
+over the process environment and over `~/.claude/settings.json` — a fact about *Claude Code's*
+behaviour, not kitty's, and the assumption under suspicion in the KBR-1 investigation. A run in
+which nothing competes cannot distinguish correct precedence from accidental agreement: an
+implementation with the order backwards passes it.
+
+So the test creates a genuine conflict and points every loser at a **sentinel recorder** of its
+own:
+
+| Source | Points at | Expected |
+|---|---|---|
+| `ANTHROPIC_BASE_URL` in the child's environment | sentinel A | receives **nothing** |
+| `env.ANTHROPIC_BASE_URL` in `~/.claude/settings.json` (a temp `HOME`) | sentinel B | receives **nothing** |
+| kitty's per-session `--settings` file | the real recorder | receives **the request** |
+
+Assert on all three: the request arrives at the recorder **and** both sentinels stay silent. A
+test that checks only the recorder cannot tell "precedence is correct" from "the request went
+everywhere."
+
+*The control.* Sentinels that are never hit prove nothing unless they can be hit. A second case
+removes kitty's settings file and asserts B wins over A — demonstrating both sentinels are live
+and the harness can distinguish them. Without it, a typo in a sentinel URL reads as a pass.
 
 Pinning it in CI has real questions attached — which distribution, how tightly version-pinned, licensing for
 redistribution in a CI image — recorded as Q12 rather than assumed away.
@@ -1166,7 +1244,10 @@ the design needs repetition and an interval, not a single paired run and a singl
 | **Pinning** | Model id, provider, dataset revision, temperature and all sampling settings pinned and recorded with each run. An unpinned model makes the series meaningless. |
 | **Statistic** | Difference in pass rate between arms, with a confidence interval — not a point estimate. |
 | **Decision rule** | A **pre-registered regression margin**: the alert fires when the interval excludes a delta smaller than the margin. Chosen before the data, not after. |
-| **Failure attribution** | Provider outage, rate limiting and refusals are classified and excluded from the pass-rate denominator, or a bad afternoon at the provider reads as a product regression. |
+| **Primary outcome** | **Successes ÷ scheduled trials.** Not successes ÷ completed trials. A bridge arm that refuses 90 of 100 tasks and answers the other 10 correctly scores 10%, which is the truth; excluding refusals would score it 100% and report a catastrophic regression as a clean run. |
+| **Failure taxonomy** | Every non-success is classified and reported separately — refusal, upstream error, timeout, rate limit, harness fault — per arm. The categories are the diagnosis; they are not deductions from the denominator. A refusal is **evidence about the arm**: changed instructions or lost context cause refusals, and both are exactly what compaction can do. |
+| **Exclusions** | Only for pre-defined infrastructure incidents, applied **symmetrically to both arms** by a rule written before the run. Every exclusion is reported with its reason. |
+| **Missing-data ceiling** | If exclusions plus harness faults exceed a fixed fraction of scheduled trials, the run is **void**, not adjusted. Below that ceiling the comparison stands; above it there is no comparison to make. |
 
 **The compaction arm needs a different baseline.** For an input that exceeds the model's context
 window, the direct-provider arm does not produce a worse answer — it produces a 400. There is
@@ -1323,20 +1404,47 @@ release must not wait on an LLM eval. Both cannot hold. Evals and the live-agent
 **alerting**, not gating: they are nondeterministic and depend on a third party's availability,
 and a release that can be blocked by someone else's rate limiter is not a release process.
 
-**`@ratchet` scenarios report but do not gate.** Two acceptance scenarios assert the target state
-of currently-open defects (§6.4.1). The Acceptance job runs them, records the result, and fails
-only on the non-ratchet set. When G3 and G14 close, the markers come off and they gate like
-everything else. A gate that is red for a known reason on the day it is introduced does not
-survive contact with a release.
+**`@ratchet` exempts one named assertion, not a scenario.** A scenario-wide exemption is a
+blanket amnesty: a broken fixture, a failure in a `Given` step, or an unrelated regression inside
+that scenario all become invisible, indistinguishable from the known defect. That is a worse
+outcome than the red gate it was meant to avoid.
+
+The exemption is therefore narrow and accountable:
+
+- It attaches to **one assertion**, named, with its expected failure condition and its issue key
+  (TR-1c's header-subset assertion → KBR-8; TR-4's no-vendor-content assertion → KBR-5).
+- **Setup and every other assertion in the scenario gate normally.** If TR-4 cannot reach the
+  bridge, the job fails — that is not the known defect.
+- **An unexpected pass fails the job.** When the assertion starts passing, the defect is fixed
+  and the exemption must come off; `xfail(strict=True)` semantics, so nobody has to remember.
+- All exemptions live in one registry with their issue keys, so the list is short, visible and
+  obviously temporary rather than scattered through the suite.
+
+A gate that is red for a known reason on the day it is introduced does not survive contact with a
+release. A gate that is green because it stopped looking is worse.
 
 **Skips are failures in a gating job.** If `agent_smoke` cannot find its pinned binary, or `l3`
 cannot start its proxy, the job fails. A gating job that goes green because it ran nothing is the
 most expensive kind of false confidence.
 
-The existing arrangement — `publish.yml` and `ci.yml` both calling one reusable `tests.yml` so a
-release runs exactly the checks a PR ran — is correct in shape and extended rather than replaced:
-the reusable workflow gains the Subsystem and Acceptance jobs, and the nightly and pre-release
-jobs live in their own workflows.
+**The load gate has to be wired, not merely declared.** The table above marks Load as gating a
+release, but `publish.yml` currently depends only on the reusable `tests.yml`. Putting the load
+run in "its own workflow" would leave publication free to proceed while load fails — or while it
+never ran at all for that commit, which is the more likely failure. A row in a table is not a
+dependency.
+
+The arrangement, made explicit:
+
+- `tests.yml` — reusable. Gains the Subsystem and Acceptance jobs. Called by `ci.yml` (push, PR)
+  and by `publish.yml`.
+- `load.yml` — **reusable**, and `publish.yml` calls it too, `needs:`-gated on the tag commit, so
+  publication cannot complete without a successful load run **for that exact commit**. A
+  scheduled nightly caller of the same reusable workflow gives early warning; it does not
+  substitute for the release call, because a nightly result belongs to a different commit.
+- Nightly Deep, Agent-live and Eval workflows stand alone and gate nothing.
+
+That keeps the property the existing setup gets right — a release runs exactly the checks a PR
+ran, from one definition — while extending it to the one gate that runs only at release time.
 
 **A note on the existing runtime.** The suite already takes ~18.5 minutes per Python version, ×4
 versions. The new L3 work adds real sockets to that gate. If the fast gate stops being fast,
@@ -1448,9 +1556,12 @@ on the rota.
 a survivor list nobody reads and a nightly job nobody waits for. The subset rule — modules whose
 silent misbehaviour breaches an invariant — keeps the output actionable.
 
-**A paired delta for answer quality, not an absolute threshold (§6.4.3).** Absolute thresholds on
-LLM output are flaky, and a flaky gate at L4 trains people to re-run rather than investigate. The
-paired comparison cancels the model's own variance.
+**A paired delta for answer quality, not an absolute threshold (§6.4.3).** Absolute thresholds
+on LLM output are flaky, and a flaky gate at L4 trains people to re-run rather than investigate.
+Pairing holds *task difficulty* constant, which removes the largest nuisance term. It does **not**
+cancel the model's independent sampling on each call — which is why §6.4.3 specifies repetition,
+a confidence interval and a pre-registered margin rather than a single delta. The eval is a
+measurement, not a comparison of two numbers.
 
 **Real-agent E2E stays out of the default run (§6.4.2).** It needs four CLIs, live credentials and
 live network. A default suite that cannot run on a developer's laptop stops being run, and then
@@ -1522,7 +1633,8 @@ memory does not grow is false on the paths that buffer a whole response.
 
 ## 11. Open questions for the product owner
 
-Answers belong in this document. They are not invented here.
+Answers belong in this document. They are not invented here. Q10-Q14 are prerequisites for the
+implementation work they name — each blocks a test whose acceptance oracle depends on it.
 
 **Q1 — How faithful should the agent's identity be (F1, G3, KBR-8)?** Three options, materially
 different: (a) forward a curated allowlist of the agent's real headers, uniformly, so every
@@ -1600,3 +1712,12 @@ limitation should be stated rather than papered over.
 input the direct-provider arm returns a 400, so there is no answer to compare against.
 Candidates: kitty against a larger-context model, or kitty with compaction relaxed. The choice
 determines what a regression in that arm actually means.
+
+**Q14 — What is a correct stream recovery after bytes have reached the client (§6.3.1)?** Failover
+before the first downstream byte is unambiguous. After text has been emitted, or mid tool-call
+arguments, there is no obvious right answer: abandon the partial block and re-open under a new
+id, fail the turn and let the agent retry, or something else. Until this is decided the L3 row
+can assert only the negatives — no duplicated text, no reused tool-call id across attempts, no
+spliced arguments — which catches corruption but cannot confirm correct behaviour. This is the
+one place in the design where a test is specified without a full acceptance oracle, and it is
+recorded here rather than papered over.

--- a/.system_design/TEST_SUITE.md
+++ b/.system_design/TEST_SUITE.md
@@ -1,0 +1,1151 @@
+# Kitty Bridge — Test Suite Design
+
+**Status:** To Be. Describes the suite Kitty Bridge should have, not the one it has.
+**Scope:** The whole product, with Claude Code as the primary agent.
+**Traces to:** [KBR-2](https://shelpuk.atlassian.net/browse/KBR-2).
+**Method:** The four-layer model from the `test-development` skill, instantiated for this
+codebase.
+
+**On citations.** Symbols are named, not line-numbered. `server.py` is 6,463 lines and line
+numbers rot on the next edit; `grep -n` or a symbol lookup recovers them, and a stale number is
+worse than none.
+
+> **Five defects were found while writing this document, three of them live breaches of the
+> invariants it defines** (§4.4). Each is filed as its own Jira bug — KBR-5 through KBR-9 —
+> and none is fixed by this change. That the *design* work found them, before a single test
+> was written, is the argument for the design work.
+>
+> **Standing policy:** any defect this suite reveals — by a failing test, by observed
+> behaviour, or by reading the code — is filed as a Jira ticket when it is found, not
+> collected in a document. §4.4 is a summary of tickets, not a substitute for them.
+
+---
+
+## 0. How to read this
+
+§1 states what the suite exists to prove. §2 says which layer proves what. §3–§5 specify the
+three invariants that carry the product's commercial promise; they are the reason this document
+exists and they are where the new work is. §6 specifies each layer. §7 specifies the shared
+infrastructure. §9 is the honest gap list.
+
+If you are adding a test and want one rule: **prove each behaviour at the lowest layer that can
+prove it** (§2.2).
+
+---
+
+## 1. What the suite must prove
+
+Kitty Bridge sits on the wire between a coding agent and an LLM provider. That position creates
+three promises whose breach is not a bug but a product failure, and they are not currently
+stated anywhere as checkable claims.
+
+| ID | Invariant | Breach looks like |
+|---|---|---|
+| **I1** | **Message Fidelity** — the bridge forwards the agent's message content unchanged except for mutations on an explicit register | The agent's prompt silently loses a tool result; the model answers a question the user did not ask |
+| **I2** | **Bridge Indistinguishability** — nothing the upstream provider can observe reveals that Kitty Bridge is in the path | A coding-plan provider fingerprints bridge traffic and blocks the account |
+| **I3** | **Egress Containment** — when an egress gateway is configured, no provider-bound traffic reaches upstream except through it, and kitty refuses to start when it cannot honour that | Ten machines the operator believed shared one IP present ten; or one request in a thousand leaks the real address |
+
+Alongside these sit the ordinary correctness claims any proxy needs: protocol translation is
+faithful, failover and retry behave, credentials never leak, the agent's config files are
+restored after a crash. Those are well served by the existing suite (§9.1) and are specified
+here only where the invariants touch them.
+
+**Why invariants first.** A test suite organised by module tells you the code does what it does.
+A test suite organised by invariant tells you the product keeps its promises. Kitty's promises
+are unusual — they are about *absence* (nothing changed, nothing visible, nothing leaked) — and
+absence is not provable by adding more example tests. It needs differential and structural
+tests, which have to be designed deliberately. That is §3–§5, and it is how §4.4's findings
+surfaced.
+
+---
+
+## 2. The layer model
+
+### 2.1 The four layers, instantiated
+
+```
+L4  Product     Claude Code ─► kitty launcher ─► BridgeServer ─► provider ─► upstream
+                proves: a developer's session through kitty is indistinguishable,
+                        faithful, and contained — end to end, with real binaries
+                covers: Gherkin acceptance · real-agent E2E · answer-quality evals · load
+                speed:  minutes · a handful · nightly and pre-release
+
+L3  Subsystem   [BridgeServer + real sockets + recording upstream + real CONNECT proxy]
+                [kitty CLI + real filesystem + real child process]
+                proves: the pieces wire up correctly against real infrastructure
+                covers: what actually leaves the socket · settings-file lifecycle ·
+                        concurrent sessions · crash and recovery · failover on real TCP
+                speed:  ~100ms–seconds · dozens · every pull request
+
+L2  Contract    endpoint schemas ⇄ handlers · README tables ⇄ code · dependency behaviour
+                proves: two things that must agree still agree
+                covers: SSE event grammar · Messages API conformance · env-var and
+                        header registers · docs/code sync · proxy semantics per transport
+                speed:  fast and isolated · every pull request
+
+L1  Component   translators · compaction · tool pairing · should_bypass · parse_proxy_url
+                proves: a unit's logic is right for every input that matters
+                covers: unit · property-based · validated by mutation testing
+                speed:  milliseconds · thousands · every pull request
+```
+
+### 2.2 The allocation rule
+
+Prove each behaviour at the lowest layer that can prove it. Worked examples from this codebase:
+
+| Claim | Layer | Why not higher / lower |
+|---|---|---|
+| `should_bypass("http://10.0.0.5/")` is `True` | **L1** | Pure function of a string. A subsystem test proving it would be 1000× slower and no more conclusive. |
+| Compaction never orphans a `tool_result` from its `tool_use` | **L1** (property) | `_compact_messages` is deterministic given its inputs. The property holds for all of them; an example test only samples. It is *not* a pure function — it calls `self._validate_tool_call_pairing` and reads its budget from `self._backends` / `self._active_model` — so the test must construct a server, not call a free function. |
+| The README's endpoint table names the routes the code registers | **L2** | Both artifacts are readable statically. No server needed. |
+| A `curl_cffi` session built with `proxies=` proxies, and its precedence over `NO_PROXY` | **L2** | A claim about a dependency, not about kitty. Belongs in a dependency contract test (§6.2.4). |
+| No connection reaches the upstream host except from the proxy | **L3** | Requires real sockets. Cannot be proven by inspecting code, and does not need a real agent. |
+| Two concurrent `kitty claude` sessions do not disturb each other's settings | **L3** | Requires the real filesystem and two real processes. |
+| A developer running `kitty claude` gets a working Claude Code session against Z.AI | **L4** | Only a real agent binary exercises the real request shapes. |
+| Compaction has not degraded the model's answers | **L4** (eval) | Semantic, nondeterministic, and only observable end to end. |
+
+Two consequences, stated because they are routinely violated in suites of this size:
+
+**Do not re-prove lower-layer claims higher up.** The L4 acceptance scenario for I1 asserts the
+session works. It does not re-check that `_validate_tool_call_pairing` drops orphans — L1 owns
+that.
+
+**When a bug escapes, add the test at the lowest layer that would have caught it.** Add a
+higher-layer smoke test only when the wiring itself was at fault. kitty-bridge#33 (a malformed
+`tool_use` forwarded in silence) is the pattern: the detector is L1, the "the auditor sees what
+the client sees" claim is L3.
+
+---
+
+## 3. Invariant I1 — Message Fidelity
+
+> The bridge forwards the agent's message content to the upstream provider unchanged, except
+> for mutations named on the Permitted-Mutation Register, each of which fires only under its
+> stated trigger.
+
+### 3.1 The problem with testing this the obvious way
+
+The obvious approach is a golden-file test: record the upstream body for a fixed input, commit
+it, and fail on any diff. It is the wrong tool here. Golden files fail on *every* change,
+including intended ones, so they get regenerated reflexively and stop meaning anything. Worse,
+they say nothing about inputs nobody recorded.
+
+The design instead makes the *permitted* set explicit and tests the complement. Anything not on
+the register is a violation, for every input, not just the recorded ones. The register becomes a
+reviewed artifact: adding a mutation means adding a row, and a reviewer sees a mutation being
+introduced rather than a golden file being refreshed.
+
+### 3.2 The Permitted-Mutation Register
+
+Every place kitty changes the agent's request between the inbound HTTP request and the upstream
+body. Established by reading `src/kitty/bridge/server.py` and all 23 adapters in
+`src/kitty/providers/`.
+
+#### 3.2.1 Bridge-level
+
+Eleven request-path rows (M1–M11) plus one response-path row (M12) and one substitution (M13).
+
+| # | Mutation | Site | Trigger | Why it is necessary |
+|---|---|---|---|---|
+| M1 | Replace `model` with the profile's model, then provider-normalise it | `BridgeServer._normalize_model` | Always, when the profile sets a model | This is the product. The agent asks for one model; the profile decides what actually runs. |
+| M2 | Translate the agent's protocol → Chat Completions | `MessagesTranslator` / `ResponsesTranslator` / `GeminiTranslator` `.translate_request` | Provider has `use_native_messages == False`, or the agent speaks Responses/Gemini | The upstream speaks a different protocol. Skipped entirely for native-Anthropic providers such as `zai_coding`. |
+| M3 | Truncate a tool result over 50,000 chars (`_TOOL_RESULT_TRUNCATION_LIMIT`) | `_truncate_oversized_tool_results` | A single tool result exceeds the limit | A single oversized result can exceed the model's window on its own. |
+| M4 | Truncate a tool result over the same limit, again, inside compaction | `_compact_messages` step 1 | Compaction ran **and** a `role: "tool"` message's string content exceeds the limit | Second pass, CC-shape only. Distinct from M3: M3 is unconditional pre-processing, M4 fires only once compaction is already engaged. |
+| M5 | Compact the message history | `_apply_compaction` → `_compact_messages` | Serialized messages exceed the model-derived budget | Without it the upstream rejects the request outright. |
+| M6 | Re-compact at half budget and re-send the same backend | `_compact_with_tighter_budget`, called only from `_request_with_retry_balancing` | Upstream returned 400/413 **and** `_is_context_too_large_error` **and** `_is_oversized_request` | Recovery from a rejection kitty's own budget estimate failed to prevent. **Balancing profiles only** — `_request_with_retry` (single backend) has no compaction recovery. Also an I2 exception; see §4.3 C3. |
+| M7 | Drop orphan `tool_result` blocks | `_validate_tool_call_pairing` | A `tool_result` has no matching `tool_use` after compaction | An orphan triggers upstream error 2013 and fails the turn. |
+| M8 | Add a thinking-carrier block and re-send the same backend | `_repair_thinking_roundtrip` / `_with_thinking_carrier` | This backend rejected this transcript for a thinking round-trip mismatch (issue #32) | Avoids one rejected round-trip per turn against backends that require it. Also an I2 exception. |
+| M9 | Convert a native Messages body to CC format and re-send the same backend | `_convert_native_to_cc_format`, then a re-run of `_normalize_model` and `normalize_request` | Upstream returned a `tool_use` format error on the native path | Fallback that keeps the session alive rather than failing the turn. Also an I2 exception. |
+| M10 | Inject the model from the URL path into the body | `_handle_gemini` | Gemini protocol only | Gemini carries the model in the path, not the body; `_normalize_model` needs it in the body to override it. |
+| M11 | Force `stream: False` | `_handle_gemini` | Gemini protocol, non-streaming `:generateContent` | The Gemini translator defaults `stream=True`; the non-streaming endpoint must not open an SSE stream. |
+| M12 | Substitute fallback assistant text | `_EMPTY_ASSISTANT_FALLBACK_TEXT` in `bridge/messages/translator.py` **and** `bridge/responses/translator.py` | Upstream returned an empty response | **Response-side**, not part of the eleven request-path rows. |
+| M13 | **Discard the conversation and substitute a `[Kitty Bridge: …]` user message** | `_compact_messages` post-condition | No non-system message survives compaction (F25/F26 path — the system prompt alone exceeds the window) | Produces a legible error instead of a confusing upstream 400. **Qualitatively unlike M5**: M5 shrinks history, M13 replaces it — and it writes the product's name into the upstream body. See finding F3. |
+
+#### 3.2.2 Provider-level
+
+`ProviderAdapter` gives every adapter three hooks that can reshape the body:
+`normalize_request`, `translate_to_upstream`, and the `_INTERNAL_KEYS` strip. Rolling 23
+adapters into one row would make the register unfalsifiable — "the provider overrides it" is a
+trigger no test can fail — so each material mutation gets its own row.
+
+| # | Mutation | Site | Trigger | Why it is necessary |
+|---|---|---|---|---|
+| P1 | Strip kitty's internal metadata keys | `ProviderAdapter._INTERNAL_KEYS` via `translate_to_upstream` | Always | These keys are kitty's own; forwarding them is both an I1 and an I2 breach. **The set is incomplete — see F4.** Note it also strips `base_url`, which is *not* kitty-internal: it is defence-in-depth against a URL override arriving in the body, and is the one entry that could discard a field a caller meant. |
+| P2a | Inject `thinking: {"type": "enabled"}` | `_ZaiBase.translate_to_upstream` (`ZaiRegularAdapter`, `ZaiCodingAdapter`) | `_thinking_enabled` truthy, or a reasoning effort other than `none` | Z.AI's wire format for a signal the agent sent differently. |
+| P2b | Inject `thinking: {"type": "disabled"}` | same | `_thinking_enabled is False` **or** effort `== "none"` | The `else` branch. Listed separately because the oracle must not treat one as covering the other. |
+| P3 | Inject `reasoning: {"effort": …}` | `OpenRouterAdapter` | `_reasoning_effort` present | OpenRouter's spelling of the same signal. |
+| P4 | Inject `reasoning_effort` | `OpenAIAdapter` | `_reasoning_effort` present | OpenAI's spelling. |
+| P5a | Default `max_tokens` to `_DEFAULT_MAX_TOKENS` (4096) | `AnthropicAdapter.translate_to_upstream` | Agent omitted `max_tokens` | The Messages API requires it. |
+| P5b | Join system blocks with `\n` | same | Multiple system blocks | Messages API takes one system string. |
+| P5c | **Raise** `max_tokens` to at least 1025 and set `thinking.budget_tokens = max_tokens - 1` | same | Thinking enabled | Anthropic requires `budget_tokens >= 1024` and `< max_tokens`. **User-visible**: it increases the agent's own `max_tokens`. |
+| P5d | Map `_thinking_adaptive` → `thinking: {"type":"adaptive"}` and `_effort` → top-level `effort` | same | Those keys present | Passthrough of an agent signal. |
+| P5e | Inject an empty `{"type":"thinking","thinking":""}` block into assistant messages | `AnthropicAdapter._translate_assistant_msg` | Assistant message lacks one while thinking is active | The Anthropic-path analogue of P8. **A message-content change**, not a parameter change. |
+| P6 | Remove `model` from the body | `AzureOpenAIAdapter` | Always | Azure selects the model by deployment id in the URL; the body field is rejected. |
+| P7 | **Cap the agent's `max_tokens` at 4096** | `FireworksAdapter.normalize_request` | Non-streaming request with `max_tokens > 4096` | Fireworks rejects non-streaming requests above 4096. **User-visible** as shortened output. |
+| P8 | Inject empty `reasoning_content` into assistant messages | `ProviderAdapter._inject_empty_reasoning_content`, called from `KimiCodeAdapter`, `_ZaiBase`, `CustomOpenAIAdapter` | Thinking signalled **or** inferred from prior `reasoning_content` via `_detect_thinking_from_messages` | Those providers reject the request without it. The *inferred* trigger matters: it fires with no signal from the agent at all. |
+| P9a | Set `User-Agent` to `claude-code/1.0` | `KimiCodeAdapter`, `BytePlusAdapter`, `MimoAdapter` `.build_upstream_headers` | Always, on those three | Those providers 403 without a recognised coding-agent user-agent. Central to I2 — F1. |
+| P9b | Remove `Authorization`, add `api-key` | `MimoAdapter.build_upstream_headers` | Always | MiMo does not use Bearer auth. An auth-**scheme** change §4.3 C1's exact-set assertion must encode. |
+| P9c | Synthesise a Codex CLI `User-Agent` and a `version` header | `OpenAISubscriptionAdapter` | Always | Impersonation required by the subscription endpoint. **The two disagree — see F1.** |
+| P10 | Set `reasoning_split = True` | `MiniMaxAdapter.normalize_request` | **Unconditionally** | Makes MiniMax return thinking in `reasoning_details` instead of inline tags. Unconditional, so exempt from §3.3 assertion 2. |
+| P11 | Translate CC → Bedrock Converse | `BedrockAdapter.translate_to_upstream` | Always, on `bedrock` | A third upstream wire format M2 does not name. Custom transport — see §3.3.2. |
+| P12 | Translate CC → Ollama `/api/chat` | `OllamaCloudAdapter.translate_to_upstream` | Always, on `ollama_cloud` | A fourth wire format. Custom transport. |
+
+**Conditional rows are the point.** Every row whose trigger is a condition must be provably
+*inert* when that condition is absent — the sharpest form of "unless absolutely necessary", and
+what §3.3 assertion 2 tests. M1, M2, M10, P1, P6, P9a–c, P10, P11 and P12 are unconditional by
+design and are exempt from that assertion.
+
+**Register maintenance.** The register is the specification. A pull request that adds a mutation
+site without adding a row fails the L2 register guards (§6.2.3).
+
+### 3.3 The transparency oracle
+
+The single piece of new infrastructure that makes I1 testable.
+
+**What it is.** A test harness that runs a request through the real `BridgeServer` into a
+recording fake upstream, then diffs the captured upstream body against the inbound agent body
+and classifies every difference against the register.
+
+```
+inbound agent body ──► BridgeServer ──► recording upstream
+        │                                      │
+        └───────── structural diff ────────────┘
+                          │
+                classify each delta
+                          │
+     ┌────────────────────┴────────────────────┐
+claimed by a register row              unclaimed  ──► FAIL
+whose trigger was present                    │
+            │                          unclaimed delta is the
+    assert the row's                   whole point of the oracle
+    stated shape held
+```
+
+**The two assertions, in priority order.**
+
+1. **No unclaimed delta.** Any difference between inbound and upstream bodies must map to a
+   register row. This is the invariant.
+2. **No mutation without its trigger.** For each conditional row, a corpus entry that does not
+   meet the trigger must show that row's mutation *absent*. This is what stops M3/M5 quietly
+   becoming unconditional.
+
+#### 3.3.1 The oracle is scoped by wire shape — and why
+
+A direct inbound-vs-upstream diff is only meaningful where the two bodies are in the same
+protocol. On a Chat-Completions-wire provider the upstream body is CC while the inbound body is
+Anthropic Messages: *every* field differs, every delta is claimed by M2, and assertion 1 passes
+trivially while proving nothing. A test that cannot fail is worse than no test.
+
+| Path | Adapters | Comparison | Why |
+|---|---|---|---|
+| **Native Messages wire** | `anthropic`, `zai_coding`, `custom_anthropic`, `minimax_token`, and `opencode_go` **for its Messages models only** | Inbound body vs. upstream body, directly | Same protocol both sides. "Unchanged" is literally meaningful, and this is the path the Jira premise names. |
+| **Chat Completions wire** | the remaining adapters | Inbound vs. **round-trip** (`translate_request` → `translate_response` back to the agent's protocol) | The claim that survives translation is semantic preservation, not byte equality. |
+| **Other wire** | `bedrock` (Converse), `ollama_cloud` (`/api/chat`) | Round-trip through that adapter's own pair | Neither Messages nor CC. Round-trip mode needs the adapter's own inverse, not the shared one (P11, P12). |
+
+**The scoping predicate is per-request, not per-adapter.** `upstream_wire_is_messages_api` is the
+natural selector, but it cannot be trusted as an adapter-level constant: `OpenCodeGoAdapter`
+inherits `True` from `AnthropicAdapter` while its `translate_to_upstream` returns a **Chat
+Completions** body for every model outside `_MESSAGES_MODELS`. See finding F5. Until that is
+fixed, the oracle must select on the observed body shape, and an L2 guard must assert the
+property agrees with the actual output shape for every adapter × representative model.
+
+#### 3.3.2 The oracle must be parametrised over transport
+
+`openai_subscription`, `bedrock` and `ollama_cloud` set `use_custom_transport = True` and never
+go through `_make_upstream_request`, so §7.2's aiohttp recording upstream never sees their
+bodies. The oracle is parametrised over transport exactly as §5.5's containment harness is:
+an aiohttp recording server for the default path, a `curl_cffi`-reachable one for the
+subscription provider, and a botocore endpoint override for Bedrock. Without this, §3.4's "every
+provider" rows are false for three adapters.
+
+**Diffing semantics.** Structural, not byte-level. JSON key order and whitespace are not part of
+the agent's meaning and vary with serialisation; a byte diff would fail constantly and teach
+people to ignore it. The oracle compares parsed JSON with a canonical ordering, and reports
+deltas as JSON-pointer paths so a failure names the exact field. The one exception is key
+ordering on the native path, which §4.3 C2 asserts for I2 reasons.
+
+**What it does not do.** It does not judge whether a translation is *semantically* correct — that
+a `tool_use` block became the right `tool_calls` entry is an L1 translator claim. The oracle
+answers a narrower question: was anything changed that nobody declared.
+
+### 3.4 Where I1 is proven
+
+| Claim | Layer | Test |
+|---|---|---|
+| Compaction preserves `tool_use`/`tool_result` atomicity, in both CC and native shapes | L1 property | `compact(m)` contains no orphan |
+| Compaction output fits the budget **unless the system block alone exceeds it** | L1 property | The guaranteed-fit loop breaks out while still over budget when it cannot shrink further; the honest property must say so |
+| The last turn survives **unless pairing validation drops it**, in which case M13 fires | L1 property | Stated with the exception, or it fails on day one and gets weakened |
+| Compaction is identity below the budget | L1 property | Short-circuit at the `original_size <= compaction_threshold` guard — M5's trigger, tested directly |
+| Truncation is identity below `_TOOL_RESULT_TRUNCATION_LIMIT` | L1 property | Same shape, for M3 and M4 |
+| Protocol round-trip preserves semantic content | L1 property | Text, tool calls, tool results and their ids survive translation both ways |
+| A **below-threshold** corpus entry on a native-wire provider shows only M1 and P1 | L2 | Scoped to below-threshold deliberately: above it, M3/M5/M7 and any triggered `normalize_request` row apply to the native path too |
+| No unclaimed delta, over the whole corpus, on every native-wire provider and model | **L3** | Transparency oracle (§3.3.1), parametrised per transport (§3.3.2) |
+| Round-trip fidelity over the whole corpus, on every CC-wire and other-wire provider | **L3** | Oracle, round-trip mode |
+| A real Claude Code session's tool calls execute correctly through kitty | L4 | Real-agent E2E (§6.4.2) |
+| Compaction has not degraded answer quality | L4 eval | §6.4.3 |
+
+---
+
+## 4. Invariant I2 — Bridge Indistinguishability
+
+> Nothing the upstream provider can observe about a request reveals that Kitty Bridge is in the
+> path, or that the client is anything other than the coding agent it claims to be.
+
+### 4.1 Why this is the load-bearing invariant
+
+A coding plan is priced for a coding agent. A provider that can tell bridge traffic from native
+agent traffic can throttle it, block it, or terminate the account — and the user finds out
+mid-session. This is the invariant with commercial consequences, so it gets an adversarial test
+design: a fake upstream that actively tries to fingerprint, rather than a test that checks a
+list of headers we happened to think of. That posture is what surfaced F3 and F4.
+
+### 4.2 The observable channels
+
+| Channel | What it exposes today | Verdict |
+|---|---|---|
+| **C1 — Request headers** | `build_upstream_headers()` constructs the set from scratch; no inbound agent header is forwarded. Four adapters supply a coding-agent `User-Agent` (P9); every other provider — including `zai_coding`, whose set is exactly `Authorization`, `anthropic-version`, `content-type` — sends aiohttp's default. | **Gap, and inconsistent.** F1. |
+| **C2 — Request body** | The register's mutations (§3.2), JSON key ordering produced by kitty's serialisation, **the literal string `[Kitty Bridge: …]` (M13)**, and **`_effort` / `_thinking_adaptive`, which are kitty-internal and reach the wire**. | **Breached.** F3 and F4. |
+| **C3 — Cross-attempt content and cadence** | Retries (`_MAX_RETRIES = 3`), failover, transport-blip re-connects, the empty-response ladder — and **four** paths that send a *different body* on a later attempt (M6, M8, M9, and failover re-normalisation). | §4.3 C3. Four declared exceptions. |
+| **C4 — Transport fingerprint** | TLS/ALPN/HTTP-2 signature of aiohttp, unlike the agent's own client. `curl_cffi` is already used for the OpenAI subscription provider precisely because that provider fingerprints TLS. | **Accepted residual risk.** §4.5. |
+| **C5 — Connection lifecycle** | `_build_client_session` uses `TCPConnector(limit=…, force_close=True)` — a fresh TCP and TLS connection for **every** upstream request, no keep-alive reuse. The agent's client does not behave that way. | **Gap.** A cheap, non-TLS fingerprint — arguably more detectable than C4. §4.3 C5. |
+
+### 4.3 Test specifications
+
+**C1 — Header contract (L2).** Assert, per adapter, an exact header set: names present, names
+absent, **casing**, and the value shape of each. Exact-set rather than subset-contains, because
+a subset assertion cannot catch a *new* header being added — precisely the failure mode. The
+forbidden set is asserted explicitly and includes any header whose name or value contains
+`kitty` in any casing, and the bridge's own `X-Kitty-*` attribution headers (downstream-only;
+they must never appear upstream).
+
+Casing is part of the assertion, not decoration: `ZaiAnthropicAdapter` sends capitalised
+`Authorization` beside lowercase `anthropic-version` and `content-type`, while the base adapter
+sends `Authorization`/`Content-Type`. `MimoAdapter` removes `Authorization` entirely (P9b). A
+provider can fingerprint any of that.
+
+**Header *order* is deliberately not asserted.** What reaches the wire is aiohttp's ordering, not
+the agent's, and pinning it would pin a dependency's internals. §7.2 records header order only
+so the fixture can *report* it against the native baseline (C1b), not so a test asserts it.
+
+Two further C1 assertions arising from F1:
+
+- No adapter's `User-Agent` or version header may be derived from `kitty.__version__`.
+- Where an adapter sends both a user-agent version and a `version` header, the two must agree.
+
+**C1b — Fingerprint parity (L3).** Compare kitty's header set against a captured Claude Code
+native set (§7.1 captures both). Assert kitty's is a *subset*, and report the difference. Today
+the difference is large; the test's job is to make it visible and stop it growing, not to fail
+the build on day one — a reported baseline with a ratchet, becoming a gate once G3 closes.
+
+**C2 — Body shape (L3).** Covered by the transparency oracle (§3.3), plus two assertions the
+oracle does not give for free:
+
+- **No forbidden token in the body.** The same `kitty` token check C1 applies to headers, applied
+  to the serialized upstream body. This is what M13 breaches, and what nothing currently checks —
+  C1's forbidden set covers headers only, and M13's string is in a message.
+- **Key order preservation on the native path.** A provider can fingerprint the JSON serialiser
+  from key ordering alone. This is the one place the oracle compares bytes rather than structure,
+  and it applies only where kitty claims to be forwarding rather than translating.
+
+**C3 — Cross-attempt content and cadence (L3).** The design must not overstate this: kitty sends
+a different body on a later attempt in **four** distinct situations, not one.
+
+| Path | What changes between attempts | Same backend? |
+|---|---|---|
+| M6 — compaction recovery | Body re-compacted at half budget | Yes |
+| M8 — thinking-carrier repair | `messages` rewritten in place | Yes |
+| M9 — native→CC fallback | Whole body converted, then re-normalised | Yes |
+| Backend failover | `_normalize_model` and `normalize_request` re-run, so a same-host different-key sibling still gets a different body | No (different backend, possibly same host) |
+
+The assertions:
+
+- *(i)* Transport-blip retries and empty-response retries — the two that repeat a request
+  unchanged — must be **byte-identical** to the attempt they repeat: same body, same headers, no
+  added retry-count or correlation header.
+- *(ii)* Each of the four paths above is a **declared exception**: assert each fires only under
+  its own trigger and never otherwise. A provider that hashes bodies can see all four; whether to
+  close any of them is Q6.
+
+**C5 — Connection lifecycle (L3).** Count distinct TCP connections the recording upstream accepts
+across an N-turn session and compare against a native Claude Code capture. Reported as a
+baseline first, like C1b. `force_close=True` exists to prevent port exhaustion, so closing this
+gap is a real trade-off, not an oversight — recorded in §4.5 until Q7 is decided.
+
+**C6 — Side traffic (L3).** Assert `GET /healthz` and `GET /stats` never cause an upstream
+request, and that a launch sequence contacts the provider only for the agent's own turns plus
+credential pre-flight validation. Pre-flight is a real upstream request the agent did not make;
+the test pins it as a *declared* exception and asserts `kitty --no-validate` removes it (Q2).
+
+### 4.4 Findings
+
+Five defects surfaced while writing this document. **None is fixed by this change**; each needs
+its own ticket. F3, F4 and F5 are live breaches of invariants defined above.
+
+- **F1 — Agent identity is handled per-provider, not by policy.** *(KBR-8.)* Upstream headers are built from
+  scratch, so Claude Code's `user-agent`, `x-app`, `anthropic-beta` and `x-stainless-*` never
+  reach the provider. Four adapters compensate ad hoc (P9): `KimiCodeAdapter`, `BytePlusAdapter`
+  and `MimoAdapter` hard-code `User-Agent: claude-code/1.0` — Kimi's carries a comment recording
+  the string was on the provider's allowlist as of 2026-04-18 — and `OpenAISubscriptionAdapter`
+  synthesises a Codex CLI identity. Everywhere else, including `zai_coding`, aiohttp's default
+  goes instead.
+  **The subscription adapter contradicts itself in a single request:** its user-agent is
+  `codex_cli_rs/{kitty.__version__}` (currently `1.9.0`) while its `version` header is the
+  constant `0.128.0`. A client claiming to be Codex CLI 1.9.0 *and* 0.128.0 at once is a one-line
+  detection rule — and the user-agent tracks kitty's release train, so it changes with every
+  kitty release and with nothing else. Tracked as G3, KBR-8 and Q1.
+- **F2 — The README's endpoint table does not match the router.** *(KBR-9.)* README documents
+  `POST /v1/gemini/generateContent`; `_register_routes` registers
+  `/v1beta/models/{model}:generateContent` and `:streamGenerateContent`, and the README omits
+  `GET /v1/models`. Exactly the drift the L2 docs⇄code layer exists to catch. Tracked as G6
+  and KBR-9.
+- **F3 — The product's own name is written into the upstream request body.** *(KBR-5.)* When compaction
+  cannot preserve any non-system message, `_compact_messages` discards the conversation and
+  substitutes a user message reading
+  `[Kitty Bridge: Unable to compact conversation — the system prompt is too large relative to the
+  model's context window. Use /clear to reset the conversation.]`. That message goes upstream via
+  `_apply_compaction`. **A direct breach of I2** — the provider sees the vendor name in the
+  request — and a fidelity mutation qualitatively unlike M5, since it replaces the conversation
+  rather than shrinking it. The intent (a legible error rather than an opaque 400) is sound; the
+  delivery is not. Register row M13; tracked as G14, KBR-5 and Q9.
+- **F4 — Kitty-internal keys reach the upstream body on every Chat-Completions-wire provider.**
+  *(KBR-6.)*
+  `MessagesTranslator.translate_request` writes `_effort` and `_thinking_adaptive` into the CC
+  request, but neither is a member of `ProviderAdapter._INTERNAL_KEYS`, so the default
+  `translate_to_upstream` — which strips only that frozenset — forwards both. Confirmed
+  empirically across `openai`, `openrouter`, `zai_regular`, `fireworks`, `minimax` and `novita`:
+  each emits `['_effort', '_thinking_adaptive']` upstream. **A breach of both I1 and I2**, and
+  the exact thing P1 exists to prevent. Underscore-prefixed keys no public API defines are an
+  unmistakable proxy signature. Note that `_reasoning_effort` and `_thinking_enabled`, written by
+  the same function, *are* in the set — so this is an omission, not a design choice. Tracked as
+  G15 and KBR-6.
+- **F5 — `OpenCodeGoAdapter.upstream_wire_is_messages_api` is wrong for most of its models.**
+  *(KBR-7.)* It
+  inherits `True` from `AnthropicAdapter`, but its `translate_to_upstream` returns a Chat
+  Completions body for every model outside `_MESSAGES_MODELS`. `ProviderAdapter`'s own docstring
+  says the property "describes the shape that actually goes on the wire" and that anything
+  shaping the serialized body must branch on it — so a `True` that is false for most models is a
+  latent defect in the thinking-repair path (M8) as well as a trap for the oracle's scoping
+  (§3.3.1). Tracked as G16 and KBR-7.
+
+### 4.5 Accepted residual risk
+
+**C4 — transport fingerprint.** Full parity is not achievable on the aiohttp serving path. A
+provider determined to fingerprint TLS can distinguish an aiohttp client from the agent's own
+runtime, and matching it would mean routing every provider through `curl_cffi` — a substantial
+change to the serving path for a threat no provider is currently known to apply to this traffic.
+Recorded so a future incident is a known gap rather than a surprise. The README's existing
+guidance ("use a CONNECT proxy, not a TLS-terminating one") already depends on this reasoning.
+
+**C5 — connection lifecycle,** until Q7 is decided. `force_close=True` is a deliberate defence
+against port exhaustion; removing it to gain keep-alive parity trades one operational risk for
+one detection risk.
+
+---
+
+## 5. Invariant I3 — Egress Containment
+
+> When an egress gateway is configured, no provider-bound traffic from the agent or the bridge
+> reaches the upstream except through that gateway. When kitty cannot honour the gateway for
+> every backend that will serve traffic, it refuses to start.
+
+### 5.1 What is already proven, and what is not
+
+**Fail-closed is built and tested.** `egress_guard.egress_block_reason()` checks every backend,
+not just the first, and is called from **five** sites in three files — `bridge_runner.py` (two),
+`cli/launcher.py`, and `cli/main.py` (two). `tests/test_egress_fail_closed.py` covers the guard's
+logic.
+
+**Real-socket transport proof already exists, and is strong.** `tests/test_egress_https_proxy.py`
+(601 lines) stands up a local TLS CONNECT proxy that enforces Basic auth and **records every
+`CONNECT` it sees**, plus a local TLS target, and performs real TLS handshakes across all three
+transport stacks kitty uses: aiohttp (driving the real `egress_cmd._probe`), `curl_cffi` with the
+exact `proxies=` mapping `openai_subscription` passes, and urllib3 shaped as
+`botocore.httpsession._get_proxy_manager` builds it. This is the strongest asset in the area and
+the foundation the rest of §5 builds on rather than replaces.
+
+**Three things are missing, and they are the gap.**
+
+1. **`BridgeServer`'s own request path is untested.** The existing module drives
+   `egress_cmd._probe` — the function behind `kitty egress test` — not `_session_for` /
+   `_make_upstream_request`. The serving path, which carries every byte of every conversation,
+   has no equivalent proof.
+2. **No negative assertion anywhere.** Nothing asserts that with the proxy *down*, the upstream
+   receives **zero** connections. Without it, a bridge that proxies most of the time and falls
+   back to a direct route on error would pass every test in the suite.
+3. **The existing start-path guard is file-granular.** `tests/test_egress_coverage.py` asserts
+   that a file constructing `BridgeServer` also *contains* a call to `egress_block_reason`.
+   `cli/main.py` already holds two start paths, so a third added to that file would pass
+   unguarded. §6.2.3 specifies the AST-level replacement.
+
+### 5.2 The sealed-network harness
+
+An L3 harness that closes gaps 1 and 2, built by extending `tests/test_egress_https_proxy.py`'s
+`_ConnectProxy` and `_TlsTarget` rather than writing new infrastructure — that proxy already
+records CONNECT attempts, which is the observation the harness needs.
+
+```
+       ┌──────────── kitty BridgeServer ────────────┐
+       │                                            │
+       │   direct session ──X (must see nothing)    │
+       │   proxy  session ──────────┐               │
+       └────────────────────────────┼───────────────┘
+                                    ▼
+                     recording CONNECT proxy  ── CONNECT log
+                                    │
+                                    ▼
+                     recording fake upstream  ── request log
+```
+
+**The assertions.**
+
+1. **Correlation, not peer address.** Every request the fake upstream records must correlate to
+   a `CONNECT` in the proxy's log for the same target and connection, and the two counts must be
+   equal. *Peer address cannot carry this*: with bridge, proxy and upstream all on loopback in
+   one test process, a proxied and a direct connection both present `127.0.0.1`, and both source
+   ports are ephemeral. Correlating on the proxy's own log discriminates; peer address does not.
+   (Binding the proxy's outbound socket to `127.0.0.2` is an alternative, but it needs an `lo0`
+   alias on macOS — a platform constraint the correlation approach avoids.)
+2. **Negative — traffic stops rather than leaks.** With the proxy stopped and egress configured,
+   the upstream accepts **zero** connections and the request fails. This is the assertion that
+   proves containment; assertion 1 alone is satisfied by a bridge that proxies *sometimes*.
+3. **Local bypass still works.** A loopback or `localhost` provider (a local Ollama) connects
+   directly and is not tunnelled — a rented proxy cannot reach the caller's LAN. **Applies to
+   the bridge's own sessions only**; see §5.5.
+4. **Fail-closed.** A profile whose adapter returns `supports_egress() == False` (Bedrock in SSO
+   mode) prevents startup, and the message names the profile.
+
+### 5.3 The addressing trap — and why the harness uses a hostname
+
+**This is the constraint that makes or breaks the harness, and it is not obvious.**
+
+`egress.should_bypass()` returns `True` for loopback, private and link-local destinations, so
+those connect directly. The naive harness binds a fake upstream on `127.0.0.1` — which
+`should_bypass` sends *direct*, so the test proxies nothing and passes vacuously while proving
+the opposite of what it claims. Binding on a Docker network does not help: `172.16.0.0/12` is
+private and is also bypassed.
+
+The escape is in `should_bypass`'s own design. It reads `urlsplit(url).hostname` and:
+
+1. returns `True` for `localhost` and any `.localhost` suffix — **checked first, by name**;
+2. returns `True` for an IP literal in a loopback, private or link-local range;
+3. for anything else, returns `False` **without resolving it** — deliberately, to avoid a DNS
+   round trip per request.
+
+So the harness must address the fake upstream by a **hostname outside the `localhost` family**.
+`upstream.kitty-test.invalid` is a good choice: RFC 2606 guarantees `.invalid` never resolves
+publicly, which is precisely why the harness must supply the mapping itself.
+
+**Name resolution, per leg.** The two legs differ, and only one needs work:
+
+- *Proxied leg* — **no resolution needed.** aiohttp's `_create_proxy_connection` resolves the
+  *proxy* and then issues `CONNECT upstream.kitty-test.invalid:443`; the test's own proxy
+  resolves the target. The harness owns the resolver because the harness is the proxy.
+- *Direct/bypass leg* — needs a local override. Use a monkeypatched aiohttp resolver, **not** an
+  `/etc/hosts` entry: hosts edits need administrator rights and are unavailable on most CI
+  runners, and `_build_client_session` constructs its own `TCPConnector` with no resolver
+  injection point.
+
+**The property that keeps the harness honest.** An L1 property test pins the premise so a future
+change to `should_bypass` cannot silently make the harness vacuous:
+
+> For every hostname that is neither an IP literal **nor `localhost` nor a `.localhost`
+> suffix**, `should_bypass` returns `False`.
+
+The `localhost` exclusions are not a caveat bolted on — `should_bypass` matches them explicitly,
+before it ever tries `ipaddress.ip_address`, and a property stated without them fails on day one
+and gets weakened, which removes the guard.
+
+**A narrower user-visible consequence.** Because names outside the `localhost` family are not
+resolved, a user whose local model server is reached by a **LAN hostname** — not `localhost`, not
+an IP — will have that traffic tunnelled to a proxy that cannot reach it. The common
+`http://localhost:11434` configuration is bypassed correctly. An L1 test documents the edge;
+whether to change it is Q3.
+
+### 5.4 Where I3 is proven
+
+| Claim | Layer | Test |
+|---|---|---|
+| `should_bypass` classifies loopback / private / link-local / `localhost` family / public / hostname correctly | L1 + property | Enumerate IPv4 and IPv6 private ranges via `ipaddress`; assert the §5.3 hostname property |
+| `parse_proxy_url` round-trips credentials, including percent-encoded `@` and `:` | L1 property | `parse(url_with_credentials(cfg)) == cfg` |
+| No `EgressConfig` representation leaks the password | L1 property | `password not in repr(cfg) + str(cfg) + cfg.masked()` for all generated passwords |
+| Every outbound HTTP client is egress-aware; no source assigns `HTTP_PROXY`; no session trusts the environment | L2 structural | **Exists:** `tests/test_egress_coverage.py` |
+| **Every** `BridgeServer` construction is dominated by an `egress_block_reason` call | L2 structural | **Must be strengthened** — the existing guard is file-granular (§5.1 gap 3) |
+| An `https://` proxy carries real traffic on all three transport stacks | L2/L3 | **Exists:** `tests/test_egress_https_proxy.py` |
+| Proxy semantics under each dependency's version range | L2 | §6.2.4 |
+| Nothing reaches upstream except via the proxy, **from the bridge's own serving path** | **L3** | Sealed-network harness (§5.2) |
+| Stopping the proxy stops the traffic — no direct fallback | **L3** | §5.2 assertion 2 |
+| Containment holds for each custom transport | **L3** | §5.5 |
+| kitty refuses to start when a backend cannot be proxied | L2 + L4 | Guard unit test + scenario EG-3 |
+| A developer's whole session presents one IP | L4 | Scenario EG-1 |
+
+### 5.5 Per-transport containment
+
+`_session_for` and `should_bypass` govern **only** `BridgeServer`'s own aiohttp sessions. Four
+other outbound paths exist, and each applies the proxy **unconditionally, without consulting
+`should_bypass`**:
+
+| Path | Client | How the proxy is applied |
+|---|---|---|
+| `openai_subscription` — serving | `curl_cffi.AsyncSession` | `proxies=egress.proxies_dict()` |
+| `openai_subscription` — OAuth token legs | its own `aiohttp.ClientSession` | `aiohttp_session_kwargs()` |
+| `bedrock` | boto3 / botocore | `BotoConfig(proxies=egress.proxies_dict())` |
+| `ollama_cloud` | its own `aiohttp.ClientSession` | `aiohttp_session_kwargs()` |
+
+Three consequences the rest of §5 must not paper over:
+
+1. **§5.2 assertion 3 is false for these paths.** They have no bypass, so a loopback or private
+   destination *is* tunnelled. Arguably safer, but different — the design must say so rather than
+   imply uniformity.
+2. **The sealed-network harness proves nothing about them** unless parametrised over the
+   transport. It must run over `{bridge aiohttp session, provider aiohttp session, curl_cffi
+   session, botocore client}` — the shape `tests/test_egress_https_proxy.py` already uses, which
+   is a further reason to extend that module rather than start fresh.
+3. **The OAuth leg runs at startup**, before anything else has been proven, and is the one most
+   likely to fire on a fresh machine. It must not be left out.
+
+**An untested interaction.** `kitty.egress`'s own docstring records that the three stacks
+disagree about `HTTP_PROXY`/`HTTPS_PROXY`: aiohttp ignores them unless `trust_env=True`, while
+curl_cffi and botocore honour them. Kitty never sets those variables — but the *user's shell*
+may have. Nothing tests what happens when an ambient `HTTP_PROXY` or `NO_PROXY` disagrees with
+the configured egress on the two stacks that read the environment. §6.2.4 pins it.
+
+---
+
+## 6. Layer specifications
+
+### 6.1 L1 — Component and property
+
+**Scope.** Pure logic: the three translators, the translation engine, compaction and tool-call
+pairing, model normalisation, `should_bypass` and `parse_proxy_url`, profile schema and
+resolver, the tool-use anomaly detector, and every `ProviderAdapter` payload builder.
+
+**Tools.** `pytest` (present) + `hypothesis` (**to add**, dev extra only).
+
+**Command.** `pytest tests/ -q`
+
+**Validation.** Mutation testing (below). This is the layer whose strength is actually measured.
+
+**Property tests to add.** Example-based tests sample; these translators and the compactor are
+exactly the kind of total function where properties pay.
+
+| Unit | Property |
+|---|---|
+| `MessagesTranslator` | Semantic round-trip: text, tool ids, tool names and tool results survive Messages → CC → Messages |
+| `_compact_messages` | Identity below budget · output ≤ budget **unless the system block alone exceeds it** · no orphaned pair · last block preserved **unless pairing validation drops it (then M13 fires)** · idempotent |
+| `_validate_tool_call_pairing` | Output contains no `tool_result` without a `tool_use`, in both message shapes |
+| `_truncate_oversized_tool_results` | Identity below the limit · output ≤ limit · non-tool-result content untouched |
+| `should_bypass` | Every address in a private range is bypassed · the §5.3 hostname property |
+| `parse_proxy_url` / `EgressConfig` | Credential round-trip · password never in any string form |
+| `describe_tool_input_anomaly` | Never reports an anomaly for input that validates against the declared schema |
+
+The two weakened properties are stated with their exceptions on purpose. A property that fails on
+day one gets weakened by whoever is on the rota, and a weakened property guards nothing.
+
+**Mutation testing.** Line coverage cannot tell a real assertion from `assert result is not
+None`. `mutmut` closes that gap.
+
+- **Tool:** `mutmut` (3.x; requires `fork`, so it runs on Linux CI — on Windows it needs WSL).
+  Configured in `pyproject.toml` under `[tool.mutmut]`, where `source_paths` and
+  `pytest_add_cli_args_test_selection` take **arrays**.
+- **Command:** `mutmut run`, then `mutmut browse` to triage and `mutmut export-cicd-stats` for
+  the CI score.
+- **In scope — not the whole codebase:** `src/kitty/bridge/messages/`,
+  `src/kitty/bridge/responses/`, `src/kitty/bridge/gemini/`, `src/kitty/bridge/engine.py`,
+  `src/kitty/bridge/tool_audit.py`, `src/kitty/egress.py`, `src/kitty/profiles/`,
+  `src/kitty/validation.py`.
+- **Why a subset.** Mutation testing on 22,700 lines would take hours and produce a survivor list
+  nobody reads. The subset is chosen by one rule: **modules whose silent misbehaviour breaches an
+  invariant**. A mutation surviving in the compactor means the suite would not notice kitty
+  eating a tool result — an I1 breach. A mutation surviving in the TUI menu means a cosmetic
+  defect. Expand when the first list is clean.
+- **Budget:** ≥ 85% killed on the in-scope set. Below that, the layer is not trusted.
+- **Triage rule:** (a) a survivor revealing a missing assertion → strengthen the test; (b)
+  revealing untested behaviour → add a test; (c) genuinely equivalent → suppress at the site with
+  `# pragma: no mutate` **and a comment saying why**. Never dismiss a survivor silently.
+- **Cadence:** nightly and pre-release. Per-PR would add tens of minutes to a gate that must stay
+  fast.
+
+### 6.2 L2 — Contract
+
+**Scope.** Any two artifacts that must agree but are deployed, edited or upgraded separately.
+
+**Command.** `pytest tests/contract -q`
+
+**Validation.** Every structural guard must assert that its own scan finds known positives, so it
+cannot rot into a no-op. `tests/test_egress_coverage.py` already does this
+(`test_the_scan_actually_finds_something`, `test_the_scan_finds_the_known_start_paths`) and is
+the pattern to copy.
+
+#### 6.2.1 Bridge endpoint schemas
+
+Publish an OpenAPI 3.1 document covering the **five** POST routes registered in bridge mode —
+`/v1/chat/completions`, `/v1/messages`, `/v1/responses`,
+`/v1beta/models/{model}:generateContent` and `:streamGenerateContent` — plus `GET /healthz`,
+`/stats` and `/v1/models`. Test the handlers against it with `schemathesis` (4.x; pytest
+integration via `@schema.parametrize()` and `case.call_and_validate()`).
+
+**The job must target a bridge started in bridge mode** (`self._adapter is None`).
+`_register_routes` registers only the routes matching `self._adapter.bridge_protocol` when an
+agent is launching — one route for Messages, Responses and Chat Completions, **two** for Gemini,
+and `GET /v1/models` in bridge mode only. A conformance run against a `kitty claude` bridge would
+see a single route, pass, and leave the rest unvalidated. A separate guard asserts the
+per-protocol registration matrix.
+
+Checks that matter here: `not_a_server_error` (the bridge must never 500 on a malformed body),
+`response_schema_conformance`, `status_code_conformance`.
+
+**Why publish a schema for a local proxy nobody integrates against?** Because the *agents*
+integrate against it, and they are third parties on their own release cycle. The schema is the
+written form of "what Claude Code may send us," and the artifact against which a Claude Code
+update can be checked. It also gives the fuzzer a target, which is how the malformed-input paths
+get exercised at all.
+
+#### 6.2.2 SSE event grammar
+
+The Anthropic streaming format is a grammar, not a schema: `message_start` …
+`content_block_start` / `content_block_delta`* / `content_block_stop` … `message_delta`,
+`message_stop`. A malformed sequence breaks Claude Code in ways a per-event schema check cannot
+see.
+
+Test as a state machine over the byte stream the bridge writes: every stream it produces —
+including error streams, failover mid-stream, and the empty-response fallback — must be a
+sentence in that grammar. Applies to all three streaming protocols.
+
+#### 6.2.3 Register and docs ⇄ code
+
+Structural guards in the style of `tests/test_egress_coverage.py`.
+
+| Guard | Asserts |
+|---|---|
+| **Register completeness — shape diff, not write scan** | For every registered adapter, feed a fixed CC request through `normalize_request` + `translate_to_upstream` and assert the resulting key-set and value deltas are **exactly** the union of that adapter's §3.2.2 rows. A write-scan cannot do this job: every provider mutation except P7 and the `normalize_request` overrides happens by *building and returning* a new dict, so a scan for writes to `cc_request` sees none of them — and would have missed F4 entirely. |
+| **Internal-key completeness** | AST-scan `bridge/**` for every `_`-prefixed key written into a request dict, and assert each is a member of `_INTERNAL_KEYS`. **This is the guard that catches F4.** The complementary check — that each `translate_to_upstream` override delegates to `super()` or excludes `_INTERNAL_KEYS` — is necessary but not sufficient: every override *does* strip the set today; the set is what is wrong. |
+| **Wire-shape honesty** | For every adapter × representative model, assert `upstream_wire_is_messages_api` agrees with the shape `translate_to_upstream` actually returns. Catches F5. |
+| **Forbidden vendor token** | No string literal reachable into a request body or upstream header contains `kitty` in any casing. Catches F3. |
+| **Start-path domination** | Every `BridgeServer(` construction is dominated by an `egress_block_reason(` call **at AST level**, not merely co-located in the same file. `cli/main.py` already holds two start paths (§5.1 gap 3). |
+| **Env-var register** | `_SETTINGS_ENV_OVERRIDE_KEYS` and `_CONFLICTING_ENV_VARS` (`launchers/claude.py`) match what `build_spawn_config` emits and what the README documents. |
+| **Endpoint table** | The README endpoint table matches `_register_routes`. Catches F2. |
+| **Attribution-header table** | The README's `X-Kitty-*` table matches `_attribution_headers()`, and none of those names can reach `build_upstream_headers()`. |
+| **Flag table** | The README logging-flag table matches the CLI parser. |
+
+**Why guard the README specifically.** For a CLI tool the README *is* the interface
+specification — it is what a user configures against. A drifted README is a defect with the same
+user impact as a drifted API, and F2 shows it has already happened.
+
+#### 6.2.4 Dependency behaviour contracts
+
+Small, fast tests pinning third-party behaviour the invariants rest on, so a dependency bump
+fails here with a clear message rather than in production. The pin situation is worse than a
+glance suggests:
+
+| Dependency | Declared pin | What must be pinned by test |
+|---|---|---|
+| `aiohttp` | `>=3.11,<3.14` | A session built with `proxy=`/`proxy_auth=` proxies, and a per-request `proxy=None` cannot escape it. `_build_client_session` sets the proxy at session level precisely so no call site can forget it, and `_session_for` depends on a request being unable to opt out. |
+| `curl_cffi` | `>=0.7` — **unbounded** | `proxies=` is honoured; its precedence over ambient `HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY` (this stack *does* read the environment); the impersonation target still exists. |
+| `botocore` | **not declared at all** — arrives transitively via `boto3>=1.34` | `Config(proxies=)` is honoured and takes precedence over the environment. It is botocore, not boto3, that implements this. An undeclared dependency owning a containment guarantee is worse than an unbounded one. |
+| `keyring` | `>=23.0` | Backend resolution on each supported platform. |
+
+The ambient-environment cases are not hypothetical: `kitty.egress`'s docstring records the
+divergence, and a user with `HTTP_PROXY` set in their shell exercises it on two of three stacks.
+
+### 6.3 L3 — Subsystem
+
+**Scope.** One subsystem plus its real infrastructure. Two here: the bridge with real sockets,
+and the CLI with the real filesystem and real child processes.
+
+**Tools.** `pytest` + real `aiohttp` servers + the CONNECT proxy from
+`tests/test_egress_https_proxy.py`. `testcontainers` only if a scenario genuinely needs process
+isolation; a local proxy and upstream do not.
+
+**Command.** `pytest tests/subsystem -q`
+
+**Validation.** Each harness must carry a **negative** case proving it can fail — the sealed
+network's proxy-down assertion, the oracle's "mutation present without its trigger" case. A
+subsystem harness with no negative is this layer's characteristic failure mode; §3.3.1 and §5.3
+each show how easily one goes vacuous.
+
+#### 6.3.1 Bridge with real sockets
+
+| Scenario | Assertion |
+|---|---|
+| Transparency oracle over the corpus (§3.3), per wire shape and per transport | No unclaimed delta; no conditional mutation without its trigger |
+| Sealed network (§5.2), parametrised per transport (§5.5) | Everything correlates to a CONNECT; nothing when the proxy is down |
+| Cross-attempt content (§4.3 C3) | Transport-blip and empty-response retries byte-identical; each of M6, M8, M9 and failover re-normalisation fires only under its own trigger |
+| Connection lifecycle (§4.3 C5) | Distinct-connection count per session, against the native baseline |
+| Forbidden vendor token (§4.3 C2) | No `kitty` token in any upstream header or body, including the M13 path |
+| Streaming failover mid-response | The client sees one well-formed stream; `/stats` is authoritative for attribution, per the README's own caveat about first-byte headers |
+| Client disconnect during a stream | Upstream connection released; the backend not marked unhealthy for a client-side fault |
+| All backends unhealthy | The 503 arrives in each protocol's native error envelope |
+| Oversized request | Rejected with the protocol's own error shape, not a raw 413 |
+
+#### 6.3.2 CLI with real filesystem and processes
+
+| Scenario | Assertion |
+|---|---|
+| Two concurrent `kitty claude` sessions | Each gets its own `--settings` temp file; neither touches `~/.claude/settings.json`; the second's start does not disturb the first (issue #22) |
+| Normal exit | Session settings file removed; user's global settings byte-identical to before |
+| `SIGTERM` | `atexit` path restores; same assertion |
+| `SIGKILL`, then `kitty cleanup` | Recovery from the backup file; the `_kitty_values_present` heuristic fires only on kitty-written state |
+| `prepare_launch` cannot write the file | Launch **fails**. It must not proceed — a session without the settings file would silently run on the user's own Anthropic credentials, which is both a fidelity and a billing failure |
+| Background bridge owned by another user | Not stopped, not restarted, no second bridge started beside it |
+
+**Why a real child process rather than a mock.** The settings/env precedence between
+`--settings`, the process environment and `~/.claude/settings.json` is Claude Code's behaviour,
+not kitty's. A mock would assert kitty's belief about that precedence — exactly the assumption
+under suspicion in the KBR-1 investigation. Only a real spawn tests it.
+
+### 6.4 L4 — Product
+
+**Tools.** `pytest-bdd` for the Gherkin layer (**to add**, dev extra only — no BDD runner is
+currently a dependency); `pytest` for the real-agent E2E; separate runners for evals and load.
+
+**Command.** `pytest tests/acceptance -q` · `pytest tests/integration -v --runslow` · the eval
+and load runners are separate entry points.
+
+**Validation.** The paired-delta band (§6.4.3), and the requirement that every scenario binds to
+an L3 harness rather than re-implementing one — an acceptance test that grows its own assertions
+has drifted into L3 and should be moved down.
+
+#### 6.4.1 Gherkin acceptance
+
+The invariants written as scenarios a product owner can read and sign.
+
+```gherkin
+Feature: The upstream provider cannot tell Kitty Bridge is there
+
+  Scenario: TR-1  Kitty leaves no fingerprint in the request
+    Given a profile using the Z.AI coding plan
+    When Claude Code sends a turn through kitty
+    Then the request the provider receives contains no header, field or value
+         naming kitty
+    And the header set is a subset of what Claude Code sends natively
+
+  Scenario: TR-2  A short turn reaches the provider unchanged
+    Given a conversation well inside the model's context window
+    When Claude Code sends a turn through kitty
+    Then the provider receives the agent's messages with no content altered
+    And the only difference from the agent's own request is the model name
+
+  Scenario: TR-3  A long turn is altered only as far as necessary
+    Given a conversation that exceeds the model's context window
+    When Claude Code sends a turn through kitty
+    Then history is compacted only as far as the budget requires
+    And no tool result is separated from the call that produced it
+    And the most recent turn is preserved in full
+
+  Scenario: TR-4  An unrecoverable conversation fails without naming kitty upstream
+    Given a system prompt larger than the model's context window
+    When Claude Code sends a turn through kitty
+    Then the user is told the conversation cannot be compacted
+    And the provider receives no message naming kitty
+
+Feature: Configured egress cannot be bypassed
+
+  Scenario: EG-1  Every request presents the gateway's address
+    Given a configured egress gateway
+    When Claude Code runs a session through kitty
+    Then every connection the provider accepts arrived through the gateway
+
+  Scenario: EG-2  Traffic stops rather than leaks
+    Given a configured egress gateway that has become unreachable
+    When Claude Code sends a turn through kitty
+    Then the turn fails with a clear error
+    And the provider receives nothing
+
+  Scenario: EG-3  An unproxyable profile stops the launch
+    Given a configured egress gateway
+    And a profile whose transport cannot honour it
+    When the user runs kitty
+    Then kitty refuses to start and names the profile
+```
+
+TR-4 is the acceptance form of F3: it states the outcome the user needs (a legible error) and the
+one they must not pay for it with (the vendor name upstream), without prescribing the fix.
+
+Step definitions bind to the L3 harnesses, so the acceptance layer stays thin: it composes, it
+does not re-implement.
+
+#### 6.4.2 Real-agent end-to-end
+
+`tests/integration/test_agent_e2e.py` exists and spawns real agent binaries. Keep it out of the
+default `pytest` run — it requires four agent CLIs, live credentials and live network, and a
+suite that cannot run on a laptop or in CI stops being trusted. Promote it to a **nightly** job
+with credentials in CI secrets, and extend it from two cases to cover, for Claude Code
+specifically: a plain turn, a tool-using turn, a multi-turn session with tool results, an
+extended-thinking turn, and a session that crosses the compaction threshold.
+
+#### 6.4.3 Answer-quality evals
+
+Compaction (M5, M6, M13) and truncation (M3, M4, P7) are the mutations that can degrade an answer
+without breaking any structural assertion. Nothing below L4 can detect that.
+
+Design: a fixed set of coding tasks with objective pass criteria (the produced code compiles; the
+test it was asked to write passes). Run each through kitty and directly against the same
+provider, and compare pass rates. The metric is the **delta**, not the absolute rate — the
+absolute rate is a property of the model and moves for reasons unrelated to kitty. Sample size
+fixed in advance, run nightly, alert on a delta beyond the band (Q4).
+
+**Why a delta rather than a threshold.** An absolute threshold on a nondeterministic system
+produces a flaky gate, and a flaky gate at L4 is worse than none: it trains people to re-run. The
+paired comparison cancels the model's own variance.
+
+#### 6.4.4 Load
+
+A concurrency and duration profile — many parallel sessions against one bridge, a long streaming
+response, and a sustained session — asserting the connection-pool limit
+(`KITTY_BRIDGE_CONN_LIMIT`, default 500) and `force_close=True` behave as intended, that memory
+does not grow across a long stream, and that the per-request `_backend_context` ContextVar does
+not leak between concurrent requests. Pre-release, not per-PR.
+
+---
+
+## 7. Shared test infrastructure
+
+### 7.1 Golden Claude Code transcript corpus
+
+**What.** Real `POST /v1/messages` bodies captured from actual Claude Code sessions, committed as
+fixtures, with the native upstream headers and connection pattern Claude Code produces captured
+alongside them (the baselines C1b and C5 compare against).
+
+**Why real rather than synthetic.** Hand-written fixtures encode our belief about what Claude
+Code sends. That belief is the thing most likely to be wrong, and it drifts every time Anthropic
+ships a release. Captured bodies are evidence.
+
+**Required entries, at minimum:** plain text turn · turn with `tools` declared · assistant
+`tool_use` · user `tool_result` · extended thinking · image content block · `system` with
+`cache_control` · a transcript above the compaction budget · a single tool result above 50,000
+chars · a transcript that provokes the 400/413 recovery path (**must run against a balancing
+profile** — M6 exists only in `_request_with_retry_balancing`) · a system prompt alone larger
+than the window, to reach M13 · a malformed body for the fuzz path.
+
+**Traps.** Captured transcripts contain prompts, file contents and API keys. The capture
+procedure must scrub credentials and the corpus must be reviewed before commit; a fixture file is
+as public as the repository. The corpus needs a refresh cadence tied to Claude Code releases and
+a recorded capture procedure — an un-refreshable corpus becomes a museum of a protocol nobody
+speaks any more.
+
+### 7.2 Recording fake upstream
+
+An `aiohttp` server that speaks the Anthropic Messages API and the Chat Completions API, records
+every request in full (method, path, **headers with original casing and order**, raw body bytes,
+arrival timestamp, and a connection identifier), and replays scripted responses including SSE
+streams, error statuses, Cloudflare blocks, empty responses, context-too-large rejections and
+mid-stream disconnects.
+
+It is the substrate for I1 (§3.3), I2 (§4.3) and I3 (§5.2). **Casing** is asserted by C1; **order**
+is recorded for the C1b baseline report only, not asserted — what reaches the wire is aiohttp's
+ordering, not the agent's. The connection identifier supports C5's distinct-connection count and
+§5.2's CONNECT correlation. Peer address is deliberately **not** used for containment (§5.2
+assertion 1).
+
+Per §3.3.2 and §5.5, equivalents are needed for the non-aiohttp transports: a `curl_cffi`-reachable
+recorder and a botocore endpoint override.
+
+### 7.3 Recording CONNECT proxy
+
+**Already exists.** `tests/test_egress_https_proxy.py` contains `_ConnectProxy` (enforces Basic
+auth, records every `CONNECT` as a `ConnectAttempt`) and `_TlsTarget`, with throwaway
+certificates on ephemeral ports. Extend it rather than build a second: expose it as a shared
+fixture, add the ability to stop it mid-test for §5.2's negative assertion, and keep the CONNECT
+log addressable for correlation.
+
+### 7.4 Transparency oracle
+
+Specified in §3.3. Implemented as a pytest fixture wrapping the recording upstream, exposing one
+assertion — `assert_no_unclaimed_mutation(inbound, recorded, register, mode)` where `mode` is
+`native`, `round_trip_cc` or `round_trip_other` per §3.3.1 — so a new corpus entry, provider or
+transport costs one parametrisation, not a new test.
+
+---
+
+## 8. CI cadence
+
+| Job | Contents | Trigger | Gate? |
+|---|---|---|---|
+| **Fast** | `ruff`, `lint-imports`, `mypy src/kitty`, L1 + L2 across Python 3.10–3.13 | every push and PR | **Yes** |
+| **Subsystem** | L3: oracle, sealed network, settings lifecycle, concurrency | every PR | **Yes** |
+| **Deep** | mutation testing, schemathesis at high `--max-examples`, extended property runs | nightly | Report + ratchet |
+| **Product** | real-agent E2E, answer-quality evals | nightly | Alert, not gate |
+| **Release** | everything above plus load | tag push, via the existing reusable `tests.yml` | **Yes** |
+
+The existing arrangement — `publish.yml` and `ci.yml` both calling one reusable `tests.yml` so a
+release runs exactly the checks a PR ran — is correct and is extended rather than replaced. The
+new L3 job joins the same reusable workflow; the nightly jobs get their own, because a release
+must not wait on an LLM eval.
+
+---
+
+## 9. Gap register
+
+### 9.1 What the current suite already does well
+
+2,880 test functions across 139 Python files under `tests/`; ~50,700 lines of test to ~22,700
+lines of source. Broad L1 coverage of translators, providers, profiles, credentials and the TUI.
+Three assets stand out and are built on rather than replaced:
+
+- `tests/test_egress_https_proxy.py` — real TLS handshakes through a local recording CONNECT
+  proxy, across all three transport stacks. The strongest existing proof of anything in this
+  document.
+- `tests/test_egress_coverage.py` — AST/regex structural guard over `src/` that also asserts its
+  own scan finds known positives, so it cannot rot into a no-op.
+- `tests/test_github_actions.py` — treats the workflow definitions as testable artifacts.
+
+Four Python versions in CI, with `mypy` and `import-linter` as gates rather than reports.
+
+### 9.2 What is missing
+
+| ID | Gap | Today | Target | Priority |
+|---|---|---|---|---|
+| **G14** | **F3 — the vendor name goes upstream in the body (M13)** — KBR-5 | Live I2 breach | Fix the message; forbidden-token guard (§6.2.3) + TR-4 | **0** |
+| **G15** | **F4 — `_effort` / `_thinking_adaptive` reach the wire** — KBR-6 | Live I1+I2 breach on every CC-wire provider | Add both to `_INTERNAL_KEYS`; internal-key completeness guard (§6.2.3) | **0** |
+| **G16** | **F5 — `OpenCodeGoAdapter` misdeclares its wire shape** — KBR-7 | Latent defect in the M8 path; trap for the oracle | Make the property per-model; wire-shape honesty guard | **1** |
+| **G1** | I1 is unstated and untested | No definition of "unchanged"; mutation sites discoverable only by reading 6,463 lines | Register (§3.2) + oracle (§3.3) | **1** |
+| **G2** | No-bypass unproven **for the bridge's serving path**; no negative assertion; start-path guard is file-granular | `test_egress_https_proxy.py` proves the transports and drives `egress_cmd._probe` | Sealed-network harness (§5.2) per transport (§5.5) + AST start-path guard | **1** |
+| **G3** | I2 partially breached (F1) — KBR-8 | Identity ad hoc per adapter; the subscription adapter reports two different versions in one request | Header contract + parity baseline, then a policy and a code fix | **2** |
+| **G4** | L1 strength unmeasured | Line coverage only | `mutmut` ≥ 85% on the in-scope set | **2** |
+| **G8** | No corpus of real agent traffic | Synthetic fixtures encode our assumptions | Golden corpus (§7.1) | **2** |
+| **G10** | Custom-transport containment untested | Proven at transport level, never through the bridge; ambient `HTTP_PROXY`/`NO_PROXY` untested; the OAuth leg untested | §5.5 + §6.2.4 | **2** |
+| **G5** | No contract layer | No published schema; SSE grammar unchecked | OpenAPI + `schemathesis` + grammar state machine | **3** |
+| **G6** | Docs drift undetected (F2) — KBR-9 | README endpoint table already wrong | README ⇄ code guards | **3** |
+| **G7** | No property-based tests | All example-based | `hypothesis` on the §6.1 list | **3** |
+| **G9** | C5 unmeasured | `force_close=True` gives a per-request connection pattern unlike the agent's | Connection-count baseline | **3** |
+| **G11** | Dependency behaviour unpinned; `curl_cffi` unbounded and **botocore undeclared** | Containment rests on an undeclared transitive dependency | Dependency contract tests (§6.2.4) + declare botocore | **3** |
+| **G12** | Product layer effectively absent | 2 E2E tests, never run in CI | Nightly job, extended to 5 Claude Code cases | **4** |
+| **G13** | No answer-quality signal | Compaction, M13 and the Fireworks cap can degrade output invisibly | Paired delta eval | **4** |
+
+**Order of work.** G14 and G15 are priority 0: they are live breaches of the product's stated
+promise, both are small code fixes, and each has a cheap guard that stops it recurring. Then G1
+and G2 — the two invariants with the least coverage, sharing §7.2's recording upstream as their
+foundation — with G16 alongside because the oracle's scoping depends on it. G8 unblocks G1's
+corpus; G10 rides along with G2 once the harness is parametrised. G3's measurement lands with G1;
+G3's *fix* is its own ticket. G4 and G7 reinforce an existing layer and can run in parallel. G5,
+G6, G9, G11 are cheap and independent. G12 and G13 are last: most expensive to run, least caught
+per hour.
+
+---
+
+## 10. Design rationale
+
+Recorded per the repo's system-design discipline: the reasoning, especially where the choice was
+not the obvious one.
+
+**A permitted-mutation register instead of golden files (§3.1).** Golden files fail on every
+change, get regenerated reflexively, and prove nothing about unrecorded inputs. The register
+inverts it: the permitted set is small, explicit and reviewed, and everything else fails for all
+inputs. The cost is maintenance — hence the L2 guards.
+
+**Per-adapter register rows instead of one "providers may normalise" row (§3.2.2).** A trigger of
+"the provider overrides it" is unfalsifiable, and a register with an unfalsifiable row does not
+constrain the 23 adapters where most of the reshaping happens. Splitting it costs twenty lines of
+table and buys a testable claim — and writing those rows out is what surfaced P5c, P7 and P10.
+
+**The register guard is a shape-diff harness, not a source scan (§6.2.3).** Almost every provider
+mutation happens by building and returning a new dict, so a scan for writes to `cc_request` sees
+none of them. Feeding a fixed request through each adapter and diffing the output against that
+adapter's rows is falsifiable and catches added-and-returned mutations. A source scan would have
+missed F4.
+
+**The oracle is scoped by observed wire shape, not by the adapter's own property (§3.3.1).** On a
+CC-wire provider every field differs and every delta is claimed by the translation row, so a
+direct diff passes without proving anything. And the natural selector cannot be trusted:
+`OpenCodeGoAdapter` declares a Messages wire while emitting Chat Completions for most models
+(F5). Selecting on the observed shape keeps assertion 1 falsifiable regardless.
+
+**Structural diff, except key order on the passthrough path (§3.3, §4.3 C2).** Byte-comparing
+JSON fails on serialisation noise and trains people to ignore red. But key *order* is exactly what
+a provider fingerprints, so where kitty claims to be forwarding rather than translating, order is
+part of the contract. The asymmetry is deliberate — and it stops at the body: header order is
+aiohttp's, not the agent's, so pinning it would pin a dependency's internals.
+
+**CONNECT-log correlation instead of peer address (§5.2).** With bridge, proxy and upstream on
+loopback in one process, a proxied and a direct connection both present `127.0.0.1` and both
+source ports are ephemeral — peer address cannot discriminate. Correlating each recorded request
+to a recorded `CONNECT` can, and it avoids the `127.0.0.2` alias macOS needs configured.
+
+**A hostname outside the `localhost` family, never an IP literal, for the fake upstream (§5.3).**
+`should_bypass` bypasses loopback, private and `localhost`-suffixed destinations, so the obvious
+`127.0.0.1` harness proves the opposite of what it claims — silently. The premise is pinned by an
+L1 property test, stated *with* the `localhost` exclusions so it does not fail on day one and get
+weakened.
+
+**Extend the existing CONNECT proxy rather than build one (§7.3).** `test_egress_https_proxy.py`
+already owns a recording proxy across all three transport stacks. A second would duplicate the
+hard part and risk the two drifting on exactly the behaviour they both exist to pin.
+
+**Two L1 properties are stated with their exceptions (§6.1).** "Output ≤ budget" and "the last
+turn survives" are both false as absolutes — the compactor breaks out while still over budget
+when it cannot shrink further, and M13 replaces the last turn. Stating the honest version keeps
+the properties enforceable; stating the clean version guarantees they get weakened by whoever is
+on the rota.
+
+**Mutation testing on a subset (§6.1).** Whole-codebase mutation testing on 22,700 lines produces
+a survivor list nobody reads and a nightly job nobody waits for. The subset rule — modules whose
+silent misbehaviour breaches an invariant — keeps the output actionable.
+
+**A paired delta for answer quality, not an absolute threshold (§6.4.3).** Absolute thresholds on
+LLM output are flaky, and a flaky gate at L4 trains people to re-run rather than investigate. The
+paired comparison cancels the model's own variance.
+
+**Real-agent E2E stays out of the default run (§6.4.2).** It needs four CLIs, live credentials and
+live network. A default suite that cannot run on a developer's laptop stops being run, and then
+stops being trusted. Nightly with CI secrets is the right home.
+
+**C1b and C5 start as reported baselines, not gates (§4.3).** Both differences are large today. A
+gate that fails on day one gets disabled on day one. A ratcheted baseline makes the number visible
+and stops it growing while the fix is done properly.
+
+**TLS fingerprint parity is accepted residual risk, not omitted (§4.5).** Closing it means routing
+every provider through `curl_cffi`, a large change to the serving path for a threat no provider is
+currently known to apply here. Recording it means a future incident is a known gap, not a surprise.
+
+---
+
+## 11. Open questions for the product owner
+
+Answers belong in this document. They are not invented here.
+
+**Q1 — How faithful should the agent's identity be (F1, G3)?** Three options, materially
+different: (a) forward a curated allowlist of the agent's real headers, uniformly, so every
+provider sees a genuine coding agent; (b) send a neutral, stable identity that is neither kitty
+nor Claude Code; (c) leave it ad hoc and treat I2 as "no kitty fingerprint" rather than "looks
+like the agent." Option (a) is the literal reading of KBR-2 but carries provider-compatibility
+risk (some providers reject unknown `anthropic-beta` values) and would replace three working
+hard-coded strings with a general mechanism. Whichever is chosen, the current state is not a
+policy — it is four independent workarounds, one of which reports two different client versions
+in the same request. This decides both the I2 target and the C1b gate.
+
+**Q2 — Is pre-flight credential validation an acceptable I2 exception?** It is an upstream request
+the agent never made, and `--no-validate` already exists to suppress it. Declared exception, or
+suppressed by default when egress is configured?
+
+**Q3 — Should `should_bypass` resolve hostnames (§5.3)?** Not resolving saves a DNS round trip per
+request but means a LAN-hostname-configured local model server gets tunnelled to a proxy that
+cannot reach it. `localhost` is already handled by name. Keep the trade-off, or resolve-and-cache?
+
+**Q4 — What is the acceptable answer-quality delta (§6.4.3)?** A number is needed for the alert
+band. Zero is not achievable on a nondeterministic system.
+
+**Q5 — Should the Fireworks `max_tokens` cap (P7) be visible to the user?** It silently shortens
+the model's output. P5c raises `max_tokens` in the other direction. A one-line warning would make
+both visible at the cost of noise. A product call, not a test-design one, but the register
+surfaced it.
+
+**Q6 — Which of the four body-changing retry paths are acceptable (§4.3 C3)?** M6, M8, M9 and
+failover re-normalisation each send a different payload on a later attempt, and a provider that
+hashes bodies sees all four. The alternative in each case is to fail the turn, which is worse for
+the user. Declare all four as exceptions, or close some?
+
+**Q7 — Should `force_close=True` stay (C5, §4.5)?** It prevents port exhaustion but produces a
+connection pattern unlike the agent's own. Keep, or trade for keep-alive parity?
+
+**Q8 — What is the repo's policy on tracking `.system_design/`?** `.gitignore` ignored both
+`.system_design/` and `.requirements/`. KBR-2 asks for this document at a tracked path *and* for a
+PR, which cannot both hold while the directory is ignored; this change therefore un-ignores
+`.system_design/` and leaves `.requirements/` ignored as per-task working material. If that is
+wrong, say so — and note the repo has no `SYSTEM_DESIGN.md` at all, so the request path, provider
+registry and failover state machine are undocumented. A separate ticket seems right.
+
+**Q9 — What should the unrecoverable-compaction message say (F3, G14)?** It must stay legible to
+the user and stop naming the product upstream. Options: a vendor-neutral string; routing the
+error to the agent as an HTTP error instead of a synthetic assistant turn; or keeping the text but
+returning it downstream only. The third is probably right — the message is for the user, and it
+currently reaches the one audience it was never meant for.

--- a/.system_design/TEST_SUITE.md
+++ b/.system_design/TEST_SUITE.md
@@ -160,6 +160,7 @@ Eleven request-path rows (M1–M11) plus one response-path row (M12) and one sub
 | M11 | Force `stream: False` | `_handle_gemini` | Gemini protocol, non-streaming `:generateContent` | The Gemini translator defaults `stream=True`; the non-streaming endpoint must not open an SSE stream. |
 | M12 | Substitute fallback assistant text | `_EMPTY_ASSISTANT_FALLBACK_TEXT` in `bridge/messages/translator.py` **and** `bridge/responses/translator.py` | Upstream returned an empty response | **Response-side**, not part of the eleven request-path rows. |
 | M13 | **Discard the conversation and substitute a `[Kitty Bridge: …]` user message** | `_compact_messages` post-condition | No non-system message survives compaction (F25/F26 path — the system prompt alone exceeds the window) | Produces a legible error instead of a confusing upstream 400. **Qualitatively unlike M5**: M5 shrinks history, M13 replaces it — and it writes the product's name into the upstream body. See finding F3. |
+| M14 | **Replace the destination entirely** — scheme, host and path are built from the profile by `build_base_url()` + `get_upstream_path()` | `BridgeServer._build_upstream_url` | Always | The agent addressed a loopback bridge; the request has to reach the real provider. Listed because **the destination is a mutation surface the body cannot show**: on Azure an identical body sent to the wrong deployment path is a different request entirely (§3.3.5). |
 
 #### 3.2.2 Provider-level
 
@@ -181,6 +182,8 @@ trigger no test can fail — so each material mutation gets its own row.
 | P5d | Map `_thinking_adaptive` → `thinking: {"type":"adaptive"}` and `_effort` → top-level `effort` | same | Those keys present | Passthrough of an agent signal. |
 | P5e | Inject an empty `{"type":"thinking","thinking":""}` block into assistant messages | `AnthropicAdapter._translate_assistant_msg` | Assistant message lacks one while thinking is active | The Anthropic-path analogue of P8. **A message-content change**, not a parameter change. |
 | P6 | Remove `model` from the body | `AzureOpenAIAdapter` | Always | Azure selects the model by deployment id in the URL; the body field is rejected. |
+| P20 | **Encode the profile's model as the deployment id in the URL path** | `AzureOpenAIAdapter.get_upstream_path` | Always | The counterpart of P6: what P6 removes from the body reappears in the path. A register that records only P6 makes the model look *dropped* when it was *moved*, and leaves the move unchecked. |
+| P21 | Encode `project_id` and `location` in the base URL | `VertexAIAdapter.build_base_url` | Always | Vertex addresses a project-scoped endpoint. Same class as P20: routing carried outside the body. |
 | P7 | **Cap the agent's `max_tokens` at 4096** | `FireworksAdapter.normalize_request` | Non-streaming request with `max_tokens > 4096` | Fireworks rejects non-streaming requests above 4096. **User-visible** as shortened output. |
 | P8 | Inject empty `reasoning_content` into assistant messages | `ProviderAdapter._inject_empty_reasoning_content`, called from `KimiCodeAdapter`, `_ZaiBase`, `CustomOpenAIAdapter` | Thinking signalled **or** inferred from prior `reasoning_content` via `_detect_thinking_from_messages` | Those providers reject the request without it. The *inferred* trigger matters: it fires with no signal from the agent at all. |
 | P9a | Set `User-Agent` to `claude-code/1.0` | `KimiCodeAdapter`, `BytePlusAdapter`, `MimoAdapter` `.build_upstream_headers` | Always, on those three | Those providers 403 without a recognised coding-agent user-agent. Central to I2 — F1. |
@@ -401,6 +404,34 @@ path, which §4.3 C2 asserts for I2 reasons.
 `tool_use` block became the right `tool_calls` entry is an L1 translator claim. The oracle
 answers a narrower question: was anything changed that nobody declared.
 
+
+#### 3.3.5 Routing is part of the request, and the body cannot show it
+
+The envelope fixed the missing-body-fields problem, but a body-only oracle still cannot see where
+the request went. Three providers carry routing outside the body:
+
+| Provider | What lives in the URL | Consequence |
+|---|---|---|
+| Azure | The deployment id, which **is** the profile's model (P20) — and P6 deliberately removes `model` from the body | Two requests to two different deployments have **byte-identical bodies**. A body-only oracle cannot tell them apart, so a misrouted request is invisible. |
+| Vertex | `project_id` and `location` (P21) | The account being billed is a URL component |
+| Gemini | Model and operation (`:generateContent` vs `:streamGenerateContent`) in the inbound path | M10 lifts the model into the body precisely because it is not there to begin with |
+
+So the oracle takes the **whole captured request** — method, scheme, host, path, query, headers,
+body — and asserts routing separately from content.
+
+**The routing expectation is derived independently.** It is computed in the test from the
+configured profile — provider, model, `provider_config` — using the provider's *published* URL
+shape, not by calling `build_base_url()` / `get_upstream_path()`. Asking the code under test where
+it meant to go and then checking it went there proves nothing; this is the same independent-oracle
+rule §3.3.1 applies to bodies.
+
+**Falsification control.** Alongside the five body cases in §3.3.1, a sixth: change the Azure
+deployment segment in the captured path while leaving the body byte-identical. The oracle must
+fail. Without this case there is no evidence the routing assertion is wired to anything.
+
+The recorders already capture method, path and query (§7.2). The gap was that the assertion did
+not consume them.
+
 ### 3.4 Where I1 is proven
 
 | Claim | Layer | Test |
@@ -413,6 +444,8 @@ answers a narrower question: was anything changed that nobody declared.
 | Each wire projection reads its format correctly | L1 | The projections are test code and get their own tests — against published format examples, not against kitty's output |
 | A **below-threshold** corpus entry on a native-wire provider shows only M1 and P1 | L2 | Scoped to below-threshold deliberately: above it, M3/M5/M7 and any triggered provider row apply to the native path too |
 | No unclaimed delta, over the whole corpus, on every adapter × representative model × transport | **L3** | Transparency oracle (§3.3) |
+| The request reaches the destination the profile implies — host, path and query | **L3** | §3.3.5. Independently derived from the profile, never from `build_base_url()` |
+| A changed deployment path with an unchanged body is caught | **L3** | §3.3.5 falsification control — the case a body-only oracle cannot see |
 | An inbound `kitty` string survives while an injected vendor message is caught | **L3** | §3.3.3 regression case |
 | A real Claude Code session's tool calls execute correctly through kitty | L4 | Real-agent E2E (§6.4.2) |
 | Compaction has not degraded answer quality | L4 eval | §6.4.3 |
@@ -753,6 +786,7 @@ whether to change it is Q3.
 | No `EgressConfig` representation leaks the password | L1 property | Structural: the password component of `masked()` is exactly the mask. **Not** a substring test — see §6.1 |
 | Every outbound HTTP client is egress-aware; no source assigns `HTTP_PROXY`; no session trusts the environment | L2 structural | **Exists:** `tests/test_egress_coverage.py` |
 | **Every** `BridgeServer` construction is dominated by an `egress_block_reason` call | L2 structural | **Must be strengthened** — the existing guard is file-granular (§5.1 gap 3) |
+| The guard's rejection is **enforced** — no server starts on a rejecting configuration | **L3** | §6.2.3. Structural domination proves the call, not the branch that acts on it |
 | An `https://` proxy carries real traffic on all three transport stacks | L2/L3 | **Exists:** `tests/test_egress_https_proxy.py` |
 | Proxy semantics under each dependency's version range | L2 | §6.2.4 |
 | The destination is reachable directly with egress **disabled**, on every transport | **L3** | §5.2.2 phase 1 — the positive control. Without it the row below proves nothing (§5.3) |
@@ -958,11 +992,32 @@ reported the adapter clean.
 | **Internal-key completeness** | AST-scan `bridge/**` for every `_`-prefixed key written into a request dict, and assert each is a member of `_INTERNAL_KEYS`. **This is the guard that catches F4 (KBR-6).** The complementary check — that each `translate_to_upstream` override delegates or excludes the set — is necessary but not sufficient: every override strips it correctly today; the set itself is what is wrong. |
 | **Wire-shape honesty** | For every adapter × representative model, assert `upstream_wire_is_messages_api` agrees with the shape observed at the serialization boundary. Catches F5 (KBR-7). |
 | **Bridge-introduced vendor token** | No content the bridge *introduces* into a request body or header contains `kitty` in any casing. Scoped by the projection diff (§3.3.3), never a flat scan of the serialized body — a flat scan would fail on a user legitimately writing the word, and "fixing" that would breach I1. Catches F3 (KBR-5). |
-| **Start-path domination** | Every `BridgeServer(` construction is dominated by an `egress_block_reason(` call **at AST level**, not merely co-located in the same file. `cli/main.py` already holds two of the five start paths (§5.1 gap 3). |
+| **Start-path domination** | Every `BridgeServer(` construction is dominated by an `egress_block_reason(` call **at AST level**, not merely co-located in the same file. `cli/main.py` already holds two of the five start paths (§5.1 gap 3). **Necessary but not sufficient — see below.** |
 | **Env-var register** | `_SETTINGS_ENV_OVERRIDE_KEYS` and `_CONFLICTING_ENV_VARS` (`launchers/claude.py`) match what `build_spawn_config` emits and what the README documents. |
 | **Endpoint table** | The README endpoint table matches `_register_routes`. Catches F2 (KBR-9). |
 | **Attribution-header table** | The README's `X-Kitty-*` table matches `_attribution_headers()`, and none of those names can reach any `build_upstream_headers()`. |
 | **Flag table** | The README logging-flag table matches the CLI parser. |
+
+
+**Calling the guard is not enforcing it.** `egress_block_reason()` *returns a reason*; it stops
+nothing. Enforcement is the branch that follows — `if egress_error: print(...); return 1`. Delete
+that branch and every structural check above still passes while an unproxyable profile starts
+normally and leaks the machine's own address, which is the entire failure mode I3 exists to
+prevent.
+
+The structural guard is therefore paired with a behavioural one at L3:
+
+- **Per entry point.** Each of the five start paths (`bridge_runner.py` ×2, `cli/launcher.py`,
+  `cli/main.py` ×2) is driven with a configuration the guard rejects, and the assertion is that
+  **no server starts** — no listening socket, non-zero exit — not merely that a message was
+  printed.
+- **Falsification control.** A variant that keeps the `egress_block_reason()` call and discards
+  its return value must make these tests **fail**. Without it, the suite cannot distinguish
+  enforcement from decoration.
+
+This complements the guard's own unit test (which checks the returned reason) and acceptance
+scenario EG-3 (which checks the user-facing behaviour). The unit test proves the guard decides
+correctly; this proves the decision is obeyed.
 
 Every guard asserts its own scan finds known positives, so none can rot into a no-op —
 `tests/test_egress_coverage.py` already does this and is the pattern to copy.
@@ -1089,7 +1144,7 @@ Feature: The upstream provider cannot tell Kitty Bridge is there
     When Claude Code sends a turn through kitty
     Then no content the bridge added to the request names kitty
 
-  @ratchet  # not gating until G3 (KBR-8) closes — see the note below
+  # One exempt assertion: header-subset, pending KBR-8. See the exemption registry in 8.
   Scenario: TR-1c  Kitty's headers are a subset of the agent's own
     Given a profile using the Z.AI coding plan
     When Claude Code sends a turn through kitty
@@ -1120,7 +1175,7 @@ Feature: The upstream provider cannot tell Kitty Bridge is there
          the 50,000-char truncation limit, or it is dropped because its
          tool_result lost the tool_use that produced it
 
-  @ratchet  # currently fails by design — this is F3/G14 (KBR-5)
+  # One exempt assertion: no-vendor-content, pending KBR-5. Setup and all else gate.
   Scenario: TR-4  An unrecoverable conversation fails without naming kitty upstream
     Given a system prompt larger than the model's context window
     When Claude Code sends a turn through kitty
@@ -1153,15 +1208,16 @@ Feature: Configured egress cannot be bypassed
     Then kitty refuses to start and names the profile
 ```
 
-**Two scenarios are `@ratchet`, and the distinction matters.** The Acceptance job gates every PR
-(§8), so a scenario asserting behaviour the product does not yet have would make `main` red on
-day one — and a permanently red gate gets disabled, taking the working scenarios with it. TR-1c
-(header parity) and TR-4 (the vendor string) both assert the *target* state of open defects: G3
-(KBR-8) and G14 (KBR-5) respectively. They run on every PR and are reported, but they do not
-gate until their defect closes, at which point the marker is removed and they become ordinary
-gating scenarios. This is the same ratchet §4.3 C1b describes for the header baseline; the
-marker exists so the promotion is a deliberate one-line change, not something anyone has to
-remember.
+**Two scenarios carry an assertion-level exemption.** The Acceptance job gates every PR (§8), so
+an assertion about behaviour the product does not yet have would make `main` red on day one — and
+a permanently red gate gets disabled, taking the working scenarios with it.
+
+The exemption covers **one assertion**, never the scenario. In TR-1c it is the header-subset
+assertion (KBR-8); in TR-4 it is the no-vendor-content assertion (KBR-5). Every other step in
+those scenarios — setup, the `Given` clauses, and any other `Then` — gates normally, so a broken
+fixture or an unrelated regression still fails the build. An unexpected pass also fails, forcing
+the exemption off when the defect closes. The full policy and the exemption registry are in §8;
+this section does not restate it, so the two cannot drift apart.
 
 **Three scenarios were corrected against the implementation, not the other way round.**
 
@@ -1209,9 +1265,19 @@ Assert on all three: the request arrives at the recorder **and** both sentinels 
 test that checks only the recorder cannot tell "precedence is correct" from "the request went
 everywhere."
 
-*The control.* Sentinels that are never hit prove nothing unless they can be hit. A second case
-removes kitty's settings file and asserts B wins over A — demonstrating both sentinels are live
-and the harness can distinguish them. Without it, a typo in a sentinel URL reads as a pass.
+*The controls.* A sentinel that is never hit proves nothing unless it can be hit — and one
+control exercises only one sentinel. Two more runs are needed, so that **each destination wins
+under its own configuration**:
+
+| Run | Session settings | `~/.claude/settings.json` | Environment | Expected winner |
+|---|---|---|---|---|
+| Main | present | present (B) | present (A) | the recorder |
+| Control 1 | absent | present (B) | present (A) | **B** |
+| Control 2 | absent | absent | present (A) | **A** |
+
+Control 1 alone leaves A unexercised, so a typo in A's URL would read as a pass in the main run —
+A is *supposed* to be silent there, and a broken A is silent too. Three runs, three winners, and
+every sentinel demonstrated live.
 
 Pinning it in CI has real questions attached — which distribution, how tightly version-pinned, licensing for
 redistribution in a CI image — recorded as Q12 rather than assumed away.
@@ -1334,9 +1400,11 @@ same interface to the tests:
 | curl_cffi-reachable server | `openai_subscription` serving path | Must terminate TLS with the harness certificate; the only place `_cc_to_responses` output (P13, P17) can be seen |
 | botocore endpoint override | `bedrock` | Points the client at the local recorder rather than AWS; observes the Converse payload **after** the transport's `modelId`/`stream` pops (P18) |
 
-Each records every request in full: method, path, **headers with original casing and order**,
-raw body bytes, arrival timestamp, and — for containment — **the peer port of the accepted
-connection**, which is the join key against the proxy's tunnel log (§5.2.1). Each replays
+Each records every request in full: method, scheme, host, path, **query**, **headers with
+original casing and order**, raw body bytes, arrival timestamp, and — for containment — **the
+peer port of the accepted connection**, which is the join key against the proxy's tunnel log
+(§5.2.1). The routing fields are not decoration: §3.3.5 asserts on them, and on Azure they carry
+the only difference between two otherwise identical requests. Each replays
 scripted responses: SSE streams, error statuses, Cloudflare blocks, empty responses,
 context-too-large rejections, and disconnects at each of §6.3.1's four injection points.
 
@@ -1367,18 +1435,23 @@ nothing from `src/kitty/bridge`**. They are test code that the whole of I1 rests
 their own L1 tests, written against each format's published examples rather than against kitty's
 output.
 
-**The oracle** is a pytest fixture wrapping the recorders, exposing one assertion:
+**The oracle** is a pytest fixture wrapping the recorders, exposing one assertion over **complete
+requests**, not bodies:
 
 ```
-assert_no_unclaimed_mutation(inbound_body, inbound_format,
-                             captured_body, captured_format,
-                             register, triggers_met)
+CapturedRequest(method, scheme, host, path, query, headers, body)
+
+assert_no_unclaimed_mutation(inbound:  CapturedRequest, inbound_format,
+                             captured: CapturedRequest, captured_format,
+                             register, triggers_met,
+                             expected_route)   # derived from the profile, independently
 ```
 
-Both formats are supplied by the harness from the observed wire shape (§3.3.4), never read from
-the adapter's own property — that property is unreliable (F5, KBR-7) and, more fundamentally, an
-oracle must not ask the code under test what it did. A new corpus entry, adapter, model route or
-transport costs one parametrisation, not a new test.
+**Bodies alone cannot prove correct routing** (§3.3.5). Both formats are supplied by the harness
+from the observed wire shape (§3.3.4), never read from the adapter's own property — that property
+is unreliable (F5, KBR-7) and, more fundamentally, an oracle must not ask the code under test what
+it did. A new corpus entry, adapter, model route or transport costs one parametrisation, not a new
+test.
 
 ---
 
@@ -1476,6 +1549,7 @@ Four Python versions in CI, with `mypy` and `import-linter` as gates rather than
 | **G14** | **F3 — the vendor name goes upstream in the body (M13)** — KBR-5 | Live I2 breach | Fix the message; forbidden-token guard (§6.2.3) + TR-4 | **0** |
 | **G15** | **F4 — `_effort` / `_thinking_adaptive` reach the wire** — KBR-6 | Live I1+I2 breach on every CC-wire provider | Add both to `_INTERNAL_KEYS`; internal-key completeness guard (§6.2.3) | **0** |
 | **G16** | **F5 — `OpenCodeGoAdapter` misdeclares its wire shape** — KBR-7 | Latent defect in the M8 path; trap for the oracle | Make the property per-model; wire-shape honesty guard | **1** |
+| **G19** | Routing was outside the register and outside the oracle | The destination is built from the profile (M14, P20, P21); a body-only check cannot see a misrouted Azure deployment | §3.3.5 — whole-request oracle with an independently derived route | **1** |
 | **G17** | Undecided behaviour for an irreducible final turn | Compaction emits an over-budget request, or M13 replaces the conversation; neither was designed | Answer Q10, then align M3-M7/M13, the 6.1 properties and TR-3 together | **2** |
 | **G18** | P13-P19 - seven transport-level mutations, unregistered in the first draft | Necessary (the Codex backend and boto3 require them) but invisible above DEBUG, and unreachable by a guard placed at `translate_to_upstream` | Rows P13-P19; boundary corrected in 3.2.3; Q5 decides user visibility | **3** |
 | **G1** | I1 is unstated and untested | No definition of "unchanged"; mutation sites discoverable only by reading 6,463 lines | Register (§3.2) + oracle (§3.3) | **1** |

--- a/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
+++ b/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
@@ -94,14 +94,14 @@ After Milestone 0, seven streams advance independently, each owning its own modu
 | ID | Task | Depends on | Design | Size |
 |---|---|---|---|---|
 | **T-W1** | Layer markers, CI selection rules, per-category collection checks | — | §8 | M |
-| **T-W2** | Request/capture types and the projection protocol | — | §3.3.1 | S |
+| **T-W2** | **The input contract** — request/capture types and the projection protocol | — | §3.3.1 | S |
 | **T-W3** | Register schema and data | T-W2 | §3.2 | M |
-| **T-W4** | Recorder protocol + primary aiohttp recorder | — | §7.2 | M |
+| **T-W4** | Recorder implementation — primary aiohttp recorder | T-W2 | §7.2 | M |
 | **T-W5** | Shared CONNECT proxy fixture | — | §7.3 | M |
 | **T-W6** | Corpus format, capture procedure, scrubber, loader | T-W3 | §7.1 | M |
 | **T-W7** | Assertion exemption registry | T-W1 | §8 | M |
 | **T-W8** | Bridge fixture **core + transport extension interface** | T-W4 | §6.3.1 | M |
-| **T-W9** | **The proven vertical slice** | T-W1, T-W4, T-W8 | §6.3.1 | S |
+| **T-W9** | **The proven vertical slice** | T-W1, T-W2, T-W4, T-W8 | §6.3.1 | S |
 
 **T-W1 — markers and CI selection.** Register `l1`, `l2`, `l3`, `acceptance`, `agent_smoke`,
 `agent_live`, `eval`, `load`; a meta-test asserts every collected test carries exactly one. **Do
@@ -115,19 +115,25 @@ agent_smoke"` would exit 5 when agent-smoke tests were missing. **That is wrong.
 tests exist the expression collects them and passes happily with zero agent-smoke coverage. Also
 reconcile the existing `--runslow` silent skip with the same rule.
 
-**T-W2 — types.** `Request(envelope, conversation, residual)`, `Envelope`, `Conversation`, `Turn`,
-`Part` variants, `Reply` for the response direction, and the `Projection` protocol. Includes the
-**totality rule**: every key classifies into envelope, conversation or residual, and a non-empty
-residual raises. *Falsification:* a stub reader that drops an unknown key fails it.
+**T-W2 — the input contract.** One owner for everything a projection reads and a recorder produces:
+`Request(envelope, conversation, residual)`, `Envelope`, `Conversation`, `Turn`, `Part` variants,
+`Reply` for the response direction, **`CapturedRequest(method, scheme, host, path, query, headers,
+body)`**, and the `Projection` protocol.
+
+**`CapturedRequest` lives here, not in T-W4.** An earlier draft titled this task "request/capture types" while T-W4 defined `CapturedRequest` with no dependency between them — so the recorder author and the Gemini reader author (who needs the URL, §3.3.5) could have started against two different readings of the same contract. That is precisely the coordination problem Milestone 0 exists to remove.
+
+Includes the **totality rule**: every key classifies into envelope, conversation or residual, and a
+non-empty residual raises. *Falsification:* a stub reader that drops an unknown key fails it.
 
 **T-W3 — register.** One entry per row M1–M14 and P1–P21: id, site symbol, trigger predicate, the
 projection field it touches, conditional or not, design anchor. Defines the trigger vocabulary
 T-W6 indexes by. *Falsification:* delete a row from the markdown or the data; the agreement test
 fails.
 
-**T-W4 — recorder protocol.** `CapturedRequest(method, scheme, host, path, query, headers, body)`
-with original casing and order, arrival timestamp, and **the peer port of the accepted
-connection**. Ships **one minimal valid success response per protocol** — without it any request
+**T-W4 — recorder implementation.** Implements T-W2's `CapturedRequest` — original casing and order,
+arrival timestamp, and **the peer port of the accepted connection** — for the primary aiohttp
+recorder. It consumes the contract rather than defining it. Ships **one minimal valid success
+response per protocol** — without it any request
 driven through a real bridge falls into the retry paths, which are themselves body-mutating. The
 failure library is T-B4. Peer-port and casing capture are enforced by a **conformance test every
 Epic B recorder must pass**.
@@ -153,8 +159,10 @@ shared fixture. Defining the interface here lets recorder authors integrate with
 core.
 
 **T-W9 — the proven vertical slice.** Drive one request from the bridge fixture into the recorder
-and assert the capture is complete and correct. Small, but it is the first moment the contracts
-are known to compose. *Falsification:* a recorder that drops the query string fails it.
+and assert the capture is complete and **type-compatible with T-W2's declared contract** — the
+recorder's output must satisfy what a projection expects to read. Small, but it is the first
+moment the contracts are known to compose rather than merely to exist.
+*Falsification:* a recorder that drops the query string fails it.
 
 ---
 
@@ -243,17 +251,25 @@ An earlier draft made a single positive-control task wait on every transport's d
 difficult botocore route delayed even aiohttp containment — contradicting this plan's own claim
 that a stuck transport blocks only its own task.
 
+**A transport task is done when it records an outcome, not when it succeeds.** `proven`, `unsupported`
+(the harness cannot give that transport a direct route — design §5.3 requires this be reported,
+not hidden) or `failed` (a route exists and containment does not hold, which is a product defect
+and gets its own ticket). An earlier draft defined these tasks as complete only when all four
+phases passed, and then had T-E9 — the report whose entire purpose is recording that a transport
+could **not** be proven — depend on all three succeeding. The failure report could not run in the
+one case it existed for. T-E1 now ships the report; T-E9 only checks it is complete.
+
 | ID | Task | Flags | Depends on | Done when | Design | Size |
 |---|---|---|---|---|---|---|
-| **T-E1** | Harness core, aiohttp direct route, **transport extension interface** | | T-W5, T-W8, T-W9 | Upstream addressed as `upstream.kitty-test.invalid`; aiohttp direct leg via a monkeypatched resolver — **not** `/etc/hosts`, unavailable on CI runners | §5.3 | L |
+| **T-E1** | Harness core, aiohttp direct route, extension interface, **capability report** | | T-W5, T-W8, T-W9 | Upstream addressed as `upstream.kitty-test.invalid`; aiohttp direct leg via a monkeypatched resolver — **not** `/etc/hosts`, unavailable on CI runners. **Ships the per-transport capability report**, which starts with every transport `not-attempted` | §5.3 | L |
 | **T-E2** | **aiohttp containment slice, complete and falsified** | | T-E1 | Phase 1 positive control; proxy down ⇒ zero connections; proxy up ⇒ every connection joins a tunnel on the recorded source port; **and an injected bypass makes the harness fail** | §5.2.1, §5.2.2 | L |
-| **T-E3** | curl_cffi route and slice | | T-E1, T-E2, T-B2 | All four phases for curl_cffi | §5.3, §5.5 | M |
-| **T-E4** | botocore route and slice | | T-E1, T-E2, T-B3 | All four phases for botocore | §5.3, §5.5 | M |
-| **T-E5** | Provider-aiohttp route and slice | | T-E1, T-E2, T-B1 | All four phases for the provider sessions and the OAuth leg | §5.5 | M |
+| **T-E3** | curl_cffi route and slice | | T-E1, T-E2, T-B2 | **An outcome is recorded**: `proven` (all four phases pass), `unsupported` (the harness cannot give this transport a direct route — with the reason), or `failed` (a route exists and containment does not hold — a product defect, filed) | §5.3, §5.5 | M |
+| **T-E4** | botocore route and slice | | T-E1, T-E2, T-B3 | Same three outcomes as T-E3, for botocore | §5.3, §5.5 | M |
+| **T-E5** | Provider-aiohttp route and slice | | T-E1, T-E2, T-B1 | Same three outcomes, for the provider sessions and the OAuth leg | §5.5 | M |
 | **T-E6** | Guard **enforcement** | | — | Five start paths with a rejecting configuration assert **no server starts**. Falsification: a variant keeping the call and discarding its return value must fail these. **No recorder needed** | §6.2.3 | M |
 | **T-E7** | AST start-path domination | | — | Every `BridgeServer(` construction dominated by an `egress_block_reason(` call at AST level | §5.1 | M |
-| **T-E8** | Local bypass, fail-closed, transport asymmetry | | T-E2, T-E3, T-E4, T-E5 | Loopback bypass on bridge sessions; a `supports_egress() == False` profile blocks startup **and names the profile**; and the complement — those destinations **are** tunnelled on the three custom transports, which have no bypass | §5.5 | M |
-| **T-E9** | Proven / unproven report | | T-E3, T-E4, T-E5 | Each transport is either proven or **explicitly reported unproven**. A transport that cannot be given a working direct route is never silently counted as passing | §5.3 | S |
+| **T-E8** | Local bypass, fail-closed, transport asymmetry | | T-E2, T-B1, T-B2, T-B3 | Loopback bypass on bridge sessions; a `supports_egress() == False` profile blocks startup **and names the profile**; and the complement — those destinations **are** tunnelled on the three custom transports, which have no bypass. Needs the **recorders** to observe tunnelling, not the containment slices, so a stuck transport does not block it | §5.5 | M |
+| **T-E9** | Containment completeness gate | | T-E1 | Asserts **every transport has a recorded outcome and none is `not-attempted`**. `unsupported` is a permitted outcome for partial delivery; `failed` is not. It reads the report T-E1 ships — **it does not depend on any transport succeeding** | §5.3 | S |
 
 ---
 
@@ -339,11 +355,11 @@ that makes *its* bytes observable. Bundled, the Ollama half would have had no ev
 | **T-K3** | Statistics and decision rule | blocked Q4, Q13 | T-K1, T-K2 | Successes ÷ **scheduled** trials; interval; pre-registered margin; symmetric exclusions; a missing-data ceiling that **voids** the run | §6.4.3 | M |
 | **T-K4** | Load rig and baseline | | T-W8, T-B4 | Fixed workload, named runner class; latency, TTFB, completion and error rates, bounded RSS, socket recovery; streaming and buffered measured separately | §6.4.4 | L |
 | **T-K5** | `load.yml` reusable + publish gate | ci | T-K4 | `publish.yml` `needs:`-gates on a load run **for the tag commit** | §8 | M |
-| **T-K6** | Activate the Subsystem job | ci | T-W1, T-E2, T-D4 | `l3` gates PRs and releases, from the first proven slices onward | §8 | S |
+| **T-K6** | Activate the Subsystem job | ci | T-W1, T-E2, T-D3, T-D4 | `l3` gates PRs and releases. **T-D3 is required, not just T-D4**: activating the job promotes the oracle into gating infrastructure, and §1.4 forbids that before its falsification suite exists. Fixing only T-J2's dependency left this hole open | §8 | S |
 | **T-K7** | Deep nightly — mutation and schema fuzzing | ci | T-H3, T-G6 | Both exist before the job claims to run them | §8 | S |
 | **T-K8** | Per-category collection enforcement | ci | T-W1, T-K6 | Each required category has its own non-empty check. A category present but empty **fails** | §8 | S |
 | **T-K9** | Activate the Acceptance job | ci | T-J2, T-J3, T-K6 | `acceptance` gates PRs and releases | §8 | S |
-| **T-K10** | Activate the `agent_smoke` category | ci, blocked Q12 | T-I5, T-K9 | Its own required category — **it does not block Subsystem or Acceptance** | §8 | S |
+| **T-K10** | Activate the `agent_smoke` category | ci, blocked Q12 | T-W1, T-I5, T-I6 | Its own required category — **it does not block Subsystem or Acceptance**, and it does not wait for them either: the T-K9 dependency was delay with no shared prerequisite behind it. It requires **T-I6 as well as T-I5**, because startup connectivity alone would let the category go green without proving the settings precedence that is the whole reason it exists | §8 | S |
 | **T-K11** | Agent-live nightly | ci | T-I14 | Runs the **expanded** five-scenario coverage, not the two existing cases | §8 | S |
 | **T-K12** | Eval nightly | ci | T-K3 | Runs once the decision rule exists; alerts, never gates | §8 | S |
 
@@ -355,66 +371,77 @@ Q12 as a separate category so it cannot hold up Subsystem or Acceptance.
 
 ## 14. Derived schedule
 
-Computed from the dependency columns above, not written by hand. **Recompute after any dependency
-change** — these numbers go stale the moment the tables move. 98 tasks; the graph is acyclic and
-every dependency resolves.
+Computed from the dependency columns above, not written by hand. 98 tasks; the graph is acyclic
+and every dependency resolves. **Recompute after any dependency change.**
 
-### 14.1 Readiness tiers
+### 14.1 What these numbers are, and are not
 
-A tier is the earliest point a task *could* start, not a batch to wait for. **53 of 98 tasks are
-available in tiers 0–2**, which is what Milestone 0 buys.
+The durations below are **dependency-only lower bounds**. They assume every task starts the moment
+its predecessors finish, which in turn assumes enough people to run every ready task in parallel.
+They are not a delivery forecast, and two facts in this plan actively break that assumption:
+
+- **T-C1–T-C7 share one capture-and-secret-review pass** (§6) — they are seven tasks but not seven
+  parallel slots.
+- **Five shared files need a single integration owner** (§18), which serialises work that the
+  graph shows as parallel.
+
+An earlier draft said "two owners halve elapsed time." **That does not follow from this
+calculation** — the chain lengths are lower bounds under unlimited staffing, and halving is a
+statement about resourcing that this graph cannot support. What the graph *does* support is
+narrower and still useful: the fidelity and containment chains share no task until T-K9, so they
+never block each other.
+
+### 14.2 Readiness tiers
+
+A tier is the earliest point a task *could* start, not a batch to wait for. **43 of 98 tasks are
+available in tiers 0–2.**
 
 | Tier | Count | Tasks |
 |---|---|---|
-| **0** | 13 | T-E6 T-E7 T-F1 T-G12 T-I1 T-I3 T-I4 T-I14 T-K1 T-W1 T-W2 T-W4 T-W5 |
-| **1** | 22 | T-A1–T-A7 T-B4 T-F2–T-F5 T-G8 T-G10 T-G11 T-H1 T-I2 T-K2 T-K11 T-W3 T-W7 T-W8 |
-| **2** | 18 | T-B1 T-B2 T-B3 T-F6 T-G1 T-G3 T-G6 T-G7 T-G9 T-H4 T-I10 T-I11 T-I13 T-J1 T-K3 T-K4 T-W6 T-W9 |
-| **3** | 15 | T-C1–T-C7 T-E1 T-G4 T-H2 T-H5 T-I5 T-I7 T-K5 T-K12 |
-| **4** | 6 | T-D1 T-E2 T-H3 T-I6 T-I9 T-I12 |
-| **5** | 8 | T-D2 T-D10 T-E3 T-E4 T-E5 T-G5 T-I8 T-K7 |
-| **6** | 7 | T-D3 T-D4 T-D5 T-D6 T-D7 T-E8 T-E9 |
+| **0** | 12 | T-E6 T-E7 T-F1 T-G12 T-I1 T-I3 T-I4 T-I14 T-K1 T-W1 T-W2 T-W5 |
+| **1** | 21 | T-A1–T-A7 T-F2–T-F5 T-G8 T-G10 T-G11 T-H1 T-I2 T-K2 T-K11 T-W3 T-W4 T-W7 |
+| **2** | 10 | T-B4 T-F6 T-G1 T-G3 T-G9 T-H4 T-J1 T-K3 T-W6 T-W8 |
+| **3** | 18 | T-B1 T-B2 T-B3 T-C1–T-C7 T-G6 T-G7 T-I10 T-I11 T-I13 T-K4 T-K12 T-W9 |
+| **4** | 10 | T-D1 T-E1 T-G4 T-H2 T-H5 T-I5 T-I7 T-I9 T-I12 T-K5 |
+| **5** | 8 | T-D2 T-D10 T-E2 T-E9 T-G5 T-H3 T-I6 T-I8 |
+| **6** | 11 | T-D3 T-D4 T-D5 T-D6 T-D7 T-E3 T-E4 T-E5 T-E8 T-K7 T-K10 |
 | **7** | 3 | T-D9 T-J3 T-K6 |
 | **8** | 4 | T-D8 T-G2 T-J2 T-K8 |
 | **9** | 1 | T-K9 |
-| **10** | 1 | T-K10 |
 
-### 14.2 The chains, as computed
+### 14.3 The chains
 
 | Milestone | Longest chain to it | Days |
 |---|---|---|
-| Containment slice proven (**T-E2**) | T-W4 → T-W8 → T-W9 → T-E1 → T-E2 | 11.5 |
-| Containment complete (**T-E9**) | … → T-E2 → T-E3 → T-E9 | 13.5 |
-| Fidelity matrix complete (**T-D9**) | T-W2 → T-W3 → T-W6 → T-C1 → T-D1 → T-D2 → T-D4 → T-D9 | 15.0 |
-| Containment acceptance (**T-J3**) | T-W4 → T-W8 → T-W9 → T-E1 → T-E2 → T-E3 → T-E8 → T-J3 | 16.0 |
+| Oracle core proven (**T-D1**) | T-W2 → T-W3 → T-W6 → T-C1 → T-D1 | 8.0 |
+| Containment slice proven (**T-E2**) | T-W2 → T-W4 → T-W8 → T-W9 → T-E1 → T-E2 | 12.0 |
+| Fidelity matrix complete (**T-D9**) | … → T-D1 → T-D2 → T-D4 → T-D9 | 15.0 |
 | Fidelity acceptance (**T-J2**) | … → T-D9 → T-J2 | 16.5 |
 | **Everything gating (T-K9)** | … → T-J2 → T-K9 | **17.0** |
 
-**The critical path runs through the corpus, not through containment.** That is not what the
-previous draft assumed, and it changes the advice: `T-W2 → T-W3 → T-W6 → T-C1` is four sequential
-tasks before the oracle can even start, because T-D1 needs one corpus entry to run against. The
-corpus was listed as a background risk; it is in fact the front of the longest chain.
+**The critical path runs through the corpus**, not through containment:
+`T-W2 → T-W3 → T-W6 → T-C1 → T-D1 → T-D2 → T-D4 → T-D9 → T-J2 → T-K9`. Four sequential tasks
+precede the oracle, because T-D1 needs one corpus entry to run against. The corpus is not a
+background risk; it is the front of the longest chain.
 
-Two consequences:
+**A previously claimed optimisation has been withdrawn.** An earlier draft suggested letting T-D1
+run against a synthetic transcript instead of T-C1, "taking about two days off the front." That
+number was asserted, not computed. Recomputing it against the current graph gives **zero days
+saved**: dropping the T-D1 → T-C1 edge makes T-W9 the limiting predecessor at exactly the same
+length, so the chain merely moves from `T-W3 → T-W6 → T-C1` to `T-W4 → T-W8 → T-W9`. The corpus
+dependency is not what makes this path long — the path is long either way. The lever does not
+exist, and the plan should not offer it.
 
-1. **T-W2, T-W3 and T-W6 are the first three things to staff**, in that order, and T-C1 should be
-   the first corpus entry captured — not whichever is most interesting.
-2. **Containment is no longer the long pole** but finishes only half a day earlier, and it is
-   fully independent until T-K9. Two owners still halve elapsed time; the fidelity owner is simply
-   the one on the critical path.
+### 14.4 Consequences worth acting on
 
-If the corpus dependency is judged too expensive, the lever is T-D1: let it run against a
-synthetic minimal transcript rather than T-C1, which removes three tasks from the front of the
-chain. That trades a little early realism for roughly two days — a decision worth taking
-deliberately rather than by default.
-
-### 14.3 Consequences worth acting on
-
-1. **T-W2, T-W4, T-W5 and T-W8 head the chains and are all S/M.** They go first, and no two to the
-   same person.
-2. **T-E1 is the riskiest single task**; it sits early in the containment chain, which has ~1 day
-   of slack against the critical path. Slip it and containment becomes the critical path.
-3. **T-K9 is the convergence point.** Both chains stop there; it is not an afterthought.
-4. **T-K10 is the only tier-10 task** and it is blocked on Q12. It gates nothing else.
+1. **T-W2 is the single most blocking task.** It heads both chains, it is sized S, and it now owns
+   the whole input contract (§3). It goes first, alone, and lands before the streams branch.
+2. **T-W3 and T-W6 follow immediately** — they sit second and third on the critical path, ahead of
+   any test.
+3. **T-E1 is the riskiest single task**; containment carries ~5 days of slack against the critical
+   path, so a slip there is absorbed rather than fatal. That is a change from the previous draft,
+   where the two chains were nearly equal.
+4. **T-K9 is the convergence point.** Both chains stop there; it is not an afterthought.
 
 ---
 
@@ -510,10 +537,11 @@ Every design requirement has an owner. "Existing" means the current suite alread
 per-transport routes into T-E3–T-E5 means a stuck transport is one blocked M and an entry in
 T-E9's unproven report, not a blocked chain.
 
-**The corpus is on the critical path**, not merely a background risk (§14.2). T-C1–T-C7 need real
+**The corpus is on the critical path**, not merely a background risk (§14.3). T-C1–T-C7 need real
 sessions, a secret review and a named refresh owner, and share one capture pass — while
-`T-W2 → T-W3 → T-W6 → T-C1` is the front of the longest chain. Staff it first, capture T-C1 first,
-and consider the synthetic-transcript lever in §14.2 if it slips.
+`T-W2 → T-W3 → T-W6 → T-C1` is the front of the longest chain. Staff it first and capture T-C1
+first. There is **no shortcut**: §14.3 shows that dropping the corpus dependency saves nothing,
+because the alternative predecessor chain is exactly as long.
 
 **T-D9 and T-G2 are adjacent.** T-D4–T-D9 own driving the wire and capturing; T-G2 asserts
 register coverage over those captures as a meta-assertion. Implementing "per adapter × model ×

--- a/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
+++ b/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
@@ -3,540 +3,528 @@
 **Implements:** [`TEST_SUITE.md`](TEST_SUITE.md). That document says what the suite must prove and
 why; this one says who can build what, in what order, without waiting on each other.
 **Traces to:** [KBR-2](https://shelpuk.atlassian.net/browse/KBR-2).
-**Status:** Plan. No Jira issues created yet — the `T-` ids here are plan-local and become ticket
-summaries when the plan is accepted.
+**Status:** Plan. No Jira issues created — the `T-` ids are plan-local and become ticket summaries
+when the plan is accepted.
 
-> **On identifiers.** Every task id is prefixed `T-`. `TEST_SUITE.md` already uses bare `C1–C6`
-> for observable channels, `F1–F5` for findings, `G1–G19` for gaps, `I1–I3` for the invariants,
-> and `M`/`P` for register rows. Unprefixed task ids collided with all of them — the first draft
-> of this plan said "KBR-6 → G3" where the design says "KBR-6 → G15". The prefix is the fix, and
-> the **Design** column carries the reverse link.
+> **Identifiers.** Every task id is prefixed `T-`. `TEST_SUITE.md` already uses bare `C1–C6` for
+> observable channels, `F1–F5` for findings, `G1–G19` for gaps and `I1–I3` for the invariants. An
+> earlier draft collided with all of them. The **Design** column carries the reverse link.
 
----
-
-## 0. How this plan is organised
-
-The design has one shape problem for delivery: almost every interesting test depends on shared
-infrastructure that does not exist. Build it in the wrong order and one person writes harnesses
-for three weeks while everyone else waits.
-
-So the plan is arranged by **what unblocks the most people soonest**, not by importance:
-
-- **§2 Wave 0** is the enablement set — eight small artifacts, plus the handful of tasks that
-  genuinely need nothing. Until it lands, parallelism is capped around ten. After it, around
-  fifteen.
-- **§3–§13** are epics. Each task is atomic, independently landable, and carries its dependencies,
-  acceptance criteria and design reference.
-- **§14** is the wave plan and the two long chains. **§15** lists tasks blocked on decisions
-  rather than on code. **§16** covers the open defects. **§17** covers sequencing risk.
-
-**Read §1 before picking up any task.** The definition of done is unusual and it is the thing most
-likely to be got wrong.
+> **The epic tables in §4–§13 are the single source of truth for dependencies.** §14's tiers and
+> chains are *derived* from them — an earlier draft had a graph, a wave table and a duration
+> estimate that were three different schedules.
 
 ---
 
-## 1. Rules every task obeys
+## 1. How to use this plan
 
-### 1.1 Definition of done
+### 1.1 Schedule by readiness, not by wave
 
-1. The deliverable exists and satisfies the acceptance criteria in its row.
+§14 groups tasks into tiers, but **a tier is a derived view, not a gate**. A task is available the
+moment its own dependencies are done. Nobody waits for a tier to finish.
+
+### 1.2 Milestone 0 is contracts plus one proven slice
+
+Almost every interesting test needs shared infrastructure that does not exist. Milestone 0 (§3)
+delivers the **shared contracts** — types, schemas, protocols, extension interfaces — plus **one
+working vertical slice with a falsification case**, so later streams integrate against an
+interface proven once rather than against a promise.
+
+Give each shared file a named integration owner. Give each stream its own modules.
+
+### 1.3 Definition of done
+
+1. The deliverable satisfies the acceptance criteria in its row.
 2. `ruff`, `lint-imports`, `mypy src/kitty` and the full suite pass on Python 3.10–3.13.
-3. Every new test carries exactly one layer marker (**T-W1**) so it lands in exactly one CI job.
-4. Google-style docstrings on every class, method and function; module docstrings; block comments
-   explaining *why*. Test code is code.
-5. **It can land on `main` alone.** No task may leave the suite red waiting for a sibling. A check
-   that fails because of a known product defect lands with an entry in the exemption registry
-   (**T-W7**) — not disabled, not omitted.
+3. Every new test carries exactly one layer marker (**T-W1**).
+4. Google-style docstrings throughout; block comments explaining *why*. Test code is code.
+5. **It lands on `main` alone**, without leaving the suite red waiting for a sibling.
 
-### 1.2 The harness rule — a harness is not done until it has been seen to fail
+### 1.4 The harness rule
 
-This is the throughline of the design and the reason it took four review rounds. Repeatedly,
-proposed tests would have passed without proving anything: an oracle composed of two functions
-that were not inverses; a containment test asserting nothing arrived at a destination nothing
-could reach; a guard proving a function was *called* when the enforcement was the branch after it;
-a projection that could not see the model name, in a product whose purpose is changing the model
-name.
+Four review rounds on the design produced four harnesses that would have passed while proving
+nothing: an oracle composed of two functions that were not inverses; a containment test asserting
+nothing arrived at a destination nothing could reach; a guard proving a function was *called* when
+the enforcement was the branch after it; a projection that could not see the model name, in a
+product whose purpose is changing the model name.
 
-So for every task that builds a harness, assertion or guard:
+So:
 
-> **Acceptance requires a committed falsification case: a deliberate defect the harness must
-> detect, running in the suite, not demonstrated once by hand.**
+> **The first working version of every harness ships with at least one falsification case — a
+> deliberate defect it must detect, running in the suite.** The dedicated falsification task adds
+> the rest, and **is a hard prerequisite for that harness gating anything downstream.**
 
-Rows below name the specific case where the design specifies one; otherwise the author picks one
-and records it in the PR.
+An earlier draft made falsification mandatory in the definition of done and optional in the
+dependency graph, so both major harnesses could have become gating infrastructure before their
+falsification suites landed. The dependency rows below close that.
 
-### 1.3 Flags
+### 1.5 Flags and sizing
 
 | Flag | Meaning |
 |---|---|
-| **src** | Touches `src/kitty/`. Higher risk; needs a `code-reviewer` pass and a note in the PR |
-| **ci** | Touches `.github/workflows/`. Verify on a branch first — a broken gate is worse than a missing one |
-| **blocked** | Cannot start until an open question (`TEST_SUITE.md` §11) is answered. See §15 |
-| **partial** | Can start and land, but a stated part of its acceptance waits on a decision |
-| **defect** | Designed to land red, with an exemption removed by the defect's own ticket. See §16 |
+| **src** | Touches `src/kitty/`; needs a `code-reviewer` pass |
+| **ci** | Touches `.github/workflows/`; verify on a branch first |
+| **blocked** | Cannot start until an open question is answered (§15) |
+| **partial** | Lands, but a stated part of its acceptance waits on a decision |
+| **defect** | Relates to an open defect (§16) |
 | **resolves** | Its output answers an open question |
 
-### 1.4 Sizing
-
-**S** ≈ half a day · **M** ≈ 1–2 days · **L** ≈ 3–5 days. Nothing is larger than L; anything that
-looks larger is split. Sizes assume the author has read the referenced design section.
+**S** ≈ 0.5 day · **M** ≈ 1.5 days · **L** ≈ 4 days.
 
 ---
 
-## 2. Wave 0 — the enablement set
+## 2. Streams
 
-**Everything here is small, and nearly everything else waits on some of it.** Treat Wave 0 as one
-push with several people on it, not a queue.
+After Milestone 0, seven streams advance independently, each owning its own modules.
 
-| ID | Task | Depends on | Unblocks | Design | Size |
-|---|---|---|---|---|---|
-| **T-W1** | Layer markers and pytest config | — | Everything | §8 | M |
-| **T-W2** | Request types and the projection protocol | — | Epic A, then the oracle | §3.3.1 | S |
-| **T-W3** | The Permitted-Mutation Register as data | T-W2 | Oracle, register guard, corpus loader | §3.2 | M |
-| **T-W4** | Recorder protocol + primary aiohttp recorder | — | Epic B, T-W8, all of L3 | §7.2 | M |
-| **T-W5** | Shared CONNECT proxy fixture | — | All of Epic E | §7.3 | M |
-| **T-W6** | Corpus capture procedure, scrubber, loader | T-W3 | All of Epic C | §7.1 | M |
-| **T-W7** | The exemption registry | T-W1 | Every guard that lands red | §8 | M |
-| **T-W8** | Bridge-under-test fixture | T-W4 | ~15 tasks across D, E, G, I, J, K | §6.3.1 | M |
-
-**Genuinely needs nothing, start day one:** T-W1, T-W2, T-W4, T-W5, T-E6, T-E7, T-F1, T-I1, T-I3,
-T-I4, T-K1. Everything else in Wave 0 is one hop behind.
-
-### T-W1 — Layer markers and pytest config
-
-Register `l1`, `l2`, `l3`, `acceptance`, `agent_smoke`, `agent_live`, `eval`, `load`. A meta-test
-asserts **every collected test carries exactly one** — zero or two both fail.
-
-**Do not hand-edit 2,880 test functions across 139 files.** That is the worst possible first
-commit when a dozen people are about to branch, and it conflicts with every one of them. Assign
-the default in `pytest_collection_modifyitems` by path, and require an explicit marker only where
-the default is wrong. The meta-test is what stops the defaulting rotting.
-
-Also reconcile the existing `--runslow` skip-by-default mechanism with **T-K8** ("a gating job
-whose prerequisite is missing fails") — today `slow` tests silently skip, which is the pattern
-T-K8 forbids.
-
-*Done when:* removing a needed marker fails the meta-test; `pytest -m l1` collects a strict subset
-of `pytest`. *Size:* M — larger than it looks, because of the defaulting rules and the `--runslow`
-reconciliation.
-
-### T-W2 — Request types and the projection protocol
-
-`Request(envelope, conversation, residual)`, `Envelope`, `Conversation`, `Turn`, `Part` variants,
-and the `Projection` protocol. No readers — this is the shared vocabulary.
-
-Includes the **totality rule** as a reusable assertion: every key classifies into envelope,
-conversation or residual, and a non-empty residual raises. Shipping it here means all six readers
-inherit one semantics rather than six interpretations.
-
-*Done when:* a stub reader that silently drops an unknown key fails the totality assertion — the
-falsification case. *Size:* S.
-
-### T-W3 — The register as data
-
-Design §3.2 is a markdown table; the oracle takes `register` and `triggers_met` as arguments and
-the L2 completeness guard diffs against the same rows. **It has to become data, or both consume a
-prose table by hand.**
-
-One entry per row M1–M14 and P1–P21: id, site symbol, trigger predicate, the projection field it
-touches (`envelope.model`, `conversation.tools[].strict`, …), conditional or unconditional, design
-anchor. Also defines the **trigger vocabulary** T-W6's loader indexes by.
-
-*Done when:* a test asserts the markdown table and the data agree in both directions.
-Falsification: delete a row from either side. *Size:* M.
-
-### T-W4 — Recorder protocol and the primary aiohttp recorder
-
-`CapturedRequest(method, scheme, host, path, query, headers, body)` with original header casing and
-order, arrival timestamp, and **the peer port of the accepted connection** — the join key for
-containment (§5.2.1). Plus the aiohttp implementation serving Anthropic Messages and Chat
-Completions.
-
-**Ships one minimal valid success response per protocol.** Without it, any request driven through a
-real `BridgeServer` falls into the retry and failover paths — which are themselves body-mutating
-(M6, M8, M9) — and no consumer could obtain a clean baseline. The *failure* library is **T-B4**.
-
-Peer-port and casing capture are part of the **protocol**, enforced by a conformance test every
-Epic B recorder must pass — not restated per recorder and forgotten.
-
-*Done when:* casing and order survive capture; peer port is recorded; the conformance test exists
-and a recorder that lowercases headers fails it. *Size:* M.
-
-### T-W5 — Shared CONNECT proxy fixture
-
-Extract `_ConnectProxy` and `_TlsTarget` from `tests/test_egress_https_proxy.py` into a shared
-fixture. Extend it to record **the outbound source port of each tunnel** and to be stoppable
-mid-test.
-
-An extraction, not a rewrite: `test_egress_https_proxy.py` is the strongest existing asset in the
-suite and must pass unchanged against the extracted fixture.
-
-*Done when:* the existing module still passes; tunnel source port is recorded; stopping the proxy
-produces a connection failure, not a hang. *Size:* M.
-
-### T-W6 — Corpus capture procedure, scrubber and loader
-
-The capture procedure, a **credential scrubber**, and a loader exposing entries **by the register
-triggers they meet** (hence T-W3).
-
-The scrubber is load-bearing: a fixture file is as public as the repository, and captured
-transcripts carry prompts, file contents and API keys.
-
-Also **names an owner and a cadence for corpus refresh**, tied to Claude Code releases. Design
-§7.1 warns an un-refreshable corpus becomes a museum of a protocol nobody speaks; nothing else in
-this plan schedules that.
-
-*Done when:* the scrubber removes an API key, a bearer token and an absolute home path from a
-synthetic transcript; a CI lint fails on an unscrubbed fixture. *Size:* M.
-
-### T-W7 — The exemption registry
-
-Four guards and two acceptance scenarios are *designed* to land red (§16). They need the exemption
-mechanism before any of them can land, which makes this **enablement, not acceptance plumbing** —
-it sat in Epic J in the first draft, which stranded three Wave-0 tasks.
-
-Plain pytest, not BDD-specific: the Epic G guards are ordinary `l2` tests. An entry names **one
-assertion**, its expected failure condition and its ticket. Setup and every other assertion in the
-same test gate normally. **An unexpected pass fails the job** (`xfail(strict=True)` semantics). One
-registry file.
-
-*Done when:* a test with an exempt assertion **and** a second failing non-exempt assertion fails;
-an exempt assertion that starts passing fails. Those two are the falsification cases — without
-them this is the blanket amnesty the design rejects. *Size:* M.
-
-### T-W8 — Bridge-under-test fixture
-
-A profile/backend factory plus a real `BridgeServer` started against a named recorder, torn down
-cleanly. Around fifteen tasks across Epics D, E, G, I, J and K need exactly this; `conftest.py`
-offers only `sample_profile_dict` and `unused_tcp_port` today, and each of the ~40 files under
-`tests/bridge/` builds its own. Without this task, whoever picks up T-D1 builds it, and T-E3,
-T-G2 and T-I8 each build another.
-
-Constructs a profile for any adapter × model × transport, points its backend at a recorder host,
-starts the server in bridge mode, exposes both.
-
-*Done when:* one fixture call yields a running bridge for any registered adapter, and a test
-asserts teardown releases the port. *Size:* M.
+| Stream | Epics | Needs from Milestone 0 |
+|---|---|---|
+| **Fidelity** | A, D | Types, register, recorder, bridge fixture |
+| **Containment** | E | CONNECT proxy, bridge fixture |
+| **Corpus** | C | Corpus format and scrubber |
+| **Properties** | F | Nothing beyond `hypothesis` |
+| **Contracts** | G | Exemption registry, proxy fixture |
+| **Lifecycle** | I | Bridge fixture — several tasks need nothing |
+| **Evaluation** | H, K | Markers |
 
 ---
 
-## 3. Epic A — Wire projections
-
-Six independent readers, parallel after **T-W2**. Each imports **nothing from `src/kitty/bridge`**
-— that independence is the point (§3.3.1).
-
-| ID | Reader | Depends on | Design | Size |
-|---|---|---|---|---|
-| **T-A1** | Anthropic Messages | T-W2 | §3.3.1 | M |
-| **T-A2** | Chat Completions | T-W2 | §3.3.1 | M |
-| **T-A3** | OpenAI Responses | T-W2 | §3.3.1 | M |
-| **T-A4** | Gemini — **consumes the URL as well as the body**; model and operation live in the path | T-W2 | §3.3.5 | M |
-| **T-A5** | Bedrock Converse | T-W2 | §3.3.1 | M |
-| **T-A6** | Ollama `/api/chat` | T-W2 | §3.3.1 | S |
-
-**Acceptance, all six:** round-trips that format's **published examples** into `Request` with an
-empty residual — validated against the published schema, never against kitty's output. A reader
-validated against kitty's output inherits kitty's bugs and the oracle becomes circular.
-
-**Falsification, all six:** a body with one unrecognised key produces a non-empty residual and
-fails the totality assertion.
-
-**Deliberately *not* in scope here:** "residual empty across the whole corpus." That needs the
-corpus and belongs to **T-D8**, which owns coverage. Putting it in T-A1's acceptance made the
-projections silently depend on Epic C and dragged the corpus onto the critical path.
-
----
-
-## 4. Epic B — Recorders and scripted responses
-
-All depend on **T-W4** and must pass its recorder conformance test — including peer-port capture,
-which T-E4's tunnel join needs from every recorder, not only the primary.
+## 3. Milestone 0 — shared contracts and one proven slice
 
 | ID | Task | Depends on | Design | Size |
 |---|---|---|---|---|
-| **T-B1** | Provider-aiohttp recorder — `ollama_cloud` and the `openai_subscription` **OAuth legs**, which run at startup before anything else is proven | T-W4 | §5.5, §7.2 | M |
-| **T-B2** | curl_cffi-reachable recorder with harness TLS — the only place `_cc_to_responses` output (P13, P17) is observable | T-W4 | §7.2 | M |
-| **T-B3** | botocore endpoint-override recorder — captures the Converse payload **after** the transport's `modelId`/`stream` pops (P18) | T-W4 | §3.2.3, §7.2 | M |
-| **T-B4** | Scripted failure library — SSE variants, error statuses, Cloudflare blocks, empty responses, context-too-large rejections, mid-stream disconnect at each of the four §6.3.1 injection points | T-W4 | §6.3.1, §7.2 | M |
+| **T-W1** | Layer markers, CI selection rules, per-category collection checks | — | §8 | M |
+| **T-W2** | Request/capture types and the projection protocol | — | §3.3.1 | S |
+| **T-W3** | Register schema and data | T-W2 | §3.2 | M |
+| **T-W4** | Recorder protocol + primary aiohttp recorder | — | §7.2 | M |
+| **T-W5** | Shared CONNECT proxy fixture | — | §7.3 | M |
+| **T-W6** | Corpus format, capture procedure, scrubber, loader | T-W3 | §7.1 | M |
+| **T-W7** | Assertion exemption registry | T-W1 | §8 | M |
+| **T-W8** | Bridge fixture **core + transport extension interface** | T-W4 | §6.3.1 | M |
+| **T-W9** | **The proven vertical slice** | T-W1, T-W4, T-W8 | §6.3.1 | S |
+
+**T-W1 — markers and CI selection.** Register `l1`, `l2`, `l3`, `acceptance`, `agent_smoke`,
+`agent_live`, `eval`, `load`; a meta-test asserts every collected test carries exactly one. **Do
+not hand-edit 2,880 test functions** — default by path in `pytest_collection_modifyitems`, and
+require an explicit marker only where the default is wrong.
+
+This also establishes the **CI selection mechanism and per-category collection checks up front**,
+not in Epic K: parallel authors need the divided test command from day one. And a category that
+must be non-empty needs its own check — an earlier draft claimed `pytest -m "acceptance or
+agent_smoke"` would exit 5 when agent-smoke tests were missing. **That is wrong.** Once acceptance
+tests exist the expression collects them and passes happily with zero agent-smoke coverage. Also
+reconcile the existing `--runslow` silent skip with the same rule.
+
+**T-W2 — types.** `Request(envelope, conversation, residual)`, `Envelope`, `Conversation`, `Turn`,
+`Part` variants, `Reply` for the response direction, and the `Projection` protocol. Includes the
+**totality rule**: every key classifies into envelope, conversation or residual, and a non-empty
+residual raises. *Falsification:* a stub reader that drops an unknown key fails it.
+
+**T-W3 — register.** One entry per row M1–M14 and P1–P21: id, site symbol, trigger predicate, the
+projection field it touches, conditional or not, design anchor. Defines the trigger vocabulary
+T-W6 indexes by. *Falsification:* delete a row from the markdown or the data; the agreement test
+fails.
+
+**T-W4 — recorder protocol.** `CapturedRequest(method, scheme, host, path, query, headers, body)`
+with original casing and order, arrival timestamp, and **the peer port of the accepted
+connection**. Ships **one minimal valid success response per protocol** — without it any request
+driven through a real bridge falls into the retry paths, which are themselves body-mutating. The
+failure library is T-B4. Peer-port and casing capture are enforced by a **conformance test every
+Epic B recorder must pass**.
+
+**T-W5 — CONNECT proxy.** Extract `_ConnectProxy`/`_TlsTarget` from
+`tests/test_egress_https_proxy.py`; add tunnel source-port recording and mid-test stoppability. An
+extraction, not a rewrite: that module must pass unchanged.
+
+**T-W6 — corpus.** Format, capture procedure, credential scrubber, and a loader indexing entries
+by register trigger. Names an **owner and cadence for refresh**. *Falsification:* an unscrubbed
+fixture fails a CI lint.
+
+**T-W7 — exemption registry.** Plain pytest, not BDD-specific. An entry names **one assertion**,
+its expected failure condition and its ticket; everything else in the test gates normally; an
+unexpected pass fails (`xfail(strict=True)`). *Falsification:* a second, non-exempt failing
+assertion in the same test must still fail the job.
+
+**T-W8 — bridge fixture core and extension interface.** A profile/backend factory and a real
+`BridgeServer` started against a recorder, for the **default aiohttp transport only**, plus the
+**extension interface** custom transports plug into. An earlier draft promised "any registered
+adapter" while depending only on T-W4 — which would have meant implementing T-B1–T-B3 inside the
+shared fixture. Defining the interface here lets recorder authors integrate without editing the
+core.
+
+**T-W9 — the proven vertical slice.** Drive one request from the bridge fixture into the recorder
+and assert the capture is complete and correct. Small, but it is the first moment the contracts
+are known to compose. *Falsification:* a recorder that drops the query string fails it.
 
 ---
 
-## 5. Epic C — Golden corpus
+## 4. Epic A — Projections
 
-Parallel after **T-W6**. Coverage is driven by the register: every conditional row needs a trigger
-case **and** a complement.
+| ID | Task | Depends on | Design | Size |
+|---|---|---|---|---|
+| **T-A1** | Anthropic Messages reader | T-W2 | §3.3.1 | M |
+| **T-A2** | Chat Completions reader | T-W2 | §3.3.1 | M |
+| **T-A3** | OpenAI Responses reader | T-W2 | §3.3.1 | M |
+| **T-A4** | Gemini reader — **consumes the URL as well as the body** | T-W2 | §3.3.5 | M |
+| **T-A5** | Bedrock Converse reader | T-W2 | §3.3.1 | M |
+| **T-A6** | Ollama `/api/chat` reader | T-W2 | §3.3.1 | S |
+| **T-A7** | **Response-direction `Reply` projection** — parts, stop reason, usage | T-W2 | §3.3.1 | M |
+
+**All readers:** validated against that format's **published examples**, never against kitty's
+output — a reader validated against kitty's output inherits kitty's bugs and the oracle becomes
+circular. *Falsification:* one unrecognised key produces a non-empty residual.
+
+"Residual empty across the whole corpus" belongs to **T-D8**, not here; putting it in T-A1's
+acceptance made the projections silently depend on Epic C.
+
+---
+
+## 5. Epic B — Recorders
+
+Each task delivers a recorder **and its bridge-fixture integration** through T-W8's extension
+interface, and must pass T-W4's conformance test — including peer-port capture, which T-E2's
+tunnel join needs from every recorder.
+
+| ID | Task | Depends on | Design | Size |
+|---|---|---|---|---|
+| **T-B1** | Provider-aiohttp recorder + integration — `ollama_cloud`, and the `openai_subscription` **OAuth legs** that run at startup | T-W4, T-W8 | §5.5, §7.2 | M |
+| **T-B2** | curl_cffi recorder + integration, harness TLS — the only place `_cc_to_responses` output is observable | T-W4, T-W8 | §7.2 | M |
+| **T-B3** | botocore recorder + integration — captures the Converse payload **after** the transport's `modelId`/`stream` pops | T-W4, T-W8 | §3.2.3, §7.2 | M |
+| **T-B4** | Scripted failure library — SSE variants, errors, Cloudflare, empty responses, context-too-large, mid-stream disconnect at each of the four injection points | T-W4 | §6.3.1 | M |
+
+---
+
+## 6. Epic C — Corpus
 
 | ID | Entries | Depends on | Covers | Size |
 |---|---|---|---|---|
 | **T-C1** | Plain turn, tools declared, `tool_use`, `tool_result` | T-W6 | Complement for most conditional rows; M7 | S |
 | **T-C2** | Thinking, image, `system` with `cache_control` | T-W6 | P2a/b, P5c–e, P8, M8 | S |
-| **T-C3** | Tool result under/over 50,000 chars; transcript under/over the compaction budget | T-W6 | M3, M4, M5 — triggers and complements | M |
-| **T-C4** | 400/413 recovery against a **balancing** profile; system prompt alone over the window; a single final turn over the budget | T-W6 | M6, M13, the irreducible-set case | M |
-| **T-C5** | The vendor-string regression entry — a turn reading `Please explain how kitty-bridge works` | T-W6 | §3.3.3 | S |
-| **T-C6** | `max_tokens` above/below 4096 × streaming/non-streaming; a malformed body | T-W6 | P7, P13, the L2 fuzz path | S |
-| **T-C7** | Native Claude Code baseline — headers **and** connection pattern | T-W6 | Baselines for design channels C1b (header parity) and C5 (connection lifecycle) — consumed by T-I12 and T-I9 | M |
+| **T-C3** | Tool result under/over 50,000 chars; transcript under/over the compaction budget | T-W6 | M3, M4, M5 | M |
+| **T-C4** | 400/413 recovery on a **balancing** profile; system prompt alone over the window; a single final turn over budget | T-W6 | M6, M13, irreducible set | M |
+| **T-C5** | The vendor-string entry — `Please explain how kitty-bridge works` | T-W6 | §3.3.3 | S |
+| **T-C6** | `max_tokens` above/below 4096 × streaming/non-streaming; a malformed body | T-W6 | P7, P13, fuzz path | S |
+| **T-C7** | Native Claude Code baseline — headers and connection pattern | T-W6 | Baselines for design channels C1b and C5 | M |
 
-**T-C4's M6 entry must be authored against a balancing profile.** `_compact_with_tighter_budget`
-is called only from `_request_with_retry_balancing`; a single-backend profile never reaches it and
-the entry would silently never fire.
+**T-C4's recovery entry must use a balancing profile** — `_compact_with_tighter_budget` is reached
+only from `_request_with_retry_balancing`. **T-C4 and T-C6 are deliberately synthesised**: a
+system prompt over the window and a malformed body do not occur in a real session on demand, so
+design §7.1's "real, not synthetic" rationale does not apply; record that beside the fixtures.
 
-**T-C4 and T-C6 are deliberately synthesised, not captured.** A system prompt larger than the
-window, and a malformed body, do not occur in a real session on demand — so design §7.1's
-"real, not synthetic" rationale does not apply to them. Record that reasoning beside the fixtures;
-the scrubber and lint rules still apply.
-
-**Scheduling note:** T-C1–T-C7 share one capture-and-secret-review pass. Seven tasks, not seven
-independent parallel slots.
+**T-C1–T-C7 share one capture-and-secret-review pass** — seven tasks, not seven parallel slots.
 
 ---
 
-## 6. Epic D — The fidelity oracle (I1)
+## 7. Epic D — Fidelity oracle
+
+**T-D4–T-D7 are siblings, not a chain.** Each consumes the oracle interface plus its own
+transport's prerequisites. An earlier draft made T-D5–T-D7 wait for the full 20-adapter default
+matrix, serialising unrelated provider coverage.
 
 | ID | Task | Depends on | Done when | Design | Size |
 |---|---|---|---|---|---|
-| **T-D1** | Oracle core | T-W2, T-W3, T-W4, T-W8, T-A1, T-A2, T-C1 | `assert_no_unclaimed_mutation` runs end to end on one default-transport adapter with both §3.3.2 assertions. **Accepts `expected_route`** so T-D2 is a filling-in, not a signature change. **Includes the byte-level key-order assertion on the native passthrough path** — the one place the comparison is not projected | §3.3, §4.3 C2 | L |
-| **T-D2** | Independent routing expectation | T-D1, T-A4 | Expected host/path/query computed from the profile using the provider's *published* URL shape — **never** by calling `build_base_url()` / `get_upstream_path()` | §3.3.5 | M |
-| **T-D3** | Falsification suite | T-D1, T-D2 | Six cases, all failing the oracle, in the suite: changed model · flipped `stream` · deleted tool description · stripped `strict` · injected metadata field (non-empty residual) · **changed Azure deployment segment with a byte-identical body** | §3.3.1, §3.3.5 | M |
-| **T-D4** | Parametrise — default aiohttp transport | T-D1, T-D2, T-A1–T-A4, T-B4, T-C1–T-C6, T-W8 | The 20 default-transport adapters at their representative models; `opencode_go` per route | §3.3.4 | L |
-| **T-D5** | Parametrise — curl_cffi | T-D4, T-B2, T-A3 | `openai_subscription` serving path, observing P13–P17 | §3.3.2 | M |
-| **T-D6** | Parametrise — botocore | T-D4, T-B3, T-A5 | `bedrock`, observing the Converse payload after P18 | §3.3.2 | M |
-| **T-D7** | Parametrise — provider aiohttp | T-D4, T-B1, T-A6 | `ollama_cloud` after P19; the subscription OAuth leg | §3.3.2 | M |
-| **T-D8** | Coverage checker | T-D4, T-W3, T-C1–T-C6 | A meta-test failing when any conditional register row lacks a trigger case or a complement. **Also owns "residual empty across the whole corpus"** for all six readers | §3.3.4 | M |
-
-**T-D3 lands immediately after T-D1/T-D2, not at the end.** It is what distinguishes an oracle from
-a decoration.
-
-**T-D4 was one L covering four transports.** Split per transport so each is landable and each
-extends the parametrisation, rather than one task with thirteen predecessors on the critical path.
+| **T-D1** | Oracle core **+ first falsification case** | T-W2, T-W3, T-W8, T-W9, T-A1, T-A2, T-C1 | Both §3.3.2 assertions on one adapter; accepts `expected_route` so T-D2 is a filling-in; includes the byte-level key-order assertion on the native passthrough path; **a changed model must fail the oracle** | §3.3, §4.3 C2 | L |
+| **T-D2** | Routing expectation **+ its falsification** | T-D1, T-A4 | Route derived from the profile using the provider's *published* URL shape, never `build_base_url()`; a changed Azure deployment segment with a byte-identical body must fail | §3.3.5 | M |
+| **T-D3** | Remaining falsification cases | T-D1, T-D2 | Flipped `stream`, deleted tool description, stripped `strict`, injected metadata field. **Hard prerequisite for T-J2** — the oracle does not gate acceptance until its falsification suite is complete | §3.3.1 | M |
+| **T-D4** | Default-transport slice | T-D1, T-D2, T-B4 | One representative default adapter, end to end | §3.3.4 | M |
+| **T-D5** | curl_cffi slice | T-D1, T-D2, T-B2, T-A3 | `openai_subscription`, observing P13–P17 | §3.3.2 | M |
+| **T-D6** | botocore slice | T-D1, T-D2, T-B3, T-A5 | `bedrock`, observing the Converse payload after P18 | §3.3.2 | M |
+| **T-D7** | Provider-aiohttp slice | T-D1, T-D2, T-B1, T-A6 | `ollama_cloud` after P19; the subscription OAuth leg | §3.3.2 | M |
+| **T-D9** | Full default-transport matrix | T-D4, T-A3, T-A4, T-C2, T-C3, T-C4, T-C6 | All 20 default adapters at representative models; `opencode_go` per route | §3.3.4 | L |
+| **T-D10** | Response-direction comparison | T-D1, T-A7 | `Reply` projections compared on the response path — a separate claim from request fidelity, tested separately | §3.3.1 | M |
+| **T-D8** | Coverage checker | T-D9, T-D5, T-D6, T-D7, T-W3, T-A5, T-A6, T-A7, T-C5 | Fails when any conditional register row lacks a trigger case or a complement. **Owns "residual empty across the whole corpus" for all seven readers** | §3.3.4 | M |
 
 ---
 
-## 7. Epic E — Containment (I3)
+## 8. Epic E — Containment
+
+**T-E2 is one complete, falsified aiohttp slice.** T-E3–T-E5 extend it per transport as siblings.
+An earlier draft made a single positive-control task wait on every transport's direct route, so a
+difficult botocore route delayed even aiohttp containment — contradicting this plan's own claim
+that a stuck transport blocks only its own task.
 
 | ID | Task | Flags | Depends on | Done when | Design | Size |
 |---|---|---|---|---|---|---|
-| **T-E1** | Hostname harness + aiohttp direct route | | T-W5, T-W4, T-W8 | Upstream addressed as `upstream.kitty-test.invalid`; direct leg resolves via a monkeypatched aiohttp resolver — **not** `/etc/hosts`, which needs admin rights and is unavailable on most CI runners | §5.3 | L |
-| **T-E2** | curl_cffi and botocore direct routes | | T-E1, T-B2, T-B3 | curl's `resolve` mapping and a botocore `endpoint_url` override. **A transport that cannot be given a working direct route is reported `unproven`, not passed** | §5.3, §5.5 | M |
-| **T-E3** | Phase 1 — positive controls | | T-E1, T-E2 | With egress **disabled**, each transport reaches the upstream directly and the connection is recorded | §5.2.2 | M |
-| **T-E4** | Phase 2/2b — containment and tunnel correlation | | T-E3, T-W5 | Proxy down ⇒ **zero** upstream connections and the request fails. Proxy up ⇒ every accepted connection joins a tunnel on the recorded source port, N requests per tunnel allowed, failed tunnels contributing none | §5.2.1, §5.2.2 | L |
-| **T-E5** | Phase 3 — falsification | | T-E4 | A deliberately injected bypass — patched `should_bypass`, or a session built without the proxy — makes the harness fail | §5.2.2 | M |
-| **T-E6** | Guard **enforcement** | | — | Each of the five start paths driven with a rejecting configuration asserts **no server starts**: no listening socket, non-zero exit. Falsification: a variant keeping the `egress_block_reason()` call and discarding its return value must make these fail. **No recorder needed — nothing reaches upstream by construction** | §6.2.3 | M |
-| **T-E7** | AST start-path domination guard | | — | Every `BridgeServer(` construction is dominated by an `egress_block_reason(` call at AST level, not file level. Falsification: move a construction above its guard call in the same file | §5.1, §6.2.3 | M |
-| **T-E8** | Local bypass, fail-closed, and the transport asymmetry | | T-E1 | Loopback/`localhost` provider connects directly **on bridge sessions**; a `supports_egress() == False` profile blocks startup **and the message names the profile** (EG-3's assertion); and the complement — those destinations **are** tunnelled on curl_cffi, botocore and provider-aiohttp, which have no bypass. Pinning the asymmetry stops a future "fix" quietly adding one | §5.5, §5.2.2 | M |
-
-**T-E6 and T-E7 are complements and both are needed.** T-E7 proves the guard is *called*; T-E6
-proves its answer is *obeyed*. Deleting `if egress_error: return 1` passes T-E7 and fails T-E6.
-Both need nothing and belong in Wave 0.
+| **T-E1** | Harness core, aiohttp direct route, **transport extension interface** | | T-W5, T-W8, T-W9 | Upstream addressed as `upstream.kitty-test.invalid`; aiohttp direct leg via a monkeypatched resolver — **not** `/etc/hosts`, unavailable on CI runners | §5.3 | L |
+| **T-E2** | **aiohttp containment slice, complete and falsified** | | T-E1 | Phase 1 positive control; proxy down ⇒ zero connections; proxy up ⇒ every connection joins a tunnel on the recorded source port; **and an injected bypass makes the harness fail** | §5.2.1, §5.2.2 | L |
+| **T-E3** | curl_cffi route and slice | | T-E1, T-E2, T-B2 | All four phases for curl_cffi | §5.3, §5.5 | M |
+| **T-E4** | botocore route and slice | | T-E1, T-E2, T-B3 | All four phases for botocore | §5.3, §5.5 | M |
+| **T-E5** | Provider-aiohttp route and slice | | T-E1, T-E2, T-B1 | All four phases for the provider sessions and the OAuth leg | §5.5 | M |
+| **T-E6** | Guard **enforcement** | | — | Five start paths with a rejecting configuration assert **no server starts**. Falsification: a variant keeping the call and discarding its return value must fail these. **No recorder needed** | §6.2.3 | M |
+| **T-E7** | AST start-path domination | | — | Every `BridgeServer(` construction dominated by an `egress_block_reason(` call at AST level | §5.1 | M |
+| **T-E8** | Local bypass, fail-closed, transport asymmetry | | T-E2, T-E3, T-E4, T-E5 | Loopback bypass on bridge sessions; a `supports_egress() == False` profile blocks startup **and names the profile**; and the complement — those destinations **are** tunnelled on the three custom transports, which have no bypass | §5.5 | M |
+| **T-E9** | Proven / unproven report | | T-E3, T-E4, T-E5 | Each transport is either proven or **explicitly reported unproven**. A transport that cannot be given a working direct route is never silently counted as passing | §5.3 | S |
 
 ---
 
-## 8. Epic F — L1 component and property
+## 9. Epic F — Properties
 
-| ID | Task | Depends on | Done when | Design | Size |
-|---|---|---|---|---|---|
-| **T-F1** | `hypothesis` in the dev extra + a shared strategy library for Messages/CC transcripts | — | Strategies reusable by T-F2–T-F5 | §6.1 | M |
-| **T-F2** | Compaction properties | T-F1 | Identity below budget · no orphaned pair · idempotent · **output ≤ budget unless the surviving set is irreducible**, stated with the exception | §6.1 | M |
-| **T-F3** | Pairing and truncation properties | T-F1 | No orphan in either shape; truncation identity below the limit, bounded above it | §6.1 | M |
-| **T-F4** | Egress properties | T-F1 | Private ranges bypassed; **no hostname outside the `localhost` family bypassed**; `parse_proxy_url` round-trip; **structural** redaction — the password component of `masked()` is exactly the mask, never a substring test | §5.3, §6.1 | M |
-| **T-F5** | `describe_tool_input_anomaly` property | T-F1 | Never reports an anomaly for input valid against the declared schema | §6.1 | S |
-| **T-F6** | Translator semantic property via the projections | T-F1, T-A1, T-A2 | `project_messages(inbound)` equals `project_cc(translate_request(inbound))` — the projections, never a translator round-trip | §3.3.1, §6.1 | M |
+| ID | Task | Depends on | Design | Size |
+|---|---|---|---|---|
+| **T-F1** | `hypothesis` + shared transcript strategies | — | §6.1 | M |
+| **T-F2** | Compaction properties — including **output ≤ budget unless the surviving set is irreducible** | T-F1 | §6.1 | M |
+| **T-F3** | Pairing and truncation properties | T-F1 | §6.1 | M |
+| **T-F4** | Egress properties — private ranges; **no hostname outside the `localhost` family bypassed**; **structural** password redaction, never a substring test | T-F1 | §5.3, §6.1 | M |
+| **T-F5** | `describe_tool_input_anomaly` property | T-F1 | §6.1 | S |
+| **T-F6** | Translator semantic property **via the projections** | T-F1, T-A1, T-A2 | §3.3.1 | M |
 
-**T-F4's `should_bypass` property is load-bearing beyond L1**: it is the premise T-E1's harness
-rests on. If someone adds name resolution to `should_bypass`, T-F4 fails and T-E1's design is
-re-examined — rather than T-E1 quietly going vacuous.
+**T-F4 is load-bearing beyond L1**: it pins the premise T-E1's harness rests on.
 
 ---
 
-## 9. Epic G — L2 contract
+## 10. Epic G — Contracts
 
 | ID | Task | Flags | Depends on | Done when | Design | Size |
 |---|---|---|---|---|---|---|
-| **T-G1** | README ⇄ code table guards | defect | T-W7 | Endpoint, attribution-header, env-var and logging-flag tables. Lands red against the endpoint table → exemption (KBR-9 / gap G6) | §6.2.3 | M |
-| **T-G2** | Register completeness — coverage over the captures | | T-W3, T-D4 | Per adapter × model × transport, the captured delta equals the union of that adapter's rows whose triggers the input met. **A meta-assertion over T-D4–T-D7's captures, marked `l3`** — it does not re-drive the wire, and it must not put real sockets in the fast gate | §6.2.3 | M |
-| **T-G3** | Internal-key completeness AST guard | defect | T-W7 | Every `_`-prefixed key written into a request dict in `bridge/**` is in `_INTERNAL_KEYS`. Lands red → exemption (KBR-6 / gap G15) | §6.2.3 | M |
-| **T-G4** | Wire-shape honesty guard | defect | T-W7, T-W8, T-B1–T-B3 | `upstream_wire_is_messages_api` agrees with the observed output shape per adapter × representative model. Lands red → exemption (KBR-7 / gap G16) | §6.2.3 | M |
-| **T-G5** | Bridge-introduced vendor token guard | defect | T-D1, T-W7, T-C5 | No **bridge-introduced** content contains `kitty` in any casing, scoped by the projection diff — **and, in the same run**, an inbound turn containing `kitty-bridge` survives byte-identically. A harness that cannot do both at once has not solved the problem. Lands red → exemption (KBR-5 / gap G14) | §3.3.3, §6.2.3 | M |
-| **T-G6** | OpenAPI 3.1 document + schemathesis | | T-W8 | Five POST routes plus `/healthz`, `/stats`, `/v1/models`, **targeting a bridge started in bridge mode**; a separate guard asserts the per-protocol registration matrix | §6.2.1 | L |
-| **T-G7** | SSE grammar state machine | | T-B4, T-W8 | Every stream — including error streams, mid-stream failover and the empty-response fallback — is a sentence in the Anthropic event grammar, across all three streaming protocols | §6.2.2 | M |
-| **T-G8** | Dependency behaviour contracts | | T-W5 | aiohttp session proxy across `>=3.11,<3.14`; `curl_cffi` `proxies=` precedence over ambient `HTTP_PROXY`/`NO_PROXY`; `botocore Config(proxies=)` precedence; `keyring` backends. **Also declares `botocore` explicitly** — a containment guarantee currently rests on an undeclared transitive dependency | §6.2.4 | M |
-| **T-G9** | **Header contract** | defect | T-W7 | Per adapter, an **exact** header set — names present, names absent, casing, value shape. Plus: no adapter derives a `User-Agent` or version header from `kitty.__version__`, and where both a UA version and a `version` header are sent they agree. **This is the test that catches KBR-8.** Lands red → exemption (gap G3) | §4.3 C1 | M |
+| **T-G1** | README ⇄ code table guards | defect | T-W7 | Endpoint, attribution-header, env-var, logging-flag tables (KBR-9) | §6.2.3 | M |
+| **T-G2** | Register coverage meta-assertion | | T-W3, T-D9, T-D5, T-D6, T-D7 | Over T-D4–T-D9's captures — **it does not re-drive the wire**, and is marked `l3` so it cannot put sockets in the fast gate | §6.2.3 | M |
+| **T-G3** | Internal-key completeness AST guard | defect | T-W7 | Every `_`-prefixed key written into a request dict is in `_INTERNAL_KEYS` (KBR-6) | §6.2.3 | M |
+| **T-G4** | Wire-shape honesty guard | defect | T-W7, T-B1, T-B2, T-B3 | `upstream_wire_is_messages_api` agrees with the observed output shape per adapter × model (KBR-7) | §6.2.3 | M |
+| **T-G5** | Bridge-introduced vendor token guard | defect | T-D1, T-W7, T-C5 | No bridge-introduced content names kitty — **and in the same run** an inbound turn containing `kitty-bridge` survives byte-identically (KBR-5) | §3.3.3 | M |
+| **T-G6** | OpenAPI 3.1 + schemathesis | | T-W8 | Five POST routes plus `/healthz`, `/stats`, `/v1/models`, **targeting bridge mode**; plus a per-protocol registration-matrix guard | §6.2.1 | L |
+| **T-G7** | SSE grammar state machine | | T-B4, T-W8 | Every stream, including error streams and mid-stream failover, is a sentence in the grammar | §6.2.2 | M |
+| **T-G8** | aiohttp proxy contract | | T-W5 | Session-level proxy across `>=3.11,<3.14`; a per-request `proxy=None` cannot escape it | §6.2.4 | S |
+| **T-G9** | **Header contract** | defect | T-W7 | Exact header set per adapter — names, absences, casing, value shape. No `User-Agent` or version header derived from `kitty.__version__`; where both are sent they agree. **This catches KBR-8** | §4.3 C1 | M |
+| **T-G10** | curl_cffi proxy contract | | T-W5 | `proxies=` honoured; precedence over ambient `HTTP_PROXY`/`NO_PROXY` | §6.2.4 | S |
+| **T-G11** | botocore proxy contract + **declare `botocore`** | | T-W5 | `Config(proxies=)` precedence over the environment; and the dependency is declared, since a containment guarantee currently rests on an undeclared transitive | §6.2.4 | S |
+| **T-G12** | `keyring` backend contract | | — | Backend resolution on each supported platform | §6.2.4 | S |
 
 ---
 
-## 10. Epic H — Mutation validation
+## 11. Epic H — Mutation validation
 
 | ID | Task | Flags | Depends on | Done when | Design | Size |
 |---|---|---|---|---|---|---|
-| **T-H1** | `mutmut` config, L1 selection, baseline | | T-W1 | `[tool.mutmut]` with array `source_paths` and `pytest_add_cli_args_test_selection = ["-m", "l1"]`; a recorded baseline per target group | §6.1 | M |
-| **T-H2** | Extract pure payload builders | **src** | T-B3 | `_bedrock_body(...)` and `_ollama_body(...)` extracted from `make_request`/`stream_request`. **Depends on T-B3 because "behaviour unchanged" needs a characterisation test** — T-B3 is what makes the post-mutation Converse payload observable | §6.1 | M |
-| **T-H3** | Per-component thresholds + CI reporting | ci | T-H1, T-H2, T-F2–T-F6 | ≥ 85% killed **per target group**, not one aggregate; survivor triage documented; `mutmut export-cicd-stats` in the nightly job | §6.1 | M |
-| **T-H4** | Measure changed-code mutation runtime | resolves Q11 | T-H1 | Timed `mutmut run` restricted to a representative PR's functions, against the fast gate's budget | §6.1 | S |
+| **T-H1** | `mutmut` config, L1 selection, baseline | | T-W1 | Array `source_paths`, `pytest_add_cli_args_test_selection = ["-m", "l1"]`, baseline per target group | §6.1 | M |
+| **T-H2** | Extract `_bedrock_body` | **src** | T-B3 | Payload shaping out of `make_request`/`stream_request`, behind T-B3's characterisation capture | §6.1 | M |
+| **T-H5** | Extract `_ollama_body` | **src** | T-B1 | Same for `ollama_cloud`, behind **its own** characterisation capture | §6.1 | M |
+| **T-H3** | Per-component thresholds + nightly reporting | ci | T-H1, T-H2, T-H5, T-F2, T-F3, T-F4, T-F5, T-F6 | ≥ 85% killed **per target group**, not one aggregate | §6.1 | M |
+| **T-H4** | Measure changed-code mutation runtime | resolves Q11 | T-H1 | Timed against the fast gate's budget | §6.1 | S |
+
+**T-H2 and T-H5 are separate** — one refactor per module, each behind the characterisation test
+that makes *its* bytes observable. Bundled, the Ollama half would have had no evidence.
 
 ---
 
-## 11. Epic I — L3 subsystem
+## 12. Epic I — Lifecycle and subsystem
 
 | ID | Task | Flags | Depends on | Done when | Design | Size |
 |---|---|---|---|---|---|---|
-| **T-I1** | Settings lifecycle | | — | Normal exit, `SIGTERM`, `SIGKILL` + `kitty cleanup`; global settings byte-identical before and after; `_kitty_values_present` fires only on kitty-written state | §6.3.2 | M |
-| **T-I2** | Concurrent sessions | | T-I1 | Two sessions, separate `--settings` files, neither touches `~/.claude/settings.json`, the second does not disturb the first (issue #22) | §6.3.2 | M |
-| **T-I3** | `prepare_launch` failure fails the launch | | — | When the session file cannot be written, launch **fails** rather than running on the user's own Anthropic credentials | §6.3.2 | S |
-| **T-I4** | Background bridge ownership | | — | A bridge owned by another user is not stopped, not restarted, no second bridge starts beside it | §6.3.2 | S |
-| **T-I5** | Agent startup smoke | blocked Q12 | T-W4, T-W8, T-B4 | Pinned real Claude Code binary, one non-interactive turn against the recorder, clean exit | §6.4.2 | M |
-| **T-I6** | Agent settings precedence | blocked Q12 | T-I5 | Three runs, three winners: session file beats both; without it the global file beats the environment; without either the environment wins. Every sentinel demonstrated live | §6.4.2 | M |
-| **T-I7** | Streaming recovery — content | partial Q14 | T-B4, T-G7, T-W8 | Four injection points; no duplicated text, no tool-call id reused across attempts, no spliced arguments, exactly one terminal outcome. **Positive post-emission oracle waits on Q14**; until then the negatives only | §6.3.1 | L |
-| **T-I8** | Cross-attempt content and cadence | | T-D1, T-W8, T-B4 | Transport-blip and empty-response retries byte-identical; M6, M8, M9 and failover re-normalisation each fire only under their own trigger | §4.3 C3 | M |
-| **T-I9** | Connection lifecycle baseline | | T-W4, T-W8, T-C7 | Distinct TCP connections per N-turn session against the native capture; reported baseline, ratcheted | §4.3 C5 | M |
-| **T-I10** | `_backend_context` isolation | | T-W8 | Concurrent requests never observe each other's backend selection. Deterministic — belongs here, not in the load profile | §6.3.1 | S |
-| **T-I11** | Failover, disconnect, error envelopes | | T-B4, T-W8 | Streaming failover mid-response; client disconnect releases the upstream connection without marking the backend unhealthy; all-backends-unhealthy 503 in each protocol's native envelope; oversized request in the protocol's own error shape | §6.3.1 | M |
-| **T-I12** | Fingerprint parity report | | T-C7, T-W8, T-G9 | kitty's header set compared against the native baseline; **reported with a ratchet, not gating**, until gap G3 closes | §4.3 C1b | M |
-| **T-I13** | Side traffic | | T-W4, T-W8 | `GET /healthz` and `GET /stats` never cause an upstream request; a launch contacts the provider only for the agent's turns plus pre-flight validation, pinned as a declared exception; `kitty --no-validate` removes it | §4.3 C6 | M |
+| **T-I1** | Settings lifecycle | | — | Normal exit, `SIGTERM`, `SIGKILL` + `kitty cleanup`; global settings byte-identical | §6.3.2 | M |
+| **T-I2** | Concurrent sessions | | T-I1 | Separate `--settings` files; neither touches the global file (issue #22) | §6.3.2 | M |
+| **T-I3** | `prepare_launch` failure fails the launch | | — | Never proceeds on the user's own credentials | §6.3.2 | S |
+| **T-I4** | Background bridge ownership | | — | Not stopped, not restarted, no second bridge | §6.3.2 | S |
+| **T-I5** | Agent startup smoke | blocked Q12 | T-W8, T-W9, T-B4 | Pinned Claude Code binary, one turn, clean exit | §6.4.2 | M |
+| **T-I6** | Agent settings precedence | blocked Q12 | T-I5 | Three runs, three winners; every sentinel demonstrated live | §6.4.2 | M |
+| **T-I7** | Streaming recovery — content | partial Q14 | T-B4, T-G7, T-W8 | Four injection points; no duplicated text, no reused tool-call id, no spliced arguments. Positive oracle waits on Q14 | §6.3.1 | L |
+| **T-I8** | Cross-attempt content and cadence | | T-D1, T-W8, T-B4 | Blip and empty-response retries byte-identical; M6, M8, M9 and failover re-normalisation each fire only on trigger | §4.3 C3 | M |
+| **T-I9** | Connection lifecycle baseline | | T-W8, T-C7 | Distinct connections per session vs the native capture; ratcheted | §4.3 C5 | M |
+| **T-I10** | `_backend_context` isolation | | T-W8 | Deterministic; belongs here, not in load | §6.3.1 | S |
+| **T-I11** | Failover, disconnect, error envelopes | | T-B4, T-W8 | Mid-stream failover; disconnect releases upstream without marking unhealthy; 503 in each native envelope; oversized in the protocol's error shape | §6.3.1 | M |
+| **T-I12** | Fingerprint parity report | | T-C7, T-W8, T-G9 | Header set vs the native baseline; **reported with a ratchet, not gating**, until gap G3 closes | §4.3 C1b | M |
+| **T-I13** | Side traffic | | T-W8 | `/healthz` and `/stats` cause no upstream request; pre-flight pinned as a declared exception; `--no-validate` removes it | §4.3 C6 | M |
+| **T-I14** | **Expand live-agent coverage to five Claude Code scenarios** | | — | Plain turn, tool-using turn, multi-turn with tool results, extended thinking, and a session crossing the compaction threshold. The existing file has two cases; scheduling it nightly does not expand it | §6.4.2 | M |
 
 ---
 
-## 12. Epic J — L4 acceptance
+## 13. Epic J — Acceptance · Epic K — Evaluation, load, CI
 
 | ID | Task | Flags | Depends on | Done when | Design | Size |
 |---|---|---|---|---|---|---|
-| **T-J1** | `pytest-bdd` wiring and step definitions | | T-W1, T-W7 | Gherkin runs under pytest; steps bind to the L3 harnesses rather than re-implementing them. The exemption mechanism itself is T-W7 | §6.4.1 | M |
-| **T-J2** | TR scenarios — fidelity and indistinguishability | defect | T-J1, T-D4, T-C7, T-G9 | TR-1, TR-1c, TR-2, TR-3, TR-4. TR-1c and TR-4 land with exemptions (KBR-8, KBR-5). **No egress dependency — none of the TR scenarios involves containment** | §6.4.1 | M |
-| **T-J3** | EG scenarios — containment | | T-J1, T-E3, T-E4, T-E6, T-E8 | EG-0 (the reachability control), EG-1, EG-2, EG-3. T-E8 supplies EG-3's "names the profile" assertion | §6.4.1 | M |
+| **T-J1** | `pytest-bdd` wiring and step definitions | | T-W1, T-W7 | Steps bind to the L3 harnesses rather than re-implementing them | §6.4.1 | M |
+| **T-J2** | TR scenarios | defect | T-J1, T-D3, T-D9, T-C7, T-G9 | TR-1, **TR-1b**, TR-1c, TR-2, TR-3, TR-4. Depends on T-D3 because the oracle may not gate acceptance before its falsification suite is complete. No egress dependency — no TR scenario involves containment | §6.4.1 | M |
+| **T-J3** | EG scenarios | | T-J1, T-E2, T-E6, T-E8 | EG-0 (the reachability control), EG-1, EG-2, EG-3. T-E2 already carries its falsification | §6.4.1 | M |
+| **T-K1** | Eval harness skeleton | | — | Two arms; model, provider, dataset, sampling pinned per run; failure taxonomy per arm | §6.4.3 | M |
+| **T-K2** | Independently authored task set | | T-K1 | Acceptance tests **written by a person** | §6.4.3 | L |
+| **T-K3** | Statistics and decision rule | blocked Q4, Q13 | T-K1, T-K2 | Successes ÷ **scheduled** trials; interval; pre-registered margin; symmetric exclusions; a missing-data ceiling that **voids** the run | §6.4.3 | M |
+| **T-K4** | Load rig and baseline | | T-W8, T-B4 | Fixed workload, named runner class; latency, TTFB, completion and error rates, bounded RSS, socket recovery; streaming and buffered measured separately | §6.4.4 | L |
+| **T-K5** | `load.yml` reusable + publish gate | ci | T-K4 | `publish.yml` `needs:`-gates on a load run **for the tag commit** | §8 | M |
+| **T-K6** | Activate the Subsystem job | ci | T-W1, T-E2, T-D4 | `l3` gates PRs and releases, from the first proven slices onward | §8 | S |
+| **T-K7** | Deep nightly — mutation and schema fuzzing | ci | T-H3, T-G6 | Both exist before the job claims to run them | §8 | S |
+| **T-K8** | Per-category collection enforcement | ci | T-W1, T-K6 | Each required category has its own non-empty check. A category present but empty **fails** | §8 | S |
+| **T-K9** | Activate the Acceptance job | ci | T-J2, T-J3, T-K6 | `acceptance` gates PRs and releases | §8 | S |
+| **T-K10** | Activate the `agent_smoke` category | ci, blocked Q12 | T-I5, T-K9 | Its own required category — **it does not block Subsystem or Acceptance** | §8 | S |
+| **T-K11** | Agent-live nightly | ci | T-I14 | Runs the **expanded** five-scenario coverage, not the two existing cases | §8 | S |
+| **T-K12** | Eval nightly | ci | T-K3 | Runs once the decision rule exists; alerts, never gates | §8 | S |
+
+**CI activation is incremental.** Each job turns on when its first independently runnable slice
+lands, and each required category carries its own collection check. `agent_smoke` stays pending
+Q12 as a separate category so it cannot hold up Subsystem or Acceptance.
 
 ---
 
-## 13. Epic K — Evals, load and CI wiring
+## 14. Derived schedule
 
-| ID | Task | Flags | Depends on | Done when | Design | Size |
-|---|---|---|---|---|---|---|
-| **T-K1** | Eval harness skeleton | | — | Two arms; model, provider, dataset and sampling pinned and recorded per run; failure taxonomy captured per arm | §6.4.3 | M |
-| **T-K2** | Independently authored task set | | T-K1 | Coding tasks whose acceptance tests are **written by a person**. A model-generated test passing the model's own code shares its misunderstandings | §6.4.3 | L |
-| **T-K3** | Statistics and decision rule | blocked Q4, Q13 | T-K1, T-K2 | Successes ÷ **scheduled** trials; repetition; confidence interval; pre-registered margin; symmetric exclusion rule; missing-data ceiling that **voids** the run | §6.4.3 | M |
-| **T-K4** | Load rig and baseline | | T-W4, T-W8, T-B4 | Fixed workload and named runner class; bridge-added latency p50/p95, TTFB, completion and error rates, bounded RSS, socket/fd recovery; streaming and buffered paths measured separately | §6.4.4 | L |
-| **T-K5** | `load.yml` reusable + publish dependency | ci | T-K4 | `publish.yml` `needs:`-gates on a successful load run **for the tag commit**; a nightly caller warns but does not substitute | §8 | M |
-| **T-K6** | `tests.yml` gains Subsystem and Acceptance | ci | T-W1, T-E4, T-J3, T-I5 | Both gate PRs and releases through the one reusable workflow. **T-I5 is a dependency because `agent_smoke` is in the Acceptance selection**: if it never lands the selection collects nothing, pytest exits 5, and T-K8 turns that into a hard failure. Either T-I5 lands first, or T-K6 ships with `acceptance` only and T-I5 adds `agent_smoke` | §8 | M |
-| **T-K7** | Nightly workflows | ci | T-H3, T-K1 | Deep (mutation, schemathesis at high `--max-examples`), Agent-live, Eval. **Agent-live runs the existing `tests/integration/test_agent_e2e.py`, which needs no pinned binary** — so this does not wait on Q12. None of these gate | §8 | M |
-| **T-K8** | Skip-is-failure enforcement | ci | T-K6 | A gating job whose prerequisite is missing **fails**. A green tick meaning "we did not test this" is worse than a red one | §8 | S |
+Computed from the dependency columns above, not written by hand. **Recompute after any dependency
+change** — these numbers go stale the moment the tables move. 98 tasks; the graph is acyclic and
+every dependency resolves.
 
----
+### 14.1 Readiness tiers
 
-## 14. Sequencing
+A tier is the earliest point a task *could* start, not a batch to wait for. **53 of 98 tasks are
+available in tiers 0–2**, which is what Milestone 0 buys.
 
-### 14.1 Dependency graph, condensed
-
-```
-T-W1 ──────────────────────────────────────► everything (markers)
-T-W1 ──► T-W7 ──► T-G1, T-G3, T-G4, T-G5, T-G9, T-J1
-T-W2 ──► T-A1..T-A6 ──┐
-T-W3 ─────────────────┼──► T-D1 ──► T-D2 ──► T-D3
-T-W4 ──► T-B1..T-B4 ──┤          └─► T-D4 ──► T-D5/6/7, T-D8, T-G2 ──┐
-T-W4 ──► T-W8 ────────┤                                              ├──► T-J2 ──┐
-T-W6 ──► T-C1..T-C7 ──┘                                 T-C7, T-G9 ──┘           │
-                                                                                 │
-T-W5 ──► T-E1 ──► T-E2 ──► T-E3 ──► T-E4 ──► T-E5                                │
-                    └────► T-E8 ──┐                                              │
-              T-E6, T-E7 ─────────┴──► T-J3 ──► T-K6 ──► T-K8 ◄──────────────────┘
-
-independent from day one:  T-F1 ──► T-F2..T-F5      T-I1 ──► T-I2
-                           T-I3, T-I4, T-K1, T-E6, T-E7
-```
-
-### 14.2 Waves
-
-| Wave | Content | Parallel capacity |
+| Tier | Count | Tasks |
 |---|---|---|
-| **0** | T-W1–T-W8, T-E6, T-E7, T-F1, T-I1, T-I3, T-I4, T-K1 | ~10 — T-W* is the constraint, staff it first |
-| **1** | T-A1–T-A6, T-B1–T-B4, T-C1–T-C7, T-E1, T-F2–T-F5, T-G1, T-G3, T-G8, T-G9, T-H1, T-H2, T-I2, T-K2 | **~15**, the widest point — though T-C1–T-C7 share one capture pass and are not seven independent slots |
-| **2** | T-D1, T-E2, T-E3, T-F6, T-G4, T-G6, T-I10, T-I13, T-J1 | ~9 |
-| **3** | T-D2, T-D3, T-D4, T-E4, T-E8, T-G5, T-G7, T-H3, T-I8, T-I9, T-I11, T-I12, T-K4 | ~12 |
-| **4** | T-D5, T-D6, T-D7, T-D8, T-E5, T-G2, T-I5, T-I6, T-I7, T-J2, T-J3, T-K5 | ~11 |
-| **5** | T-K6, T-K7, T-K8, T-K3, T-H4 | ~5 — CI wiring plus the decision-blocked tail |
+| **0** | 13 | T-E6 T-E7 T-F1 T-G12 T-I1 T-I3 T-I4 T-I14 T-K1 T-W1 T-W2 T-W4 T-W5 |
+| **1** | 22 | T-A1–T-A7 T-B4 T-F2–T-F5 T-G8 T-G10 T-G11 T-H1 T-I2 T-K2 T-K11 T-W3 T-W7 T-W8 |
+| **2** | 18 | T-B1 T-B2 T-B3 T-F6 T-G1 T-G3 T-G6 T-G7 T-G9 T-H4 T-I10 T-I11 T-I13 T-J1 T-K3 T-K4 T-W6 T-W9 |
+| **3** | 15 | T-C1–T-C7 T-E1 T-G4 T-H2 T-H5 T-I5 T-I7 T-K5 T-K12 |
+| **4** | 6 | T-D1 T-E2 T-H3 T-I6 T-I9 T-I12 |
+| **5** | 8 | T-D2 T-D10 T-E3 T-E4 T-E5 T-G5 T-I8 T-K7 |
+| **6** | 7 | T-D3 T-D4 T-D5 T-D6 T-D7 T-E8 T-E9 |
+| **7** | 3 | T-D9 T-J3 T-K6 |
+| **8** | 4 | T-D8 T-G2 T-J2 T-K8 |
+| **9** | 1 | T-K9 |
+| **10** | 1 | T-K10 |
 
-### 14.3 The two long chains
+### 14.2 The chains, as computed
 
-Two chains of comparable length; the containment one is longer. Both end at CI wiring, not at the
-acceptance scenario — a scenario that gates nothing is not delivered.
+| Milestone | Longest chain to it | Days |
+|---|---|---|
+| Containment slice proven (**T-E2**) | T-W4 → T-W8 → T-W9 → T-E1 → T-E2 | 11.5 |
+| Containment complete (**T-E9**) | … → T-E2 → T-E3 → T-E9 | 13.5 |
+| Fidelity matrix complete (**T-D9**) | T-W2 → T-W3 → T-W6 → T-C1 → T-D1 → T-D2 → T-D4 → T-D9 | 15.0 |
+| Containment acceptance (**T-J3**) | T-W4 → T-W8 → T-W9 → T-E1 → T-E2 → T-E3 → T-E8 → T-J3 | 16.0 |
+| Fidelity acceptance (**T-J2**) | … → T-D9 → T-J2 | 16.5 |
+| **Everything gating (T-K9)** | … → T-J2 → T-K9 | **17.0** |
 
-```
-Containment  T-W4(M) → T-W8(M) → T-E1(L) → T-E2(M) → T-E3(M) → T-E4(L) → T-J3(M) → T-K6(M) → T-K8(S)
-             ≈ 17–18 days
+**The critical path runs through the corpus, not through containment.** That is not what the
+previous draft assumed, and it changes the advice: `T-W2 → T-W3 → T-W6 → T-C1` is four sequential
+tasks before the oracle can even start, because T-D1 needs one corpus entry to run against. The
+corpus was listed as a background risk; it is in fact the front of the longest chain.
 
-Fidelity     T-W2(S) → T-A1(M) → T-D1(L) → T-D2(M) → T-D4(L) → T-J2(M) → T-K6(M) → T-K8(S)
-             ≈ 15 days
-```
+Two consequences:
 
-They converge only at **T-K6**. Nothing in one waits on anything in the other before that, so
-**running them as two streams with different owners roughly halves elapsed time on the two hardest
-parts of the suite** — the single biggest scheduling lever in this plan.
+1. **T-W2, T-W3 and T-W6 are the first three things to staff**, in that order, and T-C1 should be
+   the first corpus entry captured — not whichever is most interesting.
+2. **Containment is no longer the long pole** but finishes only half a day earlier, and it is
+   fully independent until T-K9. Two owners still halve elapsed time; the fidelity owner is simply
+   the one on the critical path.
 
-Four consequences worth acting on:
+If the corpus dependency is judged too expensive, the lever is T-D1: let it run against a
+synthetic minimal transcript rather than T-C1, which removes three tasks from the front of the
+chain. That trades a little early realism for roughly two days — a decision worth taking
+deliberately rather than by default.
 
-1. **T-W2, T-W4, T-W5 and T-W8 head the chains and are all small.** They go first, and no two of
-   them to the same person.
-2. **T-A1 and T-A2 gate T-D1**, so those two projections go before the other four, which can be
-   built during T-D1's construction.
-3. **T-E1 is the riskiest task in the plan** and sits second in the longer chain. If it slips,
-   containment slips one-for-one. Start it earliest, review it hardest.
-4. **T-K6 is a convergence point and a single point of failure.** Both chains stop there; it
-   should not be scheduled as an afterthought.
+### 14.3 Consequences worth acting on
+
+1. **T-W2, T-W4, T-W5 and T-W8 head the chains and are all S/M.** They go first, and no two to the
+   same person.
+2. **T-E1 is the riskiest single task**; it sits early in the containment chain, which has ~1 day
+   of slack against the critical path. Slip it and containment becomes the critical path.
+3. **T-K9 is the convergence point.** Both chains stop there; it is not an afterthought.
+4. **T-K10 is the only tier-10 task** and it is blocked on Q12. It gates nothing else.
 
 ---
 
-## 15. Blocked on decisions, not on code
+## 15. Blocked on decisions
 
 | Question | Blocks | Cost of leaving it open |
 |---|---|---|
-| **Q4** + **Q13** — eval margin, compaction baseline | T-K3 | The eval runs and cannot conclude. T-K1/T-K2 proceed |
-| **Q10** — irreducible final turn | T-F2's exact bound, TR-3's wording, register rows M3–M7/M13 | T-F2 lands with the observed-behaviour property and is revised once — but it must be revised **together with** TR-3 and the register |
-| **Q11** — per-PR mutation cadence | Nothing. **T-H4 answers it** | T-H3 lands nightly-only; a later change moves it |
-| **Q12** — pinned Claude Code binary | T-I5, T-I6 — and therefore T-K6's `agent_smoke` selection | **The most expensive open question.** It blocks the only test of a third-party behaviour the product depends on, and it reaches into CI wiring |
-| **Q14** — post-emission stream recovery | T-I7's positive assertions | T-I7 lands asserting only the negatives: catches corruption, cannot confirm correctness |
+| **Q4** + **Q13** | T-K3, and therefore T-K12 | The eval runs and cannot conclude; T-K1/T-K2 proceed |
+| **Q10** | T-F2's exact bound, TR-3's wording, register rows M3–M7/M13 | T-F2 lands with the observed-behaviour property and is revised **together with** TR-3 and the register |
+| **Q11** | Nothing — **T-H4 answers it** | T-H3 lands nightly-only |
+| **Q12** | T-I5, T-I6, T-K10 | The settings-precedence claim has no per-PR proof. **It no longer blocks Subsystem or Acceptance** — T-K10 is a separate category |
+| **Q14** | T-I7's positive assertions | T-I7 lands asserting only the negatives |
 
-**Q1** (agent identity) blocks no task but decides whether T-I12 and T-J2's TR-1c exemption ever
-become gating. **Q5, Q6, Q7** affect register rows and residual-risk wording, not delivery.
+**Q1** blocks no task but decides whether T-I12 and TR-1c ever gate. **Q5–Q7** affect register
+rows and wording, not delivery.
 
 ---
 
-## 16. Relationship to the open defects
+## 16. Defects and regression evidence
 
-Five defects are filed. The dependency runs one way only:
+An earlier draft required every guard to **merge red** before its fix. That is stronger than the
+goal requires and it delays production fixes — KBR-5's acceptance scenario sits in tier 9 while
+the design ranks the defect priority 0.
 
-- **The guard lands first, red, with an exemption.** Writing it *after* the fix proves nothing
-  about whether it would have caught the defect — and the fix then has no regression test that
-  ever failed.
-- **The defect's ticket removes the exemption**, as its acceptance criterion. T-W7's
-  unexpected-pass rule makes forgetting impossible.
+**The goal is evidence that the regression test fails on the unfixed revision — not a separate red
+merge.** So:
 
-| Defect | Design gap | Guard that lands red | Exemption removed by |
+- **Default: one atomic PR** containing the regression test **and** the fix, with evidence in the
+  PR that the test fails at the base revision and passes with the fix. A guard written after the
+  fix with no such evidence is still not acceptable — that is what the rule exists to prevent.
+- **Exemption path** only where the fix must genuinely follow later, or where the guard's scope is
+  broader than one defect. T-G1, T-G3, T-G4, T-G5 and T-G9 each cover a class of check beyond a
+  single defect, so they may land first with a single-assertion exemption.
+- **Later acceptance scenarios pass normally** if the defect is already fixed. T-J2 does not need
+  TR-1c and TR-4 to be red; it needs them to be correct.
+
+| Defect | Design gap | Broader guard | Fastest route |
 |---|---|---|---|
-| KBR-5 — vendor string upstream | G14 | T-G5, T-J2 (TR-4) | KBR-5's fix |
-| KBR-6 — internal keys on the wire | G15 | T-G3 | KBR-6's fix |
-| KBR-7 — wire-shape mismatch | G16 | T-G4 | KBR-7's fix |
-| KBR-8 — contradictory client versions | G3 | T-G9, T-J2 (TR-1c) | KBR-8's fix |
-| KBR-9 — README endpoint table | G6 | T-G1 | KBR-9's fix |
+| KBR-5 | G14 | T-G5, TR-4 | Atomic fix + test now |
+| KBR-6 | G15 | T-G3 | Atomic fix + test now |
+| KBR-7 | G16 | T-G4 | Atomic fix + test now |
+| KBR-8 | G3 | T-G9, TR-1c | Atomic fix + test now |
+| KBR-9 | G6 | T-G1 | Atomic fix + test now |
 
 ---
 
-## 17. Risks in the sequencing
+## 17. Design-to-deliverable coverage
 
-**T-E1 is the hardest single task and the easiest to underestimate.** Direct-route resolution needs
-a different mechanism per transport, and T-E2 is explicit that a transport which cannot be given
-one is reported **unproven** rather than passed. Splitting T-E1/T-E2 means a stuck transport is one
-blocked M, not a blocked L.
+Every design requirement has an owner. "Existing" means the current suite already covers it.
 
-**The corpus is the quiet long pole.** T-C1–T-C7 are individually small but need real captured
-sessions, a secret review, and an owner for refresh. Start T-W6 on day one even though nothing
-visibly depends on it yet.
+| Design | Requirement | Owner |
+|---|---|---|
+| §3.2 | The register, machine-readable | T-W3 |
+| §3.3.1 | Six request projections | T-A1–T-A6 |
+| §3.3.1 | Response-direction `Reply` projection and comparison | T-A7, T-D10 |
+| §3.3.1 | Oracle falsification suite | T-D1, T-D3 |
+| §3.3.2 | Both oracle assertions | T-D1 |
+| §3.3.3 | Bridge-introduced scoping + the survival complement | T-G5 |
+| §3.3.4 | Trigger complements across models | T-D8, T-C1–T-C6 |
+| §3.3.5 | Routing in the oracle + deployment falsification | T-D2 |
+| §4.3 C1 | Header contract | T-G9 |
+| §4.3 C1b | Fingerprint parity baseline and report | T-C7, T-I12 |
+| §4.3 C2 | Key-order on the native path | T-D1 |
+| §4.3 C3 | Cross-attempt content | T-I8 |
+| §4.3 C5 | Connection lifecycle | T-C7, T-I9 |
+| §4.3 C6 | Side traffic | T-I13 |
+| §5.2.1 | Tunnel correlation | T-E2 |
+| §5.2.2 | Three phases + falsification, per transport | T-E2–T-E5, T-E9 |
+| §5.3 | Hostname harness, per-transport resolution | T-E1–T-E5 |
+| §5.4 | Guard enforcement and domination | T-E6, T-E7 |
+| §5.5 | Per-transport containment and the bypass asymmetry | T-E3–T-E5, T-E8 |
+| §6.1 | Properties · mutation validation | T-F1–T-F6 · T-H1–T-H5 |
+| §6.2.1 | OpenAPI, schemathesis, registration matrix | T-G6 |
+| §6.2.2 | SSE grammar | T-G7 |
+| §6.2.3 | Register, internal-key, wire-shape, vendor-token, docs guards | T-G1–T-G5 |
+| §6.2.4 | Four dependency contracts | T-G8, T-G10, T-G11, T-G12 |
+| §6.3.1 | Bridge-with-sockets scenarios | T-I7–T-I11 |
+| §6.3.2 | CLI lifecycle | T-I1–T-I4 |
+| §6.4.1 | Gherkin scenarios | T-J1–T-J3 |
+| §6.4.2 | Agent smoke · precedence · **five live scenarios** | T-I5 · T-I6 · T-I14 |
+| §6.4.3 | Eval harness, task set, statistics | T-K1–T-K3 |
+| §6.4.4 | Load rig and gate | T-K4, T-K5 |
+| §7.1–§7.4 | Corpus, recorders, proxy, oracle | T-W6/Epic C, T-W4/Epic B, T-W5, T-W2/T-D1 |
+| §8 | Markers, selection, job activation | T-W1, T-K6–T-K12 |
+| §5.1 | Real-socket transport proof across three stacks | **Existing** — `tests/test_egress_https_proxy.py`, extended by T-W5 |
+| §6.2.3 | A structural scan that asserts its own positives | **Existing** — `tests/test_egress_coverage.py`, the pattern T-E7 copies |
 
-**T-D4–T-D7 and T-G2 are adjacent and easy to duplicate.** T-D4–T-D7 own driving the wire and
-capturing; T-G2 owns asserting register-row coverage over those captures, as a meta-assertion. Two
-teams implementing "per adapter × model × transport" independently is the most likely wasted work
-in this plan — and if T-G2 re-drives the wire under an `l2` marker it puts real sockets in the
-fast gate.
+---
 
-**T-H2 is the only source change.** Keep it out of every test PR so a revert is cheap. It now
-depends on T-B3 so "behaviour unchanged" has evidence behind it rather than assertion.
+## 18. Risks
 
-**The existing suite already runs ~18.5 minutes per Python version.** Wave 3 onward adds real
-sockets to the PR gate. T-K6 should land with a measured runtime; if the gate crosses the point
-where people route around it, the marker split is the mechanism for pulling work back to nightly —
-that is what T-W1 buys beyond tidiness.
+**T-E1 is the hardest single task**, and T-E2's slice depends on it entirely. Splitting the
+per-transport routes into T-E3–T-E5 means a stuck transport is one blocked M and an entry in
+T-E9's unproven report, not a blocked chain.
+
+**The corpus is on the critical path**, not merely a background risk (§14.2). T-C1–T-C7 need real
+sessions, a secret review and a named refresh owner, and share one capture pass — while
+`T-W2 → T-W3 → T-W6 → T-C1` is the front of the longest chain. Staff it first, capture T-C1 first,
+and consider the synthetic-transcript lever in §14.2 if it slips.
+
+**T-D9 and T-G2 are adjacent.** T-D4–T-D9 own driving the wire and capturing; T-G2 asserts
+register coverage over those captures as a meta-assertion. Implementing "per adapter × model ×
+transport" twice is the most likely wasted work here — and if T-G2 re-drives the wire under an
+`l2` marker it puts real sockets in the fast gate.
+
+**T-H2 and T-H5 are the only source changes.** Keep them out of test PRs so a revert is cheap.
+
+**The suite already runs ~18.5 minutes per Python version.** Real sockets reach the PR gate at
+T-K6. It should land with a measured runtime; the marker split is the mechanism for pulling work
+back to nightly if the gate stops being fast.
+
+**Shared files need a named integration owner** — T-W2, T-W3, T-W4, T-W8 and T-W9 are touched by
+several streams. Everything else lives in stream-owned modules.

--- a/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
+++ b/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,542 @@
+# Kitty Bridge — Test Suite Implementation Plan
+
+**Implements:** [`TEST_SUITE.md`](TEST_SUITE.md). That document says what the suite must prove and
+why; this one says who can build what, in what order, without waiting on each other.
+**Traces to:** [KBR-2](https://shelpuk.atlassian.net/browse/KBR-2).
+**Status:** Plan. No Jira issues created yet — the `T-` ids here are plan-local and become ticket
+summaries when the plan is accepted.
+
+> **On identifiers.** Every task id is prefixed `T-`. `TEST_SUITE.md` already uses bare `C1–C6`
+> for observable channels, `F1–F5` for findings, `G1–G19` for gaps, `I1–I3` for the invariants,
+> and `M`/`P` for register rows. Unprefixed task ids collided with all of them — the first draft
+> of this plan said "KBR-6 → G3" where the design says "KBR-6 → G15". The prefix is the fix, and
+> the **Design** column carries the reverse link.
+
+---
+
+## 0. How this plan is organised
+
+The design has one shape problem for delivery: almost every interesting test depends on shared
+infrastructure that does not exist. Build it in the wrong order and one person writes harnesses
+for three weeks while everyone else waits.
+
+So the plan is arranged by **what unblocks the most people soonest**, not by importance:
+
+- **§2 Wave 0** is the enablement set — eight small artifacts, plus the handful of tasks that
+  genuinely need nothing. Until it lands, parallelism is capped around ten. After it, around
+  fifteen.
+- **§3–§13** are epics. Each task is atomic, independently landable, and carries its dependencies,
+  acceptance criteria and design reference.
+- **§14** is the wave plan and the two long chains. **§15** lists tasks blocked on decisions
+  rather than on code. **§16** covers the open defects. **§17** covers sequencing risk.
+
+**Read §1 before picking up any task.** The definition of done is unusual and it is the thing most
+likely to be got wrong.
+
+---
+
+## 1. Rules every task obeys
+
+### 1.1 Definition of done
+
+1. The deliverable exists and satisfies the acceptance criteria in its row.
+2. `ruff`, `lint-imports`, `mypy src/kitty` and the full suite pass on Python 3.10–3.13.
+3. Every new test carries exactly one layer marker (**T-W1**) so it lands in exactly one CI job.
+4. Google-style docstrings on every class, method and function; module docstrings; block comments
+   explaining *why*. Test code is code.
+5. **It can land on `main` alone.** No task may leave the suite red waiting for a sibling. A check
+   that fails because of a known product defect lands with an entry in the exemption registry
+   (**T-W7**) — not disabled, not omitted.
+
+### 1.2 The harness rule — a harness is not done until it has been seen to fail
+
+This is the throughline of the design and the reason it took four review rounds. Repeatedly,
+proposed tests would have passed without proving anything: an oracle composed of two functions
+that were not inverses; a containment test asserting nothing arrived at a destination nothing
+could reach; a guard proving a function was *called* when the enforcement was the branch after it;
+a projection that could not see the model name, in a product whose purpose is changing the model
+name.
+
+So for every task that builds a harness, assertion or guard:
+
+> **Acceptance requires a committed falsification case: a deliberate defect the harness must
+> detect, running in the suite, not demonstrated once by hand.**
+
+Rows below name the specific case where the design specifies one; otherwise the author picks one
+and records it in the PR.
+
+### 1.3 Flags
+
+| Flag | Meaning |
+|---|---|
+| **src** | Touches `src/kitty/`. Higher risk; needs a `code-reviewer` pass and a note in the PR |
+| **ci** | Touches `.github/workflows/`. Verify on a branch first — a broken gate is worse than a missing one |
+| **blocked** | Cannot start until an open question (`TEST_SUITE.md` §11) is answered. See §15 |
+| **partial** | Can start and land, but a stated part of its acceptance waits on a decision |
+| **defect** | Designed to land red, with an exemption removed by the defect's own ticket. See §16 |
+| **resolves** | Its output answers an open question |
+
+### 1.4 Sizing
+
+**S** ≈ half a day · **M** ≈ 1–2 days · **L** ≈ 3–5 days. Nothing is larger than L; anything that
+looks larger is split. Sizes assume the author has read the referenced design section.
+
+---
+
+## 2. Wave 0 — the enablement set
+
+**Everything here is small, and nearly everything else waits on some of it.** Treat Wave 0 as one
+push with several people on it, not a queue.
+
+| ID | Task | Depends on | Unblocks | Design | Size |
+|---|---|---|---|---|---|
+| **T-W1** | Layer markers and pytest config | — | Everything | §8 | M |
+| **T-W2** | Request types and the projection protocol | — | Epic A, then the oracle | §3.3.1 | S |
+| **T-W3** | The Permitted-Mutation Register as data | T-W2 | Oracle, register guard, corpus loader | §3.2 | M |
+| **T-W4** | Recorder protocol + primary aiohttp recorder | — | Epic B, T-W8, all of L3 | §7.2 | M |
+| **T-W5** | Shared CONNECT proxy fixture | — | All of Epic E | §7.3 | M |
+| **T-W6** | Corpus capture procedure, scrubber, loader | T-W3 | All of Epic C | §7.1 | M |
+| **T-W7** | The exemption registry | T-W1 | Every guard that lands red | §8 | M |
+| **T-W8** | Bridge-under-test fixture | T-W4 | ~15 tasks across D, E, G, I, J, K | §6.3.1 | M |
+
+**Genuinely needs nothing, start day one:** T-W1, T-W2, T-W4, T-W5, T-E6, T-E7, T-F1, T-I1, T-I3,
+T-I4, T-K1. Everything else in Wave 0 is one hop behind.
+
+### T-W1 — Layer markers and pytest config
+
+Register `l1`, `l2`, `l3`, `acceptance`, `agent_smoke`, `agent_live`, `eval`, `load`. A meta-test
+asserts **every collected test carries exactly one** — zero or two both fail.
+
+**Do not hand-edit 2,880 test functions across 139 files.** That is the worst possible first
+commit when a dozen people are about to branch, and it conflicts with every one of them. Assign
+the default in `pytest_collection_modifyitems` by path, and require an explicit marker only where
+the default is wrong. The meta-test is what stops the defaulting rotting.
+
+Also reconcile the existing `--runslow` skip-by-default mechanism with **T-K8** ("a gating job
+whose prerequisite is missing fails") — today `slow` tests silently skip, which is the pattern
+T-K8 forbids.
+
+*Done when:* removing a needed marker fails the meta-test; `pytest -m l1` collects a strict subset
+of `pytest`. *Size:* M — larger than it looks, because of the defaulting rules and the `--runslow`
+reconciliation.
+
+### T-W2 — Request types and the projection protocol
+
+`Request(envelope, conversation, residual)`, `Envelope`, `Conversation`, `Turn`, `Part` variants,
+and the `Projection` protocol. No readers — this is the shared vocabulary.
+
+Includes the **totality rule** as a reusable assertion: every key classifies into envelope,
+conversation or residual, and a non-empty residual raises. Shipping it here means all six readers
+inherit one semantics rather than six interpretations.
+
+*Done when:* a stub reader that silently drops an unknown key fails the totality assertion — the
+falsification case. *Size:* S.
+
+### T-W3 — The register as data
+
+Design §3.2 is a markdown table; the oracle takes `register` and `triggers_met` as arguments and
+the L2 completeness guard diffs against the same rows. **It has to become data, or both consume a
+prose table by hand.**
+
+One entry per row M1–M14 and P1–P21: id, site symbol, trigger predicate, the projection field it
+touches (`envelope.model`, `conversation.tools[].strict`, …), conditional or unconditional, design
+anchor. Also defines the **trigger vocabulary** T-W6's loader indexes by.
+
+*Done when:* a test asserts the markdown table and the data agree in both directions.
+Falsification: delete a row from either side. *Size:* M.
+
+### T-W4 — Recorder protocol and the primary aiohttp recorder
+
+`CapturedRequest(method, scheme, host, path, query, headers, body)` with original header casing and
+order, arrival timestamp, and **the peer port of the accepted connection** — the join key for
+containment (§5.2.1). Plus the aiohttp implementation serving Anthropic Messages and Chat
+Completions.
+
+**Ships one minimal valid success response per protocol.** Without it, any request driven through a
+real `BridgeServer` falls into the retry and failover paths — which are themselves body-mutating
+(M6, M8, M9) — and no consumer could obtain a clean baseline. The *failure* library is **T-B4**.
+
+Peer-port and casing capture are part of the **protocol**, enforced by a conformance test every
+Epic B recorder must pass — not restated per recorder and forgotten.
+
+*Done when:* casing and order survive capture; peer port is recorded; the conformance test exists
+and a recorder that lowercases headers fails it. *Size:* M.
+
+### T-W5 — Shared CONNECT proxy fixture
+
+Extract `_ConnectProxy` and `_TlsTarget` from `tests/test_egress_https_proxy.py` into a shared
+fixture. Extend it to record **the outbound source port of each tunnel** and to be stoppable
+mid-test.
+
+An extraction, not a rewrite: `test_egress_https_proxy.py` is the strongest existing asset in the
+suite and must pass unchanged against the extracted fixture.
+
+*Done when:* the existing module still passes; tunnel source port is recorded; stopping the proxy
+produces a connection failure, not a hang. *Size:* M.
+
+### T-W6 — Corpus capture procedure, scrubber and loader
+
+The capture procedure, a **credential scrubber**, and a loader exposing entries **by the register
+triggers they meet** (hence T-W3).
+
+The scrubber is load-bearing: a fixture file is as public as the repository, and captured
+transcripts carry prompts, file contents and API keys.
+
+Also **names an owner and a cadence for corpus refresh**, tied to Claude Code releases. Design
+§7.1 warns an un-refreshable corpus becomes a museum of a protocol nobody speaks; nothing else in
+this plan schedules that.
+
+*Done when:* the scrubber removes an API key, a bearer token and an absolute home path from a
+synthetic transcript; a CI lint fails on an unscrubbed fixture. *Size:* M.
+
+### T-W7 — The exemption registry
+
+Four guards and two acceptance scenarios are *designed* to land red (§16). They need the exemption
+mechanism before any of them can land, which makes this **enablement, not acceptance plumbing** —
+it sat in Epic J in the first draft, which stranded three Wave-0 tasks.
+
+Plain pytest, not BDD-specific: the Epic G guards are ordinary `l2` tests. An entry names **one
+assertion**, its expected failure condition and its ticket. Setup and every other assertion in the
+same test gate normally. **An unexpected pass fails the job** (`xfail(strict=True)` semantics). One
+registry file.
+
+*Done when:* a test with an exempt assertion **and** a second failing non-exempt assertion fails;
+an exempt assertion that starts passing fails. Those two are the falsification cases — without
+them this is the blanket amnesty the design rejects. *Size:* M.
+
+### T-W8 — Bridge-under-test fixture
+
+A profile/backend factory plus a real `BridgeServer` started against a named recorder, torn down
+cleanly. Around fifteen tasks across Epics D, E, G, I, J and K need exactly this; `conftest.py`
+offers only `sample_profile_dict` and `unused_tcp_port` today, and each of the ~40 files under
+`tests/bridge/` builds its own. Without this task, whoever picks up T-D1 builds it, and T-E3,
+T-G2 and T-I8 each build another.
+
+Constructs a profile for any adapter × model × transport, points its backend at a recorder host,
+starts the server in bridge mode, exposes both.
+
+*Done when:* one fixture call yields a running bridge for any registered adapter, and a test
+asserts teardown releases the port. *Size:* M.
+
+---
+
+## 3. Epic A — Wire projections
+
+Six independent readers, parallel after **T-W2**. Each imports **nothing from `src/kitty/bridge`**
+— that independence is the point (§3.3.1).
+
+| ID | Reader | Depends on | Design | Size |
+|---|---|---|---|---|
+| **T-A1** | Anthropic Messages | T-W2 | §3.3.1 | M |
+| **T-A2** | Chat Completions | T-W2 | §3.3.1 | M |
+| **T-A3** | OpenAI Responses | T-W2 | §3.3.1 | M |
+| **T-A4** | Gemini — **consumes the URL as well as the body**; model and operation live in the path | T-W2 | §3.3.5 | M |
+| **T-A5** | Bedrock Converse | T-W2 | §3.3.1 | M |
+| **T-A6** | Ollama `/api/chat` | T-W2 | §3.3.1 | S |
+
+**Acceptance, all six:** round-trips that format's **published examples** into `Request` with an
+empty residual — validated against the published schema, never against kitty's output. A reader
+validated against kitty's output inherits kitty's bugs and the oracle becomes circular.
+
+**Falsification, all six:** a body with one unrecognised key produces a non-empty residual and
+fails the totality assertion.
+
+**Deliberately *not* in scope here:** "residual empty across the whole corpus." That needs the
+corpus and belongs to **T-D8**, which owns coverage. Putting it in T-A1's acceptance made the
+projections silently depend on Epic C and dragged the corpus onto the critical path.
+
+---
+
+## 4. Epic B — Recorders and scripted responses
+
+All depend on **T-W4** and must pass its recorder conformance test — including peer-port capture,
+which T-E4's tunnel join needs from every recorder, not only the primary.
+
+| ID | Task | Depends on | Design | Size |
+|---|---|---|---|---|
+| **T-B1** | Provider-aiohttp recorder — `ollama_cloud` and the `openai_subscription` **OAuth legs**, which run at startup before anything else is proven | T-W4 | §5.5, §7.2 | M |
+| **T-B2** | curl_cffi-reachable recorder with harness TLS — the only place `_cc_to_responses` output (P13, P17) is observable | T-W4 | §7.2 | M |
+| **T-B3** | botocore endpoint-override recorder — captures the Converse payload **after** the transport's `modelId`/`stream` pops (P18) | T-W4 | §3.2.3, §7.2 | M |
+| **T-B4** | Scripted failure library — SSE variants, error statuses, Cloudflare blocks, empty responses, context-too-large rejections, mid-stream disconnect at each of the four §6.3.1 injection points | T-W4 | §6.3.1, §7.2 | M |
+
+---
+
+## 5. Epic C — Golden corpus
+
+Parallel after **T-W6**. Coverage is driven by the register: every conditional row needs a trigger
+case **and** a complement.
+
+| ID | Entries | Depends on | Covers | Size |
+|---|---|---|---|---|
+| **T-C1** | Plain turn, tools declared, `tool_use`, `tool_result` | T-W6 | Complement for most conditional rows; M7 | S |
+| **T-C2** | Thinking, image, `system` with `cache_control` | T-W6 | P2a/b, P5c–e, P8, M8 | S |
+| **T-C3** | Tool result under/over 50,000 chars; transcript under/over the compaction budget | T-W6 | M3, M4, M5 — triggers and complements | M |
+| **T-C4** | 400/413 recovery against a **balancing** profile; system prompt alone over the window; a single final turn over the budget | T-W6 | M6, M13, the irreducible-set case | M |
+| **T-C5** | The vendor-string regression entry — a turn reading `Please explain how kitty-bridge works` | T-W6 | §3.3.3 | S |
+| **T-C6** | `max_tokens` above/below 4096 × streaming/non-streaming; a malformed body | T-W6 | P7, P13, the L2 fuzz path | S |
+| **T-C7** | Native Claude Code baseline — headers **and** connection pattern | T-W6 | Baselines for design channels C1b (header parity) and C5 (connection lifecycle) — consumed by T-I12 and T-I9 | M |
+
+**T-C4's M6 entry must be authored against a balancing profile.** `_compact_with_tighter_budget`
+is called only from `_request_with_retry_balancing`; a single-backend profile never reaches it and
+the entry would silently never fire.
+
+**T-C4 and T-C6 are deliberately synthesised, not captured.** A system prompt larger than the
+window, and a malformed body, do not occur in a real session on demand — so design §7.1's
+"real, not synthetic" rationale does not apply to them. Record that reasoning beside the fixtures;
+the scrubber and lint rules still apply.
+
+**Scheduling note:** T-C1–T-C7 share one capture-and-secret-review pass. Seven tasks, not seven
+independent parallel slots.
+
+---
+
+## 6. Epic D — The fidelity oracle (I1)
+
+| ID | Task | Depends on | Done when | Design | Size |
+|---|---|---|---|---|---|
+| **T-D1** | Oracle core | T-W2, T-W3, T-W4, T-W8, T-A1, T-A2, T-C1 | `assert_no_unclaimed_mutation` runs end to end on one default-transport adapter with both §3.3.2 assertions. **Accepts `expected_route`** so T-D2 is a filling-in, not a signature change. **Includes the byte-level key-order assertion on the native passthrough path** — the one place the comparison is not projected | §3.3, §4.3 C2 | L |
+| **T-D2** | Independent routing expectation | T-D1, T-A4 | Expected host/path/query computed from the profile using the provider's *published* URL shape — **never** by calling `build_base_url()` / `get_upstream_path()` | §3.3.5 | M |
+| **T-D3** | Falsification suite | T-D1, T-D2 | Six cases, all failing the oracle, in the suite: changed model · flipped `stream` · deleted tool description · stripped `strict` · injected metadata field (non-empty residual) · **changed Azure deployment segment with a byte-identical body** | §3.3.1, §3.3.5 | M |
+| **T-D4** | Parametrise — default aiohttp transport | T-D1, T-D2, T-A1–T-A4, T-B4, T-C1–T-C6, T-W8 | The 20 default-transport adapters at their representative models; `opencode_go` per route | §3.3.4 | L |
+| **T-D5** | Parametrise — curl_cffi | T-D4, T-B2, T-A3 | `openai_subscription` serving path, observing P13–P17 | §3.3.2 | M |
+| **T-D6** | Parametrise — botocore | T-D4, T-B3, T-A5 | `bedrock`, observing the Converse payload after P18 | §3.3.2 | M |
+| **T-D7** | Parametrise — provider aiohttp | T-D4, T-B1, T-A6 | `ollama_cloud` after P19; the subscription OAuth leg | §3.3.2 | M |
+| **T-D8** | Coverage checker | T-D4, T-W3, T-C1–T-C6 | A meta-test failing when any conditional register row lacks a trigger case or a complement. **Also owns "residual empty across the whole corpus"** for all six readers | §3.3.4 | M |
+
+**T-D3 lands immediately after T-D1/T-D2, not at the end.** It is what distinguishes an oracle from
+a decoration.
+
+**T-D4 was one L covering four transports.** Split per transport so each is landable and each
+extends the parametrisation, rather than one task with thirteen predecessors on the critical path.
+
+---
+
+## 7. Epic E — Containment (I3)
+
+| ID | Task | Flags | Depends on | Done when | Design | Size |
+|---|---|---|---|---|---|---|
+| **T-E1** | Hostname harness + aiohttp direct route | | T-W5, T-W4, T-W8 | Upstream addressed as `upstream.kitty-test.invalid`; direct leg resolves via a monkeypatched aiohttp resolver — **not** `/etc/hosts`, which needs admin rights and is unavailable on most CI runners | §5.3 | L |
+| **T-E2** | curl_cffi and botocore direct routes | | T-E1, T-B2, T-B3 | curl's `resolve` mapping and a botocore `endpoint_url` override. **A transport that cannot be given a working direct route is reported `unproven`, not passed** | §5.3, §5.5 | M |
+| **T-E3** | Phase 1 — positive controls | | T-E1, T-E2 | With egress **disabled**, each transport reaches the upstream directly and the connection is recorded | §5.2.2 | M |
+| **T-E4** | Phase 2/2b — containment and tunnel correlation | | T-E3, T-W5 | Proxy down ⇒ **zero** upstream connections and the request fails. Proxy up ⇒ every accepted connection joins a tunnel on the recorded source port, N requests per tunnel allowed, failed tunnels contributing none | §5.2.1, §5.2.2 | L |
+| **T-E5** | Phase 3 — falsification | | T-E4 | A deliberately injected bypass — patched `should_bypass`, or a session built without the proxy — makes the harness fail | §5.2.2 | M |
+| **T-E6** | Guard **enforcement** | | — | Each of the five start paths driven with a rejecting configuration asserts **no server starts**: no listening socket, non-zero exit. Falsification: a variant keeping the `egress_block_reason()` call and discarding its return value must make these fail. **No recorder needed — nothing reaches upstream by construction** | §6.2.3 | M |
+| **T-E7** | AST start-path domination guard | | — | Every `BridgeServer(` construction is dominated by an `egress_block_reason(` call at AST level, not file level. Falsification: move a construction above its guard call in the same file | §5.1, §6.2.3 | M |
+| **T-E8** | Local bypass, fail-closed, and the transport asymmetry | | T-E1 | Loopback/`localhost` provider connects directly **on bridge sessions**; a `supports_egress() == False` profile blocks startup **and the message names the profile** (EG-3's assertion); and the complement — those destinations **are** tunnelled on curl_cffi, botocore and provider-aiohttp, which have no bypass. Pinning the asymmetry stops a future "fix" quietly adding one | §5.5, §5.2.2 | M |
+
+**T-E6 and T-E7 are complements and both are needed.** T-E7 proves the guard is *called*; T-E6
+proves its answer is *obeyed*. Deleting `if egress_error: return 1` passes T-E7 and fails T-E6.
+Both need nothing and belong in Wave 0.
+
+---
+
+## 8. Epic F — L1 component and property
+
+| ID | Task | Depends on | Done when | Design | Size |
+|---|---|---|---|---|---|
+| **T-F1** | `hypothesis` in the dev extra + a shared strategy library for Messages/CC transcripts | — | Strategies reusable by T-F2–T-F5 | §6.1 | M |
+| **T-F2** | Compaction properties | T-F1 | Identity below budget · no orphaned pair · idempotent · **output ≤ budget unless the surviving set is irreducible**, stated with the exception | §6.1 | M |
+| **T-F3** | Pairing and truncation properties | T-F1 | No orphan in either shape; truncation identity below the limit, bounded above it | §6.1 | M |
+| **T-F4** | Egress properties | T-F1 | Private ranges bypassed; **no hostname outside the `localhost` family bypassed**; `parse_proxy_url` round-trip; **structural** redaction — the password component of `masked()` is exactly the mask, never a substring test | §5.3, §6.1 | M |
+| **T-F5** | `describe_tool_input_anomaly` property | T-F1 | Never reports an anomaly for input valid against the declared schema | §6.1 | S |
+| **T-F6** | Translator semantic property via the projections | T-F1, T-A1, T-A2 | `project_messages(inbound)` equals `project_cc(translate_request(inbound))` — the projections, never a translator round-trip | §3.3.1, §6.1 | M |
+
+**T-F4's `should_bypass` property is load-bearing beyond L1**: it is the premise T-E1's harness
+rests on. If someone adds name resolution to `should_bypass`, T-F4 fails and T-E1's design is
+re-examined — rather than T-E1 quietly going vacuous.
+
+---
+
+## 9. Epic G — L2 contract
+
+| ID | Task | Flags | Depends on | Done when | Design | Size |
+|---|---|---|---|---|---|---|
+| **T-G1** | README ⇄ code table guards | defect | T-W7 | Endpoint, attribution-header, env-var and logging-flag tables. Lands red against the endpoint table → exemption (KBR-9 / gap G6) | §6.2.3 | M |
+| **T-G2** | Register completeness — coverage over the captures | | T-W3, T-D4 | Per adapter × model × transport, the captured delta equals the union of that adapter's rows whose triggers the input met. **A meta-assertion over T-D4–T-D7's captures, marked `l3`** — it does not re-drive the wire, and it must not put real sockets in the fast gate | §6.2.3 | M |
+| **T-G3** | Internal-key completeness AST guard | defect | T-W7 | Every `_`-prefixed key written into a request dict in `bridge/**` is in `_INTERNAL_KEYS`. Lands red → exemption (KBR-6 / gap G15) | §6.2.3 | M |
+| **T-G4** | Wire-shape honesty guard | defect | T-W7, T-W8, T-B1–T-B3 | `upstream_wire_is_messages_api` agrees with the observed output shape per adapter × representative model. Lands red → exemption (KBR-7 / gap G16) | §6.2.3 | M |
+| **T-G5** | Bridge-introduced vendor token guard | defect | T-D1, T-W7, T-C5 | No **bridge-introduced** content contains `kitty` in any casing, scoped by the projection diff — **and, in the same run**, an inbound turn containing `kitty-bridge` survives byte-identically. A harness that cannot do both at once has not solved the problem. Lands red → exemption (KBR-5 / gap G14) | §3.3.3, §6.2.3 | M |
+| **T-G6** | OpenAPI 3.1 document + schemathesis | | T-W8 | Five POST routes plus `/healthz`, `/stats`, `/v1/models`, **targeting a bridge started in bridge mode**; a separate guard asserts the per-protocol registration matrix | §6.2.1 | L |
+| **T-G7** | SSE grammar state machine | | T-B4, T-W8 | Every stream — including error streams, mid-stream failover and the empty-response fallback — is a sentence in the Anthropic event grammar, across all three streaming protocols | §6.2.2 | M |
+| **T-G8** | Dependency behaviour contracts | | T-W5 | aiohttp session proxy across `>=3.11,<3.14`; `curl_cffi` `proxies=` precedence over ambient `HTTP_PROXY`/`NO_PROXY`; `botocore Config(proxies=)` precedence; `keyring` backends. **Also declares `botocore` explicitly** — a containment guarantee currently rests on an undeclared transitive dependency | §6.2.4 | M |
+| **T-G9** | **Header contract** | defect | T-W7 | Per adapter, an **exact** header set — names present, names absent, casing, value shape. Plus: no adapter derives a `User-Agent` or version header from `kitty.__version__`, and where both a UA version and a `version` header are sent they agree. **This is the test that catches KBR-8.** Lands red → exemption (gap G3) | §4.3 C1 | M |
+
+---
+
+## 10. Epic H — Mutation validation
+
+| ID | Task | Flags | Depends on | Done when | Design | Size |
+|---|---|---|---|---|---|---|
+| **T-H1** | `mutmut` config, L1 selection, baseline | | T-W1 | `[tool.mutmut]` with array `source_paths` and `pytest_add_cli_args_test_selection = ["-m", "l1"]`; a recorded baseline per target group | §6.1 | M |
+| **T-H2** | Extract pure payload builders | **src** | T-B3 | `_bedrock_body(...)` and `_ollama_body(...)` extracted from `make_request`/`stream_request`. **Depends on T-B3 because "behaviour unchanged" needs a characterisation test** — T-B3 is what makes the post-mutation Converse payload observable | §6.1 | M |
+| **T-H3** | Per-component thresholds + CI reporting | ci | T-H1, T-H2, T-F2–T-F6 | ≥ 85% killed **per target group**, not one aggregate; survivor triage documented; `mutmut export-cicd-stats` in the nightly job | §6.1 | M |
+| **T-H4** | Measure changed-code mutation runtime | resolves Q11 | T-H1 | Timed `mutmut run` restricted to a representative PR's functions, against the fast gate's budget | §6.1 | S |
+
+---
+
+## 11. Epic I — L3 subsystem
+
+| ID | Task | Flags | Depends on | Done when | Design | Size |
+|---|---|---|---|---|---|---|
+| **T-I1** | Settings lifecycle | | — | Normal exit, `SIGTERM`, `SIGKILL` + `kitty cleanup`; global settings byte-identical before and after; `_kitty_values_present` fires only on kitty-written state | §6.3.2 | M |
+| **T-I2** | Concurrent sessions | | T-I1 | Two sessions, separate `--settings` files, neither touches `~/.claude/settings.json`, the second does not disturb the first (issue #22) | §6.3.2 | M |
+| **T-I3** | `prepare_launch` failure fails the launch | | — | When the session file cannot be written, launch **fails** rather than running on the user's own Anthropic credentials | §6.3.2 | S |
+| **T-I4** | Background bridge ownership | | — | A bridge owned by another user is not stopped, not restarted, no second bridge starts beside it | §6.3.2 | S |
+| **T-I5** | Agent startup smoke | blocked Q12 | T-W4, T-W8, T-B4 | Pinned real Claude Code binary, one non-interactive turn against the recorder, clean exit | §6.4.2 | M |
+| **T-I6** | Agent settings precedence | blocked Q12 | T-I5 | Three runs, three winners: session file beats both; without it the global file beats the environment; without either the environment wins. Every sentinel demonstrated live | §6.4.2 | M |
+| **T-I7** | Streaming recovery — content | partial Q14 | T-B4, T-G7, T-W8 | Four injection points; no duplicated text, no tool-call id reused across attempts, no spliced arguments, exactly one terminal outcome. **Positive post-emission oracle waits on Q14**; until then the negatives only | §6.3.1 | L |
+| **T-I8** | Cross-attempt content and cadence | | T-D1, T-W8, T-B4 | Transport-blip and empty-response retries byte-identical; M6, M8, M9 and failover re-normalisation each fire only under their own trigger | §4.3 C3 | M |
+| **T-I9** | Connection lifecycle baseline | | T-W4, T-W8, T-C7 | Distinct TCP connections per N-turn session against the native capture; reported baseline, ratcheted | §4.3 C5 | M |
+| **T-I10** | `_backend_context` isolation | | T-W8 | Concurrent requests never observe each other's backend selection. Deterministic — belongs here, not in the load profile | §6.3.1 | S |
+| **T-I11** | Failover, disconnect, error envelopes | | T-B4, T-W8 | Streaming failover mid-response; client disconnect releases the upstream connection without marking the backend unhealthy; all-backends-unhealthy 503 in each protocol's native envelope; oversized request in the protocol's own error shape | §6.3.1 | M |
+| **T-I12** | Fingerprint parity report | | T-C7, T-W8, T-G9 | kitty's header set compared against the native baseline; **reported with a ratchet, not gating**, until gap G3 closes | §4.3 C1b | M |
+| **T-I13** | Side traffic | | T-W4, T-W8 | `GET /healthz` and `GET /stats` never cause an upstream request; a launch contacts the provider only for the agent's turns plus pre-flight validation, pinned as a declared exception; `kitty --no-validate` removes it | §4.3 C6 | M |
+
+---
+
+## 12. Epic J — L4 acceptance
+
+| ID | Task | Flags | Depends on | Done when | Design | Size |
+|---|---|---|---|---|---|---|
+| **T-J1** | `pytest-bdd` wiring and step definitions | | T-W1, T-W7 | Gherkin runs under pytest; steps bind to the L3 harnesses rather than re-implementing them. The exemption mechanism itself is T-W7 | §6.4.1 | M |
+| **T-J2** | TR scenarios — fidelity and indistinguishability | defect | T-J1, T-D4, T-C7, T-G9 | TR-1, TR-1c, TR-2, TR-3, TR-4. TR-1c and TR-4 land with exemptions (KBR-8, KBR-5). **No egress dependency — none of the TR scenarios involves containment** | §6.4.1 | M |
+| **T-J3** | EG scenarios — containment | | T-J1, T-E3, T-E4, T-E6, T-E8 | EG-0 (the reachability control), EG-1, EG-2, EG-3. T-E8 supplies EG-3's "names the profile" assertion | §6.4.1 | M |
+
+---
+
+## 13. Epic K — Evals, load and CI wiring
+
+| ID | Task | Flags | Depends on | Done when | Design | Size |
+|---|---|---|---|---|---|---|
+| **T-K1** | Eval harness skeleton | | — | Two arms; model, provider, dataset and sampling pinned and recorded per run; failure taxonomy captured per arm | §6.4.3 | M |
+| **T-K2** | Independently authored task set | | T-K1 | Coding tasks whose acceptance tests are **written by a person**. A model-generated test passing the model's own code shares its misunderstandings | §6.4.3 | L |
+| **T-K3** | Statistics and decision rule | blocked Q4, Q13 | T-K1, T-K2 | Successes ÷ **scheduled** trials; repetition; confidence interval; pre-registered margin; symmetric exclusion rule; missing-data ceiling that **voids** the run | §6.4.3 | M |
+| **T-K4** | Load rig and baseline | | T-W4, T-W8, T-B4 | Fixed workload and named runner class; bridge-added latency p50/p95, TTFB, completion and error rates, bounded RSS, socket/fd recovery; streaming and buffered paths measured separately | §6.4.4 | L |
+| **T-K5** | `load.yml` reusable + publish dependency | ci | T-K4 | `publish.yml` `needs:`-gates on a successful load run **for the tag commit**; a nightly caller warns but does not substitute | §8 | M |
+| **T-K6** | `tests.yml` gains Subsystem and Acceptance | ci | T-W1, T-E4, T-J3, T-I5 | Both gate PRs and releases through the one reusable workflow. **T-I5 is a dependency because `agent_smoke` is in the Acceptance selection**: if it never lands the selection collects nothing, pytest exits 5, and T-K8 turns that into a hard failure. Either T-I5 lands first, or T-K6 ships with `acceptance` only and T-I5 adds `agent_smoke` | §8 | M |
+| **T-K7** | Nightly workflows | ci | T-H3, T-K1 | Deep (mutation, schemathesis at high `--max-examples`), Agent-live, Eval. **Agent-live runs the existing `tests/integration/test_agent_e2e.py`, which needs no pinned binary** — so this does not wait on Q12. None of these gate | §8 | M |
+| **T-K8** | Skip-is-failure enforcement | ci | T-K6 | A gating job whose prerequisite is missing **fails**. A green tick meaning "we did not test this" is worse than a red one | §8 | S |
+
+---
+
+## 14. Sequencing
+
+### 14.1 Dependency graph, condensed
+
+```
+T-W1 ──────────────────────────────────────► everything (markers)
+T-W1 ──► T-W7 ──► T-G1, T-G3, T-G4, T-G5, T-G9, T-J1
+T-W2 ──► T-A1..T-A6 ──┐
+T-W3 ─────────────────┼──► T-D1 ──► T-D2 ──► T-D3
+T-W4 ──► T-B1..T-B4 ──┤          └─► T-D4 ──► T-D5/6/7, T-D8, T-G2 ──┐
+T-W4 ──► T-W8 ────────┤                                              ├──► T-J2 ──┐
+T-W6 ──► T-C1..T-C7 ──┘                                 T-C7, T-G9 ──┘           │
+                                                                                 │
+T-W5 ──► T-E1 ──► T-E2 ──► T-E3 ──► T-E4 ──► T-E5                                │
+                    └────► T-E8 ──┐                                              │
+              T-E6, T-E7 ─────────┴──► T-J3 ──► T-K6 ──► T-K8 ◄──────────────────┘
+
+independent from day one:  T-F1 ──► T-F2..T-F5      T-I1 ──► T-I2
+                           T-I3, T-I4, T-K1, T-E6, T-E7
+```
+
+### 14.2 Waves
+
+| Wave | Content | Parallel capacity |
+|---|---|---|
+| **0** | T-W1–T-W8, T-E6, T-E7, T-F1, T-I1, T-I3, T-I4, T-K1 | ~10 — T-W* is the constraint, staff it first |
+| **1** | T-A1–T-A6, T-B1–T-B4, T-C1–T-C7, T-E1, T-F2–T-F5, T-G1, T-G3, T-G8, T-G9, T-H1, T-H2, T-I2, T-K2 | **~15**, the widest point — though T-C1–T-C7 share one capture pass and are not seven independent slots |
+| **2** | T-D1, T-E2, T-E3, T-F6, T-G4, T-G6, T-I10, T-I13, T-J1 | ~9 |
+| **3** | T-D2, T-D3, T-D4, T-E4, T-E8, T-G5, T-G7, T-H3, T-I8, T-I9, T-I11, T-I12, T-K4 | ~12 |
+| **4** | T-D5, T-D6, T-D7, T-D8, T-E5, T-G2, T-I5, T-I6, T-I7, T-J2, T-J3, T-K5 | ~11 |
+| **5** | T-K6, T-K7, T-K8, T-K3, T-H4 | ~5 — CI wiring plus the decision-blocked tail |
+
+### 14.3 The two long chains
+
+Two chains of comparable length; the containment one is longer. Both end at CI wiring, not at the
+acceptance scenario — a scenario that gates nothing is not delivered.
+
+```
+Containment  T-W4(M) → T-W8(M) → T-E1(L) → T-E2(M) → T-E3(M) → T-E4(L) → T-J3(M) → T-K6(M) → T-K8(S)
+             ≈ 17–18 days
+
+Fidelity     T-W2(S) → T-A1(M) → T-D1(L) → T-D2(M) → T-D4(L) → T-J2(M) → T-K6(M) → T-K8(S)
+             ≈ 15 days
+```
+
+They converge only at **T-K6**. Nothing in one waits on anything in the other before that, so
+**running them as two streams with different owners roughly halves elapsed time on the two hardest
+parts of the suite** — the single biggest scheduling lever in this plan.
+
+Four consequences worth acting on:
+
+1. **T-W2, T-W4, T-W5 and T-W8 head the chains and are all small.** They go first, and no two of
+   them to the same person.
+2. **T-A1 and T-A2 gate T-D1**, so those two projections go before the other four, which can be
+   built during T-D1's construction.
+3. **T-E1 is the riskiest task in the plan** and sits second in the longer chain. If it slips,
+   containment slips one-for-one. Start it earliest, review it hardest.
+4. **T-K6 is a convergence point and a single point of failure.** Both chains stop there; it
+   should not be scheduled as an afterthought.
+
+---
+
+## 15. Blocked on decisions, not on code
+
+| Question | Blocks | Cost of leaving it open |
+|---|---|---|
+| **Q4** + **Q13** — eval margin, compaction baseline | T-K3 | The eval runs and cannot conclude. T-K1/T-K2 proceed |
+| **Q10** — irreducible final turn | T-F2's exact bound, TR-3's wording, register rows M3–M7/M13 | T-F2 lands with the observed-behaviour property and is revised once — but it must be revised **together with** TR-3 and the register |
+| **Q11** — per-PR mutation cadence | Nothing. **T-H4 answers it** | T-H3 lands nightly-only; a later change moves it |
+| **Q12** — pinned Claude Code binary | T-I5, T-I6 — and therefore T-K6's `agent_smoke` selection | **The most expensive open question.** It blocks the only test of a third-party behaviour the product depends on, and it reaches into CI wiring |
+| **Q14** — post-emission stream recovery | T-I7's positive assertions | T-I7 lands asserting only the negatives: catches corruption, cannot confirm correctness |
+
+**Q1** (agent identity) blocks no task but decides whether T-I12 and T-J2's TR-1c exemption ever
+become gating. **Q5, Q6, Q7** affect register rows and residual-risk wording, not delivery.
+
+---
+
+## 16. Relationship to the open defects
+
+Five defects are filed. The dependency runs one way only:
+
+- **The guard lands first, red, with an exemption.** Writing it *after* the fix proves nothing
+  about whether it would have caught the defect — and the fix then has no regression test that
+  ever failed.
+- **The defect's ticket removes the exemption**, as its acceptance criterion. T-W7's
+  unexpected-pass rule makes forgetting impossible.
+
+| Defect | Design gap | Guard that lands red | Exemption removed by |
+|---|---|---|---|
+| KBR-5 — vendor string upstream | G14 | T-G5, T-J2 (TR-4) | KBR-5's fix |
+| KBR-6 — internal keys on the wire | G15 | T-G3 | KBR-6's fix |
+| KBR-7 — wire-shape mismatch | G16 | T-G4 | KBR-7's fix |
+| KBR-8 — contradictory client versions | G3 | T-G9, T-J2 (TR-1c) | KBR-8's fix |
+| KBR-9 — README endpoint table | G6 | T-G1 | KBR-9's fix |
+
+---
+
+## 17. Risks in the sequencing
+
+**T-E1 is the hardest single task and the easiest to underestimate.** Direct-route resolution needs
+a different mechanism per transport, and T-E2 is explicit that a transport which cannot be given
+one is reported **unproven** rather than passed. Splitting T-E1/T-E2 means a stuck transport is one
+blocked M, not a blocked L.
+
+**The corpus is the quiet long pole.** T-C1–T-C7 are individually small but need real captured
+sessions, a secret review, and an owner for refresh. Start T-W6 on day one even though nothing
+visibly depends on it yet.
+
+**T-D4–T-D7 and T-G2 are adjacent and easy to duplicate.** T-D4–T-D7 own driving the wire and
+capturing; T-G2 owns asserting register-row coverage over those captures, as a meta-assertion. Two
+teams implementing "per adapter × model × transport" independently is the most likely wasted work
+in this plan — and if T-G2 re-drives the wire under an `l2` marker it puts real sockets in the
+fast gate.
+
+**T-H2 is the only source change.** Keep it out of every test PR so a revert is cheap. It now
+depends on T-B3 so "behaviour unchanged" has evidence behind it rather than assertion.
+
+**The existing suite already runs ~18.5 minutes per Python version.** Wave 3 onward adds real
+sockets to the PR gate. T-K6 should land with a measured runtime; if the gate crosses the point
+where people route around it, the marker split is the mechanism for pulling work back to nightly —
+that is what T-W1 buys beyond tidiness.


### PR DESCRIPTION
Closes [KBR-2](https://shelpuk.atlassian.net/browse/KBR-2).

**Two documents, no code.** A test-suite design and its implementation plan, plus one line removed from `.gitignore` so `.system_design/` can be tracked at all. No test code, no product code, no behaviour change.

## Context for the Product Owner

Kitty Bridge sells three promises. Two of them are the reason anyone chooses it over pointing an agent straight at a provider, and until now **neither was written down anywhere as something we check**:

1. **We don't touch your conversation.** What Claude Code sends is what the provider gets — except where translation genuinely requires otherwise.
2. **The provider can't tell we exist.** A coding plan is priced for a coding agent. If a provider can fingerprint bridge traffic it can throttle or terminate the account, and the user finds out mid-session.
3. **If you configure a shared egress IP, nothing escapes it.** Not one request in a thousand.

### `TEST_SUITE.md` — the design

Three named, checkable invariants and the four-layer suite that proves them, from millisecond unit tests up to sessions with real agent binaries.

- **A 35-row register** of every place the bridge is permitted to alter or redirect an agent's request, each with the condition under which it fires and why it is unavoidable. This is what turns "we don't change your messages unless necessary" into something a test can fail.
- **A fidelity oracle built from independent readers**, not from the code under test. Every request projects into a common form — envelope, conversation, residual — and any field a reader cannot account for **fails the run**, because an unaccounted field is exactly where an unregistered change hides.
- **A containment test that proves the negative**: with the proxy off, the provider must receive *zero* connections. Nothing checks this today, so a bridge that quietly fell back to a direct route would pass our entire current suite.
- **Falsification controls on both harnesses.** A test never shown to fail is indistinguishable from one that *cannot* fail.
- 19 gaps, priority-ordered. 14 open questions I did not invent answers to.

### `TEST_SUITE_IMPLEMENTATION_PLAN.md` — the plan

**98 atomic tasks** across a shared-contracts milestone and ten epics, arranged so parallel work starts early.

- **Milestone 0 is contracts plus one proven vertical slice** — types, register schema, corpus format, recorder and fixture extension interfaces, exemption registry, CI selection rules, and one request driven end to end so the contracts are known to compose before six streams build on them.
- **The schedule is derived, not asserted.** The epic tables are the only place dependencies live; tiers and chains are computed from them. 98 tasks, acyclic, every dependency resolves. 43 tasks are available in the first three tiers.
- **Durations are dependency-only lower bounds** — they assume unlimited parallel staffing, which the plan's own constraints break. Stated as such rather than presented as a forecast.

## Five defects found while writing the design

We hadn't written a single test. Specifying carefully enough to be testable was sufficient to surface these — three of which break the promises above in the shipping product today:

| | What | Impact |
|---|---|---|
| [KBR-5](https://shelpuk.atlassian.net/browse/KBR-5) | The literal string **"Kitty Bridge"** is sent to the provider inside the request body | Breaks promise 2 outright |
| [KBR-6](https://shelpuk.atlassian.net/browse/KBR-6) | Two internal fields reach the provider on **every** Chat-Completions provider | Breaks promises 1 and 2; confirmed against six providers |
| [KBR-7](https://shelpuk.atlassian.net/browse/KBR-7) | OpenCode Go declares one wire format and sends another for most models | Latent bug in the thinking-repair path |
| [KBR-8](https://shelpuk.atlassian.net/browse/KBR-8) | The ChatGPT-subscription path claims **two different client versions in one request**, one of them our own release number | The sharpest fingerprint in the codebase |
| [KBR-9](https://shelpuk.atlassian.net/browse/KBR-9) | The README documents a Gemini endpoint that doesn't exist | Anyone following it gets a 404 |

None is fixed here. KBR-5 and KBR-6 are small and ranked priority 0.

## Review history

Four rounds on the design, two on the plan, 37 findings, all adopted, none rejected.

The recurring pattern is worth stating, because it is the reason the documents look the way they do: **nearly every finding was a test that would have passed without proving anything.** A fidelity check that could not detect a changed model name, in a product whose entire function is changing the model name. A containment test asserting nothing arrived at a destination that could not be reached at all. A guard confirming a function was *called*, when that function only returns advice and the enforcement is the three lines after it. A failure report that could not run in the one case it existed for. Several of those were mine, introduced while fixing the previous one.

That is why every harness now ships with a deliberate-breakage case, and why the plan's schedule is computed rather than written — the same failure mode, applied to a document instead of a test.

## Note on `.gitignore`

`.system_design/` was ignored, so the file KBR-2 asks for could not be committed or reviewed. I removed that one line and left `.requirements/` ignored. Flagged as Q8 in the design — your call, easily reverted.

## Testing

Documentation only. `ruff check .` passes; the full suite is unaffected. A cross-reference pass confirms every identifier in both documents resolves and no section reference dangles. The plan's dependency graph is verified acyclic with no undefined predecessors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kq96s1XUMZtR9fxtoQJNeQ


[KBR-2]: https://shelpuk.atlassian.net/browse/KBR-2?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KBR-5]: https://shelpuk.atlassian.net/browse/KBR-5?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ