### PR TITLE
Release 1.9.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kitty-bridge"
-version = "1.9.0"
+version = "1.9.1"
 description = "Kitty Bridge — launch coding agents through a local API bridge"
 readme = "README.md"
 license = "MIT"

--- a/src/kitty/__init__.py
+++ b/src/kitty/__init__.py
@@ -4,5 +4,5 @@ import logging
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
-__version__ = "1.9.0"
+__version__ = "1.9.1"
 __all__ = ["__version__"]


### PR DESCRIPTION
> **Correction, added after merge.** PR #48 (KBR-7) merged 76 seconds before this one, so it is
> in the 1.9.1 release but is not named in the release commit message, which was written before it
> landed. **This release carries two user-facing fixes, not one.** The version is unaffected —
> KBR-7 is a defect fix too, so 1.9.1 remains correct — but the commit message understates what
> shipped. Recorded here because the commit itself is on `main` and not worth rewriting history to
> amend.
>
> **KBR-7** — `OpenCodeGoAdapter` declared the wrong API dialect for its GLM, Kimi and MiMo models.
> When a provider rejected a conversation and the bridge tried to repair it, the repair was written
> in the wrong dialect, corrupting the request on the retry path — precisely when the user is
> already having a bad time. The declaration is now per-model, with a check across all 23 providers
> so it cannot drift again.

Bumps the package version to **1.9.1** in the two places that carry it. No other change.

## Context for the Product Owner

A patch release. One thing in it matters to users, and it is a fix rather than a feature.

Kitty Bridge sells invisibility: it sits between a developer's coding agent and whatever AI
provider they pay for, and its value depends on the provider seeing traffic that looks like an
ordinary client. Providers who sell flat-rate coding plans police them, and a fingerprintable
intermediary is grounds to throttle or ban a customer's account.

We were not invisible. On every request, the bridge stamped two of its own bookkeeping fields into
the body it sent upstream. No AI vendor's public API defines fields shaped like that. Anyone
looking would have seen a proxy.

**The exposure was wider than recorded.** The ticket named six affected providers from a spot
check. Sweeping the whole registry found **20 of 23 adapters** affected across **37 of 48 request
routes** — nearly every path we sell. One provider hid it: OpenAI's subscription path happens to
rebuild requests from a fixed list of permitted fields and dropped the strays, so the leak was
invisible on exactly the provider a developer is most likely to try first.

Nothing users configure changes. Reasoning-depth control works exactly as before, and there is a
test asserting that specifically — the cheapest way to make the leak tests pass would have been to
delete the feature carrying those fields, and that would have been a worse bug than the one fixed.

## Why patch and not minor

Semver, and this repo's own practice. `v1.9.0` was a minor because it carried a real feature — the
all-unhealthy 503 rendered in each protocol's native error envelope. Nothing comparable landed
here: one defect fix in `src/kitty`, and everything else is documentation, test infrastructure or
CI tooling that users never see.

## What is in the release

| | Since v1.9.0 |
|---|---|
| **Fix** | `_effort` and `_thinking_adaptive` no longer reach any provider (#47) |
| **Fix** | OpenCode Go declares its wire shape per model, so retry repairs are no longer corrupted (#48) |
| **Data** | OpenRouter model metadata refresh (#46) |
| **Docs** | Test suite design and implementation plan (#43), Claude Code scroll FAQ (#44) |
| **CI** | Automated pull request reviewer (#45); review-script guard repaired (#47) |

Two of these change shipped behaviour; the rest are documentation, test infrastructure and CI.

## Verification

- `test_version_in_init_matches_pyproject` passes — the two files agree, which is also what
  `publish.yml` re-checks against the tag before it will publish.
- The guards that keep #47 fixed pass on this branch: 111 tests.
- Full CI gate runs on this PR as usual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
