### PR TITLE
Document the Claude Code mouse-wheel scrolling fix (KBR-1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -642,6 +642,25 @@ kitty setup
 
 The conversation has grown beyond the model's context window. Use `/clear` in the agent to reset.
 
+### Mouse wheel scrolls through previous prompts instead of the conversation (Claude Code)
+
+The wheel steps backwards through your prompt history while the transcript stays put. This is Claude Code's renderer
+setting, not the bridge — kitty writes no terminal escape sequences and never sits between your terminal and the agent.
+
+Claude Code's classic renderer leaves the wheel to your terminal. Over SSH the wheel can arrive as arrow keys, which the
+prompt box reads as history navigation. The fullscreen renderer handles the wheel inside Claude Code instead. Reported
+from PowerShell on Windows over SSH to a Linux host, with the console maximised.
+
+Switch renderer from inside the session:
+
+```
+/tui fullscreen
+```
+
+Claude Code saves the choice and relaunches with your conversation intact, so it applies to later sessions too. Run
+`/tui` with no argument to print which renderer is active. `PgUp` / `PgDn` scroll and `Ctrl+End` jumps to the latest
+message in either renderer.
+
 ### Can I use kitty with Cursor, Windsurf, or other IDEs?
 
 Yes, but with caveats. Cursor uses a proprietary protocol that Kitty cannot integrate with automatically. However, you

--- a/README.md
+++ b/README.md
@@ -645,11 +645,13 @@ The conversation has grown beyond the model's context window. Use `/clear` in th
 ### Mouse wheel scrolls through previous prompts instead of the conversation (Claude Code)
 
 The wheel steps backwards through your prompt history while the transcript stays put. This is Claude Code's renderer
-setting, not the bridge — kitty writes no terminal escape sequences and never sits between your terminal and the agent.
+setting, not the bridge. Kitty prints its startup banner and then hands the terminal straight to the agent: it sets no
+terminal modes — no mouse tracking, no alternate screen — and writes nothing to your terminal while the agent runs.
 
-Claude Code's classic renderer leaves the wheel to your terminal. Over SSH the wheel can arrive as arrow keys, which the
-prompt box reads as history navigation. The fullscreen renderer handles the wheel inside Claude Code instead. Reported
-from PowerShell on Windows over SSH to a Linux host, with the console maximised.
+Claude Code's classic renderer keeps the conversation in your terminal's own scrollback and does not request mouse
+events. Many terminals then translate the wheel into Up/Down arrow keys, which the prompt box reads as history
+navigation. The fullscreen renderer requests mouse events and scrolls the conversation itself. Reported from PowerShell
+on Windows over SSH to a Linux host.
 
 Switch renderer from inside the session:
 
@@ -658,8 +660,11 @@ Switch renderer from inside the session:
 ```
 
 Claude Code saves the choice and relaunches with your conversation intact, so it applies to later sessions too. Run
-`/tui` with no argument to print which renderer is active. `PgUp` / `PgDn` scroll and `Ctrl+End` jumps to the latest
-message in either renderer.
+`/tui default` to switch back, or `/tui` with no argument to print which renderer is active. In fullscreen, `PgUp` /
+`PgDn` scroll and `Ctrl+End` jumps back to the latest message.
+
+One trade-off: fullscreen captures the mouse, so your terminal's own copy-on-select stops working. Hold `Shift` while
+dragging (`Option` in iTerm2, `Fn` in Terminal.app) when you want a native selection.
 
 ### Can I use kitty with Cursor, Windsurf, or other IDEs?
 


### PR DESCRIPTION
## Context for the Product Owner

A user reported that Kitty Bridge "breaks scrolling": in Claude Code, the mouse wheel stepped backwards through their
previous prompts instead of scrolling the conversation. It only happened under kitty — an identical VM without kitty
scrolled fine — so the bridge looked responsible.

**It isn't.** The cause is a Claude Code display setting, and the user confirmed that running `/tui fullscreen` inside
the session fixes it. Nothing in the bridge needs to change.

This PR adds a README FAQ entry so the next person who hits this finds the answer in seconds instead of opening a bug
against us. It is documentation only — no behaviour change, no code touched.

## Why we are confident kitty is not at fault

Every path by which kitty could reach the terminal was checked and eliminated:

- sets **no terminal modes** — no mouse tracking, no alternate screen, no cursor-key mode; no `pty` / `termios` / `tty`
  use anywhere in `src/`
- hands the child the **real TTY** (`stdin=sys.stdin, stdout=sys.stdout, stderr=sys.stderr`, `src/kitty/cli/launcher.py`)
  and never reads stdin while the agent runs
- leaves `TERM` and `COLORTERM` alone; sets no proxy variables (`src/kitty/egress.py`)
- loggers attach a `NullHandler` (`src/kitty/__init__.py`), so nothing kitty emits reaches the terminal mid-session
- `status_spinner` (rich `Console.status`) never enters the alternate screen or touches mouse modes, and exits before
  the child spawns
- on >= 1.4.1 the user-global `~/.claude/settings.json` is never written — verified by driving the adapter directly

kitty's entire footprint on the `claude` child is the `--settings` flag, eight env vars, three cleared vars, and being a
Python parent process. None of those select the renderer.

Claude Code picks its renderer from per-machine state, which is exactly why two otherwise identical VMs diverged.

## What the entry says

Symptom, why it is a renderer setting rather than a bridge fault, the one-line fix (`/tui fullscreen`), how to go back
(`/tui default`), how to check which renderer is active (`/tui`), and the copy-on-select trade-off that fullscreen's
mouse capture introduces.

## Review notes

The first commit contained two factual errors that a review pass caught and the second commit fixes — recorded here
because both were wrong in a way a reader would have acted on:

1. `PgUp` / `PgDn` / `Ctrl+End` were described as working "in either renderer". They are fullscreen scroll keys.
2. "kitty writes no terminal escape sequences" was false — `main()` prints a rich-styled banner on every invocation. The
   claim is now scoped to terminal *modes*, which is what actually matters for wheel handling and is true.

## Testing

Documentation only. `tests/test_pypi_packaging.py` (the only suite that consumes README) passes 25/25 locally; its
`test_twine_check` case fails on this machine because the venv's `twine` rejects `Metadata-Version: 2.5` from a newer
build backend — a pre-existing local toolchain mismatch, unrelated to this change. CI will confirm.

Closes KBR-1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q3FxGt7jueXmTahcnnmkR4
