### PR TITLE
Divide the test suite by layer, so a CI job can say what it runs (T-W1)

### DIFF
--- a/.github/review/rules/python-tests.md
+++ b/.github/review/rules/python-tests.md
@@ -1,10 +1,11 @@
 # Rule: tests (`tests/**`, `.github/review/tests/**`)
 
 Two suites live under this rule. `tests/` is the repository's own suite, run by
-`tests.yml` on Python 3.10–3.13 with `pytest -q`. `.github/review/tests/` is the
-review system's suite, run by `ci.yml` on a **bare interpreter with no installed
-dependencies** — see `rules/ci.md` for why, and never add a third-party import
-there.
+`tests.yml` on Python 3.10–3.13 with
+`pytest -m "l1 or l2" --require-category=l1 --require-category=l2`.
+`.github/review/tests/` is the review system's suite, run by `ci.yml` on a
+**bare interpreter with no installed dependencies** — see `rules/ci.md` for why,
+and never add a third-party import there.
 
 ## The one question worth asking about every test
 
@@ -46,14 +47,32 @@ filesystem, the network, the environment, and the user's real config directory.
 
 Prove each behaviour at the lowest layer that can prove it.
 
-| The claim | Where it belongs |
-|---|---|
-| A translator maps this field to that one | unit, in `tests/bridge/` |
-| A launcher builds this exact env map | unit, in `tests/` |
-| A profile written by an old version still loads | unit, over a committed fixture |
-| Agent and bridge agree on the wire shape | protocol/contract test |
-| The bridge survives an upstream disconnect mid-stream | subsystem, against a real local server |
-| `kitty claude` end to end | `tests/integration/` |
+| The claim | Where it belongs | Marker |
+|---|---|---|
+| A translator maps this field to that one | unit, in `tests/bridge/` | `l1` |
+| A launcher builds this exact env map | unit, in `tests/` | `l1` |
+| A profile written by an old version still loads | unit, over a committed fixture | `l1` |
+| Agent and bridge agree on the wire shape | protocol/contract test | `l2` |
+| The bridge survives an upstream disconnect mid-stream | subsystem, against a real local server | `l3` |
+| `kitty claude` end to end | `tests/integration/` | `agent_live` |
+
+**Every test carries exactly one layer marker, and a CI job is a marker
+expression over them.** The marker is assigned from the file's path by
+`tests/conftest.py`, so a new test in an existing directory needs nothing; a
+file declares its own layer only where that default is wrong, and
+`tests/test_layer_markers.py` fails the suite if any test carries none or two.
+
+Two things to raise when reviewing a change here:
+
+- **A marker added by hand needs a reason in the diff.** The default is right
+  for almost everything; an explicit one says "this file is not what its
+  directory suggests", which is a claim worth reading.
+- 🔴 **Moving a test to a layer no job runs removes it from CI, silently.**
+  Only `l1` and `l2` are gated today. `PENDING_ACTIVATION_LAYERS` in
+  `tests/layers.py` lists the rest with the task that activates each, and a
+  test fails if a populated layer is neither run nor listed — but a *file*
+  moved into a listed layer is not caught by that. Treat such a move as a
+  coverage deletion unless the job that runs it lands in the same change.
 
 Two findings follow from this table:
 

--- a/.github/review/tests/test_review_scripts.py
+++ b/.github/review/tests/test_review_scripts.py
@@ -12147,7 +12147,14 @@ class ReusableTestJobWiringTests(unittest.TestCase):
             "ruff check .",
             "lint-imports",
             "mypy src/kitty",
