### PR TITLE
KBR-7: declare the upstream wire shape per model, and guard the whole registry

### DIFF
--- a/.system_design/TEST_SUITE.md
+++ b/.system_design/TEST_SUITE.md
@@ -213,9 +213,10 @@ site without adding a row fails the L2 register guards (§6.2.3).
 
 The register is only enforceable at the point where bytes are handed to a transport. That point
 is **not** `translate_to_upstream` for any of the three custom-transport providers, and assuming
-it is hid seven rows in the first draft: on `openai_subscription` the hook returns a Chat
-Completions shape and the real body is built afterwards (P13–P17), while on `bedrock` and
-`ollama_cloud` the hook builds the body and the transport then **mutates it** (P18, P19).
+it is hid seven rows in the first draft: on `openai_subscription` the hook is **never invoked on
+the request path at all** — `_cc_to_responses` builds the Responses body inside the transport
+(P13–P17) — while on `bedrock` and `ollama_cloud` the hook builds the body and the transport then
+**mutates it** (P18, P19).
 
 | Path | Adapters | Where the final bytes are decided |
 |---|---|---|
@@ -375,12 +376,15 @@ not solved the problem.
 
 #### 3.3.4 Scoping, triggers and transports
 
-**Scoped by observed wire shape, per request.** `upstream_wire_is_messages_api` is the natural
-selector but cannot be trusted as an adapter-level constant: `OpenCodeGoAdapter` inherits `True`
+**Scoped by observed wire shape, per request.** The declared wire shape is the natural selector
+but must not be trusted as an adapter-level constant. `OpenCodeGoAdapter` used to inherit `True`
 from `AnthropicAdapter` while emitting Chat Completions for every model outside
-`_MESSAGES_MODELS` (F5, KBR-7). The oracle selects the projection by the shape actually observed
-on the wire, and an L2 guard asserts the property agrees with that shape for every adapter ×
-representative model.
+`_MESSAGES_MODELS` (F5, KBR-7); that is fixed, and the declaration is now per-model. **The
+decision here stands regardless**, for the reason given in §7.4 rather than because of that one
+bug: an oracle must not ask the code under test what shape it emitted, and a declaration is a
+claim, not an observation. So the oracle selects the projection by the shape actually observed on
+the wire, and the L2 guard (§6.2.3) separately asserts that the declaration agrees with that
+shape for every adapter × representative model.
 
 **Triggers and their complements, across representative models.** A single fixed request cannot
 establish register completeness. For every conditional row the corpus must contain a case that
@@ -546,8 +550,10 @@ the test pins it as a *declared* exception and asserts `kitty --no-validate` rem
 
 ### 4.4 Findings
 
-Five defects surfaced while writing this document. **None is fixed by this change**; each needs
-its own ticket. F3, F4 and F5 are live breaches of invariants defined above.
+Five defects surfaced while writing this document. **None was fixed by this change** — it added
+documentation only; each needed its own ticket. F3, F4 and F5 were live breaches of invariants
+defined above. **F5 has since been fixed under KBR-7**, together with the hook-level half of its
+guard; see its entry below and §6.2.3. The rest remain open.
 
 - **F1 — Agent identity is handled per-provider, not by policy.** *(KBR-8.)* Upstream headers are built from
   scratch, so Claude Code's `user-agent`, `x-app`, `anthropic-beta` and `x-stainless-*` never
@@ -586,14 +592,20 @@ its own ticket. F3, F4 and F5 are live breaches of invariants defined above.
   unmistakable proxy signature. Note that `_reasoning_effort` and `_thinking_enabled`, written by
   the same function, *are* in the set — so this is an omission, not a design choice. Tracked as
   G15 and KBR-6.
-- **F5 — `OpenCodeGoAdapter.upstream_wire_is_messages_api` is wrong for most of its models.**
-  *(KBR-7.)* It
-  inherits `True` from `AnthropicAdapter`, but its `translate_to_upstream` returns a Chat
+- **F5 — `OpenCodeGoAdapter.upstream_wire_is_messages_api` was wrong for most of its models.**
+  *(KBR-7 — **fixed**.)* It
+  inherited `True` from `AnthropicAdapter`, while its `translate_to_upstream` returned a Chat
   Completions body for every model outside `_MESSAGES_MODELS`. `ProviderAdapter`'s own docstring
   says the property "describes the shape that actually goes on the wire" and that anything
-  shaping the serialized body must branch on it — so a `True` that is false for most models is a
+  shaping the serialized body must branch on it — so a `True` that was false for most models was a
   latent defect in the thinking-repair path (M8) as well as a trap for the oracle's scoping
-  (§3.3.4). Tracked as G16 and KBR-7.
+  (§3.3.4). Tracked as G16 and KBR-7. The declaration is now per-model —
+  `upstream_wire_is_messages_api_for_model(model)` mirrors `translate_to_upstream`'s own routing,
+  and the bare property reports the adapter's default (Chat Completions) route — and both bridge
+  repair sites read it from the `cc_request` the adapter routes on. The hook-level honesty guard
+  landed with the fix; §6.2.3 records what it does and does not prove. §3.3.4's decision stands
+  regardless: the oracle still selects on the observed shape, because an oracle must not ask the
+  code under test what shape it emitted.
 
 ### 4.5 Accepted residual risk
 
@@ -982,15 +994,16 @@ Structural guards in the style of `tests/test_egress_coverage.py`.
 **The register guard runs at the serialization boundary (§3.2.3), not at `translate_to_upstream`.**
 An earlier draft specified feeding a request through `normalize_request` + `translate_to_upstream`
 and diffing the result. That misses every transformation inside a custom transport — and P13 is
-exactly that case: on `openai_subscription` those two hooks return a Chat Completions shape, and
-`_cc_to_responses` drops fourteen parameters afterwards. A guard checking the hook would have
-reported the adapter clean.
+exactly that case: on `openai_subscription` `translate_to_upstream` is never called on the request
+path, and `_cc_to_responses` builds the Responses body from `cc_request` directly, dropping
+fourteen parameters. A guard checking the hook would have reported the adapter clean while
+inspecting a body it never sends.
 
 | Guard | Asserts |
 |---|---|
 | **Register completeness — shape diff at the wire** | For every adapter × representative model × transport, capture the body at the §3.2.3 boundary and assert the projected delta from the input is exactly the union of that adapter's register rows whose triggers the input met. **One fixed request is not sufficient** — each conditional row needs a trigger case and a complement case (§3.3.4), and adapters that route by model need one input per route. |
 | **Internal-key completeness** | AST-scan `bridge/**` for every `_`-prefixed key written into a request dict, and assert each is a member of `_INTERNAL_KEYS`. **This is the guard that catches F4 (KBR-6).** The complementary check — that each `translate_to_upstream` override delegates or excludes the set — is necessary but not sufficient: every override strips it correctly today; the set itself is what is wrong. |
-| **Wire-shape honesty** | For every adapter × representative model, assert `upstream_wire_is_messages_api` agrees with the shape observed at the serialization boundary. Catches F5 (KBR-7). |
+| **Wire-shape honesty** | For every adapter × representative model, assert the adapter's declared wire shape agrees with the shape the body is actually written in. Catches F5 (KBR-7). **Two boundaries, two owners.** The *hook* form — observing `translate_to_upstream`'s return value — landed with **KBR-7** as `tests/test_wire_shape_honesty.py`, together with the fix: it asserts the per-model declaration `upstream_wire_is_messages_api_for_model(model)` against the emitted body, and the bare property against an explicitly declared default-route model. It guards itself so it cannot rot — the classifier is pinned against known Messages, Chat Completions and Converse bodies (including a Converse body with no tools, since the tools axis is what separates Converse from Messages); every registry key must be represented; every route of a model-routing adapter must be represented; and the custom-transport set is asserted rather than narrated. The *wire* form — observing the body at the §3.2.3 boundary — is **T-G4 / KBR-80** and is **not** delivered: for the three `use_custom_transport` adapters nothing in the hook-level guard observes the bytes that ship. On `openai_subscription` `translate_to_upstream` is never invoked on the request path at all — `_cc_to_responses` builds the Responses body inside the transport (P13–P17) — so there the exemption is load-bearing. On `bedrock` and `ollama_cloud` the transport mutates the hook's body afterwards (P18, P19); neither mutation changes the body's *shape family*, so for those two the exemption is precautionary — a guard must observe the shipped bytes, not infer them. The hook form also does not cover adapters constructed with `provider_config`, native-passthrough requests, whether a non-Messages body is *well-formed* (the declaration is a boolean, so Chat Completions and "neither" are collapsed) — **T-G4 inherits that one**, because it is a property of the declaration and not of the boundary — or whether the routing table matches the provider's published endpoint table (**KBR-126**). The declaration stays boolean deliberately: its consumer is binary (`_repair_thinking_roundtrip` picks between exactly two carriers), so widening it to an enum would change the repair's contract rather than this declaration's. If a routing adapter ever gains a third wire, the boolean must be **replaced**, not extended — a `False` meaning "Responses" would be F5 again in a new costume. |
 | **Bridge-introduced vendor token** | No content the bridge *introduces* into a request body or header contains `kitty` in any casing. Scoped by the projection diff (§3.3.3), never a flat scan of the serialized body — a flat scan would fail on a user legitimately writing the word, and "fixing" that would breach I1. Catches F3 (KBR-5). |
 | **Start-path domination** | Every `BridgeServer(` construction is dominated by an `egress_block_reason(` call **at AST level**, not merely co-located in the same file. `cli/main.py` already holds two of the five start paths (§5.1 gap 3). **Necessary but not sufficient — see below.** |
 | **Env-var register** | `_SETTINGS_ENV_OVERRIDE_KEYS` and `_CONFLICTING_ENV_VARS` (`launchers/claude.py`) match what `build_spawn_config` emits and what the README documents. |
@@ -1448,10 +1461,11 @@ assert_no_unclaimed_mutation(inbound:  CapturedRequest, inbound_format,
 ```
 
 **Bodies alone cannot prove correct routing** (§3.3.5). Both formats are supplied by the harness
-from the observed wire shape (§3.3.4), never read from the adapter's own property — that property
-is unreliable (F5, KBR-7) and, more fundamentally, an oracle must not ask the code under test what
-it did. A new corpus entry, adapter, model route or transport costs one parametrisation, not a new
-test.
+from the observed wire shape (§3.3.4), never read from the adapter's own declaration. That
+declaration was unreliable (F5, KBR-7, since fixed) — but the decision does not rest on that: an
+oracle must not ask the code under test what it did, and a **boolean** declaration cannot
+select among the six projections listed above in any case. A new corpus entry, adapter, model
+route or transport costs one parametrisation, not a new test.
 
 ---
 
@@ -1544,11 +1558,16 @@ Four Python versions in CI, with `mypy` and `import-linter` as gates rather than
 
 ### 9.2 What is missing
 
+**Status convention.** A closed gap keeps its row — the reasoning is still worth reading — with
+**CLOSED** in the *Gap* column, *Today* in the past tense, and Priority `—`, so a scan by priority
+does not surface work that is done. `TEST_SUITE_IMPLEMENTATION_PLAN.md` §16 mirrors it.
+
 | ID | Gap | Today | Target | Priority |
 |---|---|---|---|---|
 | **G14** | **F3 — the vendor name goes upstream in the body (M13)** — KBR-5 | Live I2 breach | Fix the message; forbidden-token guard (§6.2.3) + TR-4 | **0** |
 | **G15** | **F4 — `_effort` / `_thinking_adaptive` reach the wire** — KBR-6 | Live I1+I2 breach on every CC-wire provider | Add both to `_INTERNAL_KEYS`; internal-key completeness guard (§6.2.3) | **0** |
-| **G16** | **F5 — `OpenCodeGoAdapter` misdeclares its wire shape** — KBR-7 | Latent defect in the M8 path; trap for the oracle | Make the property per-model; wire-shape honesty guard | **1** |
+| **G16** | **F5 — `OpenCodeGoAdapter` misdeclared its wire shape** — KBR-7 · **CLOSED** | Was a latent defect in the M8 path and a trap for the oracle | Done: the declaration is per-model, both repair sites branch on it, and the **hook-level** honesty guard landed with the fix. The **wire-level** guard remains T-G4 / KBR-80 | — |
+| **G20** | **OpenCode Go's routing table does not match the provider** — KBR-126 | Found while fixing G16. As of 2026-09-07 (<https://opencode.ai/docs/go/>, "Endpoints") the provider serves eight models on `/v1/messages`; `_MESSAGES_MODELS` holds two, and a `/v1/responses` endpoint (four models) has no route at all. The wire-shape guard correctly reports the adapter *honest* — declaration and emitted body agree — because this is routing, not shape | Refresh the table against the provider's endpoint list; decide the Responses route; replace the stale `validation_model`. Consider a checked-in snapshot of the endpoint table, so the routing question gets an in-repo oracle | **1** |
 | **G19** | Routing was outside the register and outside the oracle | The destination is built from the profile (M14, P20, P21); a body-only check cannot see a misrouted Azure deployment | §3.3.5 — whole-request oracle with an independently derived route | **1** |
 | **G17** | Undecided behaviour for an irreducible final turn | Compaction emits an over-budget request, or M13 replaces the conversation; neither was designed | Answer Q10, then align M3-M7/M13, the 6.1 properties and TR-3 together | **2** |
 | **G18** | P13-P19 - seven transport-level mutations, unregistered in the first draft | Necessary (the Codex backend and boto3 require them) but invisible above DEBUG, and unreachable by a guard placed at `translate_to_upstream` | Rows P13-P19; boundary corrected in 3.2.3; Q5 decides user visibility | **3** |
@@ -1569,7 +1588,8 @@ Four Python versions in CI, with `mypy` and `import-linter` as gates rather than
 **Order of work.** G14 and G15 are priority 0: they are live breaches of the product's stated
 promise, both are small code fixes, and each has a cheap guard that stops it recurring. Then G1
 and G2 — the two invariants with the least coverage, sharing §7.2's recording upstream as their
-foundation — with G16 alongside because the oracle's scoping depends on it. G8 unblocks G1's
+foundation. (G16 was originally scheduled alongside them; it is closed, and per §3.3.4 the
+oracle's scoping never depended on it.) G8 unblocks G1's
 corpus; G10 rides along with G2 once the harness is parametrised. G3's measurement lands with G1;
 G3's *fix* is its own ticket. G4 and G7 reinforce an existing layer and can run in parallel. G5,
 G6, G9, G11 are cheap and independent. G12 and G13 are last: most expensive to run, least caught
@@ -1600,9 +1620,11 @@ missed F4.
 
 **The oracle is scoped by observed wire shape, not by the adapter's own property (§3.3.4).** On a
 CC-wire provider every field differs and every delta is claimed by the translation row, so a
-direct diff passes without proving anything. And the natural selector cannot be trusted:
-`OpenCodeGoAdapter` declares a Messages wire while emitting Chat Completions for most models
-(F5). Selecting on the observed shape keeps assertion 1 falsifiable regardless.
+direct diff passes without proving anything. And the natural selector must not be trusted: it is a
+claim by the code under test, and it is a boolean where §7.4 needs six projections. It was also in
+fact wrong (`OpenCodeGoAdapter` declared a Messages wire while emitting Chat Completions for most
+models — F5, since fixed), but the first two reasons stand without it. Selecting on the observed
+shape keeps assertion 1 falsifiable regardless.
 
 **Structural diff, except key order on the passthrough path (§3.3, §4.3 C2).** Byte-comparing
 JSON fails on serialisation noise and trains people to ignore red. But key *order* is exactly what

--- a/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
+++ b/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
@@ -295,7 +295,7 @@ one case it existed for. T-E1 now ships the report; T-E9 only checks it is compl
 | **T-G1** | README ⇄ code table guards | defect | T-W7 | Endpoint, attribution-header, env-var, logging-flag tables (KBR-9) | §6.2.3 | M |
 | **T-G2** | Register coverage meta-assertion | | T-W3, T-D9, T-D5, T-D6, T-D7 | Over T-D4–T-D9's captures — **it does not re-drive the wire**, and is marked `l3` so it cannot put sockets in the fast gate | §6.2.3 | M |
 | **T-G3** | Internal-key completeness AST guard | defect | T-W7 | Every `_`-prefixed key written into a request dict is in `_INTERNAL_KEYS` (KBR-6) | §6.2.3 | M |
-| **T-G4** | Wire-shape honesty guard | defect | T-W7, T-B1, T-B2, T-B3 | `upstream_wire_is_messages_api` agrees with the observed output shape per adapter × model (KBR-7) | §6.2.3 | M |
+| **T-G4** | Wire-shape honesty guard **at the wire** | defect | T-W7, T-B1, T-B2, T-B3 | The declaration agrees with the shape observed at the §3.2.3 boundary, per adapter × model × transport. **The hook-level form already landed with KBR-7** (`tests/test_wire_shape_honesty.py`) and is not this row. What remains is the three `use_custom_transport` adapters, for which nothing at the hook observes the bytes that ship: `openai_subscription` never invokes `translate_to_upstream` on the request path (P13–P17), and `bedrock` and `ollama_cloud` mutate the hook's body in the transport (P18, P19) — those two mutations do not change the shape family, so there the wire check is precautionary. Plus `provider_config`-constructed adapters and native-passthrough requests | §6.2.3 | M |
 | **T-G5** | Bridge-introduced vendor token guard | defect | T-D1, T-W7, T-C5 | No bridge-introduced content names kitty — **and in the same run** an inbound turn containing `kitty-bridge` survives byte-identically (KBR-5) | §3.3.3 | M |
 | **T-G6** | OpenAPI 3.1 + schemathesis | | T-W8 | Five POST routes plus `/healthz`, `/stats`, `/v1/models`, **targeting bridge mode**; plus a per-protocol registration-matrix guard | §6.2.1 | L |
 | **T-G7** | SSE grammar state machine | | T-B4, T-W8 | Every stream, including error streams and mid-stream failover, is a sentence in the grammar | §6.2.2 | M |
@@ -482,7 +482,7 @@ merge.** So:
 |---|---|---|---|
 | KBR-5 | G14 | T-G5, TR-4 | Atomic fix + test now |
 | KBR-6 | G15 | T-G3 | Atomic fix + test now |
-| KBR-7 | G16 | T-G4 | Atomic fix + test now |
+| KBR-7 · **CLOSED** | G16 | T-G4 | Route taken: atomic fix + hook-level guard landed together, red evidence in the PR. T-G4 still owns the wire boundary. (Status convention: `TEST_SUITE.md` §9.2.) |
 | KBR-8 | G3 | T-G9, TR-1c | Atomic fix + test now |
 | KBR-9 | G6 | T-G1 | Atomic fix + test now |
 
@@ -516,7 +516,7 @@ Every design requirement has an owner. "Existing" means the current suite alread
 | §6.1 | Properties · mutation validation | T-F1–T-F6 · T-H1–T-H5 |
 | §6.2.1 | OpenAPI, schemathesis, registration matrix | T-G6 |
 | §6.2.2 | SSE grammar | T-G7 |
-| §6.2.3 | Register, internal-key, wire-shape, vendor-token, docs guards | T-G1–T-G5 |
+| §6.2.3 | Register, internal-key, wire-shape, vendor-token, docs guards | T-G1–T-G5 — except the **hook-level** half of wire-shape honesty, delivered by KBR-7 |
 | §6.2.4 | Four dependency contracts | T-G8, T-G10, T-G11, T-G12 |
 | §6.3.1 | Bridge-with-sockets scenarios | T-I7–T-I11 |
 | §6.3.2 | CLI lifecycle | T-I1–T-I4 |

--- a/src/kitty/bridge/server.py
+++ b/src/kitty/bridge/server.py
@@ -392,8 +392,11 @@ def _repair_thinking_roundtrip(body: dict, *, native: bool) -> bool:
     The dialect is passed in rather than inferred, because
     ``{"role": "assistant", "content": "..."}`` is valid in both and guessing
     would silently write the wrong carrier for one of them.  It must come from
-    the adapter's :attr:`ProviderAdapter.upstream_wire_is_messages_api`, not
-    from ``_native_messages_request`` — see :meth:`BridgeServer._upstream_body_for`.
+    :meth:`ProviderAdapter.upstream_wire_is_messages_api_for_model`, asked with
+    the model the body was serialized for — not from the bare property, which
+    on a model-routing adapter answers only for the default route (KBR-7), and
+    not from ``_native_messages_request`` — see
+    :meth:`BridgeServer._upstream_body_for`.
 
     Changed messages are **copied**, not edited in place, and ``messages`` is
     replaced with a new list.  ``translate_to_upstream`` returns a shallow copy
@@ -3463,7 +3466,9 @@ class BridgeServer:
                                 and _is_thinking_roundtrip_error(upstream.status, error_body)
                                 and _repair_thinking_roundtrip(
                                     upstream_body,
-                                    native=self._active_provider.upstream_wire_is_messages_api,
+                                    native=self._active_provider.upstream_wire_is_messages_api_for_model(
+                                        cc_request.get("model", "")
+                                    ),
                                 )
                             ):
                                 self._thinking_repair_backends.add(self._current_backend_idx)
@@ -6285,6 +6290,14 @@ class BridgeServer:
         re-serializes with ``translate_to_upstream`` directly would carry the
         previous backend's carrier to a sibling that never asked for it.
 
+        The carrier's dialect is read per model, from ``cc_request`` itself
+        rather than from ``_active_model`` — the adapter routes on that same
+        key, and only that key is normalized (KBR-7; the URL and header helpers
+        still read ``_active_model``, which is KBR-127).  This depends on every
+        failover site rebuilding the body from the ``cc_request`` it has just
+        re-normalized; a site that reused a stale body would pair it with a
+        fresh model.
+
         Args:
             cc_request: The normalized request. Never modified — the carrier is
                 written to the returned body only.
@@ -6294,7 +6307,10 @@ class BridgeServer:
         """
         upstream_body = self._active_provider.translate_to_upstream(cc_request)
         if self._current_backend_idx in self._thinking_repair_backends:
-            _repair_thinking_roundtrip(upstream_body, native=self._active_provider.upstream_wire_is_messages_api)
+            _repair_thinking_roundtrip(
+                upstream_body,
+                native=self._active_provider.upstream_wire_is_messages_api_for_model(cc_request.get("model", "")),
+            )
         return upstream_body
 
     def _build_upstream_headers(self) -> dict[str, str]:

--- a/src/kitty/providers/anthropic.py
+++ b/src/kitty/providers/anthropic.py
@@ -72,11 +72,19 @@ class AnthropicAdapter(ProviderAdapter):
 
     @property
     def upstream_wire_is_messages_api(self) -> bool:
-        """Always True — every path through ``translate_to_upstream`` emits Messages API.
+        """True — this class's ``translate_to_upstream`` emits Messages API.
 
-        Subclasses either forward a native Messages body unchanged or fall back
-        to this class's Chat Completions → Messages translation, so the wire
-        shape does not depend on ``_native_messages_request``.
+        Holds for subclasses that do **not** route by model: they either
+        forward a native Messages body unchanged or fall back to this class's
+        Chat Completions → Messages translation, so the wire shape does not
+        depend on ``_native_messages_request``.
+
+        It does **not** hold for a subclass that routes by model.
+        :class:`~kitty.providers.opencode.OpenCodeGoAdapter` emits Chat
+        Completions for every model outside its ``_MESSAGES_MODELS``, and
+        inheriting this ``True`` was KBR-7.  Such a subclass must override
+        **both** this property, reporting its default route, and
+        ``upstream_wire_is_messages_api_for_model``, mirroring its own routing.
         """
         return True
 

--- a/src/kitty/providers/base.py
+++ b/src/kitty/providers/base.py
@@ -266,9 +266,39 @@ class ProviderAdapter(ABC):
         Anthropic body, built from the Chat Completions request.
 
         Anything shaping the serialized body — notably the bridge's thinking
-        round-trip repair — must branch on this, never on the request flag.
+        round-trip repair — must branch on the declared wire shape, never on
+        the request flag.
+
+        On an adapter that routes by model this answers only for the **default**
+        route.  A caller holding a model must ask
+        :meth:`upstream_wire_is_messages_api_for_model` instead: branching on
+        this property with a routed adapter in hand is what KBR-7 was.
         """
         return False
+
+    def upstream_wire_is_messages_api_for_model(self, model: str) -> bool:
+        """Whether ``translate_to_upstream`` emits a Messages body for *model*.
+
+        The per-model form of :attr:`upstream_wire_is_messages_api`, for
+        adapters that route to different endpoints depending on the model —
+        the same pairing as :attr:`upstream_path` / :meth:`get_upstream_path`
+        and ``build_upstream_headers`` / ``build_upstream_headers_for_model``.
+
+        Callers that have a model in hand must use this rather than the bare
+        property, and must read the model from the request being serialized so
+        the two agree by construction (KBR-7).
+
+        An adapter that routes by model overrides **both**: this, mirroring its
+        own routing predicate, and the property, reporting its default route.
+
+        Args:
+            model: The model name the request will be sent with, exactly as
+                ``translate_to_upstream`` will read it — unnormalized.
+
+        Returns:
+            True when the body for *model* is an Anthropic Messages body.
+        """
+        return self.upstream_wire_is_messages_api
 
     @property
     def use_custom_transport(self) -> bool:

--- a/src/kitty/providers/opencode.py
+++ b/src/kitty/providers/opencode.py
@@ -82,6 +82,36 @@ class OpenCodeGoAdapter(AnthropicAdapter):
     def get_upstream_path(self, model: str) -> str:
         return "/v1/messages" if _is_messages_model(model) else "/v1/chat/completions"
 
+    @property
+    def upstream_wire_is_messages_api(self) -> bool:
+        """Default wire shape (Chat Completions).  Routed per model below.
+
+        Overrides ``AnthropicAdapter``'s unconditional ``True``, which was
+        false for every model outside ``_MESSAGES_MODELS`` (KBR-7).  Like
+        ``upstream_path`` and ``build_upstream_headers`` above, this reports the
+        adapter's default route; callers holding a model must ask
+        :meth:`upstream_wire_is_messages_api_for_model`.
+        """
+        return False
+
+    def upstream_wire_is_messages_api_for_model(self, model: str) -> bool:
+        """Report the wire shape ``translate_to_upstream`` emits for *model*.
+
+        Uses ``_is_messages_model`` on the raw name, which is exactly what
+        ``translate_to_upstream`` routes on — deliberately without
+        ``normalize_model_name``, so the two agree by construction rather than
+        by a second copy of the rule.  Normalizing here would be more correct in
+        isolation and less correct against the contract, which is agreement with
+        the router.
+
+        Args:
+            model: The model name, exactly as ``translate_to_upstream`` reads it.
+
+        Returns:
+            True for the models served on ``/v1/messages``.
+        """
+        return _is_messages_model(model)
+
     def build_upstream_headers(self, api_key: str) -> dict[str, str]:
         """Default headers (Chat Completions — Bearer auth)."""
         return {

--- a/tests/bridge/test_thinking_roundtrip_per_model_wire.py
+++ b/tests/bridge/test_thinking_roundtrip_per_model_wire.py
@@ -1,0 +1,244 @@
+"""Subsystem tests for the thinking round-trip repair on a per-model-routed provider.
+
+Covers KBR-7.  ``OpenCodeGoAdapter`` routes by model — an Anthropic Messages
+body for ``_MESSAGES_MODELS`` and a Chat Completions body for everything else —
+while it inherited a single ``upstream_wire_is_messages_api == True`` from
+:class:`~kitty.providers.anthropic.AnthropicAdapter`.  The bridge's thinking
+round-trip repair branches on that declaration to choose a carrier, so on a
+Chat-Completions-routed model it wrote an Anthropic ``thinking`` content block
+into a Chat Completions body.
+
+The repair reaches the wire through two independent call sites, and both are
+tested here.  A fix applied to only one of them is worse than no fix: once the
+adapter's bare property reports Chat Completions, the site left behind would
+write ``reasoning_content`` into an Anthropic transcript instead — the same
+defect inverted, on the error-recovery path.
+
+Covers ``.requirements/20260907T142619Z_wire_shape_honesty`` R4a, R4b and R5.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from aioresponses import CallbackResult, aioresponses
+
+from kitty.bridge.server import BridgeServer
+from kitty.providers.opencode import OpenCodeGoAdapter
+from tests.bridge.test_thinking_roundtrip_failover import (
+    _anthropic_sse,
+    _post,
+    _rejection,
+    _ScriptedUpstream,
+    _StubLauncher,
+)
+
+# The adapter ignores ``provider_config`` for its base URL, so these are the
+# real routed endpoints.  ``aioresponses`` intercepts both; nothing leaves the
+# process.
+CC_URL = "https://opencode.ai/zen/go/v1/chat/completions"
+MESSAGES_URL = "https://opencode.ai/zen/go/v1/messages"
+
+# Served on the Chat Completions endpoint and the Messages endpoint respectively
+# (https://opencode.ai/docs/go/, verified 2026-09-07).
+CC_MODEL = "glm-5.2"
+MESSAGES_MODEL = "minimax-m2.5"
+
+
+def _chat_completions_sse() -> bytes:
+    """A minimal, well-formed Chat Completions SSE stream.
+
+    The Anthropic stream in the sibling module cannot stand in for this one:
+    the Chat-Completions-routed model returns CC chunks, and the bridge
+    translates them back to Messages events for the client.
+    """
+    chunks = [
+        {
+            "id": "chatcmpl-ok",
+            "object": "chat.completion.chunk",
+            "created": 1700000000,
+            "model": CC_MODEL,
+            "choices": [{"index": 0, "delta": {"role": "assistant", "content": "Recovered"}, "finish_reason": None}],
+        },
+        {
+            "id": "chatcmpl-ok",
+            "object": "chat.completion.chunk",
+            "created": 1700000000,
+            "model": CC_MODEL,
+            "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+        },
+    ]
+    body = b"".join(f"data: {json.dumps(chunk)}\n\n".encode() for chunk in chunks)
+    return body + b"data: [DONE]\n\n"
+
+
+def _stream_ok(sse: bytes) -> CallbackResult:
+    return CallbackResult(status=200, headers={"Content-Type": "text/event-stream"}, body=sse)
+
+
+def _transcript_without_reasoning() -> dict:
+    """A client request whose assistant turn carries no reasoning of any kind.
+
+    The sibling module's fixture cannot be reused here.  It asks for thinking,
+    and this provider is not a native-passthrough one, so the Messages route
+    translates Anthropic → Chat Completions → Anthropic and
+    :meth:`AnthropicAdapter.translate_to_upstream` injects the empty thinking
+    block on the way back.  The transcript would then already satisfy the
+    round-trip contract, ``_repair_thinking_roundtrip`` would report no change,
+    and the retry branch under test would never run — the test would fail on a
+    plain 400 rather than on the carrier.
+
+    Omitting ``thinking`` reproduces the incident this repair exists for: a
+    transcript authored by a different provider, replayed against a backend
+    that enforces the round-trip.
+    """
+    return {
+        "model": "claude-sonnet-4-6",
+        "max_tokens": 4096,
+        "stream": True,
+        "system": [{"type": "text", "text": "You are a reviewer."}],
+        "messages": [
+            {"role": "user", "content": [{"type": "text", "text": "Review this diff"}]},
+            {"role": "assistant", "content": [{"type": "text", "text": "Reading the file."}]},
+            {"role": "user", "content": [{"type": "text", "text": "Carry on"}]},
+        ],
+    }
+
+
+def _make_server(model: str) -> BridgeServer:
+    """Build a single-backend OpenCode Go bridge pinned to *model*.
+
+    Single-backend mode keys the repair set by index -1, which is the shape a
+    user running one profile actually gets.
+    """
+    return BridgeServer(
+        adapter=_StubLauncher(),
+        provider=OpenCodeGoAdapter(),
+        resolved_key="key-opencode",
+        model=model,
+        provider_config={},
+        host="127.0.0.1",
+        port=0,
+    )
+
+
+def _assistants(body: dict) -> list[dict]:
+    """Return the assistant turns of an upstream body."""
+    return [m for m in body["messages"] if m.get("role") == "assistant"]
+
+
+class TestProactiveRepairBranchesPerModel:
+    """R4a — ``_upstream_body_for`` picks the carrier the emitted body takes."""
+
+    def test_uses_the_chat_completions_carrier_for_a_cc_routed_model(self):
+        """The carrier is a field, and the turn's string content survives.
+
+        Before KBR-7 this produced ``[{"type": "thinking", ...}, {"type":
+        "text", ...}]`` — Anthropic content blocks inside a Chat Completions
+        body, which the endpoint cannot read.
+        """
+        server = _make_server(CC_MODEL)
+        server._thinking_repair_backends.add(server._current_backend_idx)
+
+        body = server._upstream_body_for(
+            {
+                "model": CC_MODEL,
+                "max_tokens": 4096,
+                "messages": [
+                    {"role": "user", "content": "Review this diff"},
+                    {"role": "assistant", "content": "Reading the file."},
+                ],
+            }
+        )
+
+        assistants = _assistants(body)
+        assert assistants, body
+        for msg in assistants:
+            assert msg["reasoning_content"] == ""
+            assert msg["content"] == "Reading the file.", "the Chat Completions carrier must not rewrite content"
+
+    def test_uses_the_thinking_block_for_a_messages_routed_model(self):
+        """The complement — the Messages route still gets the Anthropic carrier.
+
+        Without this, a fix that simply hard-coded Chat Completions for the
+        whole adapter would pass the test above.
+        """
+        server = _make_server(MESSAGES_MODEL)
+        server._thinking_repair_backends.add(server._current_backend_idx)
+
+        body = server._upstream_body_for(
+            {
+                "model": MESSAGES_MODEL,
+                "max_tokens": 4096,
+                "messages": [
+                    {"role": "user", "content": "Review this diff"},
+                    {"role": "assistant", "content": "Reading the file."},
+                ],
+            }
+        )
+
+        assistants = _assistants(body)
+        assert assistants, body
+        for msg in assistants:
+            assert "reasoning_content" not in msg
+            assert msg["content"][0] == {"type": "thinking", "thinking": ""}
+
+
+class TestReactiveRepairBranchesPerModel:
+    """R4b — the streaming retry branch picks the same carrier.
+
+    The repair set starts empty, so the first attempt goes out unrepaired and
+    only the retry branch can have written the carrier.  That isolates this
+    call site from the proactive one above.
+    """
+
+    @pytest.mark.asyncio
+    async def test_uses_the_chat_completions_carrier_for_a_cc_routed_model(self):
+        server = _make_server(CC_MODEL)
+        upstream = _ScriptedUpstream(_rejection(), _stream_ok(_chat_completions_sse()))
+
+        with aioresponses(passthrough=["http://127.0.0.1"]) as m:
+            m.post(CC_URL, callback=upstream, repeat=True)
+
+            await server.start_async()
+            try:
+                status, body = await _post(server, _transcript_without_reasoning())
+            finally:
+                await server.stop_async()
+
+        assert status == 200, body
+        assert len(upstream.bodies) == 2, "expected one rejected attempt and one repaired retry"
+        retried = _assistants(upstream.bodies[1])
+        assert retried, upstream.bodies[1]
+        for msg in retried:
+            assert msg.get("reasoning_content") == ""
+            assert not isinstance(msg["content"], list), "an Anthropic carrier must not reach a CC body"
+
+    @pytest.mark.asyncio
+    async def test_uses_the_thinking_block_for_a_messages_routed_model(self):
+        """The complement, and the case a one-site fix would break.
+
+        If only ``_upstream_body_for`` were changed, this branch would read the
+        adapter's newly-honest ``False`` property and write the Chat
+        Completions carrier into an Anthropic body.
+        """
+        server = _make_server(MESSAGES_MODEL)
+        upstream = _ScriptedUpstream(_rejection(), _stream_ok(_anthropic_sse()))
+
+        with aioresponses(passthrough=["http://127.0.0.1"]) as m:
+            m.post(MESSAGES_URL, callback=upstream, repeat=True)
+
+            await server.start_async()
+            try:
+                status, body = await _post(server, _transcript_without_reasoning())
+            finally:
+                await server.stop_async()
+
+        assert status == 200, body
+        assert len(upstream.bodies) == 2, "expected one rejected attempt and one repaired retry"
+        retried = _assistants(upstream.bodies[1])
+        assert retried, upstream.bodies[1]
+        for msg in retried:
+            assert "reasoning_content" not in msg, "a CC carrier must not reach an Anthropic body"
+            assert msg["content"][0] == {"type": "thinking", "thinking": ""}

--- a/tests/bridge/test_thinking_roundtrip_per_model_wire.py
+++ b/tests/bridge/test_thinking_roundtrip_per_model_wire.py
@@ -19,20 +19,25 @@ Covers ``.requirements/20260907T142619Z_wire_shape_honesty`` R4a, R4b and R5.
 
 from __future__ import annotations
 
+import copy
 import json
 
+import aiohttp
 import pytest
 from aioresponses import CallbackResult, aioresponses
 
 from kitty.bridge.server import BridgeServer
+from kitty.launchers.base import LauncherAdapter, SpawnConfig
 from kitty.providers.opencode import OpenCodeGoAdapter
-from tests.bridge.test_thinking_roundtrip_failover import (
-    _anthropic_sse,
-    _post,
-    _rejection,
-    _ScriptedUpstream,
-    _StubLauncher,
-)
+from kitty.types import BridgeProtocol
+
+# The stubs below duplicate `test_thinking_roundtrip_failover.py`'s rather than
+# importing them.  Every bridge test module defines its own — `_StubLauncher`
+# already appears independently in that module and in
+# `test_client_disconnect_health.py` — and `tests/` is not a package, so a
+# cross-module import resolves only when the repository root happens to be on
+# `sys.path` (as `python -m pytest` puts it there, but the bare `pytest` CI runs
+# does not).
 
 # The adapter ignores ``provider_config`` for its base URL, so these are the
 # real routed endpoints.  ``aioresponses`` intercepts both; nothing leaves the
@@ -44,6 +49,87 @@ MESSAGES_URL = "https://opencode.ai/zen/go/v1/messages"
 # (https://opencode.ai/docs/go/, verified 2026-09-07).
 CC_MODEL = "glm-5.2"
 MESSAGES_MODEL = "minimax-m2.5"
+
+THINKING_ROUNDTRIP_400 = (
+    '{"error":{"message":"The `content[].thinking` in the thinking mode must be '
+    'passed back to the API.","type":"invalid_request_error","param":null,'
+    '"code":"invalid_request_error"}}'
+)
+
+
+class _StubLauncher(LauncherAdapter):
+    """Minimal launcher that selects the Messages API bridge protocol."""
+
+    @property
+    def name(self) -> str:
+        return "stub"
+
+    @property
+    def binary_name(self) -> str:
+        return "stub"
+
+    @property
+    def bridge_protocol(self) -> BridgeProtocol:
+        return BridgeProtocol.MESSAGES_API
+
+    def build_spawn_config(self, profile, bridge_port: int, resolved_key: str) -> SpawnConfig:
+        return SpawnConfig(env_overrides={}, env_clear=[], cli_args=[])
+
+
+class _ScriptedUpstream:
+    """Records every request body and replies from a scripted sequence.
+
+    The body is deep-copied on arrival: the repair rewrites the outgoing body in
+    place after it has been sent, so recording the reference would let the retry
+    retroactively rewrite what the first attempt is recorded as having sent.
+    """
+
+    def __init__(self, *responses: CallbackResult) -> None:
+        self._responses = list(responses)
+        self.bodies: list[dict] = []
+
+    def __call__(self, url, **kwargs) -> CallbackResult:
+        self.bodies.append(copy.deepcopy(kwargs.get("json", {})))
+        if len(self._responses) > 1:
+            return self._responses.pop(0)
+        return self._responses[0]
+
+
+def _rejection() -> CallbackResult:
+    """The upstream's thinking-round-trip 400."""
+    return CallbackResult(status=400, content_type="application/json", body=THINKING_ROUNDTRIP_400)
+
+
+def _anthropic_sse() -> bytes:
+    """A minimal, well-formed Anthropic Messages SSE stream."""
+    events = [
+        {
+            "type": "message_start",
+            "message": {
+                "id": "msg_ok",
+                "type": "message",
+                "role": "assistant",
+                "content": [],
+                "model": MESSAGES_MODEL,
+                "usage": {"input_tokens": 10, "output_tokens": 0},
+            },
+        },
+        {"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}},
+        {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "Recovered"}},
+        {"type": "content_block_stop", "index": 0},
+        {"type": "message_delta", "delta": {"stop_reason": "end_turn"}, "usage": {"output_tokens": 3}},
+        {"type": "message_stop"},
+    ]
+    return b"".join(f"event: {e['type']}\ndata: {json.dumps(e)}\n\n".encode() for e in events)
+
+
+async def _post(server: BridgeServer, request: dict) -> tuple[int, str]:
+    """POST a Messages-API request at the running bridge over loopback."""
+    async with (
+        aiohttp.ClientSession() as session,
+        session.post(f"http://127.0.0.1:{server.port}/v1/messages", json=request) as resp,
+    ):
+        return resp.status, (await resp.read()).decode("utf-8")
 
 
 def _chat_completions_sse() -> bytes:

--- a/tests/test_provider_base.py
+++ b/tests/test_provider_base.py
@@ -66,6 +66,39 @@ class TestUpstreamPathDefault:
         assert adapter.get_upstream_path("gpt-4o") == "/chat/completions"
 
 
+class TestUpstreamWireIsMessagesApiForModelDefault:
+    """The per-model wire-shape declaration defaults to the bare property.
+
+    Guards the delegation KBR-7 introduces: an adapter that does not route by
+    model must not have to override anything for the bridge's per-model reads
+    to keep working.
+    """
+
+    def test_default_follows_the_property_for_any_model(self):
+        adapter = _stub_adapter()
+        assert adapter.upstream_wire_is_messages_api is False
+        assert adapter.upstream_wire_is_messages_api_for_model("gpt-4o") is False
+        assert adapter.upstream_wire_is_messages_api_for_model("") is False
+
+    def test_follows_a_subclass_property_override(self):
+        """A subclass declaring only the property is still answered correctly.
+
+        The delegation is load-bearing for existing code, not only for a
+        purpose-built double: ``CustomAnthropicAdapter`` declares the property
+        and nothing else, and five tests in
+        ``tests/bridge/test_thinking_roundtrip_failover.py`` go red if this
+        method stops following it.
+        """
+
+        class _MessagesWireAdapter(type(_stub_adapter())):  # type: ignore[misc]  # concrete stub
+            @property
+            def upstream_wire_is_messages_api(self) -> bool:
+                return True
+
+        adapter = _MessagesWireAdapter()
+        assert adapter.upstream_wire_is_messages_api_for_model("claude-opus-5") is True
+
+
 class TestBuildUpstreamHeadersDefault:
     """Default build_upstream_headers returns Bearer auth."""
 

--- a/tests/test_provider_opencode.py
+++ b/tests/test_provider_opencode.py
@@ -2,7 +2,9 @@
 
 import json
 
-from kitty.providers.opencode import OpenCodeGoAdapter
+import pytest
+
+from kitty.providers.opencode import _MESSAGES_MODELS, OpenCodeGoAdapter
 
 # ── CC format samples ──────────────────────────────────────────────────────
 
@@ -238,6 +240,89 @@ class TestOpenCodeGoHeadersRouting:
 # ═══════════════════════════════════════════════════════════════════════════
 # Chat Completions passthrough
 # ═══════════════════════════════════════════════════════════════════════════
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Auto-routing: upstream_wire_is_messages_api (KBR-7)
+# ═══════════════════════════════════════════════════════════════════════════
+#
+# The model names here are the ones OpenCode Go serves today.  The older
+# classes above still name `glm-5`, `kimi-k2.5` and `mimo-v2-*`, which the
+# provider has since retired; refreshing them is the deferred catalogue ticket
+# recorded in this task's REQUIREMENTS.md §3.1(b), not this change.
+
+
+# Models the adapter routes to Chat Completions, plus the two inputs that have
+# no model at all.  `glm-5` is kept deliberately: a retired name is now exactly
+# the "unknown model" case, and the default must stay Chat Completions.
+_CHAT_COMPLETIONS_MODELS = ["glm-5.2", "glm-5.1", "kimi-k2.7-code", "mimo-v2.5-pro", "glm-5", "", "some-future-model"]
+
+
+class TestOpenCodeGoWireShapeDeclaration:
+    """The declared wire shape must agree with what ``translate_to_upstream`` emits.
+
+    KBR-7: the adapter inherited ``upstream_wire_is_messages_api == True`` from
+    :class:`AnthropicAdapter` while emitting Chat Completions for every model
+    outside ``_MESSAGES_MODELS``.  The bridge's thinking round-trip repair
+    branches on that declaration, so a wrong answer writes an Anthropic
+    ``thinking`` block into a Chat Completions body.
+    """
+
+    def setup_method(self):
+        self.adapter = OpenCodeGoAdapter()
+
+    @pytest.mark.parametrize("model", sorted(_MESSAGES_MODELS))
+    def test_declares_messages_for_each_messages_model(self, model):
+        assert self.adapter.upstream_wire_is_messages_api_for_model(model) is True
+
+    @pytest.mark.parametrize("model", _CHAT_COMPLETIONS_MODELS)
+    def test_declares_chat_completions_for_non_messages_models(self, model):
+        assert self.adapter.upstream_wire_is_messages_api_for_model(model) is False
+
+    def test_bare_property_reports_the_default_chat_completions_route(self):
+        """The bare property answers for the default route, like its neighbours.
+
+        ``upstream_path`` and ``build_upstream_headers`` both report the Chat
+        Completions default with a per-model form alongside; this declaration
+        now does the same instead of inheriting Anthropic's ``True``.
+        """
+        assert self.adapter.upstream_wire_is_messages_api is False
+
+    def test_declaration_does_not_call_translate_to_upstream(self):
+        """The declaration is a predicate, not an observation.
+
+        Implementing it by classifying ``translate_to_upstream``'s output would
+        make the registry-wide guard a tautology: the declaration would carry no
+        information, and an oracle must not ask the code under test what shape
+        it emitted.
+        """
+
+        def _explode(cc_request):
+            raise AssertionError("the declaration must not serialize a request")
+
+        self.adapter.translate_to_upstream = _explode  # type: ignore[method-assign]  # deliberate tripwire
+        assert self.adapter.upstream_wire_is_messages_api_for_model("minimax-m2.5") is True
+        assert self.adapter.upstream_wire_is_messages_api_for_model("glm-5.2") is False
+
+    @pytest.mark.parametrize("model", ["minimax-m2.5", "glm-5.2"])
+    def test_declaration_matches_the_body_translate_to_upstream_returns(self, model):
+        """Assert against the emitted body, not against a restated constant.
+
+        A test that repeated the routing predicate would keep passing through
+        the very drift KBR-7 is about.
+        """
+        body = self.adapter.translate_to_upstream(
+            {
+                "model": model,
+                "max_tokens": 100,
+                "messages": [{"role": "system", "content": "sys"}, {"role": "user", "content": "hi"}],
+                "tools": [{"type": "function", "function": {"name": "t", "parameters": {}}}],
+            }
+        )
+        # An Anthropic Messages body hoists the system prompt out of `messages`
+        # and carries `input_schema` tools; a Chat Completions body does neither.
+        emitted_messages_api = "system" in body and "input_schema" in body["tools"][0]
+        assert self.adapter.upstream_wire_is_messages_api_for_model(model) is emitted_messages_api
 
 
 class TestOpenCodeGoChatCompletionsPassthrough:

--- a/tests/test_wire_shape_honesty.py
+++ b/tests/test_wire_shape_honesty.py
@@ -361,6 +361,21 @@ def test_classifier_reports_other_for_a_converse_body_without_tools():
     assert classify_wire_shape(body) is WireShape.OTHER
 
 
+def test_the_converse_fixture_matches_what_bedrock_actually_emits():
+    """Pin the hand-written Converse fixture against the real adapter.
+
+    ``OTHER`` is the classifier's fallback, so a typo in ``_CONVERSE_BODY``
+    would leave the two tests above green while proving nothing about a real
+    Converse body.  This asserts the fixture carries the same markers on the
+    two axes the classifier reads as the body ``BedrockAdapter`` emits.
+    """
+    emitted = get_provider("bedrock").translate_to_upstream(copy.deepcopy(_probe_request("kitty-test-model")))
+
+    assert ("tools" in emitted) == ("tools" in _CONVERSE_BODY)
+    assert ("system" in emitted) == ("system" in _CONVERSE_BODY)
+    assert classify_wire_shape(emitted) is classify_wire_shape(_CONVERSE_BODY)
+
+
 def test_classifier_needs_the_tools_axis():
     """A probe without tools cannot be classified — hence R6's pinned shape.
 

--- a/tests/test_wire_shape_honesty.py
+++ b/tests/test_wire_shape_honesty.py
@@ -1,0 +1,371 @@
+"""Contract guard — a provider adapter must declare the wire shape it actually emits.
+
+`.system_design/TEST_SUITE.md` §6.2.3, "Wire-shape honesty".  Catches finding
+**F5** (KBR-7): ``OpenCodeGoAdapter`` inherited ``upstream_wire_is_messages_api
+== True`` from :class:`~kitty.providers.anthropic.AnthropicAdapter` while
+emitting a Chat Completions body for every model outside ``_MESSAGES_MODELS``.
+The bridge's thinking round-trip repair branches on that declaration, so a
+wrong answer malforms the transcript it was sent to fix.
+
+**What this guard does not prove.**  Five things, deliberately, so a green run
+is not over-read:
+
+1. **The serialization boundary.**  This observes ``translate_to_upstream``'s
+   return value.  Three adapters set ``use_custom_transport`` and bypass
+   ``_make_upstream_request``, and what a green result means differs for each:
+
+   * ``openai_subscription`` — never calls the hook on the request path at all
+     (``_cc_to_responses`` builds the Responses body inside the transport).
+     The sweep checks its declaration against a body this adapter never sends,
+     so here the exemption is **load-bearing**.
+   * ``bedrock`` — calls the hook, then pops ``modelId`` and ``stream`` and
+     reshapes into boto3 kwargs.
+   * ``ollama_cloud`` — calls the hook, then overwrites ``stream``.
+
+   For the latter two the mutation is scalar and does not change the body's
+   **shape family**, so the exemption is precautionary rather than load-bearing
+   — but a guard must observe the shipped bytes, not infer them.  Extending it
+   to the wire needs the per-transport recorders and is **KBR-80 / T-G4**.
+   :func:`test_custom_transport_adapters_are_the_known_exempt_set` pins the set
+   so a fourth such adapter forces a decision rather than quietly inheriting a
+   clean bill of health.
+2. **Adapters constructed with ``provider_config``.**  ``get_provider`` forwards
+   it to adapters that accept it, and at least one branches on it.  Default
+   construction only, here.
+3. **Native-passthrough requests.**  The probe is a Chat Completions request
+   with no ``_native_messages_request`` flag.
+4. **That the routing table matches the provider.**  This guard proves the
+   declaration matches the *emitted body*.  It cannot prove that the models
+   kitty routes to the Messages endpoint are the models the provider serves
+   there — that oracle is the provider's published endpoint table, and it is
+   stale today.  Tracked as **KBR-126**; see
+   :func:`test_messages_routing_table_is_unchanged`.
+5. **That a ``False`` body is well-formed Chat Completions.**  The declaration
+   is a boolean, so the sweep asserts "Messages" against
+   :attr:`WireShape.MESSAGES` and collapses ``CHAT_COMPLETIONS`` with ``OTHER``.
+   A declared-``False`` adapter that began emitting a malformed body would
+   still pass.  The failure direction is the safe one — a Messages body that
+   degrades to ``OTHER`` turns a ``True``-declaring adapter red — but a green
+   sweep is not a well-formedness check.
+
+Every check below asserts its own subject set, in the style of
+``tests/test_egress_coverage.py``, so none can rot into a no-op.
+"""
+
+from __future__ import annotations
+
+import copy
+from dataclasses import dataclass
+from enum import Enum
+
+import pytest
+
+from kitty.providers.base import ProviderAdapter
+from kitty.providers.opencode import _MESSAGES_MODELS
+from kitty.providers.registry import _registry, get_provider
+
+
+class WireShape(Enum):
+    """The request dialects a provider adapter can put on the wire."""
+
+    MESSAGES = "anthropic_messages"
+    CHAT_COMPLETIONS = "chat_completions"
+    OTHER = "other"
+
+
+def classify_wire_shape(body: dict) -> WireShape:
+    """Classify an upstream request body by its observable markers.
+
+    Keys on **tool-entry shape plus system placement**, never on the presence of
+    a top-level ``system`` key: Bedrock's Converse body also carries one and is
+    not a Messages body.  Requiring both axes to agree means a body matching
+    neither dialect — Converse, Responses — is reported as
+    :attr:`WireShape.OTHER` rather than guessed at.
+
+    The probe request must therefore carry a system message and a tool; see
+    :func:`_probe_request`.  :func:`test_classifier_needs_the_tools_axis` pins
+    that dependency.
+
+    Args:
+        body: The dict an adapter's ``translate_to_upstream`` returned.
+
+    Returns:
+        The dialect the body is written in.
+    """
+    tools = body.get("tools")
+    first_tool = tools[0] if isinstance(tools, list) and tools and isinstance(tools[0], dict) else None
+    roles = {m.get("role") for m in body.get("messages", []) if isinstance(m, dict)}
+
+    # Anthropic hoists the system prompt to a top-level field and describes a
+    # tool with `input_schema`; Chat Completions keeps a system turn and wraps
+    # each tool in a `function` envelope.
+    if first_tool is not None and "input_schema" in first_tool and "system" not in roles:
+        return WireShape.MESSAGES
+    if first_tool is not None and "function" in first_tool and "system" in roles:
+        return WireShape.CHAT_COMPLETIONS
+    return WireShape.OTHER
+
+
+@dataclass(frozen=True)
+class _Representation:
+    """The models a provider is exercised with.
+
+    Attributes:
+        models: Every model class the adapter routes differently, plus enough
+            ordinary cases to be meaningful.
+        default_route_model: A model that takes the adapter's **default** route.
+            This is what the bare property is measured against.  It is a field
+            of its own and deliberately not ``validation_model``: that answers a
+            different question (a model whose credential check will not be
+            misread as an auth failure) and its value is scheduled to change.
+    """
+
+    models: tuple[str, ...]
+    default_route_model: str
+
+
+def _single_route(model: str = "kitty-test-model") -> _Representation:
+    """Represent an adapter whose wire shape does not depend on the model."""
+    return _Representation(models=(model,), default_route_model=model)
+
+
+# Every registry key appears, so adding a provider forces a decision here.
+REPRESENTATIVE_MODELS: dict[str, _Representation] = {
+    "anthropic": _single_route(),
+    "azure": _single_route(),
+    "bedrock": _single_route(),
+    "byteplus": _single_route(),
+    "custom_anthropic": _single_route(),
+    "custom_openai": _single_route(),
+    "fireworks": _single_route(),
+    "google_aistudio": _single_route(),
+    "kimi": _single_route(),
+    "mimo": _single_route(),
+    "minimax": _single_route(),
+    "minimax_token": _single_route(),
+    "novita": _single_route(),
+    "ollama": _single_route(),
+    "ollama_cloud": _single_route(),
+    "openai": _single_route(),
+    "openai_subscription": _single_route(),
+    # The one adapter that routes by model.  Both routes are represented, and
+    # `test_a_routing_adapter_represents_both_of_its_routes` keeps it that way.
+    "opencode_go": _Representation(
+        models=("minimax-m2.5", "minimax-m2.7", "glm-5.2", "kimi-k2.7-code", "mimo-v2.5-pro", ""),
+        default_route_model="glm-5.2",
+    ),
+    "openrouter": _single_route(),
+    "vertex": _single_route(),
+    "zai_coding": _single_route(),
+    "zai_coding_cc": _single_route(),
+    "zai_regular": _single_route(),
+}
+
+# The three adapters that bypass `_make_upstream_request`.  What the sweep
+# proves for each differs — see non-claim 1 in the module docstring.  The set is
+# asserted rather than narrated so a fourth one forces a decision.
+CUSTOM_TRANSPORT_ADAPTERS = frozenset({"openai_subscription", "bedrock", "ollama_cloud"})
+
+
+def _probe_request(model: str) -> dict:
+    """Build the request every adapter is asked to translate.
+
+    The system turn and the tool are load-bearing, not decoration:
+    :func:`classify_wire_shape` reads both axes, and a probe missing either
+    would make two dialects indistinguishable.
+    """
+    return {
+        "model": model,
+        "max_tokens": 100,
+        "messages": [
+            {"role": "system", "content": "You are a reviewer."},
+            {"role": "user", "content": "Review this diff"},
+            {"role": "assistant", "content": "Reading the file."},
+        ],
+        "tools": [
+            {
+                "type": "function",
+                "function": {
+                    "name": "read_file",
+                    "description": "Read a file",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ],
+    }
+
+
+def _provider_model_pairs() -> list[tuple[str, str]]:
+    """Enumerate every (provider, model) case the sweep covers."""
+    return [(name, model) for name, rep in sorted(REPRESENTATIVE_MODELS.items()) for model in rep.models]
+
+
+# ── The sweep ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(("provider_type", "model"), _provider_model_pairs())
+def test_declared_wire_shape_matches_the_emitted_body(provider_type: str, model: str):
+    """The per-model declaration agrees with what the adapter emits.
+
+    This is the assertion that fails on the unfixed revision for
+    ``opencode_go``'s Chat-Completions models.
+
+    Note the declaration is a boolean, so a ``False`` here proves only "not a
+    Messages body" — ``CHAT_COMPLETIONS`` and ``OTHER`` are not distinguished
+    (non-claim 5).
+    """
+    adapter = get_provider(provider_type)
+    body = adapter.translate_to_upstream(copy.deepcopy(_probe_request(model)))
+    declared = adapter.upstream_wire_is_messages_api_for_model(model)
+
+    assert declared is (classify_wire_shape(body) is WireShape.MESSAGES), (
+        f"{provider_type} × {model!r} declares "
+        f"{'Anthropic Messages' if declared else 'not Anthropic Messages'} "
+        f"but emits {classify_wire_shape(body).value}"
+    )
+
+
+@pytest.mark.parametrize("provider_type", sorted(REPRESENTATIVE_MODELS))
+def test_bare_property_matches_the_per_model_form_at_the_default_route_model(provider_type: str):
+    """R6b — the bare property honestly reports the adapter's default route.
+
+    Guards the half of KBR-7 the per-model form does not: without this,
+    ``OpenCodeGoAdapter.upstream_wire_is_messages_api`` could drift back to
+    ``True`` with every other test still green.
+    """
+    adapter = get_provider(provider_type)
+    default_model = REPRESENTATIVE_MODELS[provider_type].default_route_model
+
+    assert adapter.upstream_wire_is_messages_api is adapter.upstream_wire_is_messages_api_for_model(default_model)
+
+
+# ── Guards on the guard ────────────────────────────────────────────────────
+
+
+def test_every_registered_provider_is_represented():
+    """R7b — a new provider cannot slip past the sweep."""
+    assert set(REPRESENTATIVE_MODELS) == set(_registry)
+
+
+def test_every_messages_route_model_is_represented():
+    """R7c — a model added to the routing table cannot skip the sweep."""
+    covered = set(REPRESENTATIVE_MODELS["opencode_go"].models)
+    assert covered >= _MESSAGES_MODELS
+
+
+def test_a_routing_adapter_represents_both_of_its_routes():
+    """R7e — the representative table cannot be narrowed until it proves nothing.
+
+    An adapter that overrides the per-model form has more than one route.  If
+    its list covered only one of them, the sweep would go green while saying
+    nothing about the other — the failure mode the sweep exists to catch.
+    """
+    checked = 0
+    for provider_type, rep in sorted(REPRESENTATIVE_MODELS.items()):
+        adapter = get_provider(provider_type)
+        overrides = (
+            type(adapter).upstream_wire_is_messages_api_for_model
+            is not ProviderAdapter.upstream_wire_is_messages_api_for_model
+        )
+        if not overrides:
+            continue
+        declared = {adapter.upstream_wire_is_messages_api_for_model(m) for m in rep.models}
+        assert declared == {True, False}, f"{provider_type} routes by model but only one route is represented"
+        checked += 1
+
+    # Without this the loop passes vacuously the moment no adapter overrides
+    # the per-model form — the one check in this module that would otherwise
+    # rot into the no-op its docstring promises it cannot become.
+    assert checked, "no adapter overrides the per-model form — this check has nothing to guard"
+
+
+def test_custom_transport_adapters_are_the_known_exempt_set():
+    """R7d — a fourth custom-transport adapter forces a decision.
+
+    For these three the hook body is not the shipped bytes — see non-claim 1
+    in the module docstring for what a green result means for each.  Mechanized
+    rather than narrated: a new one must be classified, not silently exempted.
+    """
+    observed = {name for name in _registry if get_provider(name).use_custom_transport}
+    assert observed == CUSTOM_TRANSPORT_ADAPTERS
+
+
+def test_messages_routing_table_is_unchanged():
+    """Tripwire on ``_MESSAGES_MODELS`` — the routing table is stale (KBR-126).
+
+    OpenCode Go serves eight models on ``/v1/messages`` today — ``minimax-m3``,
+    ``minimax-m2.7``, ``minimax-m2.5``, ``qwen3.8-max``, ``qwen3.8-flash``,
+    ``qwen3.7-max``, ``qwen3.7-plus`` and ``qwen3.6-plus`` — and four more on
+    ``/v1/responses``, which this adapter has no route for at all.  kitty's
+    table holds two of the eight.
+
+    That is a **routing** defect and not KBR-7's — the declaration and the
+    emitted body agree for those models, which is why the sweep above reports
+    this adapter honest — so this asserts the table rather than correcting it.
+    It fires the moment anyone edits the set, so KBR-126 has a red test waiting
+    for it.
+    """
+    assert frozenset({"minimax-m2.5", "minimax-m2.7"}) == _MESSAGES_MODELS
+
+
+# ── Known positives for the classifier ─────────────────────────────────────
+
+_MESSAGES_BODY = {
+    "model": "claude-opus-5",
+    "max_tokens": 100,
+    "system": "You are a reviewer.",
+    "messages": [{"role": "user", "content": "hi"}],
+    "tools": [{"name": "read_file", "description": "Read a file", "input_schema": {"type": "object"}}],
+}
+
+_CHAT_COMPLETIONS_BODY = {
+    "model": "gpt-4o",
+    "max_tokens": 100,
+    "messages": [{"role": "system", "content": "You are a reviewer."}, {"role": "user", "content": "hi"}],
+    "tools": [{"type": "function", "function": {"name": "read_file", "parameters": {}}}],
+}
+
+_CONVERSE_BODY = {
+    "modelId": "anthropic.claude-v2",
+    "system": [{"text": "You are a reviewer."}],
+    "messages": [{"role": "user", "content": [{"text": "hi"}]}],
+    "inferenceConfig": {"maxTokens": 100},
+    "toolConfig": {"tools": [{"toolSpec": {"name": "read_file", "inputSchema": {"json": {}}}}]},
+}
+
+
+def test_classifier_recognises_a_messages_body():
+    assert classify_wire_shape(_MESSAGES_BODY) is WireShape.MESSAGES
+
+
+def test_classifier_recognises_a_chat_completions_body():
+    assert classify_wire_shape(_CHAT_COMPLETIONS_BODY) is WireShape.CHAT_COMPLETIONS
+
+
+def test_classifier_reports_other_for_a_converse_body():
+    """Converse is a third dialect, not a Messages body wearing a hat.
+
+    It carries a top-level ``system`` exactly as Messages does, so a classifier
+    keying on that alone would call Bedrock dishonest on every request.
+    """
+    assert classify_wire_shape(_CONVERSE_BODY) is WireShape.OTHER
+
+
+def test_classifier_reports_other_for_a_converse_body_without_tools():
+    """The tools axis must do the separating, not the system axis.
+
+    Strip ``toolConfig`` and Converse and Messages agree on every other marker;
+    only the absence of an ``input_schema`` tool keeps them apart.
+    """
+    body = {k: v for k, v in _CONVERSE_BODY.items() if k != "toolConfig"}
+    assert classify_wire_shape(body) is WireShape.OTHER
+
+
+def test_classifier_needs_the_tools_axis():
+    """A probe without tools cannot be classified — hence R6's pinned shape.
+
+    Asserted rather than assumed: if this ever returns ``MESSAGES``, the probe
+    request may be weakened without anyone noticing the sweep went blind.
+    """
+    body = {k: v for k, v in _MESSAGES_BODY.items() if k != "tools"}
+    assert classify_wire_shape(body) is WireShape.OTHER


### PR DESCRIPTION
Fixes [KBR-7](https://shelpuk.atlassian.net/browse/KBR-7). Closes design gap **G16** / finding **F5**.

## Context for the Product Owner

Kitty Bridge lets one coding agent talk to any model provider. Each provider adapter declares which API dialect it speaks, and the bridge trusts that declaration when it has to repair a conversation.

**The OpenCode Go adapter was declaring the wrong dialect for most of its models.** It said "Anthropic" but actually speaks "Chat Completions" for the GLM, Kimi and MiMo models. So when a provider rejected a conversation and the bridge tried to repair it, the bridge wrote the repair in the wrong dialect — corrupting the very request it was trying to fix, on the retry path where the user is already having a bad time.

Nothing was silently wrong-but-working: on those models a repair attempt sent a malformed request. This makes the declaration honest per model, and adds a check across all 23 providers so it cannot drift again.

Two adjacent defects were found, filed, and deliberately **not** fixed here — folding them in would have made this three changes wearing one hat:

* **[KBR-126](https://shelpuk.atlassian.net/browse/KBR-126)** — OpenCode Go's routing table is stale against the live provider. Worth a look: the provider now serves **eight** models on its Anthropic endpoint and kitty knows **two**, and there is a whole third endpoint (`/v1/responses`, four models including Grok 4.6 and GPT 5.6 Luna) kitty has no route for. User-visible on six models today.
* **[KBR-127](https://shelpuk.atlassian.net/browse/KBR-127)** — the upstream URL and auth headers are resolved from an un-normalized model name, so a profile written `opencode/minimax-m2.5` sends the right body to the wrong endpoint with the wrong auth.

---

## The defect

`OpenCodeGoAdapter` subclasses `AnthropicAdapter` and inherited `upstream_wire_is_messages_api == True`, while its own `translate_to_upstream` returns a Chat Completions body for every model outside `_MESSAGES_MODELS`.

That property is not decorative. Its own docstring says it "describes the shape that actually goes on the wire" and that anything shaping the serialized body "must branch on this" — and the bridge's thinking round-trip repair does, at two call sites. With `native=True` on a Chat Completions body, `_with_thinking_carrier` rewrites an assistant turn's string content into Anthropic content blocks:

```python
{"role": "assistant", "content": "hi"}
# becomes, inside a Chat Completions body:
{"role": "assistant", "content": [{"type": "thinking", "thinking": ""},
                                  {"type": "text", "text": "hi"}]}
```

The correct Chat Completions carrier is a `reasoning_content: ""` field with `content` untouched. So the repair path was **broken, not merely mislabelled**.

## The fix

`ProviderAdapter` gains `upstream_wire_is_messages_api_for_model(model)`, defaulting to the existing property — the same pairing this codebase already uses for routed adapters (`upstream_path` / `get_upstream_path`, `build_upstream_headers` / `build_upstream_headers_for_model`, both already in this adapter). `OpenCodeGoAdapter` overrides both: the per-model form mirrors its routing predicate exactly, and the bare property reports its default (Chat Completions) route, as the two declarations beside it already do.

Both repair sites read the model from `cc_request`, not `_active_model`. That is what makes declaration and body agree **by construction rather than by coincidence**: `translate_to_upstream` routes on `cc_request["model"]`, and `_normalize_model` normalizes only that key. `.get("model", "")` matches the adapter's own read including its default — a subscript would raise `KeyError` inside the branch that exists to recover from an upstream rejection.

The method is concrete on the base class rather than an optional `hasattr` hook, because the guard must be able to ask *every* adapter; a hook would let it silently skip whatever did not define it.

`AnthropicAdapter`'s property docstring — the sentence that was the origin of F5 — and `ProviderAdapter`'s, which told callers to branch on the bare property, are both corrected.

## Evidence of red

Per `TEST_SUITE_IMPLEMENTATION_PLAN.md` §16, an atomic fix must show its tests failing at the base revision. Reproduced by exporting `origin/main` to a scratch tree and copying only the new test files in:

**At the true base revision** — the bridge tests show the actual corruption:

```
FAILED TestProactiveRepairBranchesPerModel::test_uses_the_chat_completions_carrier_for_a_cc_routed_model
FAILED TestReactiveRepairBranchesPerModel::test_uses_the_chat_completions_carrier_for_a_cc_routed_model
2 failed, 2 passed

E  assert None == ''
E   +  where ... = {'content': [{'thinking': '', 'type': 'thinking'},
                                {'text': 'Reading the file.', 'type': 'text'}],
                    'role': 'assistant'}.get
```

Both Messages-routed tests pass at base, so the pair localises the defect rather than just flagging it.

**With only the base delegation added**, so the sweep can run against the unfixed adapter:

```
FAILED test_declared_wire_shape_matches_the_emitted_body[opencode_go-glm-5.2]
FAILED test_declared_wire_shape_matches_the_emitted_body[opencode_go-kimi-k2.7-code]
FAILED test_declared_wire_shape_matches_the_emitted_body[opencode_go-mimo-v2.5-pro]
FAILED test_declared_wire_shape_matches_the_emitted_body[opencode_go-]
5 failed, 56 passed

E  AssertionError: opencode_go x 'glm-5.2' declares Anthropic Messages but emits chat_completions
```

Red on exactly the four Chat-Completions-routed cases; green for the other 22 providers.

## Tests

Proved at the lowest layer that can prove each claim (`.github/review/rules/python-tests.md`).

**Component** — `tests/test_provider_base.py`, `tests/test_provider_opencode.py`: the base delegation, and that a subclass declaring only the property is still answered correctly (load-bearing for `CustomAnthropicAdapter`); the per-model declaration over both routes; the bare property; and that the declaration is a **predicate, not an observation** — with `translate_to_upstream` monkeypatched to raise, it must still answer, so the registry sweep cannot become a tautology.

**Contract** — `tests/test_wire_shape_honesty.py`, the §6.2.3 guard, in the style of `tests/test_egress_coverage.py`. Sweeps all 23 providers × representative models. Six self-checks so it cannot rot: the classifier pinned against known Messages, Chat Completions and Converse bodies — including a Converse body **without** tools, since the tools axis is what separates Converse from Messages, and a Bedrock Converse body carries a top-level `system` exactly as Messages does; registry coverage; `_MESSAGES_MODELS` coverage; both routes represented for any routing adapter, *and that it has a subject at all*; and the custom-transport set asserted rather than narrated.

**Subsystem** — `tests/bridge/test_thinking_roundtrip_per_model_wire.py`: both repair call sites, each with its Messages-routed complement. The two sites are separate tests deliberately — a fix applied to only one would be **worse than no fix**, because once the bare property reports Chat Completions the site left behind would write `reasoning_content` into an Anthropic transcript. Verified: reverting either site alone reddens exactly its own complement.

The reactive tests use a transcript with no reasoning rather than the sibling module's fixture. This provider is not native-passthrough, so a thinking-enabled request has the carrier injected by `AnthropicAdapter.translate_to_upstream` on the way back through the CC round trip; the repair would be a no-op and the test would fail on a plain 400 instead of on the carrier.

## Scope — what this does *not* deliver

The guard observes `translate_to_upstream`, not the serialization boundary. For the three `use_custom_transport` adapters nothing at the hook observes the bytes that ship: `openai_subscription` never invokes the hook on the request path at all (`_cc_to_responses` builds the Responses body inside the transport), while `bedrock` and `ollama_cloud` mutate the hook's body afterwards (P18, P19) — those two mutations do not change the shape family, so there the exemption is precautionary rather than load-bearing.

The wire-level form remains **T-G4 / KBR-80**. `TEST_SUITE.md` §6.2.3, the T-G4 row, §16 and §17 all now say so explicitly, so a green run here cannot be read as T-G4 delivered.

## Checks

* Full suite: **3144 passed, 5 skipped**, across three independent runs. The only red anywhere is `tests/test_egress_https_proxy.py`, whose fixture needs `openssl x509 -copy_extensions`; reproduced identically on `origin/main`, so it is environmental (Git-for-Windows OpenSSL) and untouched by this diff.
* `ruff check src tests` — clean. `mypy src/kitty` — clean.
* Reviewed by `system-design-reviewer` (three rounds: five blockers and twelve concerns, all resolved) and `code-reviewer` (two rounds, **APPROVE**), each pointed at the requirements and `.system_design/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017EWo9i9PUfivaoe8sPL7K8


[KBR-7]: https://shelpuk.atlassian.net/browse/KBR-7?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KBR-126]: https://shelpuk.atlassian.net/browse/KBR-126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