-            "pytest -q",
+            # Not a bare `pytest -q` any more. The suite is divided by layer
+            # marker, and the SELECTION is part of what the gate enforces: a
+            # `pytest` naming no layers would silently inherit the local
+            # convenience default from `addopts` and gate a different set than
+            # anyone declared. The `--require-category` flags pairing with this
+            # expression are checked in `tests/test_github_actions.py`, which
+            # can parse the YAML; this file runs on a bare interpreter.
+            'pytest -m "l1 or l2"',
         ):
             with self.subTest(command=command):
                 self.assertIn(

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,6 +47,20 @@ jobs:
       - name: Type check
         run: mypy src/kitty
 
+      # The Fast gate: the L1 and L2 layers, named explicitly.
+      #
+      # 🔴 `--require-category` for EVERY layer the expression selects, and the
+      # pairing is enforced by a test. `-m "l1 or l2"` is satisfied by `l1`
+      # alone, so without these flags the job reports success for a layer it
+      # never ran -- the same mistake an earlier draft of the design made when
+      # it claimed an `or` expression would fail on an empty side. It will not.
+      #
+      # `--strict-markers` is on the command line, NOT in `addopts`: pytest 9.0
+      # silently ignores it there and 9.1 does not, so a config-file placement
+      # would mean the gate behaves differently on two contributors' machines.
+      # `pyproject.toml` carries the reasoning in full.
       - name: Test
-        run: pytest -q
+        run: >-
+          pytest -m "l1 or l2" -q --strict-markers
+          --require-category=l1 --require-category=l2
 

--- a/.system_design/TEST_SUITE.md
+++ b/.system_design/TEST_SUITE.md
@@ -1611,6 +1611,81 @@ release. A gate that is green because it stopped looking is worse.
 cannot start its proxy, the job fails. A gating job that goes green because it ran nothing is the
 most expensive kind of false confidence.
 
+**One exception, stated so the rule is honest.** A **platform or interpreter** skip is permitted:
+`tests/test_launcher_discovery.py` skips POSIX cases on Windows, and the matrix is what covers
+them. A **resource-availability** skip is not, and the suite has one today —
+`tests/bridge/test_bridge_state.py` calls `pytest.skip("openssl not available")` inside a gating
+job, which is the exact shape this rule forbids. Filed as KBR-132 rather than quietly
+grandfathered — the rule is only worth stating if its one known breach has an owner.
+
+### 8.1 The selection mechanism
+
+Delivered by T-W1, ahead of the jobs that use it, because parallel authors need the divided test
+command from day one.
+
+- **`tests/layers.py`** owns the vocabulary and every decision over it as a **pure function**:
+  the path default, the exactly-one predicate, the required-category predicate, and which layers
+  a marker expression positively selects. Pure so that each can be handed a deliberate defect —
+  plan §1.4 makes that mandatory, and a decision entangled with a pytest hook cannot be given one.
+- **`tests/conftest.py`** wires them with a single `wrapper=True`
+  `pytest_collection_modifyitems`. Defaults are applied **before** pytest's `-m` deselection —
+  otherwise `-m l1` deselects a suite whose files carry no markers — and the category check runs
+  **after** it, or it counts tests the job will not run. A wrapper gets that ordering from the
+  hook protocol rather than from plugin registration order.
+- **`--require-category=NAME`**, repeatable, fails the run when a named layer collected nothing.
+  This is the fix for the `or` problem above, and every job must pass one per layer its
+  expression selects. A test enforces that pairing across every workflow.
+- **`--layer-report=PATH`** dumps the collected items and their layers as JSON, which is how the
+  whole-suite checks reason about labelling without re-deriving it.
+
+**The default is by path, and the vocabulary is by marker.** Thousands of tests predate the scheme
+and are not edited one at a time: `tests/integration/**` defaults to `agent_live`, everything else
+to `l1`, and a file names its own layer only where that is wrong. An unrecognised path falls back
+to `l1` — a new corner of the tree joining the fast gate uninvited is visible and cheap, whereas
+one joining a nightly job is invisible until something ships broken.
+
+**`--runslow` is gone.** It attached `pytest.mark.skip` to the 32 live-agent tests, so the gating
+job collected them, skipped them, and reported green — the failure this section names, running in
+production. They are `agent_live` now, and a bare `pytest` excludes them through an `addopts`
+marker expression instead. The difference is not cosmetic: the run now reports *32 deselected*, a
+statement about what was **selected**, where it used to report *32 skipped*, a statement about
+tests that were supposed to run and did not.
+
+**Two hand-maintained copies of one list is a defect in waiting**, so the `addopts` expression is
+asserted equal to one derived from `RESOURCE_DEPENDENT_LAYERS` — the layers needing a resource CI
+has and a developer's machine may not. `agent_smoke` is on that list before it has a single test,
+because §6.4.2 launches a real pinned binary and the task that makes the category live should not
+have to rediscover the rule.
+
+**`--strict-markers` is passed on the command line, never through `addopts`.** pytest 9.0 silently
+ignores it there; 9.1 honours it (upstream issue 14442). With `pytest>=8.0` and no upper bound, a
+config-file placement would mean the gate behaves differently for two contributors looking at the
+same tree, which is worse than not having it.
+
+### 8.2 Activation is incremental, and the gap is on the record
+
+The matrix above describes the finished state. Today only the Fast job exists, so `l3`,
+`acceptance`, `agent_smoke`, `agent_live`, `eval` and `load` are selected by **no job at all**.
+
+That is a real hole and it is the one this mechanism could most easily hide: before the split,
+`pytest -q` ran everything, so a subsystem test written tomorrow ran in CI. After it, that test
+runs nowhere — silently, because a job nobody has written cannot go red.
+
+`PENDING_ACTIVATION_LAYERS` is the answer: a registry mapping each not-yet-run layer to the plan
+task that activates it. It is checked in **both** directions, which is what stops it becoming a
+standing amnesty:
+
+- a layer holding tests that no job selects and that is **not** in the registry fails the suite;
+- a layer in the registry that a job **does** now select also fails, so an entry cannot outlive
+  its reason.
+
+A consequence worth stating: **a test may not be moved to `l3` before the Subsystem job exists.**
+Roughly six modules under `tests/` bind real sockets or spawn processes and are `l1` by default
+today — `test_egress_https_proxy.py` foremost among them. Reclassifying them is correct and is
+T-K6's business, together with the job that runs them; doing it earlier would remove them from
+every gate. T-H1 must take that reclassification into account before it measures a mutation
+baseline, because it selects on `l1`.
+
 **The load gate has to be wired, not merely declared.** The table above marks Load as gating a
 release, but `publish.yml` currently depends only on the reusable `tests.yml`. Putting the load
 run in "its own workflow" would leave publication free to proceed while load fails — or while it

--- a/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
+++ b/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
@@ -93,7 +93,7 @@ After Milestone 0, seven streams advance independently, each owning its own modu
 
 | ID | Task | Depends on | Design | Size |
 |---|---|---|---|---|
-| **T-W1** | Layer markers, CI selection rules, per-category collection checks | — | §8 | M |
+| **T-W1** | Layer markers, CI selection rules, per-category collection checks | — | §8, §8.1, §8.2 | M |
 | **T-W2** | **The input contract** — request/capture types and the projection protocol | — | §3.3.1 | S |
 | **T-W3** | Register schema and data | T-W2 | §3.2 | M |
 | **T-W4** | Recorder implementation — primary aiohttp recorder | T-W2 | §7.2 | M |
@@ -357,7 +357,7 @@ that makes *its* bytes observable. Bundled, the Ollama half would have had no ev
 | **T-K5** | `load.yml` reusable + publish gate | ci | T-K4 | `publish.yml` `needs:`-gates on a load run **for the tag commit** | §8 | M |
 | **T-K6** | Activate the Subsystem job | ci | T-W1, T-E2, T-D3, T-D4 | `l3` gates PRs and releases. **T-D3 is required, not just T-D4**: activating the job promotes the oracle into gating infrastructure, and §1.4 forbids that before its falsification suite exists. Fixing only T-J2's dependency left this hole open | §8 | S |
 | **T-K7** | Deep nightly — mutation and schema fuzzing | ci | T-H3, T-G6 | Both exist before the job claims to run them | §8 | S |
-| **T-K8** | Per-category collection enforcement | ci | T-W1, T-K6 | Each required category has its own non-empty check. A category present but empty **fails** | §8 | S |
+| **T-K8** | Attach the per-category checks to each job | ci | T-W1, T-K6 | **The mechanism is T-W1's** — `--require-category`, and the test pairing it to every job's marker expression, landed there. What is left here is attaching a flag per category as each job activates, and removing that layer from `PENDING_ACTIVATION_LAYERS`. Narrowed after T-W1 delivered the enforcement rather than only the vocabulary | §8.1 | S |
 | **T-K9** | Activate the Acceptance job | ci | T-J2, T-J3, T-K6 | `acceptance` gates PRs and releases | §8 | S |
 | **T-K10** | Activate the `agent_smoke` category | ci, blocked Q12 | T-W1, T-I5, T-I6 | Its own required category — **it does not block Subsystem or Acceptance**, and it does not wait for them either: the T-K9 dependency was delay with no shared prerequisite behind it. It requires **T-I6 as well as T-I5**, because startup connectivity alone would let the category go green without proving the settings precedence that is the whole reason it exists | §8 | S |
 | **T-K11** | Agent-live nightly | ci | T-I14 | Runs the **expanded** five-scenario coverage, not the two existing cases | §8 | S |

--- a/README.md
+++ b/README.md
@@ -735,6 +735,29 @@ ruff check .
 mypy src/kitty
 ```
 
+### Running a subset of the tests
+
+Every test carries exactly one layer marker, so you can ask for the part you need:
+
+```bash
+pytest -m l1          # component and property tests -- the fast majority
+pytest -m l2          # contract tests: two artifacts that must agree
+pytest -m "l1 or l2"  # what CI gates every pull request on
+pytest -m ""          # everything, including the categories excluded below
+```
+
+A bare `pytest` runs everything except the categories that need a resource your machine may not
+have -- a pinned agent binary, live provider credentials, a load rig. Those are excluded by
+selection, not skipped, so the run tells you they were deselected rather than pretending to have
+considered them. To run them, name them:
+
+```bash
+pytest -m agent_live  # launches real agent CLIs against live credentials
+```
+
+The marker is assigned automatically from the file's path; a test only declares its own layer
+where that default is wrong. `.system_design/TEST_SUITE.md` §8 has the full matrix.
+
 ## License
 
 MIT

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,55 @@ packages = ["src/kitty"]
 asyncio_mode = "auto"
 testpaths = ["tests"]
 
+# Every test carries exactly one of these, and a CI job is a marker expression
+# over them and nothing else -- so no test can fall between two jobs or land in
+# both. See `.system_design/TEST_SUITE.md` section 8 for the job/marker matrix.
+#
+# The marker is assigned by PATH DEFAULT in `tests/conftest.py`, not by hand;
+# a file only names its own layer where the default is wrong. `tests/layers.py`
+# owns both the vocabulary and the default map, and this list is checked against
+# it by `tests/test_layer_markers.py`.
+markers = [
+    "l1: component and property tests -- a unit's logic, in milliseconds",
+    "l2: contract tests -- two artifacts that must agree, checked statically",
+    "l3: subsystem tests -- one service against real sockets, files and processes",
+    "acceptance: Gherkin scenarios over the product's stated promises",
+    "agent_smoke: a real agent binary starts and reaches the bridge",
+    "agent_live: a real agent binary against live provider credentials",
+    "eval: answer-quality evaluation -- nondeterministic, alerts and never gates",
+    "load: load and endurance runs",
+]
+
+# IMPORTANT: `-m` here is a DEFAULT, not a policy: a command-line `-m` replaces it
+# outright (verified against pytest 9.0.3, and the reason `tests.yml` can name
+# its own expression). It exists so a bare `pytest` -- a developer's local run,
+# or a future caller that forgets an expression -- does not try to launch four
+# real agent CLIs against live credentials.
+#
+# The string is asserted equal to `layers.default_marker_expression()`, derived
+# from `RESOURCE_DEPENDENT_LAYERS`. Do not edit one without the other; two
+# hand-maintained copies of one list is how a layer gets excluded in the module
+# and keeps running locally anyway.
+#
+# It replaces a `--runslow` flag that attached `pytest.mark.skip` to those tests
+# instead. The difference is the whole point: this run reports "32 deselected",
+# a statement about what was SELECTED, where the old one reported "32 skipped",
+# a statement about tests that were supposed to run and did not. section 8: "Skips are
+# failures in a gating job."
+#
+# IMPORTANT: `--strict-markers` is deliberately NOT here, and must not be added.
+# pytest 9.0 regressed so that `--strict-markers` given through `addopts` is
+# silently ignored; the fix landed in 9.1.0 (upstream issue 14442). Verified
+# against 9.0.3: from `addopts` a bogus marker is a warning and the run exits 0,
+# from the command line it is a collection error and the run exits 2.
+#
+# A strictness setting that depends on the patch version of pytest a contributor
+# happens to have is worse than no setting: it is a gate that reports differently
+# to two people looking at the same tree. So `tests.yml` passes the flag on the
+# command line, where every supported version honours it, and
+# `tests/test_layer_selection.py` proves the flag works rather than assuming it.
+addopts = ["-m", "not agent_smoke and not agent_live and not eval and not load"]
+
 [tool.ruff]
 line-length = 120
 target-version = "py310"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,57 @@
-"""Shared fixtures for kitty tests."""
+"""Shared fixtures for kitty tests, and the layer-marker wiring."""
 
+from __future__ import annotations
+
+import json
 import socket
+from collections.abc import Generator
 from pathlib import Path
 
 import pytest
+from layers import (
+    ENFORCEMENT_PREFIX,
+    LAYER_MARKERS,
+    default_layer_for,
+    layer_markers_in,
+    missing_required_categories,
+    unknown_categories,
+)
+
+# The collected items and their layers, as `(node id, [layer names])`, published
+# for `tests/test_layer_markers.py`. A stash key rather than a module global so
+# it is scoped to the session and typed.
+collected_layer_records: pytest.StashKey[list[tuple[str, list[str]]]] = pytest.StashKey()
+
+
+def _marker_names(item: pytest.Item) -> list[str]:
+    """Return every marker name on an item, layer and otherwise.
+
+    Args:
+        item: A collected test item.
+
+    Returns:
+        The marker names, including inherited class- and module-level ones.
+    """
+    return [mark.name for mark in item.iter_markers()]
+
+
+def _relative_path(item: pytest.Item, rootpath: Path) -> str:
+    """Return an item's file path relative to the repository root.
+
+    Args:
+        item: A collected test item.
+        rootpath: The pytest root directory.
+
+    Returns:
+        The relative path, or the absolute one when the item somehow sits
+        outside the root -- in which case the path default falls back to the
+        gating layer rather than raising, because refusing to collect is a
+        worse answer than over-including one test.
+    """
+    try:
+        return str(item.path.relative_to(rootpath))
+    except ValueError:
+        return str(item.path)
 
 
 @pytest.fixture(autouse=True)
@@ -49,25 +97,144 @@ def _session_settings_in_tmp(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) ->
     monkeypatch.setattr(tempfile, "tempdir", str(tmp_path))
 
 
+# ── Layer markers and job selection ────────────────────────────────────────
+#
+# `.system_design/TEST_SUITE.md` §8 defines each CI job as a marker expression
+# over the eight layers in `tests/layers.py`, which only divides the suite
+# cleanly if every test carries exactly one. The decisions live in that module,
+# pure and separately testable; what is left here is the wiring.
+
+
 def pytest_addoption(parser: pytest.Parser) -> None:
-    """Add CLI flag to include slow tests."""
-    parser.addoption("--runslow", action="store_true", default=False, help="run tests marked as slow")
+    """Add the per-category collection check flag.
+
+    Args:
+        parser: The pytest option parser.
+    """
+    parser.addoption(
+        "--layer-report",
+        default=None,
+        dest="layer_report",
+        metavar="PATH",
+        help=(
+            "Write the collected items and their layer markers to PATH as JSON. "
+            "Lets a check outside this process reason about the whole suite's "
+            "labelling without re-deriving it."
+        ),
+    )
+    parser.addoption(
+        "--require-category",
+        action="append",
+        default=[],
+        dest="require_category",
+        metavar="LAYER",
+        help=(
+            "Fail the run unless this layer collected at least one test. "
+            "Repeatable. A job names every category its -m expression claims "
+            "to run, because an 'or' expression is satisfied by either side."
+        ),
+    )
 
 
-def pytest_configure(config: pytest.Config) -> None:
-    """Register custom markers used by the suite."""
-    config.addinivalue_line("markers", "slow: mark test as slow to run")
+@pytest.hookimpl(wrapper=True)
+def pytest_collection_modifyitems(
+    config: pytest.Config, items: list[pytest.Item]
+) -> Generator[None, object, object]:
+    """Apply layer defaults, then enforce the run's required categories.
 
+    Args:
+        config: The active pytest configuration.
+        items: The collected items, mutated in place by this and other hooks.
 
-def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
-    """Skip slow tests unless explicitly requested."""
-    if config.getoption("--runslow"):
-        return
+    Yields:
+        Control to the remaining ``pytest_collection_modifyitems`` implementations.
 
-    skip_slow = pytest.mark.skip(reason="need --runslow option to run")
+    Returns:
+        The wrapped hook result, unchanged.
+
+    Raises:
+        UsageError: When ``--require-category`` names an unknown layer, or names
+            a layer that collected nothing.
+
+    The wrapper form is load-bearing, not stylistic. Defaults must be applied
+    **before** pytest's own ``-m`` deselection -- otherwise ``-m l1`` deselects a
+    suite whose files carry no markers yet -- and the category check must run
+    **after** it, or it counts tests the job will not run. A wrapper puts both
+    halves in one function with the ordering guaranteed by the hook protocol
+    rather than by plugin registration order, which is an implementation detail.
+    """
+    # Default by path. An item that already names a layer -- by decorator or by
+    # module-level `pytestmark` -- is left alone: the default exists to spare
+    # 3,266 pre-existing tests an edit each, not to overrule a deliberate choice.
+    rootpath = config.rootpath
     for item in items:
-        if "slow" in item.keywords:
-            item.add_marker(skip_slow)
+        if layer_markers_in(_marker_names(item)):
+            continue
+
+        item.add_marker(getattr(pytest.mark, default_layer_for(_relative_path(item, rootpath))))
+
+    result = yield
+
+    # `items` is now the surviving selection: pytest's mark plugin deselects in
+    # place during the wrapped call.
+    #
+    # Stash the judged list FIRST, unconditionally. It is what the meta-test
+    # reads, and populating it only on the branch that also runs the category
+    # check would leave the meta-test judging an absent list on every ordinary
+    # run -- which is the "stopped looking" failure, introduced by the very code
+    # meant to prevent it.
+    records = [(item.nodeid, layer_markers_in(_marker_names(item))) for item in items]
+    config.stash[collected_layer_records] = records
+
+    # Publish to a file when asked. The whole-suite checks in
+    # `tests/test_layer_selection.py` read this rather than re-deriving the
+    # labelling, so what they judge is what this hook actually assigned.
+    report_path: str | None = config.getoption("layer_report")
+    if report_path is not None:
+        # An unwritable path is the caller's mistake, so it is reported as one.
+        # Left unhandled it surfaces as pytest's INTERNALERROR traceback, which
+        # reads as a bug in the suite rather than as a bad flag -- exactly the
+        # confusion `ENFORCEMENT_PREFIX` exists to prevent.
+        try:
+            Path(report_path).write_text(
+                json.dumps(
+                    [{"nodeid": node_id, "layers": layers} for node_id, layers in records]
+                ),
+                encoding="utf-8",
+            )
+        except OSError as exc:
+            raise pytest.UsageError(
+                f"{ENFORCEMENT_PREFIX} could not write --layer-report to {report_path}: {exc}"
+            ) from exc
+
+    required: list[str] = config.getoption("require_category")
+    if not required:
+        return result
+
+    unknown = unknown_categories(required)
+    if unknown:
+        raise pytest.UsageError(
+            f"{ENFORCEMENT_PREFIX} --require-category names unknown layers: "
+            + ", ".join(unknown)
+            + f". Known layers: {', '.join(LAYER_MARKERS)}."
+        )
+
+    counts: dict[str, int] = {}
+    for item in items:
+        for name in layer_markers_in(_marker_names(item)):
+            counts[name] = counts.get(name, 0) + 1
+
+    missing = missing_required_categories(counts, required)
+    if missing:
+        raise pytest.UsageError(
+            f"{ENFORCEMENT_PREFIX} these required categories collected no "
+            "tests: "
+            + ", ".join(missing)
+            + ". A job that reports success without running a category it "
+            "claims is worse than one that fails."
+        )
+
+    return result
 
 
 @pytest.fixture()
@@ -115,3 +282,31 @@ def unused_tcp_port() -> int:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         s.bind(("127.0.0.1", 0))
         return s.getsockname()[1]
+
+
+@pytest.fixture()
+def collected_layer_markers(
+    pytestconfig: pytest.Config,
+) -> list[tuple[str, list[str]]]:
+    """Return ``(node id, [layer names])`` for every item this run selected.
+
+    Args:
+        pytestconfig: The active pytest configuration.
+
+    Returns:
+        One record per collected, non-deselected item, exactly as the collection
+        hook saw them.
+
+    Raises:
+        RuntimeError: When the collection hook did not run, which would
+            otherwise let the meta-test certify an empty list.
+    """
+    records = pytestconfig.stash.get(collected_layer_records, None)
+
+    if records is None:
+        raise RuntimeError(
+            "The layer-marker collection hook did not publish its records. "
+            "The meta-test cannot certify a run it never saw."
+        )
+
+    return records

--- a/tests/integration/test_agent_e2e.py
+++ b/tests/integration/test_agent_e2e.py
@@ -185,7 +185,6 @@ async def _run_agent_through_bridge(
 # ── Tests ──────────────────────────────────────────────────────────────────
 
 
-@pytest.mark.slow
 class TestAgentMathE2E:
     """Test that each agent returns 4 when asked 2+2."""
 
@@ -203,7 +202,6 @@ class TestAgentMathE2E:
         assert MATH_EXPECTED in output, f"Expected '4' in output, got: {output[:500]}"
 
 
-@pytest.mark.slow
 class TestAgentWebSearchE2E:
     """Test that each agent can use Kindly MCP to search the web."""
 

--- a/tests/layers.py
+++ b/tests/layers.py
@@ -1,0 +1,453 @@
+"""Layer-marker vocabulary and the pure decisions the pytest hooks apply.
+
+``.system_design/TEST_SUITE.md`` §8 defines every CI job as a marker expression
+over eight layer names and nothing else.  This module owns that vocabulary and
+the decisions taken over it:
+
+* which layer a test file gets **by default**, from its path;
+* whether a collected item's marker set is **legal** (exactly one layer);
+* whether a job's **required categories** actually collected anything;
+* which layers a marker expression can **positively select**, which is how a
+  job's claim about itself is checked against the tests that exist.
+
+Every function here is pure — no pytest objects, no filesystem, no clock — so
+each can be handed a deliberate defect and asked whether it notices.  That is
+required, not stylistic: the implementation plan's §1.4 harness rule says the
+first working version of a harness ships with a falsification case it must
+detect, and a decision entangled with the collection hook cannot be given one.
+
+The hooks that apply these decisions live in :mod:`tests.conftest`.
+
+**A note on units.** The design document counts 2,880 *test functions*; the
+numbers here and in the tests count *collected items*, which is larger because
+``parametrize`` expands.  The two are both right and are not comparable.
+
+**Import note.** Imported as ``layers``, not ``tests.layers``: ``tests/`` has no
+``__init__.py``, so pytest's ``prepend`` import mode puts that directory on
+``sys.path``.  ``tests/internal_key_scan.py`` is imported the same way and the
+same caveat applies — adding ``tests/__init__.py`` would break both.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from collections.abc import Iterable, Mapping, Sequence
+from pathlib import Path
+
+# The vocabulary, in the order TEST_SUITE.md §8 lists it: the four layers of the
+# model, then the four product-level cadences that are selected separately
+# because they are slow, nondeterministic, or need credentials.
+LAYER_MARKERS: tuple[str, ...] = (
+    "l1",
+    "l2",
+    "l3",
+    "acceptance",
+    "agent_smoke",
+    "agent_live",
+    "eval",
+    "load",
+)
+
+# Every enforcement failure this module feeds is prefixed with this, so a CI
+# summary can tell "the suite is mis-labelled" apart from "somebody fat-fingered
+# a flag in the workflow" -- pytest reports both as exit code 4.
+ENFORCEMENT_PREFIX = "layer-selection:"
+
+# Layers whose tests need a resource CI provides and a developer's machine may
+# not: a pinned agent binary, live provider credentials, a load rig. A bare
+# `pytest` excludes these by default, because the alternative is a local run
+# that tries to launch four real agent CLIs.
+#
+# Membership is about the RESOURCE, not about whether the layer gates. Two of
+# these gate a release; `agent_smoke` is here before it has a single test,
+# because §6.4.2 launches a real pinned Claude Code binary and the task that
+# makes that category live should not also have to discover this rule.
+RESOURCE_DEPENDENT_LAYERS: tuple[str, ...] = (
+    "agent_smoke",
+    "agent_live",
+    "eval",
+    "load",
+)
+
+# Layers that have, or may have, tests but that no CI job runs yet, each mapped
+# to the plan task that turns its job on.
+#
+# 🔴 This is a registry of ACKNOWLEDGED DEBT, not a permanent exemption, and it
+# is checked in both directions. A layer here that a job now selects is a stale
+# entry and fails; a populated layer that is neither selected by a job nor
+# listed here also fails. Without it, splitting the suite by marker silently
+# stops running any test written at a layer whose job has not been activated --
+# which today runs in the one undivided `pytest -q`.
+PENDING_ACTIVATION_LAYERS: Mapping[str, str] = {
+    "l3": "the Subsystem job — plan task T-K6",
+    "acceptance": "the Acceptance job — plan task T-K9",
+    "agent_smoke": "the agent-smoke category — plan task T-K10",
+    "agent_live": "the Agent-live nightly — plan task T-K11",
+    "eval": "the Eval nightly — plan task T-K12",
+    "load": "the Load workflow — plan task T-K5",
+}
+
+_FALLBACK_LAYER = "l1"
+
+# Longest-prefix-first. One entry today; the shape is what matters, because
+# every later plan task that adds a directory of tests adds a row here rather
+# than a marker to each of its files.
+_PATH_DEFAULTS: tuple[tuple[str, str], ...] = (("tests/integration/", "agent_live"),)
+
+# A pytest invocation, anchored on the command position so that
+# `pip install pytest-xdist` is not read as a test job.
+_PYTEST_COMMAND = re.compile(r"(?:^|\s|&&|\|\||;)\s*pytest\s")
+_MARKER_EXPRESSION = re.compile(r'-m\s+"([^"]*)"')
+_REQUIRE_CATEGORY = re.compile(r"--require-category=([A-Za-z_0-9]+)")
+
+
+def default_layer_for(relative_path: str) -> str:
+    """Return the layer a test file gets when it declares none.
+
+    The default is by path so that adding a test to an existing directory needs
+    no ceremony, and so that the thousands of tests predating the marker scheme
+    did not have to be edited one at a time.
+
+    Args:
+        relative_path: The test file's path relative to the repository root, in
+            either POSIX or Windows form.
+
+    Returns:
+        One of :data:`LAYER_MARKERS`.  Never ``None`` — a test with no layer is
+        a test that runs in no job.
+
+    A path this function does not recognise falls back to ``l1``, the gating
+    layer, rather than to nothing or to a nightly one.  A new corner of the tree
+    joining the fast gate uninvited is a visible, cheap mistake; one joining a
+    nightly job is invisible until something ships broken.  The case is
+    reachable: ``.github/review/tests/`` matches pytest's ``python_files``.
+    """
+    # Normalise before matching. The hook builds this string from a Path, which
+    # renders with backslashes on Windows; a prefix match against "tests/" would
+    # otherwise miss every file and default the live-agent tests into the gate.
+    normalised = relative_path.replace("\\", "/")
+
+    for prefix, layer in _PATH_DEFAULTS:
+        if normalised.startswith(prefix):
+            return layer
+
+    return _FALLBACK_LAYER
+
+
+def default_marker_expression() -> str:
+    """Return the ``-m`` expression a bare ``pytest`` run should carry.
+
+    Returns:
+        The conjunction excluding every resource-dependent layer, in
+        :data:`LAYER_MARKERS` order.
+
+    ``pyproject.toml`` carries this string literally, and a test asserts the two
+    agree.  Two hand-maintained copies of one list is how a layer gets added to
+    :data:`RESOURCE_DEPENDENT_LAYERS` and keeps running locally anyway.
+    """
+    return " and ".join(f"not {name}" for name in RESOURCE_DEPENDENT_LAYERS)
+
+
+def layer_markers_in(marker_names: Iterable[str]) -> list[str]:
+    """Return the layer markers among an item's full marker set.
+
+    Args:
+        marker_names: Every marker name on the item, layer and otherwise —
+            ``asyncio`` and ``parametrize`` are the common non-layer members.
+
+    Returns:
+        The layer names present, in :data:`LAYER_MARKERS` order.  All of them,
+        not the first: the violation this feeds is *having two*, so collapsing
+        to one would hide exactly the case it exists to find.
+    """
+    present = set(marker_names)
+
+    return [name for name in LAYER_MARKERS if name in present]
+
+
+def find_layer_violations(records: Iterable[tuple[str, Iterable[str]]]) -> list[str]:
+    """Return one human-readable line per item that does not carry exactly one layer.
+
+    Args:
+        records: ``(node id, marker names)`` pairs for the collected items.
+
+    Returns:
+        A message per offending item, naming the item and the layers found.
+        Empty when every record is legal.  Every offender is reported, not the
+        first: at ~18 minutes a CI round, a guard that surfaces one problem per
+        round is a guard people turn off.
+    """
+    violations: list[str] = []
+
+    for node_id, marker_names in records:
+        layers = layer_markers_in(marker_names)
+        if len(layers) == 1:
+            continue
+
+        # Name the layers found, not just the count. A maintainer reading this
+        # in a CI log has no other way to see which two collided.
+        found = ", ".join(layers) if layers else "none"
+        violations.append(f"{node_id} carries {len(layers)} layer markers (found: {found})")
+
+    return violations
+
+
+def assert_no_layer_violations(records: Iterable[tuple[str, Iterable[str]]]) -> None:
+    """Fail unless every record carries exactly one layer marker.
+
+    Args:
+        records: ``(node id, marker names)`` pairs for the collected items.
+
+    Raises:
+        AssertionError: When any record carries zero or more than one layer, or
+            when ``records`` is empty.
+
+    The empty case is an error rather than a pass, and that is the point of
+    having this helper at all.  "No violations found" is satisfied perfectly by
+    having looked at nothing, and a checker in that state is indistinguishable
+    from a healthy one — the failure ``TEST_SUITE.md`` §8 calls green because it
+    stopped looking.
+    """
+    materialised = [(node_id, list(names)) for node_id, names in records]
+
+    assert materialised, (
+        f"{ENFORCEMENT_PREFIX} the layer-marker check was handed no items. It "
+        "cannot pass by having nothing to check; something upstream stopped "
+        "collecting."
+    )
+
+    violations = find_layer_violations(materialised)
+
+    assert not violations, (
+        f"{ENFORCEMENT_PREFIX} every collected test must carry exactly one layer "
+        f"marker ({', '.join(LAYER_MARKERS)}). {len(violations)} do not:\n  "
+        + "\n  ".join(violations)
+    )
+
+
+def unknown_categories(required: Sequence[str]) -> list[str]:
+    """Return the requested category names that are not layer markers.
+
+    Args:
+        required: Category names a job asked to be verified as non-empty.
+
+    Returns:
+        The unrecognised names, in the order given.
+
+    A misspelled ``--require-category=acceptence`` would otherwise be a
+    requirement that can never be met, which reads in CI as a permanently broken
+    job; or, worse, if the check silently ignored unknown names, a job would
+    claim a category it never verified.
+    """
+    return [name for name in required if name not in LAYER_MARKERS]
+
+
+def missing_required_categories(
+    counts: Mapping[str, int], required: Sequence[str]
+) -> list[str]:
+    """Return the required categories that collected nothing.
+
+    Args:
+        counts: Collected item count per layer, after deselection.
+        required: Category names the job declared it runs.
+
+    Returns:
+        The names whose count is zero or absent, in the order given.
+
+    This exists because a marker *expression* cannot express it.  ``-m
+    "acceptance or agent_smoke"`` is satisfied by ``acceptance`` alone: once
+    acceptance tests exist the job collects them and passes happily with zero
+    agent-smoke coverage, reporting a category it never ran.
+    """
+    return [name for name in required if counts.get(name, 0) == 0]
+
+
+def positively_selected_layers(expression: str) -> list[str]:
+    """Return the layers a marker expression can select.
+
+    Args:
+        expression: A pytest ``-m`` expression over layer names.
+
+    Returns:
+        Every layer the expression admits, in :data:`LAYER_MARKERS` order.  An
+        empty or whitespace-only expression selects all of them, matching
+        pytest's own treatment of ``-m ""``.
+
+    Raises:
+        ValueError: When the expression is not a boolean combination of layer
+            names — an unknown name, an unsupported operator, or a syntax error.
+
+    Computed by evaluation, one layer at a time, rather than by scanning the
+    string for names.  Scanning is correct for ``"l1 or l2"`` and wrong for
+    every expression containing ``not``: it would read ``"not agent_live"`` as a
+    job that claims to run the live-agent tests.  That distinction is the whole
+    reason this function exists — the workflow check built on it asks "which
+    categories does this job actually run", not "which words appear in it".
+    """
+    if not expression.strip():
+        return list(LAYER_MARKERS)
+
+    # Parse to a tree and walk it with an explicit node allowlist, rather than
+    # calling `eval` behind an identifier check. An identifier check passes
+    # `9**9**9` (which hangs) and `1/0` (which raises something the signature
+    # does not document); the allowlist admits only `and`, `or`, `not` and a
+    # layer name, so anything else is a ValueError before it can run.
+    try:
+        tree = ast.parse(expression, mode="eval")
+    except SyntaxError as exc:
+        raise ValueError(
+            f"{ENFORCEMENT_PREFIX} marker expression {expression!r} does not parse: {exc}"
+        ) from exc
+
+    selected: list[str] = []
+    for candidate in LAYER_MARKERS:
+        # One layer true, the rest false: does a test carrying only this layer
+        # survive the expression?
+        bindings = {name: name == candidate for name in LAYER_MARKERS}
+        if _evaluate_expression(tree.body, bindings, expression):
+            selected.append(candidate)
+
+    return selected
+
+
+def _evaluate_expression(
+    node: ast.expr, bindings: Mapping[str, bool], expression: str
+) -> bool:
+    """Evaluate one node of a parsed marker expression.
+
+    Args:
+        node: The node to evaluate.
+        bindings: Truth value per layer name.
+        expression: The original text, for error messages.
+
+    Returns:
+        The node's truth value.
+
+    Raises:
+        ValueError: When the node is not `and`, `or`, `not` or a layer name.
+    """
+    if isinstance(node, ast.BoolOp):
+        values = [_evaluate_expression(v, bindings, expression) for v in node.values]
+        return all(values) if isinstance(node.op, ast.And) else any(values)
+
+    if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.Not):
+        return not _evaluate_expression(node.operand, bindings, expression)
+
+    if isinstance(node, ast.Name):
+        if node.id not in bindings:
+            raise ValueError(
+                f"{ENFORCEMENT_PREFIX} marker expression {expression!r} names "
+                f"{node.id!r}, which is not a layer ({', '.join(LAYER_MARKERS)})."
+            )
+        return bindings[node.id]
+
+    raise ValueError(
+        f"{ENFORCEMENT_PREFIX} marker expression {expression!r} uses "
+        f"{type(node).__name__}, which is not one of and / or / not / a layer name."
+    )
+
+
+def unaccounted_layers(
+    populated: Iterable[str], run_by_a_job: Iterable[str], pending: Iterable[str]
+) -> list[str]:
+    """Return layers that hold tests, that no job runs, and that nothing acknowledges.
+
+    Args:
+        populated: Layers that at least one collected test carries.
+        run_by_a_job: Layers some CI job's marker expression positively selects.
+        pending: Layers the pending-activation registry names.
+
+    Returns:
+        The unaccounted layers, sorted.
+
+    This is the arithmetic behind the hole the marker split creates: before it,
+    one undivided ``pytest -q`` ran every test, so a test written at any layer
+    ran in CI.  After it, a test at a layer whose job has not been activated
+    runs nowhere, silently, because a job nobody wrote cannot go red.
+    """
+    return sorted(set(populated) - set(run_by_a_job) - set(pending))
+
+
+def stale_pending_layers(run_by_a_job: Iterable[str], pending: Iterable[str]) -> list[str]:
+    """Return layers listed as pending activation that a job already runs.
+
+    Args:
+        run_by_a_job: Layers some CI job's marker expression positively selects.
+        pending: Layers the pending-activation registry names.
+
+    Returns:
+        The stale entries, sorted.
+
+    Checked so that a registry entry cannot outlive its reason.  Without this
+    direction the registry is a standing amnesty: every layer could be listed,
+    and the check that nothing falls through would pass while nothing ran.
+    """
+    return sorted(set(run_by_a_job) & set(pending))
+
+
+def workflow_pytest_invocations(workflows_dir: Path) -> list[str]:
+    """Return every ``pytest`` command line any workflow job runs.
+
+    Args:
+        workflows_dir: The ``.github/workflows`` directory.
+
+    Returns:
+        One whitespace-collapsed command string per ``run:`` step that invokes
+        pytest, across every job in every workflow.
+
+    One implementation, shared by the two modules that need it, because they
+    check opposite directions and a narrower sweep fails **open** in one of
+    them: a job activating a layer in a file this missed would leave a stale
+    registry entry undetected.
+
+    Both ``*.yml`` and ``*.yaml`` — GitHub accepts either, and a ``.yaml`` added
+    later must not slip past a ``.yml``-only sweep.  Whitespace is collapsed so
+    a folded or literal block scalar reads the same as a single line.
+    """
+    # Imported here rather than at module scope: this module is imported by
+    # `conftest.py` on every single pytest run, and only these two tests need
+    # a YAML parser.
+    import yaml
+
+    invocations: list[str] = []
+
+    for path in sorted([*workflows_dir.glob("*.yml"), *workflows_dir.glob("*.yaml")]):
+        document = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        for job in (document.get("jobs") or {}).values():
+            for step in job.get("steps") or []:
+                run = " ".join((step.get("run") or "").split())
+                # Anchored on the command position: a bare `\bpytest\b` also
+                # matches `pip install pytest-xdist`, which would then be read
+                # as a test job that names no layers.
+                if _PYTEST_COMMAND.search(run):
+                    invocations.append(run)
+
+    return invocations
+
+
+def marker_expression_of(command: str) -> str | None:
+    """Return the ``-m`` expression a pytest command carries, if any.
+
+    Args:
+        command: A whitespace-collapsed pytest command line.
+
+    Returns:
+        The expression inside the quotes, or ``None`` when the command names no
+        marker expression.
+    """
+    found = _MARKER_EXPRESSION.search(command)
+
+    return found.group(1) if found else None
+
+
+def required_categories_of(command: str) -> set[str]:
+    """Return the categories a pytest command declares it verifies as non-empty.
+
+    Args:
+        command: A whitespace-collapsed pytest command line.
+
+    Returns:
+        Every name given to ``--require-category``.
+    """
+    return set(_REQUIRE_CATEGORY.findall(command))

--- a/tests/test_egress_coverage.py
+++ b/tests/test_egress_coverage.py
@@ -19,6 +19,13 @@ from pathlib import Path
 
 import pytest
 
+# L2: the subject of this file is an artifact outside `src/kitty` Python code,
+# or a structural scan of source text -- two things edited separately that must
+# agree. It gates pull requests exactly as before, in the `l1 or l2` job; the
+# marker records which half of that expression it answers to, and keeps a
+# source-text scan out of the L1 set that mutation testing will judge.
+pytestmark = pytest.mark.l2
+
 SRC = Path(__file__).resolve().parent.parent / "src" / "kitty"
 
 #: Patterns that open a connection to somewhere the user does not control.

--- a/tests/test_github_actions.py
+++ b/tests/test_github_actions.py
@@ -11,6 +11,19 @@ from pathlib import Path
 
 import pytest
 import yaml
+from layers import (
+    marker_expression_of,
+    positively_selected_layers,
+    required_categories_of,
+    workflow_pytest_invocations,
+)
+
+# L2: the subject of this file is an artifact outside `src/kitty` Python code,
+# or a structural scan of source text -- two things edited separately that must
+# agree. It gates pull requests exactly as before, in the `l1 or l2` job; the
+# marker records which half of that expression it answers to, and keeps a
+# source-text scan out of the L1 set that mutation testing will judge.
+pytestmark = pytest.mark.l2
 
 ROOT = Path(__file__).resolve().parent.parent
 GITHUB_DIR = ROOT / ".github"
@@ -516,3 +529,103 @@ class TestTypeCheckIsEnforced:
         pytest_at = next(i for i, c in enumerate(commands) if "pytest" in c)
 
         assert mypy_at < pytest_at, "mypy runs after the suite, so type errors are reported last"
+
+
+def _pytest_invocations() -> list[str]:
+    """Return every ``pytest`` command line across all workflows.
+
+    Returns:
+        One string per ``run:`` step that invokes pytest, whitespace collapsed
+        so a folded YAML scalar reads the same as a single line.
+
+    Delegates to :func:`layers.workflow_pytest_invocations` so that this module
+    and ``tests/test_layer_selection.py`` cannot disagree about which jobs
+    exist.  They check opposite directions, and a sweep that misses a workflow
+    fails **open** in one of them.
+    """
+    return workflow_pytest_invocations(WORKFLOWS_DIR)
+
+
+class TestEveryJobVerifiesTheCategoriesItClaims:
+    """A job must require every layer its own marker expression selects.
+
+    ``-m "acceptance or agent_smoke"`` is satisfied by ``acceptance`` alone: the
+    job collects, passes, and reports a category it never ran. ``TEST_SUITE.md``
+    §8 records that an earlier draft of the design believed pytest would exit 5
+    in that case and says plainly: "That is wrong."
+
+    ``--require-category`` is the fix, and this is what stops a *future* job
+    from being added without it -- which is why the sweep covers every workflow
+    rather than naming the one job that exists today.
+    """
+
+    def test_the_sweep_actually_found_the_pytest_invocations(self):
+        """The self-check: prove the scan still matches something.
+
+        A structural guard that has rotted into matching nothing passes forever
+        and silently. This is the pattern ``tests/test_egress_coverage.py``
+        established and §6.2 requires of every guard here.
+        """
+        assert _pytest_invocations(), "no pytest invocation found in any workflow"
+
+    def test_the_fast_job_selects_the_two_gating_layers(self):
+        """Pin the divided command the whole plan schedules against.
+
+        Parallel authors need the selection expression from day one; this is the
+        artifact they read, so a change to it should be deliberate enough to
+        update a test.
+        """
+        commands = " || ".join(_pytest_invocations())
+
+        assert 'pytest -m "l1 or l2"' in commands
+
+    def test_no_job_runs_pytest_without_naming_a_marker_expression(self):
+        """Every job says which layers it runs.
+
+        A bare ``pytest`` in a workflow inherits the default exclusion from
+        ``addopts``, which is a developer-convenience setting. A CI job that
+        depends on it is a job whose coverage can be changed by editing a
+        comment about local runs.
+        """
+        undeclared = [
+            cmd for cmd in _pytest_invocations() if marker_expression_of(cmd) is None
+        ]
+
+        assert undeclared == [], f"these CI pytest runs name no layers: {undeclared}"
+
+    def test_the_gate_passes_strict_markers_on_the_command_line(self):
+        """``--strict-markers`` belongs here, not in ``addopts``.
+
+        pytest 9.0.x silently ignores it in ``addopts``; 9.1.0 honours it
+        (upstream issue 14442). With ``pytest>=8.0`` and no upper bound, a
+        config-file placement would make the gate strict for one contributor and
+        not another. Asserted here, and asserted *absent* from ``addopts`` in
+        ``tests/test_layer_markers.py`` -- the natural tidy-up is to move it
+        there, and one assertion alone would not notice.
+        """
+        commands = " || ".join(_pytest_invocations())
+
+        assert "--strict-markers" in commands
+
+    def test_each_job_requires_every_layer_its_expression_selects(self):
+        """The pairing that makes a job's claim about itself checkable.
+
+        "Selects" is computed by evaluating the expression, never by looking for
+        layer names in the string. The two differ on every expression containing
+        ``not``: a string scan reads ``-m "not agent_live"`` as a job that runs
+        the live-agent tests and would demand it guarantee them.
+        """
+        gaps: list[str] = []
+
+        for command in _pytest_invocations():
+            expression = marker_expression_of(command)
+            if expression is None:
+                continue
+
+            unverified = set(positively_selected_layers(expression)) - required_categories_of(
+                command
+            )
+            if unverified:
+                gaps.append(f"{command!r} selects {sorted(unverified)} without requiring it")
+
+        assert gaps == []

--- a/tests/test_internal_key_completeness.py
+++ b/tests/test_internal_key_completeness.py
@@ -29,6 +29,13 @@ from internal_key_scan import SRC, KeyWrite, scan_source, scan_tree
 
 from kitty.providers.base import ProviderAdapter
 
+# L2: the subject of this file is an artifact outside `src/kitty` Python code,
+# or a structural scan of source text -- two things edited separately that must
+# agree. It gates pull requests exactly as before, in the `l1 or l2` job; the
+# marker records which half of that expression it answers to, and keeps a
+# source-text scan out of the L1 set that mutation testing will judge.
+pytestmark = pytest.mark.l2
+
 #: Which file is expected to mint which internal keys.
 #:
 #: A *key set* per file, not a per-file count.  ``server.py`` holds roughly

--- a/tests/test_layer_markers.py
+++ b/tests/test_layer_markers.py
@@ -1,0 +1,642 @@
+"""The layer-marker meta-suite: every test declares exactly one layer.
+
+``.system_design/TEST_SUITE.md`` §8 defines a CI job as a marker expression and
+nothing else.  That only divides the suite cleanly if every collected test
+carries **exactly one** layer marker: a test with none falls between two jobs and
+is never run, a test with two runs in both and is paid for twice.
+
+This module holds that property three ways, and the three are deliberately
+different in kind:
+
+* the pure predicates in :mod:`tests.layers` are exercised against deliberate
+  defects, so the checker is known to detect what it claims to detect;
+* the assertion helper is handed an injected violation, so the *enforcement* is
+  known to be the assertion rather than a call whose result is discarded;
+* the meta-test judges the real, collected run, and first proves the list it is
+  judging is the real one rather than an empty list.
+
+The third point is the one worth stating twice.  A checker that reads an empty
+collection and reports success is the failure §8 calls "green because it stopped
+looking", and it is indistinguishable from a passing suite unless the checker is
+made to say how much it looked at.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+from layers import (
+    LAYER_MARKERS,
+    PENDING_ACTIVATION_LAYERS,
+    RESOURCE_DEPENDENT_LAYERS,
+    assert_no_layer_violations,
+    default_layer_for,
+    default_marker_expression,
+    find_layer_violations,
+    layer_markers_in,
+    missing_required_categories,
+    positively_selected_layers,
+    stale_pending_layers,
+    unaccounted_layers,
+    unknown_categories,
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _modules_applying_the_slow_marker(root: Path) -> list[str]:
+    """Return every ``file:line`` under ``root`` that applies a ``slow`` marker.
+
+    Args:
+        root: Directory to scan recursively.
+
+    Returns:
+        One ``path:lineno`` string per occurrence, sorted by path.
+
+    Matches the **attribute** ``.slow``, so it finds both a
+    ``@pytest.mark.slow`` decorator and a ``pytestmark = pytest.mark.slow``
+    assignment.  Parsed, never grepped: a text sweep for ``mark.slow`` matches
+    this module's own docstrings and the design documents discussing the change
+    — ``mem:test_design_traps`` #10 and #11 are that defect twice over.
+    """
+    offenders: list[str] = []
+
+    for path in sorted(root.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Attribute) and node.attr == "slow":
+                offenders.append(f"{path.name}:{node.lineno}")
+
+    return offenders
+
+# This module compares the suite's declared metadata against the suite's actual
+# metadata -- two artifacts edited separately, which is the L2 definition. It
+# also sits at `tests/` root, where the path default is `l1`, so it is the first
+# live exercise of "an explicit marker wins over the default".
+pytestmark = pytest.mark.l2
+
+
+class TestTheVocabulary:
+    """The eight marker names, and their registration with pytest."""
+
+    def test_the_eight_layers_are_exactly_the_ones_the_design_names(self) -> None:
+        """Pin the vocabulary against ``TEST_SUITE.md`` §8.
+
+        Written as an equality rather than a membership sweep: a ninth marker
+        added without a job to run it is the same defect as a missing one, and
+        only equality catches that direction.
+        """
+        assert LAYER_MARKERS == (
+            "l1",
+            "l2",
+            "l3",
+            "acceptance",
+            "agent_smoke",
+            "agent_live",
+            "eval",
+            "load",
+        )
+
+    def test_every_layer_marker_is_registered_with_pytest(
+        self, pytestconfig: pytest.Config
+    ) -> None:
+        """Assert each layer name appears in the ``markers`` ini setting.
+
+        Registration is what makes ``--strict-markers`` able to reject a typo.
+        An unregistered marker still *works*, silently, which is why this is
+        checked rather than assumed.
+        """
+        registered = {line.split(":", 1)[0].strip() for line in pytestconfig.getini("markers")}
+
+        assert set(LAYER_MARKERS) <= registered
+
+    def test_the_superseded_slow_marker_is_gone(self, pytestconfig: pytest.Config) -> None:
+        """Assert ``slow`` is no longer a registered marker.
+
+        Two vocabularies for "do not run this now" is how a test ends up in
+        neither job.  ``slow`` was the old one; its 32 users are ``agent_live``
+        now, selected by expression instead of skipped in place.
+        """
+        registered = {line.split(":", 1)[0].strip() for line in pytestconfig.getini("markers")}
+
+        assert "slow" not in registered
+
+
+class TestDefaultLayerForPath:
+    """The path → default-layer decision (R2.1, R2.4)."""
+
+    @pytest.mark.parametrize(
+        ("path", "expected"),
+        [
+            ("tests/integration/test_agent_e2e.py", "agent_live"),
+            ("tests/integration/nested/test_deep.py", "agent_live"),
+            ("tests/bridge/test_server.py", "l1"),
+            ("tests/test_egress.py", "l1"),
+            ("tests/tui/test_setup_wizard.py", "l1"),
+        ],
+    )
+    def test_it_maps_a_path_to_its_layer(self, path: str, expected: str) -> None:
+        """Map each representative path to the layer the design assigns it."""
+        assert default_layer_for(path) == expected
+
+    def test_it_accepts_a_windows_path_separator(self) -> None:
+        """Normalise ``\\`` before matching, because the suite runs on Windows.
+
+        The hook builds this string from a :class:`pathlib.Path`, which on
+        Windows renders with backslashes.  A prefix match against ``"tests/"``
+        would then miss every file and default the whole suite to ``l1`` --
+        including the live-agent tests, which CI would then try to run.
+        """
+        assert default_layer_for("tests\\integration\\test_agent_e2e.py") == "agent_live"
+
+    def test_a_path_outside_tests_still_gets_a_layer(self) -> None:
+        """Never return ``None``: an unclassified test is one that runs nowhere.
+
+        The default is deliberately the *gating* layer.  A path this function
+        does not recognise is a new corner of the tree, and a new corner joining
+        the fast gate uninvited is a visible, cheap mistake; one joining a
+        nightly job is invisible until something ships broken.
+        """
+        assert default_layer_for("some/unexpected/place/test_x.py") == "l1"
+
+
+class TestLayerMarkersIn:
+    """Extracting the layer names from an item's full marker set (R3.3)."""
+
+    def test_it_ignores_markers_that_are_not_layers(self) -> None:
+        """Return only layer names, so ``parametrize`` and friends do not count."""
+        assert layer_markers_in(["asyncio", "parametrize", "l1", "skipif"]) == ["l1"]
+
+    def test_it_preserves_every_layer_marker_present(self) -> None:
+        """Return *all* layers found, because the violation is having two."""
+        assert layer_markers_in(["l1", "asyncio", "l3"]) == ["l1", "l3"]
+
+    def test_it_returns_empty_when_no_layer_is_present(self) -> None:
+        """Return an empty list rather than raising: zero is a reportable state."""
+        assert layer_markers_in(["asyncio"]) == []
+
+
+class TestFindLayerViolationsDetectsDeliberateDefects:
+    """Falsification for the marker checker's predicate (R6.1).
+
+    Plan §1.4: the first working version of a harness ships with a deliberate
+    defect it must detect.  These are those defects.  Each case is the exact
+    shape the meta-test exists to catch, handed to the checker directly.
+    """
+
+    def test_a_test_with_no_layer_marker_is_reported(self) -> None:
+        """The falls-between-two-jobs defect."""
+        violations = find_layer_violations([("tests/test_x.py::test_a", ["asyncio"])])
+
+        assert len(violations) == 1
+        assert "tests/test_x.py::test_a" in violations[0]
+
+    def test_a_test_with_two_layer_markers_is_reported(self) -> None:
+        """The runs-in-both-jobs defect."""
+        violations = find_layer_violations([("tests/test_x.py::test_a", ["l1", "l3"])])
+
+        assert len(violations) == 1
+        assert "tests/test_x.py::test_a" in violations[0]
+
+    def test_the_report_names_the_markers_it_found(self) -> None:
+        """Name the offending markers, not just the test.
+
+        A maintainer reading this failure in CI has no other way to see which
+        two layers collided; "exactly one required" alone sends them to a
+        3,000-test suite with no starting point.
+        """
+        violations = find_layer_violations([("tests/test_x.py::test_a", ["l1", "l3"])])
+
+        assert "l1" in violations[0]
+        assert "l3" in violations[0]
+
+    def test_a_conforming_test_is_not_reported(self) -> None:
+        """The positive control.
+
+        A checker that reports everything detects both defects above and is
+        still useless.  ``test_design_traps`` #3: a negative that never had a
+        positive passes for the wrong reason.
+        """
+        assert find_layer_violations([("tests/test_x.py::test_a", ["l1", "asyncio"])]) == []
+
+    def test_it_reports_every_offender_not_only_the_first(self) -> None:
+        """Report all violations in one run.
+
+        Fixing these one CI round-trip at a time, at ~18 minutes a round, is how
+        a guard becomes something people disable.
+        """
+        violations = find_layer_violations(
+            [
+                ("tests/test_x.py::test_a", []),
+                ("tests/test_y.py::test_b", ["l1"]),
+                ("tests/test_z.py::test_c", ["l2", "load"]),
+            ]
+        )
+
+        assert len(violations) == 2
+
+
+class TestMissingRequiredCategoriesDetectsDeliberateDefects:
+    """Falsification for the category checker's predicate (R6.3).
+
+    :func:`find_layer_violations` got this treatment from the first draft and
+    its twin got none — the end-to-end subprocess cases in
+    ``test_layer_selection.py`` exercised the behaviour through a process, which
+    is the enforcement half of plan §1.4 but not the predicate half.  The
+    predicate is the part that can be handed a deliberate defect, which is
+    exactly why §1.4 asks for it.
+    """
+
+    def test_a_required_category_that_collected_nothing_is_reported(self) -> None:
+        """The defect: a job claims a category the run did not cover."""
+        missing = missing_required_categories({"l1": 5, "acceptance": 0}, ["l1", "acceptance"])
+
+        assert missing == ["acceptance"]
+
+    def test_a_category_absent_from_the_counts_is_reported(self) -> None:
+        """Absent and zero are the same claim.
+
+        A layer nothing carries never appears as a key, so a check written as
+        ``counts[name] == 0`` would raise instead of reporting -- and a check
+        written as ``name in counts`` would miss the zero case.
+        """
+        assert missing_required_categories({"l1": 5}, ["acceptance"]) == ["acceptance"]
+
+    def test_every_missing_category_is_reported_not_only_the_first(self) -> None:
+        """Report them all, for the same reason the marker checker does."""
+        missing = missing_required_categories({"l1": 5}, ["acceptance", "load"])
+
+        assert missing == ["acceptance", "load"]
+
+    def test_a_populated_category_is_not_reported(self) -> None:
+        """The positive control.
+
+        A predicate that reports everything detects the defects above and is
+        useless; this is what makes the flag safe to put on a real job.
+        """
+        assert missing_required_categories({"l1": 5, "l2": 2}, ["l1", "l2"]) == []
+
+
+class TestUnknownCategoriesDetectsDeliberateDefects:
+    """Falsification for the ``--require-category`` name check (R4.1)."""
+
+    def test_a_misspelled_layer_is_reported(self) -> None:
+        """The defect a silent implementation would turn into a permanent red."""
+        assert unknown_categories(["l1", "acceptence"]) == ["acceptence"]
+
+    def test_every_real_layer_is_accepted(self) -> None:
+        """The positive control: it rejects typos, not the vocabulary."""
+        assert unknown_categories(list(LAYER_MARKERS)) == []
+
+
+class TestTheActivationArithmetic:
+    """Falsification for the composed R5.4 guard.
+
+    The guard cannot fail against the repository as it stands — every non-gated
+    layer is in the registry, and the only job runs ``l1 or l2`` — which is
+    correct by design and leaves the set arithmetic that closes "the hole the
+    split creates" otherwise unexercised.  These give it the defects it must
+    detect.
+    """
+
+    def test_a_populated_layer_no_job_runs_and_nothing_lists_is_reported(self) -> None:
+        """The hole itself: tests exist at a layer that runs nowhere."""
+        unaccounted = unaccounted_layers(
+            populated=["l1", "l3"], run_by_a_job=["l1"], pending=[]
+        )
+
+        assert unaccounted == ["l3"]
+
+    def test_a_populated_layer_the_registry_acknowledges_is_not_reported(self) -> None:
+        """Acknowledged debt is allowed; that is what the registry is for."""
+        unaccounted = unaccounted_layers(
+            populated=["l1", "l3"], run_by_a_job=["l1"], pending=["l3"]
+        )
+
+        assert unaccounted == []
+
+    def test_a_layer_a_job_runs_is_not_reported(self) -> None:
+        """The positive control for the forward direction."""
+        assert unaccounted_layers(populated=["l1", "l2"], run_by_a_job=["l1", "l2"], pending=[]) == []
+
+    def test_a_registry_entry_for_a_layer_a_job_now_runs_is_reported(self) -> None:
+        """The reverse direction: an entry must not outlive its reason.
+
+        When an activation task lands, this is what fails until its layer comes
+        off the list -- which is how the debt is discharged rather than
+        forgotten.
+        """
+        assert stale_pending_layers(run_by_a_job=["l1", "l3"], pending=["l3"]) == ["l3"]
+
+    def test_a_registry_entry_for_a_layer_no_job_runs_is_not_reported(self) -> None:
+        """The positive control for the reverse direction."""
+        assert stale_pending_layers(run_by_a_job=["l1"], pending=["l3"]) == []
+
+
+class TestTheEnforcementIsTheAssertion:
+    """Falsification for the marker checker's enforcement path (R6.2).
+
+    §1.4's third named trap is "a guard proving a function was *called* when the
+    enforcement was the branch after it".  :func:`find_layer_violations` returning
+    a populated list changes nothing on its own -- something has to fail.  These
+    two tests pin that something.
+    """
+
+    def test_an_injected_violation_fails_the_assertion(self) -> None:
+        """A violating record must raise, not merely be returned."""
+        with pytest.raises(AssertionError) as excinfo:
+            assert_no_layer_violations([("tests/test_x.py::test_a", ["l1", "l3"])])
+
+        assert "tests/test_x.py::test_a" in str(excinfo.value)
+
+    def test_a_conforming_record_set_does_not_raise(self) -> None:
+        """The positive control for the enforcement path."""
+        assert_no_layer_violations([("tests/test_x.py::test_a", ["l1"])])
+
+    def test_an_empty_record_set_fails_rather_than_passing_vacuously(self) -> None:
+        """Refuse to certify nothing.
+
+        This is the "green because it stopped looking" case.  An empty list
+        satisfies "no violations found" perfectly, so the helper must treat
+        having been given nothing to check as the error it is.
+        """
+        with pytest.raises(AssertionError):
+            assert_no_layer_violations([])
+
+
+class TestTheRealCollectedSuite:
+    """The meta-test: the property, asserted over this very run (R3.1, R3.2).
+
+    Everything above proves the checker works on synthetic input.  This is the
+    one that proves the suite is actually in the state the checker describes.
+    """
+
+    def test_the_records_describe_this_run_and_not_an_empty_list(
+        self,
+        collected_layer_markers: list[tuple[str, list[str]]],
+        request: pytest.FixtureRequest,
+    ) -> None:
+        """Prove the judged list is the real one before judging it.
+
+        Two claims that are one logical fact: the harness is looking at this
+        run.  Without them every assertion below is satisfied by an empty list,
+        and a suite that silently stopped collecting would report the same green
+        as a healthy one.
+
+        The node-id check is what makes it specific.  A non-empty list could
+        still be a stale one from an earlier phase; a list containing *this
+        test* can only have come from this collection.
+        """
+        node_ids = {node_id for node_id, _ in collected_layer_markers}
+
+        assert collected_layer_markers, "no items were collected"
+        assert request.node.nodeid in node_ids
+
+        # Deliberately no floor on the count here. This assertion has to hold
+        # when a developer runs one file, so it cannot also carry the
+        # "the whole suite is still being collected" claim -- that one lives in
+        # `test_layer_selection.py`, which collects the suite itself and is
+        # therefore true regardless of how this session was invoked.
+
+    def test_every_collected_test_carries_exactly_one_layer_marker(
+        self, collected_layer_markers: list[tuple[str, list[str]]]
+    ) -> None:
+        """The property ``TEST_SUITE.md`` §8 depends on.
+
+        A test with no layer is in no job and never runs.  A test with two runs
+        in both and is paid for twice.  Either makes the marker expressions in
+        the CI matrix a description of intent rather than of behaviour.
+        """
+        assert_no_layer_violations(collected_layer_markers)
+
+    def test_this_run_collected_only_layers_its_own_expression_selects(
+        self,
+        collected_layer_markers: list[tuple[str, list[str]]],
+        pytestconfig: pytest.Config,
+    ) -> None:
+        """Selection matches the expression the session was actually given.
+
+        The practical claim is the one that replaced the ``--runslow`` silent
+        skip: a bare ``pytest`` must not collect the live-agent tests. But
+        asserting "no resource-dependent layer is present" outright is wrong in
+        two ways at once, and an earlier draft did exactly that.
+
+        It was **vacuous** in every invocation the project uses — under
+        ``-m "l1 or l2"`` and under the bare default, a resource layer is
+        deselected before the records are written, so the offender list is empty
+        by construction. And it was **red** under ``pytest -m ""``, which the
+        README and the command memory both document as "run everything": that
+        collects the 32 live-agent tests legitimately, and the assertion failed
+        with a message about layer markers.
+
+        Comparing against the session's own expression fixes both. It is
+        falsifiable under any invocation — a test carrying a layer this run did
+        not ask for fails it — and it is true under all of them.
+        """
+        expression = pytestconfig.getoption("markexpr")
+        selectable = set(positively_selected_layers(expression))
+
+        offenders = [
+            (node_id, layers)
+            for node_id, layers in collected_layer_markers
+            if not set(layers) <= selectable
+        ]
+
+        assert offenders == [], f"expression {expression!r} selects {sorted(selectable)}"
+
+
+class TestPositivelySelectedLayers:
+    """Which layers an expression can select -- by evaluation, not by grep.
+
+    The workflow check is built on this, and the distinction it draws is the
+    reason that check is worth anything: a job's ``-m`` string mentioning a
+    layer and a job actually running that layer are different facts, and they
+    come apart on every expression containing ``not``.
+    """
+
+    def test_an_or_expression_selects_both_sides(self) -> None:
+        """The gating job's own expression."""
+        assert positively_selected_layers("l1 or l2") == ["l1", "l2"]
+
+    def test_a_single_name_selects_only_itself(self) -> None:
+        """The shape every activation task will use."""
+        assert positively_selected_layers("l3") == ["l3"]
+
+    def test_a_negated_expression_selects_everything_it_does_not_exclude(self) -> None:
+        """The case a string scan gets exactly backwards.
+
+        ``not agent_live`` mentions ``agent_live`` and is precisely the
+        expression of a job that does **not** run it.  A check that read names
+        out of the string would demand the bare local run guarantee live-agent
+        coverage.
+        """
+        selected = positively_selected_layers("not agent_smoke and not agent_live")
+
+        assert "agent_live" not in selected
+        assert "agent_smoke" not in selected
+        assert "l1" in selected
+
+    def test_the_projects_default_expression_excludes_exactly_the_resource_layers(
+        self,
+    ) -> None:
+        """Tie the two halves of the exclusion together.
+
+        The list and the expression are separate artifacts; this is the
+        assertion that stops them drifting.
+        """
+        selected = positively_selected_layers(default_marker_expression())
+
+        assert set(selected) == set(LAYER_MARKERS) - set(RESOURCE_DEPENDENT_LAYERS)
+
+    def test_an_empty_expression_selects_everything(self) -> None:
+        """Match pytest's own treatment of ``-m ""``.
+
+        The whole-suite meta-check in ``test_layer_selection.py`` depends on
+        this being the escape hatch from the default ``addopts`` filter.
+        """
+        assert positively_selected_layers("") == list(LAYER_MARKERS)
+
+    def test_an_expression_naming_a_non_layer_is_rejected(self) -> None:
+        """Refuse to guess.
+
+        A job whose expression names something that is not a layer is a job
+        nobody can reason about, and silently returning ``[]`` for it would make
+        the workflow check pass by understanding nothing.
+        """
+        with pytest.raises(ValueError, match="acceptence"):
+            positively_selected_layers("acceptence or l1")
+
+
+class TestTheDefaultMarkerExpressionMatchesTheProjectConfig:
+    """``pyproject.toml`` carries the derived expression verbatim (R5.3)."""
+
+    def test_pyproject_addopts_carries_the_derived_expression(self) -> None:
+        """Assert the config string equals what the module derives.
+
+        Two hand-maintained copies of one list is how a layer gets added to
+        ``RESOURCE_DEPENDENT_LAYERS`` and keeps running on developer machines
+        anyway -- the exact failure the list exists to prevent.
+        """
+        pyproject = (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+
+        assert f'"-m", "{default_marker_expression()}"' in pyproject
+
+    def test_strict_markers_is_not_in_addopts(self) -> None:
+        """``--strict-markers`` must stay off the config file.
+
+        pytest 9.0.x silently ignores it in ``addopts`` and 9.1.0 honours it
+        (upstream issue 14442), and this project's floor is ``pytest>=8.0`` with
+        no ceiling -- so a config-file placement means the gate is strict for one
+        contributor and not for another, with nothing to say which. The workflow
+        passes it on the command line instead, where every supported version
+        honours it, and ``test_github_actions.py`` asserts that it does.
+
+        Guarded in this direction because the natural tidy-up is to move it here.
+        """
+        pyproject = (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+        addopts = pyproject.split("addopts = ", 1)[1].split("\n", 1)[0]
+
+        assert "--strict-markers" not in addopts, addopts
+
+    def test_pyproject_stays_ascii(self) -> None:
+        """No new non-ASCII byte in ``pyproject.toml``.
+
+        ``tests/test_pypi_packaging.py`` reads this file with ``Path.read_text()``
+        and no encoding, so on a machine whose locale is not UTF-8 a single
+        non-ASCII byte fails the release-gating version check. The
+        ``[tool.ruff]`` section says so in a comment, and nothing enforced it --
+        which is how the first draft of this very change added four such lines.
+
+        Line 8's em-dash is grandfathered; the count is what is pinned, so
+        removing it is fine and adding another is not.
+        """
+        text = (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+
+        offenders = [
+            f"line {number}"
+            for number, line in enumerate(text.splitlines(), start=1)
+            if any(ord(character) > 127 for character in line)
+        ]
+
+        assert offenders == ["line 8"], offenders
+
+
+class TestThePendingActivationRegistry:
+    """The acknowledged-debt list is coherent with the vocabulary.
+
+    Its *use* -- checking it against the jobs that exist and the tests that
+    exist -- is in ``test_layer_selection.py``, which needs an unfiltered
+    collection to do it.  These are the cheap structural claims.
+    """
+
+    def test_every_pending_layer_is_a_real_layer(self) -> None:
+        """A registry entry for a nonexistent layer excuses nothing, forever."""
+        assert set(PENDING_ACTIVATION_LAYERS) <= set(LAYER_MARKERS)
+
+    def test_the_gating_layers_are_not_listed_as_pending(self) -> None:
+        """``l1`` and ``l2`` have a job today, so they must not be excused.
+
+        This is the direction that keeps the registry from quietly growing to
+        cover the whole vocabulary, at which point splitting the suite by marker
+        would mean nothing runs anywhere.
+        """
+        assert "l1" not in PENDING_ACTIVATION_LAYERS
+        assert "l2" not in PENDING_ACTIVATION_LAYERS
+
+    def test_every_entry_names_the_task_that_activates_it(self) -> None:
+        """An entry with no owner is an exemption, not a debt."""
+        for layer, reason in PENDING_ACTIVATION_LAYERS.items():
+            assert "plan task T-" in reason, f"{layer} names no activation task"
+
+
+class TestTheSupersededSlowVocabularyIsGone:
+    """``slow`` and ``--runslow`` are gone from the code, not merely from prose.
+
+    Checked by parsing, not by grepping.  A text sweep for ``mark.slow`` matches
+    this module's own docstrings and the design documents that discuss the
+    change -- ``mem:test_design_traps`` #10 and #11 are that same defect, a
+    name-based scan over source text, twice.
+    """
+
+    def test_no_module_under_tests_still_applies_the_slow_marker(self) -> None:
+        """Scan the whole `tests/` tree for a ``slow`` marker in any form.
+
+        Every ``*.py``, not only ``test_*.py``: R1.3 says "anywhere", and a
+        ``pytest.mark.slow`` in ``conftest.py`` or in a helper module would
+        apply to real tests while sitting outside a ``test_*`` sweep.
+
+        Both syntactic forms matter too — a ``@pytest.mark.slow`` decorator and
+        a module-level ``pytestmark`` assignment — which is why the scan matches
+        the attribute rather than the decorator: a scan finding only decorators
+        would report a file clean that skips its whole module.
+        """
+        assert _modules_applying_the_slow_marker(REPO_ROOT / "tests") == []
+
+    def test_the_scan_finds_a_slow_marker_when_one_is_present(self, tmp_path: Path) -> None:
+        """The falsification case for the scan above (``TEST_SUITE.md`` §6.2).
+
+        A structural guard that has rotted into matching nothing passes forever
+        and silently.
+
+        🔴 **This calls the same function the guard above calls.** An earlier
+        version re-implemented the parse and walk over its own planted file, so
+        it proved a *copy* of the scan worked while the real one could match
+        nothing. That was confirmed by breaking the real scan's glob: both tests
+        stayed green. Sharing the function is what makes this a self-check
+        rather than a second, independent test of the same idea.
+        """
+        (tmp_path / "test_planted.py").write_text(
+            "import pytest\n\n\n@pytest.mark.slow\ndef test_x():\n    pass\n",
+            encoding="utf-8",
+        )
+        (tmp_path / "helper_planted.py").write_text(
+            "import pytest\n\npytestmark = pytest.mark.slow\n",
+            encoding="utf-8",
+        )
+
+        found = _modules_applying_the_slow_marker(tmp_path)
+
+        assert len(found) == 2, found

--- a/tests/test_layer_selection.py
+++ b/tests/test_layer_selection.py
@@ -1,0 +1,549 @@
+"""The selection and enforcement machinery, exercised through a real pytest run.
+
+``tests/test_layer_markers.py`` proves the decisions in :mod:`tests.layers` are
+correct and that this run's markers satisfy them.  Neither of those proves the
+part that matters operationally: that a **process** asked for a category it does
+not have **exits non-zero**.
+
+That distinction is the implementation plan's §1.4 harness rule, third case --
+"a guard proving a function was *called* when the enforcement was the branch
+after it".  :func:`missing_required_categories` returning a populated list is
+inert until something raises, and only a real run can show that it does.
+
+So every case here spawns ``pytest`` and asserts on its **exit code**.  Each one
+is paired with a positive control: a negative that never had a positive passes
+for the wrong reason, which is a trap this repository has already been caught by.
+
+Each subprocess targets **one small file** and stops at ``--collect-only``.  The
+claims are about collection and selection, collection is where the enforcement
+branch fires, and a case that costs milliseconds is a case nobody deletes.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from layers import (
+    LAYER_MARKERS,
+    PENDING_ACTIVATION_LAYERS,
+    assert_no_layer_violations,
+    marker_expression_of,
+    positively_selected_layers,
+    stale_pending_layers,
+    unaccounted_layers,
+    workflow_pytest_invocations,
+)
+
+# L2: this module compares the suite's declared selection rules against what a
+# real pytest process does with them -- two artifacts that must agree.
+pytestmark = pytest.mark.l2
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# A small, fast, all-`l2` target. Using this module's sibling rather than the
+# whole suite keeps every case under a second and gives each exactly one reason
+# to fail.
+L2_TARGET = "tests/test_layer_markers.py"
+
+# The live-agent target, for the two cases about the default exclusion.
+AGENT_LIVE_TARGET = "tests/integration"
+
+_TIMEOUT_SECONDS = 120
+
+
+def _run_pytest(*args: str) -> subprocess.CompletedProcess[str]:
+    """Run ``pytest`` in a subprocess from the repository root.
+
+    Args:
+        *args: Arguments appended after ``--collect-only -q``.
+
+    Returns:
+        The completed process, with ``stdout`` and ``stderr`` captured as text.
+
+    The child inherits the parent's ``sys.path`` through ``PYTHONPATH`` so it
+    imports the same ``kitty`` this run did.  Without that, a run from a git
+    worktree silently resolves the package from the main checkout and the child
+    can disagree with its parent about what exists.
+    """
+    env = dict(os.environ)
+    env["PYTHONPATH"] = os.pathsep.join(p for p in sys.path if p)
+
+    return subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "--collect-only",
+            "-q",
+            # No cache writes: a test that leaves state behind is a test that
+            # behaves differently on its second run.
+            "-p",
+            "no:cacheprovider",
+            *args,
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=_TIMEOUT_SECONDS,
+    )
+
+
+class TestRequiredCategoryEnforcement:
+    """``--require-category`` fails the process, not just a predicate (R4.2, R6.4)."""
+
+    def test_requiring_an_absent_category_exits_non_zero(self) -> None:
+        """The deliberate defect this harness must detect.
+
+        A run that collects only ``l2`` is asked to guarantee ``acceptance``.
+        There are no acceptance tests in the repository, so the requirement
+        cannot be met, and the run must say so by failing.
+
+        This is the exact shape ``TEST_SUITE.md`` §8 warns about: ``-m
+        "acceptance or agent_smoke"`` is satisfied by either side alone, so a
+        job can report success for a category it never ran.
+        """
+        result = _run_pytest("-m", "l2", L2_TARGET, "--require-category=acceptance")
+
+        assert result.returncode != 0
+        assert "acceptance" in result.stdout + result.stderr
+
+    def test_requiring_a_present_category_exits_zero(self) -> None:
+        """The positive control for the case above.
+
+        A checker that fails every run detects the defect above and is useless.
+        Same command, same target, one category name changed.
+        """
+        result = _run_pytest("-m", "l2", L2_TARGET, "--require-category=l2")
+
+        assert result.returncode == 0, result.stdout + result.stderr
+
+    def test_requiring_several_categories_reports_every_missing_one(self) -> None:
+        """Name all the unmet requirements, not the first.
+
+        A job declares one requirement per category in its expression.  Learning
+        about them one CI round-trip at a time, at ~18 minutes a round, is how a
+        gate becomes something people switch off.
+        """
+        result = _run_pytest(
+            "-m",
+            "l2",
+            L2_TARGET,
+            "--require-category=acceptance",
+            "--require-category=load",
+        )
+
+        assert result.returncode != 0
+        combined = result.stdout + result.stderr
+        assert "acceptance" in combined
+        assert "load" in combined
+
+    def test_a_misspelled_category_is_a_usage_error(self) -> None:
+        """An unknown name must fail loudly rather than be quietly satisfied (R4.1).
+
+        Both silent alternatives are worse than an error.  Ignoring the name
+        lets a job claim a category it never verified; treating it as a real
+        category that is always empty makes the job permanently, inexplicably
+        red.
+        """
+        result = _run_pytest("-m", "l2", L2_TARGET, "--require-category=acceptence")
+        combined = result.stdout + result.stderr
+
+        assert result.returncode != 0
+        # 🔴 Assert on WHICH error, not merely that one happened. Both branches
+        # of the hook put the name in the message and both exit non-zero, so
+        # `returncode != 0` plus the name is satisfied with the whole
+        # `unknown_categories` check deleted -- the typo then falls through and
+        # is reported as "that category is empty", which is precisely the
+        # misleading diagnostic this requirement exists to prevent. Confirmed by
+        # deleting the branch: the class stayed green.
+        assert "unknown layers" in combined, combined
+
+    def test_a_run_with_no_requirements_is_unaffected(self) -> None:
+        """The second positive control: the flag is opt-in.
+
+        Without it, nothing new can fail.  This is what makes the flag safe to
+        add before the jobs that will use it exist.
+        """
+        result = _run_pytest("-m", "l2", L2_TARGET)
+
+        assert result.returncode == 0, result.stdout + result.stderr
+
+
+class TestTheDefaultExclusion:
+    """A bare run excludes the non-gating categories (R5.3)."""
+
+    def test_a_bare_run_does_not_collect_the_live_agent_tests(self) -> None:
+        """The replacement for the ``--runslow`` silent skip.
+
+        Every test under ``tests/integration/`` needs four real agent binaries
+        and live provider credentials.  A bare ``pytest`` must not try to run
+        them -- and must not *skip* them either, which is what it used to do.
+        Exit code 5 is pytest's "no tests ran": everything the target holds was
+        deselected, which is a statement about selection.
+        """
+        result = _run_pytest(AGENT_LIVE_TARGET)
+
+        assert result.returncode == 5, result.stdout + result.stderr
+        assert "deselected" in result.stdout
+
+    def test_an_explicit_marker_expression_overrides_the_default(self) -> None:
+        """The positive control, and the mechanism the nightly job depends on.
+
+        ``addopts`` carries a default ``-m``; a command-line ``-m`` replaces it
+        outright.  If it did not, the exclusion above would be a policy rather
+        than a default and the live-agent tests could never be run at all --
+        the deselection would have become a new silent skip.
+        """
+        result = _run_pytest("-m", "agent_live", AGENT_LIVE_TARGET)
+
+        assert result.returncode == 0, result.stdout + result.stderr
+        # A floor, not the exact count. The requirements argue at length that an
+        # exact number fails on the next test anyone adds and then gets deleted;
+        # the real set claim lives in
+        # `test_live_agent_and_the_integration_directory_are_the_same_set`.
+        assert "deselected" not in result.stdout
+        assert "tests collected" in result.stdout or "/" in result.stdout
+
+
+class TestStrictMarkers:
+    """A misspelled marker is a collection error, not silence (R1.2)."""
+
+    def test_an_unregistered_marker_fails_collection(self, tmp_path: Path) -> None:
+        """Prove ``--strict-markers`` is in force, by tripping it.
+
+        Without it, ``pytest.mark.acceptence`` is a warning and *no marker at
+        all* -- so the test lands in whatever the path default is and the author
+        is never told.  The layer meta-test would still catch it, one round
+        later and with a message about a file the author did not touch.
+
+        The bogus file is written to ``tmp_path``, never into ``tests/``, and
+        ``-c`` points the run at the repository's own configuration so the
+        ``addopts`` under test actually apply.
+        """
+        target = tmp_path / "test_bogus_marker.py"
+        target.write_text(
+            "import pytest\n\n\n@pytest.mark.deffinitely_not_a_marker\ndef test_x():\n    pass\n",
+            encoding="utf-8",
+        )
+
+        result = _run_pytest("--strict-markers", "-c", "pyproject.toml", str(target))
+
+        assert result.returncode != 0
+        assert "deffinitely_not_a_marker" in result.stdout + result.stderr
+
+    def test_a_registered_marker_collects_cleanly(self, tmp_path: Path) -> None:
+        """The positive control: strictness rejects typos, not every marker."""
+        target = tmp_path / "test_good_marker.py"
+        target.write_text(
+            "import pytest\n\n\n@pytest.mark.l2\ndef test_x():\n    pass\n",
+            encoding="utf-8",
+        )
+
+        result = _run_pytest("--strict-markers", "-c", "pyproject.toml", str(target))
+
+        assert result.returncode == 0, result.stdout + result.stderr
+
+
+class TestTheRemovedRunslowFlag:
+    """``--runslow`` is gone from the interface, not only from the code (R1.3)."""
+
+    def test_the_flag_is_rejected(self) -> None:
+        """Prove the option no longer exists, by asking for it.
+
+        Asserting the string is absent from ``conftest.py`` would pass while an
+        alias lingered somewhere else, and would fail on a docstring mentioning
+        the removal.  Asking pytest is the claim itself.
+        """
+        result = _run_pytest("--runslow", L2_TARGET)
+
+        assert result.returncode != 0
+        assert "runslow" in result.stdout + result.stderr
+
+
+def _declared_contract_guards() -> list[tuple[Path, str]]:
+    """Return the test modules whose docstring opens by calling them a contract guard.
+
+    Returns:
+        ``(absolute path, repository-relative posix path)`` for each module
+        whose docstring's **first line** declares it a contract guard.
+
+    The first line only.  A module that cites §6.2 somewhere in its prose is
+    referring to the design, not classifying itself, and treating the two the
+    same produces a false positive on the first behavioural guard that explains
+    where it asserts.
+    """
+    guards: list[tuple[Path, str]] = []
+
+    for path in sorted(REPO_ROOT.joinpath("tests").rglob("test_*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        docstring = ast.get_docstring(tree) or ""
+
+        if docstring.splitlines()[:1] and "contract guard" in docstring.splitlines()[0].lower():
+            guards.append((path, path.relative_to(REPO_ROOT).as_posix()))
+
+    return guards
+
+
+@pytest.fixture(scope="module")
+def whole_suite_layers(tmp_path_factory: pytest.TempPathFactory) -> list[tuple[str, list[str]]]:
+    """Collect the **entire** suite, unfiltered, and return its layer records.
+
+    Args:
+        tmp_path_factory: pytest's session-scoped temporary directory factory.
+
+    Returns:
+        ``(node id, [layer names])`` for every test in the repository, including
+        the ones a default run deselects.
+
+    Raises:
+        AssertionError: When the collection fails or reports implausibly little.
+
+    ``-m ""`` is the escape hatch from the default ``addopts`` filter: without
+    it there is no way to see the whole suite at once, because every invocation
+    now carries a marker expression.  That matters because the in-session
+    meta-test judges only what its own run selected -- so an ``l3`` test with a
+    second, illegal marker would be deselected by the gating job's ``-m "l1 or
+    l2"`` before anything looked at it.
+
+    Module-scoped: one collection serves every check below, and it costs a
+    couple of seconds.
+    """
+    report = tmp_path_factory.mktemp("layer-report") / "layers.json"
+
+    result = _run_pytest("-m", "", f"--layer-report={report}")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+    records = [
+        (entry["nodeid"], entry["layers"])
+        for entry in json.loads(report.read_text(encoding="utf-8"))
+    ]
+
+    # The floor lives here rather than in the in-session meta-test, which has to
+    # stay true when a developer runs one file. A suite that quietly stopped
+    # collecting two thousand tests would satisfy every assertion below.
+    assert len(records) > 3000, f"only {len(records)} items collected for the whole suite"
+
+    return records
+
+
+class TestTheWholeSuiteIsCoherent:
+    """Claims about the suite as a whole, not about one run's slice."""
+
+    def test_every_test_in_the_repository_carries_exactly_one_layer(
+        self, whole_suite_layers: list[tuple[str, list[str]]]
+    ) -> None:
+        """The invariant §8 rests on, checked over everything that exists.
+
+        The in-session meta-test cannot make this claim.  It sees only what its
+        own marker expression selected, and the items most likely to be
+        mis-labelled are exactly the ones a gating expression deselects.
+        """
+        assert_no_layer_violations(whole_suite_layers)
+
+    def test_the_layers_partition_the_suite(
+        self, whole_suite_layers: list[tuple[str, list[str]]]
+    ) -> None:
+        """Per-layer counts sum to the total.
+
+        An identity rather than a fixed number: it holds at any suite size, so
+        it survives ordinary growth, while still failing the moment a test is
+        counted twice or not at all.
+        """
+        per_layer = {
+            layer: sum(1 for _, layers in whole_suite_layers if layer in layers)
+            for layer in LAYER_MARKERS
+        }
+
+        assert sum(per_layer.values()) == len(whole_suite_layers)
+
+    def test_live_agent_and_the_integration_directory_are_the_same_set(
+        self, whole_suite_layers: list[tuple[str, list[str]]]
+    ) -> None:
+        """The path default that decides a test's CI cadence, checked where it is real.
+
+        Asserted over an unfiltered collection, so both sides are populated.
+        The equivalent assertion inside a default-filtered session is vacuous —
+        the ``agent_live`` side is empty there by construction — and an earlier
+        draft of this suite made exactly that mistake.
+        """
+        live = {node_id for node_id, layers in whole_suite_layers if "agent_live" in layers}
+        integration = {
+            node_id for node_id, _ in whole_suite_layers if node_id.startswith("tests/integration/")
+        }
+
+        assert live == integration
+        assert live, "the live-agent set is empty; the path default stopped applying"
+
+    def test_the_contract_files_are_the_only_ones_claiming_l2(
+        self, whole_suite_layers: list[tuple[str, list[str]]]
+    ) -> None:
+        """Pin the explicit-marker list, in both directions.
+
+        The forward direction stops a rename or a lost ``pytestmark`` from
+        silently moving a structural guard into the L1 set that mutation testing
+        will judge.  The reverse direction -- that nothing *else* claims ``l2``
+        -- is what stops the list growing by accident, one convenient marker at
+        a time, until the distinction means nothing.
+        """
+        expected = {
+            "tests/test_pypi_packaging.py",
+            "tests/test_model_context_packaged_catalog.py",
+            "tests/test_review_workflow_cli_contract.py",
+            "tests/test_internal_key_completeness.py",
+            "tests/test_egress_coverage.py",
+            "tests/test_wire_shape_honesty.py",
+            "tests/test_github_actions.py",
+            "tests/test_layer_markers.py",
+            "tests/test_layer_selection.py",
+        }
+
+        actual = {
+            node_id.split("::", 1)[0]
+            for node_id, layers in whole_suite_layers
+            if "l2" in layers
+        }
+
+        assert actual == expected
+
+    def test_every_module_declaring_itself_a_contract_guard_is_marked_l2(
+        self, whole_suite_layers: list[tuple[str, list[str]]]
+    ) -> None:
+        """A module that calls itself a contract guard must be filed as one.
+
+        ``tests/test_wire_shape_honesty.py`` opens "Contract guard — ..." and was
+        still left at the ``l1`` default in the first draft of this change.
+        Nothing would have reported it, and mutation testing would have
+        attributed its kills to the wrong layer.  The set equality above catches
+        that file only because it is now named there; this catches the *next*
+        one, which nobody will think to add.
+
+        The predicate is the docstring's **first line**, not a citation anywhere
+        in the module.  Scanning for a ``§6.2`` reference was tried and is the
+        wrong shape: ``tests/test_internal_keys_not_sent_upstream.py`` cites that
+        section to say *where* it asserts, and is a behavioural regression guard,
+        correctly ``l1``.  A mention of a section is not a claim to be one --
+        ``mem:test_design_traps`` #10 and #11, again.
+        """
+        mis_filed: list[str] = []
+
+        for _path, relative in _declared_contract_guards():
+            layers = {
+                layer
+                for node_id, item_layers in whole_suite_layers
+                if node_id.split("::", 1)[0] == relative
+                for layer in item_layers
+            }
+            if layers and layers != {"l2"}:
+                mis_filed.append(f"{relative}: {sorted(layers)}")
+
+        assert mis_filed == []
+
+    def test_the_contract_guard_scan_finds_the_known_positive(self) -> None:
+        """The self-check for the scan above (``TEST_SUITE.md`` §6.2).
+
+        A structural guard that has rotted into matching nothing passes forever
+        and silently.  ``tests/test_wire_shape_honesty.py`` is the known
+        positive: it is the file whose misfiling motivated the scan, and if the
+        scan stops finding it the scan has stopped working.
+        """
+        found = {relative for _, relative in _declared_contract_guards()}
+
+        assert "tests/test_wire_shape_honesty.py" in found
+
+
+class TestEveryPopulatedLayerIsRunSomewhere:
+    """No layer may hold tests that no job runs and no registry acknowledges.
+
+    This is the hole the marker split creates and that nothing else closes.
+    Before it, ``tests.yml`` ran a bare ``pytest -q`` and every test ran.  After
+    it, a job is a marker expression, and a test written at a layer whose job
+    has not been activated yet runs **nowhere** — silently, because a job that
+    was never written cannot go red.
+
+    ``TEST_SUITE.md`` §8 asserts the opposite as a property of the design: "no
+    test can fall between two jobs". That property is only true if something
+    checks it, so this is that check.
+    """
+
+    @staticmethod
+    def _layers_run_by_a_job() -> set[str]:
+        """Return every layer some workflow job positively selects.
+
+        Returns:
+            The union over all jobs of the layers each job's marker expression
+            admits.
+
+        Built on the shared :func:`workflow_pytest_invocations`, not on a local
+        sweep.  A narrower sweep fails **open** in
+        :meth:`test_the_pending_registry_holds_no_layer_a_job_already_runs`: a
+        job activating a layer in a ``.yaml`` file, or in a multi-line ``run:``
+        block, would leave a stale registry entry undetected — the direction the
+        design calls out as the one that must not outlive its reason.
+        """
+        return {
+            layer
+            for command in workflow_pytest_invocations(REPO_ROOT / ".github" / "workflows")
+            for layer in positively_selected_layers(marker_expression_of(command) or "")
+        }
+
+    def test_the_workflow_sweep_actually_found_an_expression(self) -> None:
+        """The self-check every structural scan in this repository carries.
+
+        Without it, a change to how workflows invoke pytest turns the check
+        below into a sweep over an empty list, which passes and proves nothing.
+        ``TEST_SUITE.md`` §6.2 names this pattern and points at
+        ``tests/test_egress_coverage.py`` as the one to copy.
+        """
+        assert workflow_pytest_invocations(REPO_ROOT / ".github" / "workflows"), (
+            "no pytest invocation found in any workflow"
+        )
+        assert self._layers_run_by_a_job(), "no workflow job selects any layer"
+
+    def test_each_populated_layer_is_selected_by_a_job_or_acknowledged_as_pending(
+        self, whole_suite_layers: list[tuple[str, list[str]]]
+    ) -> None:
+        """Every layer holding tests is either run, or on the record as not run.
+
+        The registry is the deliberate part.  ``agent_live`` holds 32 tests that
+        no job runs today — true before this change too, when they were
+        collected and skipped — and the honest response is to name it and the
+        task that fixes it, not to pretend the split is complete.
+
+        The arithmetic is :func:`unaccounted_layers`, which carries its own
+        falsification cases in ``test_layer_markers.py``: this composition
+        cannot fail against the repository as it stands, which is correct by
+        design and would otherwise leave it unexercised.
+        """
+        populated = {layer for _, layers in whole_suite_layers for layer in layers}
+
+        unaccounted = unaccounted_layers(
+            populated, self._layers_run_by_a_job(), PENDING_ACTIVATION_LAYERS
+        )
+
+        assert unaccounted == [], (
+            f"These layers hold tests that no CI job runs: {unaccounted}. Either "
+            "activate a job for them or add them to PENDING_ACTIVATION_LAYERS "
+            "with the plan task that will."
+        )
+
+    def test_the_pending_registry_holds_no_layer_a_job_already_runs(self) -> None:
+        """A stale entry is a standing excuse; fail so it gets removed.
+
+        Checked in this direction so the registry cannot outlive its reason.
+        When an activation task lands, this test fails until its layer comes off
+        the list -- which is how the debt gets discharged rather than forgotten.
+        """
+        stale = stale_pending_layers(self._layers_run_by_a_job(), PENDING_ACTIVATION_LAYERS)
+
+        assert stale == [], (
+            f"These layers are run by a job but still listed as pending: {stale}. "
+            "Remove them from PENDING_ACTIVATION_LAYERS."
+        )

--- a/tests/test_model_context_packaged_catalog.py
+++ b/tests/test_model_context_packaged_catalog.py
@@ -30,6 +30,13 @@ from pathlib import Path
 
 import pytest
 
+# L2: the subject of this file is an artifact outside `src/kitty` Python code,
+# or a structural scan of source text -- two things edited separately that must
+# agree. It gates pull requests exactly as before, in the `l1 or l2` job; the
+# marker records which half of that expression it answers to, and keeps a
+# source-text scan out of the L1 set that mutation testing will judge.
+pytestmark = pytest.mark.l2
+
 EXPECTED_CATALOG: dict[str, int] = {
     "qwen3.8-max": 1_000_000,
     "MiniMax-M3": 1_048_576,

--- a/tests/test_pypi_packaging.py
+++ b/tests/test_pypi_packaging.py
@@ -18,6 +18,13 @@ from pathlib import Path
 
 import pytest
 
+# L2: the subject of this file is an artifact outside `src/kitty` Python code,
+# or a structural scan of source text -- two things edited separately that must
+# agree. It gates pull requests exactly as before, in the `l1 or l2` job; the
+# marker records which half of that expression it answers to, and keeps a
+# source-text scan out of the L1 set that mutation testing will judge.
+pytestmark = pytest.mark.l2
+
 ROOT = Path(__file__).resolve().parent.parent
 DIST_DIR = ROOT / "dist"
 

--- a/tests/test_review_workflow_cli_contract.py
+++ b/tests/test_review_workflow_cli_contract.py
@@ -35,6 +35,13 @@ from pathlib import Path
 
 import pytest
 
+# L2: the subject of this file is an artifact outside `src/kitty` Python code,
+# or a structural scan of source text -- two things edited separately that must
+# agree. It gates pull requests exactly as before, in the `l1 or l2` job; the
+# marker records which half of that expression it answers to, and keeps a
+# source-text scan out of the L1 set that mutation testing will judge.
+pytestmark = pytest.mark.l2
+
 ROOT = Path(__file__).resolve().parent.parent
 REVIEW_SCRIPTS = ROOT / ".github" / "review" / "scripts"
 CONFIGURE_KITTY = REVIEW_SCRIPTS / "configure_kitty.py"

--- a/tests/test_wire_shape_honesty.py
+++ b/tests/test_wire_shape_honesty.py
@@ -64,6 +64,12 @@ from kitty.providers.base import ProviderAdapter
 from kitty.providers.opencode import _MESSAGES_MODELS
 from kitty.providers.registry import _registry, get_provider
 
+# L2: a contract guard, per the §6.2.3 citation in this module's docstring. It
+# gates pull requests exactly as before, in the `l1 or l2` job; the marker keeps
+# it out of the L1 set that mutation testing will judge, where a contract guard
+# would have its kills attributed to the wrong layer.
+pytestmark = pytest.mark.l2
+
 
 class WireShape(Enum):
     """The request dialects a provider adapter can put on the wire."""


### PR DESCRIPTION
Implements plan task **T-W1** — layer markers, CI selection rules, and per-category collection checks. Design: `.system_design/TEST_SUITE.md` §8, §8.1, §8.2. Tracked as KBR-24.

## Context for the Product Owner

Kitty Bridge's test suite is one undivided block: 3,300 tests, one command, about 19 minutes on each of four Python versions. There is no way to ask for "just the fast checks" or "just the ones needing real infrastructure."

The recently approved test-suite plan is roughly ninety tasks that add slower, deeper tests — real sockets, real agent binaries, answer-quality evaluations, load runs. **None of them can be scheduled until the suite can be divided**, because otherwise every new slow test lands in the gate that every pull request waits on. When the gate stops being fast, people route around it, and the gate stops protecting anything.

This is the first task of that plan and the prerequisite for most of the rest. It labels every test with the tier it belongs to, so a CI job can be defined as "run tier X." Nothing about what CI runs today changes — the same tests gate the same pull requests — but from here the plan's other tasks can proceed in parallel.

**It also closes a live hole.** The gate currently *collects* 32 tests that launch real agent binaries against live provider credentials, *skips* them because those binaries are not on the runner, and reports green. The design calls that "the most expensive kind of false confidence." Those tests now sit in a named nightly tier and the gate no longer pretends to have considered them.

## What changed

- **Eight tier markers**, assigned automatically from a test's file path. 3,266 existing tests were not edited; seven files that are not what their directory suggests declare their own tier.
- **The gate becomes `pytest -m "l1 or l2"`**, with a `--require-category` flag per tier it claims to run. That flag exists because a marker expression cannot make the claim on its own: `-m "acceptance or agent_smoke"` is satisfied by either side alone, so a job can report success for a tier it never ran. The design records that an earlier draft believed pytest would fail in that case; it does not.
- **`--runslow` is removed.** The 32 live-agent tests are now excluded by *selection* rather than skipped in place — the run reports "32 deselected", a statement about what was chosen, instead of "32 skipped", a statement about tests that were meant to run and did not.
- **An acknowledged-debt registry.** Dividing a suite by marker creates a hole: a test written at a tier whose job is not yet switched on runs *nowhere*, silently, because a job nobody has written cannot go red. `PENDING_ACTIVATION_LAYERS` names every such tier against the plan task that activates it, and is checked **in both directions** — an unlisted populated tier fails the build, and so does a listed tier some job already runs, so an entry cannot outlive its reason.

Only the Fast job is added. Subsystem, Acceptance, agent-smoke, Deep, Eval and Load each have their own activation task and are deliberately left off: a job whose expression collects nothing is either noise that teaches people to ignore red, or an empty gate.

## How it was verified

Every decision is a pure function in `tests/layers.py`, and each ships with a deliberate defect it must detect, as the plan's harness rule requires. **Each was confirmed by applying the wrong fix, not by reasoning that it would fail** — five guards were individually broken and each went red.

That discipline earned its keep. The first version of the `slow`-marker self-check was found to pass while its scan was broken to match *zero files*: it was exercising a copy of the scan rather than the scan. Both now call one function.

Three pytest behaviours the mechanism rests on were confirmed by experiment against pytest 9.0.3 rather than inferred:

- a command-line `-m` replaces the one in `addopts`;
- a `wrapper=True` collection hook sees pre-deselection items before `yield` and the surviving selection after — which is why tier defaults can be applied before `-m` filtering and the category check after, from one function;
- **`--strict-markers` in `addopts` is silently ignored before pytest 9.1.0** ([pytest#14442](https://github.com/pytest-dev/pytest/issues/14442)). This project pins `pytest>=8.0` with no ceiling, so a config-file placement would make the gate strict for one contributor and not another. The workflow passes it on the command line, and tests assert both that it is there and that it is *not* in `addopts` — the natural tidy-up is to move it, and one assertion alone would not notice.

Local run: `3328 passed, 32 deselected`. Two failures are this developer machine, not the change — OpenSSL 1.1.1k predates `-copy_extensions`, and the local `twine` predates the metadata version the build emits. Both are current on the runners.

## Reviewer notes

- `tests/layers.py` — the vocabulary and every decision over it.
- `tests/conftest.py` — the collection wrapper. Its ordering is load-bearing and the docstring says why.
- `.system_design/TEST_SUITE.md` §8.1 / §8.2 — the reasoning, including what is knowingly left **over-inclusive**: about six socket- and process-bearing modules are subsystem tests by the design's own definition but stay in the fast tier, because moving them before the Subsystem job exists would remove them from every gate. Recorded so the mutation-testing task meets it as a note rather than as a mystery.
- Seven files gain a tier marker. **None is weakened** — all still gate pull requests in the same job, and `--require-category=l2` now makes their disappearance a hard failure, which is stronger than before.

## Filed, not fixed

**KBR-132** — a test inside the pull-request gate skips itself when `openssl` is missing, so the job can pass without running it. That is the rule in §8 being broken by the suite that states it. Fixing it means moving the test to the subsystem tier, which cannot happen until that job exists.

Also closed a gap this work exposed: `pyproject.toml` must stay ASCII (a release-gating test reads it without an encoding), a constraint documented in a comment and enforced by nothing — which is how the first draft of this change broke it. A test now pins it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
