### PR TITLE
Give every projection one vocabulary to be written in (KBR-25)

### DIFF
--- a/.system_design/TEST_SUITE.md
+++ b/.system_design/TEST_SUITE.md
@@ -348,8 +348,9 @@ from it and carried separately, so a changed media type is its own delta. Gemini
 `fileData.fileUri` has no bytes: `digest` is then absent and `ref` holds the URI. Unpinned, the
 Messages reader and the Chat Completions reader would produce different digests for one image.
 
-The contract lives in `tests/harness/contract.py` (T-W2), which is also the home of T-W4's
-recorder, T-W5's proxy fixture, T-W6's corpus loader and T-W8's bridge fixture.
+The contract lives in `tests/harness/contract.py` (T-W2). The **package** `tests/harness/` is the
+home of T-W4's recorder, T-W5's proxy fixture, T-W6's corpus loader and T-W8's bridge fixture, each
+in its own module beside it — `contract.py` itself captures nothing and reads nothing.
 
 **Unknown fields fail closed.** Each reader must classify **every** key in the body into exactly
 one of: mapped to the envelope, mapped to the conversation, or residual. A non-empty `residual`

--- a/.system_design/TEST_SUITE.md
+++ b/.system_design/TEST_SUITE.md
@@ -478,6 +478,12 @@ agree on a canonical form. They are six separate tasks, so the agreement is part
   building an escape out of the residual defeats the escape. A value mapped to `other` has been
   seen and classified — it is accounted for. The residual means only *nobody has looked at this*.
 
+  **The pairing is enforced, both ways.** `other` without `stop_reason_raw` is rejected, because a
+  reader that maps both `SAFETY` and `RECITATION` to a bare `other` has discarded exactly what
+  T-D10 needs; and a `stop_reason_raw` beside a canonical reason is rejected as a stale leftover.
+  An invariant stated only in a docstring is a comment, not a rule — the same posture the closed
+  vocabularies take.
+
   **`usage` is carried but excluded from the diff**: it is provider-reported, never agent-supplied,
   so a difference carries no I1 information.
 

--- a/.system_design/TEST_SUITE.md
+++ b/.system_design/TEST_SUITE.md
@@ -319,6 +319,14 @@ and catches drops; the **path-keyed** residual covers nesting and fails closed, 
 because Gemini puts every sampling parameter under `generationConfig` and Converse nests
 `inferenceConfig` and `toolConfig`.
 
+> **The boundary, stated so nobody over-reads a green run.** `consumed` holds *top-level* keys, so
+> a reader that claims `generationConfig` and **silently drops** `topK` inside it **passes**
+> `verify_total`. Catching that would require the contract to walk the body itself — making it a
+> second reader, which the independent-oracle rule forbids. What closes it instead: each reader's
+> own L1 tests against its format's published examples (§7.4), and **T-D8**, which owns "residual
+> empty across the whole corpus" for all seven readers. T-W2 pins this boundary with its own test,
+> so it stays a decision rather than an assumption.
+
 **Optional ids, because two formats have none.** Gemini's `functionCall`/`functionResponse` carry
 no id; pairing there is by tool name and the k-th unanswered call of that name in the most recent
 assistant turn. A required id would force those readers to synthesise one and show a delta on every
@@ -462,11 +470,16 @@ agree on a canonical form. They are six separate tasks, so the agreement is part
   `tool:<name>`. This is the one deliberate exception to keying `extra` by the wire key, because
   four spellings name one concept.
 - **On the response direction**, `stop_reason` is `end_turn` · `max_tokens` · `stop_sequence` ·
-  `tool_use` · `error` · `other`, where `other` carries the original string in
-  `residual["stop_reason"]` — Gemini adds `SAFETY` and `RECITATION`, and a closed set with no escape
-  would fail the run on a legitimate safety-blocked reply. **`usage` is carried but excluded from
-  the diff**: it is provider-reported, never agent-supplied, so a difference carries no I1
-  information.
+  `tool_use` · `error` · `other`, where `other` keeps the wire's own string in
+  **`Reply.stop_reason_raw`** — Gemini adds `SAFETY` and `RECITATION`, and a closed set with no
+  escape would fail the run on a legitimate safety-blocked reply.
+
+  **Not in the residual**, and the reason generalises: a non-empty residual *fails the run*, so
+  building an escape out of the residual defeats the escape. A value mapped to `other` has been
+  seen and classified — it is accounted for. The residual means only *nobody has looked at this*.
+
+  **`usage` is carried but excluded from the diff**: it is provider-reported, never agent-supplied,
+  so a difference carries no I1 information.
 
 Then write one **hand-written reader per wire format** — Anthropic Messages, Chat Completions,
 OpenAI Responses, Gemini, Bedrock Converse, Ollama `/api/chat` — each written directly against

--- a/.system_design/TEST_SUITE.md
+++ b/.system_design/TEST_SUITE.md
@@ -287,24 +287,61 @@ the whole request and accounts for every field:
 Request                          -- the complete request; nothing is dropped silently
   envelope:     Envelope         -- routing and control
   conversation: Conversation     -- semantic content
-  residual:     {key: value}     -- anything the reader did not account for
+  residual:     {path: value}    -- anything the reader did not account for
+  consumed:     {key}            -- top-level body keys the reader DID account for
+  source:       {key: value}     -- the mapping the reader parsed
 
 Envelope
   model, stream, store, and every other control field the format defines
-  (Bedrock's modelId and Responses' store live here too)
+  in `extra`, keyed by the wire key
+  (Bedrock's modelId normalises onto `model`; Responses' store lives here too)
 
 Conversation
   system:   ordered text parts
-  turns:    ordered [ Turn(role, parts) ]
+  turns:    ordered [ Turn(role, parts) ]        -- role is `user` or `assistant`, only
   tools:    ordered [ ToolDecl(name, description, schema, strict) ]
-  sampling: { max_tokens, temperature, top_p, stop, seed, ... } -- declared, may be absent
+  sampling: a CLOSED set of fifteen canonical keys (§3.3.1b) -- declared, may be absent
 
 Part = Text(str)
-     | ToolUse(id, name, arguments)
-     | ToolResult(tool_use_id, content, is_error)
-     | Thinking(text)
-     | Image(digest)
+     | ToolUse(name, arguments, id?)
+     | ToolResult(content, tool_use_id?, is_error)   -- content: [ Text | Image | Json | Opaque ]
+     | Thinking(text, signature?)
+     | Image(digest?, media_type?, ref?)
+     | Json(value)
+     | Opaque(kind, digest?)
 ```
+
+**`consumed` is why a dropped key is detectable.** A reader that *drops* an unknown key produces
+an **empty** residual, so "the residual must be empty" would pass it — and T-W2's own falsification
+case is a stub reader that drops an unknown key. Totality is decidable only against the source
+body, so the projection records what the reader claimed to handle. `consumed` covers top-level keys
+and catches drops; the **path-keyed** residual covers nesting and fails closed, which matters
+because Gemini puts every sampling parameter under `generationConfig` and Converse nests
+`inferenceConfig` and `toolConfig`.
+
+**Optional ids, because two formats have none.** Gemini's `functionCall`/`functionResponse` carry
+no id; pairing there is by tool name and the k-th unanswered call of that name in the most recent
+assistant turn. A required id would force those readers to synthesise one and show a delta on every
+tool turn.
+
+**`ToolResult.content` is wider than text and images**, because Converse's `toolResult.content`
+carries `json` (the common case), `document`, `video` and `searchResult`, Anthropic's carries
+`document` and `search_result`, and Gemini's `functionResponse.response` is a bare struct. `Json`
+carries structured results; `Opaque(kind, ...)` keeps the rest **detectable** without modelling six
+vendors' block zoos, with `kind` a canonical snake_case name rather than the wire's spelling.
+
+**An empty block is a part with an empty string, never nothing.** P5e injects an empty `thinking`
+block and P8 an empty `reasoning_content`; P8's trigger is conditional and *inferred*, so §3.3.2
+assertion 2 needs its absence to be observable. `Thinking.signature` carries what M8's carrier
+repair manipulates.
+
+**`Image.digest` is the lowercase hex SHA-256 of the decoded bytes**, with `media_type` excluded
+from it and carried separately, so a changed media type is its own delta. Gemini's
+`fileData.fileUri` has no bytes: `digest` is then absent and `ref` holds the URI. Unpinned, the
+Messages reader and the Chat Completions reader would produce different digests for one image.
+
+The contract lives in `tests/harness/contract.py` (T-W2), which is also the home of T-W4's
+recorder, T-W5's proxy fixture, T-W6's corpus loader and T-W8's bridge fixture.
 
 **Unknown fields fail closed.** Each reader must classify **every** key in the body into exactly
 one of: mapped to the envelope, mapped to the conversation, or residual. A non-empty `residual`
@@ -314,9 +351,122 @@ skips what it does not recognise is a reader that cannot prove completeness. Add
 wire format therefore forces a deliberate decision: map it, or declare it ignored with a reason.
 
 **Every register row names the field it touches.** M1 is `envelope.model`; P17 is
-`envelope.stream` and `envelope.store`; P15 is `conversation.tools[].strict`; P13 is
+`envelope.stream` and `envelope.store`; P15 is `conversation.tools[*].strict`; P13 is
 `conversation.sampling`. Without that, "claimed by a register row" is a judgement call rather
 than a lookup.
+
+#### 3.3.1a The path vocabulary
+
+T-W2 owns the string form, because it has **two** consumers that must agree exactly: a delta the
+oracle reports (§3.3.4), and the "projection field it touches" column of every register row
+(T-W3). Neither can define it without the other agreeing.
+
+| Path form | Names |
+|---|---|
+| `envelope.model` · `envelope.stream` · `envelope.store` | The named control fields |
+| `envelope.extra[<wire key>]` | A format-specific control field — P2a `thinking`, P3 `reasoning`, P4 `reasoning_effort`, P10 `reasoning_split` |
+| `conversation.system[<i>]` | One system text part |
+| `conversation.turns[<i>].role` · `.parts[<j>]` | A turn, or one part of it |
+| `conversation.tools[<name>].description` · `.schema` · `.strict` | A tool declaration, **by name** |
+| `conversation.sampling[<key>]` | One sampling parameter |
+| `conversation.turns` · `.system` · `.tools` · `.sampling` | A **whole collection** — M5 and M13 rewrite the turns, P5b joins the system blocks, §3.3.1 pins P13/P14 to the bare `sampling` |
+| `headers[<name>]` | A header — P9a, P9b, P9c, and §4.3 C1 |
+| `residual[<path>]` | An unclassified value |
+| `reply.parts[<i>]` · `reply.stop_reason` · `reply.usage[<key>]` | The response direction — M12, T-D10 |
+| `route.method` · `.scheme` · `.host` · `.path` · `.query` | The route (§3.3.5) — M14, P20, P21 |
+
+**Tools are addressed by name, not index**, because translators reorder and filter declarations; a
+positional path would report a delta whenever the order changed and the declaration did not.
+
+**Two kinds of path, and a matcher.** A register row writes a **pattern** with the `[*]` wildcard
+(`conversation.tools[*].strict` — every tool); a delta is **concrete**
+(`conversation.tools[get_weather].strict`). §3.3.2 assertion 1 is literally a match of one against
+the other, so T-W2 supplies the predicate rather than leaving T-W3 to write patterns and T-D1 a
+matcher that agree only by luck.
+
+**A pattern is a prefix.** It names its node and everything beneath it, at any depth — so a row
+anchored at `conversation.turns[*].parts[*]` claims
+`conversation.turns[2].parts[0].signature`, which is what M8's carrier repair produces.
+
+The rule is deliberately **asymmetric**, and the asymmetry is the reason to prefer it:
+under-claiming manufactures a *false* I1 breach, failing the run over a mutation that **is**
+registered; over-claiming is silent. So the error the matcher can make is the recoverable one — but
+it is recoverable only if the register is written carefully:
+
+> ⚠️ **A row must be anchored at the *narrowest* path that covers its effect.** A coarser anchor
+> silently claims every delta beneath it. Anchoring P15 at `conversation.tools[*]` rather than
+> `conversation.tools[*].strict` would claim a *deleted tool description* — which is one of
+> §3.3.1's own five oracle falsification cases. The matcher cannot catch that; **T-W3's anchoring
+> discipline and T-D3's falsification case (mutate a field beneath a registered anchor and assert
+> the oracle still fails) are what keep it honest.**
+
+**The prefix stops at a bracket.** Bracket contents are literal and are never re-parsed — which is
+what makes `residual[generationConfig.topK]` legal — so a pattern naming a *parent key* does not
+claim paths nested under it. `residual[generationConfig]` does **not** match
+`residual[generationConfig.topK]`; `residual[*]` and the bare `residual` both do. This is a second
+rule sitting beside the first and it is the one that surprises.
+
+`[*]` is the wildcard. `[]` is accepted as its **legacy spelling**, because §3.3.1 wrote P15 as
+`conversation.tools[].strict` before this vocabulary existed and a row carried over in the old
+notation must not silently match nothing. An unbalanced bracket **raises** rather than mis-splitting
+the path.
+
+**`not projectable` is a legal value for the register's field column, and it requires a reason.**
+P16 uses it — the `input_text`/`output_text` tag is redundant with the turn's role, so carrying it
+would put one vendor's spelling into a wire-independent form — as do the whole-body protocol
+translations M2, M9, P11 and P12. An empty cell would leave those rows silently unfalsifiable;
+an explicit value with a reason does not.
+
+#### 3.3.1b Normalisation rules the six readers share
+
+The claim that "a conversation is a conversation" holds only if six independently written readers
+agree on a canonical form. They are six separate tasks, so the agreement is part of the contract.
+
+- **Roles** are `user` or `assistant`, and nothing else. Gemini's `model` maps to `assistant`.
+- **System instructions lift into `Conversation.system`**, never into a turn — from a dedicated
+  field (Messages, Converse, Gemini `systemInstruction`), a `role: "system"` message, a
+  `role: "developer"` message, or Responses' `instructions` field.
+- **A tool result is a `ToolResult` part inside a `user` turn**, by a **merge rule**: a maximal run
+  of consecutive tool results forms one turn; an immediately following non-tool user message merges
+  into it; `ToolResult` parts come first; consecutive same-role turns merge. *An orphan tool result
+  still projects, in the turn where it occurred* — M7 exists to drop orphans, so a reader that
+  raised on one would fail instead of producing the delta that names it.
+
+  A lift rule ("into the user turn that follows the assistant turn") does **not** work: the standard
+  Chat Completions exchange ends `assistant(tool_calls) → tool → tool`, with no following user
+  message at all. And because paths are index-based, any disagreement about turn boundaries reports
+  a delta on *every* subsequent turn.
+- **`modelId` and Azure's deployment id normalise onto `envelope.model`**, or P18 and P6/P20 cannot
+  be expressed as `envelope.model` and a *moved* field looks *dropped*.
+- **Sampling normalises to the Chat Completions spelling**, onto this **closed set of fifteen** —
+  the fourteen P13 drops, plus `top_k`, which Gemini and Converse carry and Chat Completions does
+  not:
+
+  `temperature` · `top_p` · `top_k` · `max_tokens` · `max_completion_tokens` ·
+  `frequency_penalty` · `presence_penalty` · `logprobs` · `top_logprobs` · `response_format` ·
+  `stop` · `n` · `stream_options` · `seed` · `logit_bias`
+
+  Responses' `max_output_tokens` maps onto `max_tokens`; `max_completion_tokens` stays distinct,
+  because P13 drops it in its own right, so a reader must not collapse both. A key outside the set
+  that the reader **recognises as a declared control field of that format** maps to
+  `envelope.extra[<wire key>]` — only an *unrecognised* key residualises. Without that split,
+  Gemini's `generationConfig.responseSchema` and Converse's `guardrailConfig` would fail the run as
+  unaccounted fields, on the two formats the CC-shaped set was not derived from.
+
+  The set is **enforced**, not merely declared: `Conversation` rejects a non-canonical sampling key
+  the way `Turn` rejects a role outside `user`/`assistant`. Six readers cannot quietly disagree
+  about whether `n` is sampling.
+- **`tool_choice`** unifies four wire keys — CC/Messages `tool_choice`, Converse's
+  `toolConfig.toolChoice`, Gemini's `functionCallingConfig.mode` — onto
+  `envelope.extra["tool_choice"]`, with the **value** normalised to `auto` · `any` · `none` ·
+  `tool:<name>`. This is the one deliberate exception to keying `extra` by the wire key, because
+  four spellings name one concept.
+- **On the response direction**, `stop_reason` is `end_turn` · `max_tokens` · `stop_sequence` ·
+  `tool_use` · `error` · `other`, where `other` carries the original string in
+  `residual["stop_reason"]` — Gemini adds `SAFETY` and `RECITATION`, and a closed set with no escape
+  would fail the run on a legitimate safety-blocked reply. **`usage` is carried but excluded from
+  the diff**: it is provider-reported, never agent-supplied, so a difference carries no I1
+  information.
 
 Then write one **hand-written reader per wire format** — Anthropic Messages, Chat Completions,
 OpenAI Responses, Gemini, Bedrock Converse, Ollama `/api/chat` — each written directly against
@@ -1597,13 +1747,41 @@ output.
 requests**, not bodies:
 
 ```
-CapturedRequest(method, scheme, host, path, query, headers, body)
+CapturedRequest(method, scheme, host, path, query, headers, body,
+                arrival?, peer_port?)      -- the last two are T-W4's to populate (§5.2.1)
+CapturedReply(status, headers, body)
+
+Projection      -- wire_format: WireFormat ; read_request(CapturedRequest) -> Request
+ReplyProjection -- wire_format: WireFormat ; read_reply(CapturedReply)    -> Reply
+
+verify_total(projected)                     -- the totality rule; Request or Reply
 
 assert_no_unclaimed_mutation(inbound:  CapturedRequest, inbound_format,
                              captured: CapturedRequest, captured_format,
                              register, triggers_met,
                              expected_route)   # derived from the profile, independently
 ```
+
+`WireFormat` is a **closed** enumeration of the six formats above. §7.4 already notes that a
+boolean declaration cannot select among six projections; a bare string has the opposite failure,
+where six reader authors spell one format three ways and the format-keyed lookup silently misses.
+
+**Two protocols, not one with two methods.** §3.3.1 makes response translation "a different claim
+[that] gets a different test", and the plan splits the work as six request readers (T-A1–T-A6)
+against one reply task (T-A7) with its own comparison (T-D10).
+
+**`arrival` and `peer_port` sit on `CapturedRequest` but belong to T-W4.** They serve containment's
+tunnel join (§5.2.1), and no fidelity assertion reads them. They live on the shared type rather than
+on a T-W4 subclass so that T-W4, T-B1–T-B3 and T-E2 consume one type instead of two.
+
+**Projection values are not hashable** — `__hash__` is set to `None` on every one, deliberately, so
+the limitation is total rather than data-dependent. §3.3.3's counterpart matching must therefore be
+an **order-aware multiset** match, not a set difference: a set-based implementation would pass on
+text-only fixtures and raise on the first corpus entry carrying a `ToolUse`. Capture types *are*
+hashable; only projections are not.
+
+**A body that cannot be read raises `UnreadableBodyError`**, named in the contract so that T-C6's
+malformed corpus entry is distinguishable from an I1 breach without catching bare `Exception`.
 
 **Bodies alone cannot prove correct routing** (§3.3.5). Both formats are supplied by the harness
 from the observed wire shape (§3.3.4), never read from the adapter's own declaration. That

--- a/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
+++ b/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
@@ -122,8 +122,10 @@ query, headers, body)`**, `CapturedReply`, the closed `WireFormat` enum, the `Pr
 `ReplyProjection` protocols, **the path vocabulary and its pattern matcher (§3.3.1a)**, and **the
 cross-format normalisation rules (§3.3.1b)**.
 
-**Delivered in `tests/harness/contract.py`**, which is also the home for T-W4's recorder, T-W5's
-proxy fixture, T-W6's corpus loader and T-W8's bridge fixture.
+**Delivered in `tests/harness/contract.py`.** The **package** `tests/harness/` is the home for
+T-W4's recorder, T-W5's proxy fixture, T-W6's corpus loader and T-W8's bridge fixture — each in its
+own module beside the contract, not inside it. `contract.py` defines shapes and rules; it captures
+nothing and reads no bodies.
 
 **The path vocabulary and the normalisation rules were added after a design review**, and both are
 here for the reason `CapturedRequest` is: T-W3 cannot fill its "projection field it touches" column

--- a/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
+++ b/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
@@ -470,7 +470,7 @@ exist, and the plan should not offer it.
    a design review established that without the path vocabulary T-W3 cannot be written and without
    the normalisation rules the six readers produce incomparable output, so both moved into it. The
    day that added is on every chain (§14.3), and it is the cheapest place in the plan to spend it:
-   the alternative is ten tasks each solving the same problem differently.
+   the alternative is eleven tasks each solving the same problem differently.
 2. **T-W3 and T-W6 follow immediately** — they sit second and third on the critical path, ahead of
    any test.
 3. **T-E1 is the riskiest single task**; containment carries ~5 days of slack against the critical

--- a/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
+++ b/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
@@ -94,7 +94,7 @@ After Milestone 0, seven streams advance independently, each owning its own modu
 | ID | Task | Depends on | Design | Size |
 |---|---|---|---|---|
 | **T-W1** | Layer markers, CI selection rules, per-category collection checks | — | §8 | M |
-| **T-W2** | **The input contract** — request/capture types and the projection protocol | — | §3.3.1 | S |
+| **T-W2** | **The input contract** — request/capture types, the projection protocol, the path vocabulary and the normalisation rules | — | §3.3.1, §3.3.1a, §3.3.1b | ~~S~~ **M** |
 | **T-W3** | Register schema and data | T-W2 | §3.2 | M |
 | **T-W4** | Recorder implementation — primary aiohttp recorder | T-W2 | §7.2 | M |
 | **T-W5** | Shared CONNECT proxy fixture | — | §7.3 | M |
@@ -116,9 +116,34 @@ tests exist the expression collects them and passes happily with zero agent-smok
 reconcile the existing `--runslow` silent skip with the same rule.
 
 **T-W2 — the input contract.** One owner for everything a projection reads and a recorder produces:
-`Request(envelope, conversation, residual)`, `Envelope`, `Conversation`, `Turn`, `Part` variants,
-`Reply` for the response direction, **`CapturedRequest(method, scheme, host, path, query, headers,
-body)`**, and the `Projection` protocol.
+`Request(envelope, conversation, residual, consumed, source)`, `Envelope`, `Conversation`, `Turn`,
+`Part` variants, `Reply` for the response direction, **`CapturedRequest(method, scheme, host, path,
+query, headers, body)`**, `CapturedReply`, the closed `WireFormat` enum, the `Projection` and
+`ReplyProjection` protocols, **the path vocabulary and its pattern matcher (§3.3.1a)**, and **the
+cross-format normalisation rules (§3.3.1b)**.
+
+**Delivered in `tests/harness/contract.py`**, which is also the home for T-W4's recorder, T-W5's
+proxy fixture, T-W6's corpus loader and T-W8's bridge fixture.
+
+**The path vocabulary and the normalisation rules were added after a design review**, and both are
+here for the reason `CapturedRequest` is: T-W3 cannot fill its "projection field it touches" column
+without a path form, and T-D1 must emit the same strings when it reports a delta — neither can
+define the vocabulary without the other agreeing. Likewise six readers written by six authors
+produce incomparable output unless the canonical roles, placements and sampling spellings are fixed
+once. Both are exactly the coordination problem Milestone 0 exists to remove.
+
+**T-W3 inherits two acceptance criteria from this work.**
+
+1. Every row M1–M14 and P1–P21 carries either a path in T-W2's vocabulary or `not projectable`
+   **with a reason**, asserted against the register data so a new row cannot escape it. T-W2 proves
+   the vocabulary is *expressive*; the row-by-row assignment is T-W3's, because a copy of that
+   table inside T-W2 would be a second source of truth that stays green while the register moves.
+2. **Every row is anchored at the *narrowest* path that covers its effect.** A pattern is a prefix
+   (§3.3.1a), so a coarser anchor silently claims every delta beneath it — anchoring P15 at
+   `conversation.tools[*]` rather than `conversation.tools[*].strict` would claim a *deleted tool
+   description*, which is one of §3.3.1's own five oracle falsification cases. The matcher cannot
+   detect this, by construction; **T-D3 gains the paired falsification case** — mutate a field
+   beneath a registered row's anchor and assert the oracle still fails.
 
 **`CapturedRequest` lives here, not in T-W4.** An earlier draft titled this task "request/capture types" while T-W4 defined `CapturedRequest` with no dependency between them — so the recorder author and the Gemini reader author (who needs the URL, §3.3.5) could have started against two different readings of the same contract. That is precisely the coordination problem Milestone 0 exists to remove.
 
@@ -233,7 +258,7 @@ matrix, serialising unrelated provider coverage.
 |---|---|---|---|---|---|
 | **T-D1** | Oracle core **+ first falsification case** | T-W2, T-W3, T-W8, T-W9, T-A1, T-A2, T-C1 | Both §3.3.2 assertions on one adapter; accepts `expected_route` so T-D2 is a filling-in; includes the byte-level key-order assertion on the native passthrough path; **a changed model must fail the oracle** | §3.3, §4.3 C2 | L |
 | **T-D2** | Routing expectation **+ its falsification** | T-D1, T-A4 | Route derived from the profile using the provider's *published* URL shape, never `build_base_url()`; a changed Azure deployment segment with a byte-identical body must fail | §3.3.5 | M |
-| **T-D3** | Remaining falsification cases | T-D1, T-D2 | Flipped `stream`, deleted tool description, stripped `strict`, injected metadata field. **Hard prerequisite for T-J2** — the oracle does not gate acceptance until its falsification suite is complete | §3.3.1 | M |
+| **T-D3** | Remaining falsification cases | T-D1, T-D2 | Flipped `stream`, deleted tool description, stripped `strict`, injected metadata field, **plus a mutation *beneath* a registered row's anchor** (§3.3.1a — a pattern is a prefix, so an over-coarse anchor silently claims what it should not, and only this case catches it). **Hard prerequisite for T-J2** — the oracle does not gate acceptance until its falsification suite is complete | §3.3.1, §3.3.1a | M |
 | **T-D4** | Default-transport slice | T-D1, T-D2, T-B4 | One representative default adapter, end to end | §3.3.4 | M |
 | **T-D5** | curl_cffi slice | T-D1, T-D2, T-B2, T-A3 | `openai_subscription`, observing P13–P17 | §3.3.2 | M |
 | **T-D6** | botocore slice | T-D1, T-D2, T-B3, T-A5 | `bedrock`, observing the Converse payload after P18 | §3.3.2 | M |
@@ -413,11 +438,17 @@ available in tiers 0–2.**
 
 | Milestone | Longest chain to it | Days |
 |---|---|---|
-| Oracle core proven (**T-D1**) | T-W2 → T-W3 → T-W6 → T-C1 → T-D1 | 8.0 |
-| Containment slice proven (**T-E2**) | T-W2 → T-W4 → T-W8 → T-W9 → T-E1 → T-E2 | 12.0 |
-| Fidelity matrix complete (**T-D9**) | … → T-D1 → T-D2 → T-D4 → T-D9 | 15.0 |
-| Fidelity acceptance (**T-J2**) | … → T-D9 → T-J2 | 16.5 |
-| **Everything gating (T-K9)** | … → T-J2 → T-K9 | **17.0** |
+| Oracle core proven (**T-D1**) | T-W2 → T-W3 → T-W6 → T-C1 → T-D1 | 9.0 |
+| Containment slice proven (**T-E2**) | T-W2 → T-W4 → T-W8 → T-W9 → T-E1 → T-E2 | 13.0 |
+| Fidelity matrix complete (**T-D9**) | … → T-D1 → T-D2 → T-D4 → T-D9 | 16.0 |
+| Fidelity acceptance (**T-J2**) | … → T-D9 → T-J2 | 17.5 |
+| **Everything gating (T-K9)** | … → T-J2 → T-K9 | **18.0** |
+
+> **Recomputed 2026-09-07.** T-W2 was **S** and is now **M** (§3, and KBR-25's requirements §0.3):
+> the path vocabulary and the normalisation rules were added to it after a design review. T-W2
+> heads every chain above, so **each gained 1.0 day**. §14 opens with "recompute after any
+> dependency change"; a size change on the head of every chain is one. No ordering changed — T-W2
+> was already first and alone.
 
 **The critical path runs through the corpus**, not through containment:
 `T-W2 → T-W3 → T-W6 → T-C1 → T-D1 → T-D2 → T-D4 → T-D9 → T-J2 → T-K9`. Four sequential tasks
@@ -434,8 +465,12 @@ exist, and the plan should not offer it.
 
 ### 14.4 Consequences worth acting on
 
-1. **T-W2 is the single most blocking task.** It heads both chains, it is sized S, and it now owns
-   the whole input contract (§3). It goes first, alone, and lands before the streams branch.
+1. **T-W2 is the single most blocking task.** It heads both chains and it owns the whole input
+   contract (§3). It goes first, alone, and lands before the streams branch. **Sized M, not S** —
+   a design review established that without the path vocabulary T-W3 cannot be written and without
+   the normalisation rules the six readers produce incomparable output, so both moved into it. The
+   day that added is on every chain (§14.3), and it is the cheapest place in the plan to spend it:
+   the alternative is ten tasks each solving the same problem differently.
 2. **T-W3 and T-W6 follow immediately** — they sit second and third on the critical path, ahead of
    any test.
 3. **T-E1 is the riskiest single task**; containment carries ~5 days of slack against the critical

--- a/tests/harness/__init__.py
+++ b/tests/harness/__init__.py
@@ -1,0 +1,23 @@
+"""Shared test infrastructure for the fidelity, containment and corpus suites.
+
+`.system_design/TEST_SUITE.md` §7 · plan **Milestone 0**.
+
+This package is the home of the infrastructure several streams share, rather
+than each stream's own tests:
+
+- :mod:`harness.contract` — the input contract (T-W2): the types every wire
+  projection reads, every recorder produces, and the oracle compares.
+- T-W4's recording upstreams, T-W5's CONNECT proxy fixture, T-W6's corpus
+  loader and T-W8's bridge fixture land here alongside it.
+
+**Why a package and not loose modules.**  ``tests/`` has no ``__init__.py``, so
+pytest inserts ``tests/`` onto ``sys.path`` and these modules import as
+``harness.<name>`` — the same mechanism ``tests/bridge/`` relies on.  That works
+under **bare** ``pytest``, which is what CI runs; ``python -m pytest`` would also
+put the working directory on the path and hide a mistake here.  Adding a
+``tests/__init__.py`` would break it, exactly as
+``tests/internal_key_scan.py``'s docstring warns.
+
+The house rule that test modules are self-contained still holds: it governs
+*test* modules importing each other, not shared support modules like these.
+"""

--- a/tests/harness/contract.py
+++ b/tests/harness/contract.py
@@ -299,6 +299,45 @@ REDACTED_HEADERS = frozenset(
 REDACTED_QUERY_KEYS = frozenset({"key", "api_key", "access_token"})
 
 
+def _normalised_headers(headers: Any) -> tuple[tuple[str, str], ...]:
+    """Return ``headers`` as validated name/value pairs.
+
+    Shared by :class:`CapturedRequest` and :class:`CapturedReply`. It is a
+    function rather than a copy in each ``__post_init__`` because the two copies
+    it replaces both carried the same defect: a bug found in one was, silently,
+    a bug in the other.
+
+    Args:
+        headers: The value given for a capture's ``headers`` field.
+
+    Returns:
+        The header pairs, order and casing untouched.
+
+    Raises:
+        TypeError: When ``headers`` is a mapping, when any entry is a string or
+            bytes, or when any entry is not a name/value pair.
+    """
+    if isinstance(headers, Mapping):
+        raise TypeError("headers must be a sequence of (name, value) pairs, not a mapping")
+
+    # Materialise once. Iterating twice would consume a generator on the first
+    # pass and leave the second seeing nothing -- storing no headers at all,
+    # silently, from a guard whose whole purpose is to fail loudly.
+    entries = tuple(headers)
+
+    # A string is a sequence too, so `tuple("ab")` is a *valid-looking* 2-tuple
+    # of characters. Rejecting the type is the only check that catches it; a
+    # length check cannot.
+    if any(isinstance(entry, str | bytes) for entry in entries):
+        raise TypeError("each header must be a (name, value) pair, not a string")
+
+    pairs = tuple(tuple(entry) for entry in entries)
+    if any(len(pair) != 2 for pair in pairs):
+        raise TypeError("each header must be a (name, value) pair")
+
+    return pairs
+
+
 def _redact_headers(headers: Sequence[tuple[str, str]]) -> str:
     """Render header pairs with credential values masked.
 
@@ -383,19 +422,7 @@ class CapturedRequest:
                 shredded into character tuples and the header evidence §4.3 C1
                 asserts on would be gone. Failing loudly is the point.
         """
-        if isinstance(self.headers, Mapping):
-            raise TypeError("headers must be a sequence of (name, value) pairs, not a mapping")
-
-        # A string is a sequence too, so `tuple("ab")` is a *valid-looking*
-        # 2-tuple of characters. Rejecting the type is the only check that
-        # catches it; a length check cannot.
-        if any(isinstance(entry, str | bytes) for entry in self.headers):
-            raise TypeError("each header must be a (name, value) pair, not a string")
-
-        pairs = tuple(tuple(h) for h in self.headers)
-        if any(len(pair) != 2 for pair in pairs):
-            raise TypeError("each header must be a (name, value) pair")
-        object.__setattr__(self, "headers", pairs)
+        object.__setattr__(self, "headers", _normalised_headers(self.headers))
 
     def __repr__(self) -> str:
         """Render the capture with credentials masked.
@@ -441,19 +468,7 @@ class CapturedReply:
                 shredded into character tuples and the header evidence §4.3 C1
                 asserts on would be gone. Failing loudly is the point.
         """
-        if isinstance(self.headers, Mapping):
-            raise TypeError("headers must be a sequence of (name, value) pairs, not a mapping")
-
-        # A string is a sequence too, so `tuple("ab")` is a *valid-looking*
-        # 2-tuple of characters. Rejecting the type is the only check that
-        # catches it; a length check cannot.
-        if any(isinstance(entry, str | bytes) for entry in self.headers):
-            raise TypeError("each header must be a (name, value) pair, not a string")
-
-        pairs = tuple(tuple(h) for h in self.headers)
-        if any(len(pair) != 2 for pair in pairs):
-            raise TypeError("each header must be a (name, value) pair")
-        object.__setattr__(self, "headers", pairs)
+        object.__setattr__(self, "headers", _normalised_headers(self.headers))
 
     def __repr__(self) -> str:
         """Render the reply with credentials masked.

--- a/tests/harness/contract.py
+++ b/tests/harness/contract.py
@@ -3,7 +3,7 @@
 `.system_design/TEST_SUITE.md` §3.3.1 · plan task **T-W2** (KBR-25).
 
 This module is the single owner of the vocabulary the fidelity oracle is
-written in.  Ten tasks depend on it: the register (T-W3), the recorder (T-W4),
+written in.  Eleven tasks depend on it: the register (T-W3), the recorder (T-W4),
 the vertical slice (T-W9), the six wire readers (T-A1–T-A6), the reply
 projection (T-A7) and the oracle core (T-D1).
 
@@ -644,7 +644,27 @@ class Envelope:
     __hash__ = None  # type: ignore[assignment]
 
     def __post_init__(self) -> None:
-        """Freeze the extra mapping in place."""
+        """Validate any tool choice and freeze the extra mapping.
+
+        ``extra`` is otherwise open by design — it holds whatever control
+        fields a format defines, keyed by the wire key. ``tool_choice`` is the
+        one entry with a *canonical* value (R8.6), so it is the one entry worth
+        checking; leaving it unchecked would make :data:`TOOL_CHOICE_VALUES` a
+        comment rather than a rule.
+
+        Raises:
+            ValueError: When ``extra["tool_choice"]`` is outside
+                :data:`TOOL_CHOICE_VALUES` and is not a ``tool:<name>``
+                selection.
+        """
+        choice = (self.extra or {}).get(TOOL_CHOICE_KEY)
+        if choice is not None and not (
+            choice in TOOL_CHOICE_VALUES or (isinstance(choice, str) and choice.startswith("tool:"))
+        ):
+            raise ValueError(
+                f"tool_choice must be one of {sorted(TOOL_CHOICE_VALUES)} or 'tool:<name>', got {choice!r}"
+            )
+
         object.__setattr__(self, "extra", _freeze_mapping(self.extra))
 
 
@@ -714,7 +734,20 @@ class Reply:
     __hash__ = None  # type: ignore[assignment]
 
     def __post_init__(self) -> None:
-        """Freeze every sequence and mapping."""
+        """Validate the stop reason and freeze every sequence and mapping.
+
+        Raises:
+            ValueError: When ``stop_reason`` is outside :data:`STOP_REASONS`.
+                Closed means enforced, the same posture :class:`Turn` takes on
+                roles and :class:`Conversation` on sampling keys — a vocabulary
+                declared closed but checked nowhere is a comment, not a rule.
+        """
+        if self.stop_reason is not None and self.stop_reason not in STOP_REASONS:
+            raise ValueError(
+                f"stop_reason must be one of {sorted(STOP_REASONS)}, got {self.stop_reason!r}; "
+                "an unmapped wire value projects as 'other' with the original in stop_reason_raw"
+            )
+
         object.__setattr__(self, "parts", tuple(self.parts))
         object.__setattr__(self, "usage", _freeze_mapping(self.usage))
         object.__setattr__(self, "residual", _freeze_mapping(self.residual))

--- a/tests/harness/contract.py
+++ b/tests/harness/contract.py
@@ -1,0 +1,1210 @@
+"""The input contract — everything a wire projection reads and a recorder produces.
+
+`.system_design/TEST_SUITE.md` §3.3.1 · plan task **T-W2** (KBR-25).
+
+This module is the single owner of the vocabulary the fidelity oracle is
+written in.  Ten tasks depend on it: the register (T-W3), the recorder (T-W4),
+the vertical slice (T-W9), the six wire readers (T-A1–T-A6), the reply
+projection (T-A7) and the oracle core (T-D1).
+
+**It imports nothing from ``src/kitty``, and must not.**  §3.3.1's
+independent-oracle rule: "The oracle must not be written in terms of the code
+under test."  A projection that asked kitty how to read a body would inherit
+kitty's bugs and the whole of I1 would prove only self-consistency.
+``test_contract.py`` asserts the absence structurally.
+
+**What lives here and what does not.**  This module defines *shapes and rules*.
+It reads no bodies — the six readers do that, each against its format's
+published examples.  It captures nothing — the recorders do that.  It asserts
+nothing about kitty — the oracle does that.
+
+**The totality rule is the load-bearing part.**  §3.3.1 requires every key in a
+body to be classified into the envelope, the conversation, or the residual, and
+makes a non-empty residual fail the run.  :func:`verify_total` enforces it, and
+the reason it needs :attr:`Request.consumed` rather than just checking the
+residual is worth stating: *a reader that **drops** an unknown key produces an
+empty residual and would sail through.*  Totality is decidable only against the
+source body, so a reader must declare what it claimed to handle.  That is
+exactly the falsification case plan §1.4 requires this harness to ship with.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from enum import Enum
+from types import MappingProxyType
+from typing import Any, Protocol, runtime_checkable
+
+# --------------------------------------------------------------------------
+# Wire formats
+# --------------------------------------------------------------------------
+
+
+class WireFormat(Enum):
+    """The six wire formats §3.3.1 names, and no others.
+
+    Closed deliberately.  §7.4 notes that "a **boolean** declaration cannot
+    select among the six projections"; a bare ``str`` has the opposite failure,
+    where six reader authors spell one format three ways and the oracle's
+    format-keyed lookup silently misses.
+    """
+
+    ANTHROPIC_MESSAGES = "anthropic_messages"
+    CHAT_COMPLETIONS = "chat_completions"
+    OPENAI_RESPONSES = "openai_responses"
+    GEMINI = "gemini"
+    BEDROCK_CONVERSE = "bedrock_converse"
+    OLLAMA_CHAT = "ollama_chat"
+
+
+# --------------------------------------------------------------------------
+# Immutability helpers
+# --------------------------------------------------------------------------
+
+
+def _freeze_mapping(value: Mapping[str, Any] | None) -> Mapping[str, Any]:
+    """Return an unmodifiable view over a **shallow** copy of ``value``.
+
+    ``frozen=True`` blocks rebinding a field but not mutation *through* it, so a
+    plain ``dict`` field would leave the oracle able to alter what it compares.
+
+    **The freeze is deliberately shallow.**  Recursively freezing (dict to
+    ``MappingProxyType``, list to tuple) would close the last level, but it
+    changes *equality*: ``arguments == {"a": [1, 2]}`` becomes false once the
+    list is a tuple.  The six readers are specified to test against each
+    format's published examples, which are dict and list literals — so every one
+    of them would have to compare against a bespoke frozen form instead.  Not
+    mutating the JSON leaves is therefore a convention the oracle keeps, not a
+    guarantee this type enforces.
+
+    Args:
+        value: The mapping to freeze, or ``None`` for an empty one.
+
+    Returns:
+        A read-only mapping proxy over a shallow copy.
+    """
+    return MappingProxyType(dict(value or {}))
+
+
+def _frozen_field() -> Any:
+    """Return a dataclass field defaulting to an empty frozen mapping.
+
+    Returns:
+        A ``dataclasses.field`` with a frozen-mapping default factory.
+    """
+    return field(default_factory=lambda: _freeze_mapping(None))
+
+
+# --------------------------------------------------------------------------
+# Part variants
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Text:
+    """A run of plain text.
+
+    Carries no content-type tag.  P16 rewrites Responses' ``input_text`` to
+    ``output_text``, but that tag is redundant with :attr:`Turn.role` on that
+    path, so carrying it would put one vendor's spelling into a form whose
+    purpose is wire independence.  P16 is unconditional and therefore exempt
+    from §3.3.2 assertion 2; its guards are the Responses reader's own L1 test
+    and T-G4.
+
+    Attributes:
+        text: The text content, empty string included.
+    """
+
+    text: str
+
+    # Every projection type sets this, so unhashability is total rather than
+    # data-dependent — see the module note on multiset matching. It survives
+    # `@dataclass` only because none of these classes defines `__eq__` in its
+    # own body; adding one would silently restore a working `__hash__`.
+    __hash__ = None  # type: ignore[assignment]
+
+
+@dataclass(frozen=True)
+class ToolUse:
+    """A tool call the assistant made.
+
+    Attributes:
+        id: The call id, or ``None`` where the format carries none. Gemini's
+            ``functionCall`` is ``{name, args}`` with no id, so a required id
+            would force T-A4 to synthesise one and show a delta on every tool
+            turn.
+        name: The tool's name.
+        arguments: The parsed arguments. Chat Completions encodes these as a
+            JSON *string* and Messages as an object; normalising here stops a
+            spurious delta on every cross-format comparison.
+    """
+
+    name: str
+    arguments: Mapping[str, Any] = _frozen_field()
+    id: str | None = None
+
+    __hash__ = None  # type: ignore[assignment]
+
+    def __post_init__(self) -> None:
+        """Freeze the arguments mapping in place."""
+        object.__setattr__(self, "arguments", _freeze_mapping(self.arguments))
+
+
+@dataclass(frozen=True)
+class Json:
+    """A structured tool result.
+
+    Bedrock Converse's ``toolResult.content`` union has ``json`` as its common
+    case and Gemini's ``functionResponse.response`` is a bare struct, so a
+    text-only result type would discard the usual payload entirely.
+
+    Attributes:
+        value: The parsed JSON value. Typed ``Any`` rather than ``Mapping``
+            because a Chat Completions tool message may carry a JSON *array*,
+            while Converse's ``json`` and Gemini's ``response`` are objects.
+            Not frozen — see :func:`_freeze_mapping` on why nesting is held by
+            convention rather than enforced.
+    """
+
+    value: Any = None
+
+    __hash__ = None  # type: ignore[assignment]
+
+
+@dataclass(frozen=True)
+class Opaque:
+    """Content the grammar does not model, kept detectable rather than dropped.
+
+    Covers Converse's ``document``/``video``/``searchResult`` and Anthropic's
+    ``document``/``search_result``.  Unlike a content-type tag on :class:`Text`,
+    this names content the grammar *cannot* express — without it the content
+    vanishes from both sides identically and the "no unclaimed delta" assertion
+    passes over a real loss.
+
+    Attributes:
+        kind: A canonical snake_case name, never the wire's spelling. Anthropic
+            writes ``search_result`` and Converse ``searchResult`` for one
+            thing; the wire spellings would be a permanent unclaimed delta.
+        digest: A content digest, as for :class:`Image`.
+    """
+
+    kind: str
+    digest: str | None = None
+
+    __hash__ = None  # type: ignore[assignment]
+
+
+@dataclass(frozen=True)
+class Image:
+    """An image, identified by digest rather than carried as bytes.
+
+    Attributes:
+        digest: Lowercase hex SHA-256 of the *decoded* image bytes, or ``None``
+            when the format carries a reference instead. ``media_type`` is
+            deliberately **not** part of the digest, so a changed media type is
+            its own delta rather than an unexplained digest change.
+        media_type: The declared media type, when the format states one.
+        ref: The URI, for Gemini's ``fileData.fileUri`` which carries no bytes.
+    """
+
+    digest: str | None = None
+    media_type: str | None = None
+    ref: str | None = None
+
+    __hash__ = None  # type: ignore[assignment]
+
+
+@dataclass(frozen=True)
+class Thinking:
+    """An extended-thinking block.
+
+    An *empty* block is a part with an empty string, never nothing: P5e injects
+    ``{"type":"thinking","thinking":""}`` and P8 an empty ``reasoning_content``.
+    P8's trigger is conditional and *inferred*, so §3.3.2 assertion 2 needs its
+    absence to be observable.
+
+    Attributes:
+        text: The thinking text, empty string included.
+        signature: Anthropic's ``signature`` or Gemini's ``thoughtSignature`` —
+            what M8's carrier repair manipulates.
+    """
+
+    text: str
+    signature: str | None = None
+
+    __hash__ = None  # type: ignore[assignment]
+
+
+@dataclass(frozen=True)
+class ToolResult:
+    """The result of a tool call, as a part inside a ``user`` turn.
+
+    Attributes:
+        tool_use_id: The id of the call this answers, or ``None`` where the
+            format carries none. When absent, pairing is by tool name and the
+            k-th unanswered call of that name in the most recent assistant turn.
+        content: Ordered content. Not recursive: no format nests a tool call
+            inside a tool result.
+        is_error: Whether the tool reported failure.
+    """
+
+    content: Sequence[Text | Image | Json | Opaque] = ()
+    tool_use_id: str | None = None
+    is_error: bool = False
+
+    __hash__ = None  # type: ignore[assignment]
+
+    def __post_init__(self) -> None:
+        """Freeze the content sequence in place."""
+        object.__setattr__(self, "content", tuple(self.content))
+
+
+#: Every :data:`Part` variant, as a tuple for ``isinstance`` and for the guard
+#: that asserts the union has not silently grown.
+PART_TYPES = (Text, ToolUse, ToolResult, Thinking, Image, Json, Opaque)
+
+Part = Text | ToolUse | ToolResult | Thinking | Image | Json | Opaque
+
+
+# --------------------------------------------------------------------------
+# Captures
+# --------------------------------------------------------------------------
+
+#: What a redacted value is replaced by in a ``repr``. Masking to *nothing*
+#: would hide a missing-credential bug as effectively as a leak hides a present
+#: one, so the mask is visible.
+REDACTION_MASK = "<redacted>"
+
+#: Header names whose values never appear in a ``repr``, lowercased for
+#: case-insensitive matching. The five recorders (§7.2) will see every one of
+#: these: ``x-api-key`` from Anthropic, ``api-key`` from Azure and P9b's MiMo,
+#: ``x-goog-api-key`` from Gemini, ``authorization`` from Vertex's OAuth leg and
+#: ``proxy-authorization`` from the CONNECT legs (§5.2.1).
+REDACTED_HEADERS = frozenset(
+    {"authorization", "proxy-authorization", "x-api-key", "api-key", "x-goog-api-key", "cookie", "set-cookie"}
+)
+
+#: Query-string keys whose values never appear in a ``repr``. Gemini carries its
+#: credential in the URL, which :attr:`CapturedRequest.query` preserves verbatim.
+REDACTED_QUERY_KEYS = frozenset({"key", "api_key", "access_token"})
+
+
+def _redact_headers(headers: Sequence[tuple[str, str]]) -> str:
+    """Render header pairs with credential values masked.
+
+    Args:
+        headers: Ordered header pairs, original casing preserved.
+
+    Returns:
+        A display string safe for a log or an assertion diff.
+    """
+    shown = [(n, REDACTION_MASK if n.lower() in REDACTED_HEADERS else v) for n, v in headers]
+    return repr(tuple(shown))
+
+
+def _redact_query(query: str) -> str:
+    """Render a raw query string with credential values masked.
+
+    Splits on ``&`` and ``=`` without a URL parser, because the raw string is
+    what was on the wire and re-encoding it would misrepresent the capture.
+
+    Args:
+        query: The raw query string as observed.
+
+    Returns:
+        A display string safe for a log or an assertion diff.
+    """
+    if not query:
+        return repr(query)
+
+    parts = []
+    for pair in query.split("&"):
+        name, sep, value = pair.partition("=")
+        parts.append(f"{name}{sep}{REDACTION_MASK}" if sep and name.lower() in REDACTED_QUERY_KEYS else pair)
+    return repr("&".join(parts))
+
+
+@dataclass(frozen=True)
+class CapturedRequest:
+    """A complete request as observed on the wire.
+
+    Bodies alone cannot prove correct routing (§3.3.5): on Azure the deployment
+    id lives in the path and P6 removes ``model`` from the body, so two requests
+    to two different deployments have byte-identical bodies.  The oracle
+    therefore takes the whole request.
+
+    The first seven fields are the contract T-W2 owns.  :attr:`arrival` and
+    :attr:`peer_port` are **T-W4's to populate** and §5.2.1's to consume — they
+    live here only so that T-W4, T-B1–T-B3 and T-E2 share one type instead of a
+    subclass; no fidelity assertion reads them.
+
+    Attributes:
+        method: HTTP method.
+        scheme: URL scheme.
+        host: URL host.
+        path: URL path, including Gemini's ``:generateContent`` operation.
+        query: The raw query string, unparsed and unreordered.
+        headers: Ordered pairs with original casing and duplicates preserved,
+            because §4.3 C1 asserts on the exact header set.
+        body: Raw body bytes, undecoded.
+        arrival: Arrival timestamp. T-W4's.
+        peer_port: Peer port of the accepted connection, the join key against
+            the proxy's tunnel log (§5.2.1). T-W4's.
+    """
+
+    method: str
+    scheme: str
+    host: str
+    path: str
+    query: str
+    headers: Sequence[tuple[str, str]] = ()
+    body: bytes = b""
+    arrival: float | None = None
+    peer_port: int | None = None
+
+    def __post_init__(self) -> None:
+        """Freeze the header sequence in place.
+
+        Raises:
+            TypeError: When ``headers`` is a mapping, or any entry is not a
+                name/value pair. R1.2 makes headers a sequence of pairs
+                precisely so duplicates and casing survive — but iterating a
+                mapping yields its *keys*, so a mapping would be silently
+                shredded into character tuples and the header evidence §4.3 C1
+                asserts on would be gone. Failing loudly is the point.
+        """
+        if isinstance(self.headers, Mapping):
+            raise TypeError("headers must be a sequence of (name, value) pairs, not a mapping")
+
+        pairs = tuple(tuple(h) for h in self.headers)
+        if any(len(pair) != 2 for pair in pairs):
+            raise TypeError("each header must be a (name, value) pair")
+        object.__setattr__(self, "headers", pairs)
+
+    def __repr__(self) -> str:
+        """Render the capture with credentials masked.
+
+        A dataclass ``repr`` reaches every pytest assertion diff and every CI
+        log.  §7.1 already flags this trap for the corpus and §5.4 mandates the
+        analogous property for ``EgressConfig``; a capture carries the same
+        class of secret.
+
+        Returns:
+            A display string with no credential values in it.
+        """
+        return (
+            f"CapturedRequest(method={self.method!r}, scheme={self.scheme!r}, host={self.host!r}, "
+            f"path={self.path!r}, query={_redact_query(self.query)}, headers={_redact_headers(self.headers)}, "
+            f"body={self.body!r}, arrival={self.arrival!r}, peer_port={self.peer_port!r})"
+        )
+
+
+@dataclass(frozen=True)
+class CapturedReply:
+    """A complete reply as observed on the wire, for :class:`ReplyProjection`.
+
+    Attributes:
+        status: HTTP status code.
+        headers: Ordered pairs with original casing preserved.
+        body: Raw body bytes. A streaming reply is reassembled before it
+            reaches a reply projection; reassembly is T-A7's boundary.
+    """
+
+    status: int
+    headers: Sequence[tuple[str, str]] = ()
+    body: bytes = b""
+
+    def __post_init__(self) -> None:
+        """Freeze the header sequence in place.
+
+        Raises:
+            TypeError: When ``headers`` is a mapping, or any entry is not a
+                name/value pair. R1.2 makes headers a sequence of pairs
+                precisely so duplicates and casing survive — but iterating a
+                mapping yields its *keys*, so a mapping would be silently
+                shredded into character tuples and the header evidence §4.3 C1
+                asserts on would be gone. Failing loudly is the point.
+        """
+        if isinstance(self.headers, Mapping):
+            raise TypeError("headers must be a sequence of (name, value) pairs, not a mapping")
+
+        pairs = tuple(tuple(h) for h in self.headers)
+        if any(len(pair) != 2 for pair in pairs):
+            raise TypeError("each header must be a (name, value) pair")
+        object.__setattr__(self, "headers", pairs)
+
+    def __repr__(self) -> str:
+        """Render the reply with credentials masked.
+
+        Returns:
+            A display string with no credential values in it.
+        """
+        return (
+            f"CapturedReply(status={self.status!r}, headers={_redact_headers(self.headers)}, body={self.body!r})"
+        )
+
+
+def image_digest(raw: bytes) -> str:
+    """Return the canonical digest of decoded image bytes.
+
+    Pinned so that six independently written readers agree.  Anthropic sends
+    base64 plus a media type, Chat Completions a data URL, Converse raw bytes
+    and Gemini either inline data or a URI — without one definition the Messages
+    reader and the Chat Completions reader would produce different digests for
+    the same image and §7.1's image corpus entry would fail on every run.
+
+    Args:
+        raw: The decoded image bytes. The media type is deliberately excluded,
+            so a changed media type shows as its own delta.
+
+    Returns:
+        Lowercase hex SHA-256 of ``raw``.
+    """
+    return hashlib.sha256(raw).hexdigest()
+
+
+# --------------------------------------------------------------------------
+# Conversation
+# --------------------------------------------------------------------------
+
+#: The only two roles a projected turn may carry.  ``system``, ``developer`` and
+#: Responses' ``instructions`` all lift into :attr:`Conversation.system` instead
+#: of becoming turns (R8.2); Gemini's ``model`` maps to ``assistant``.  Closed,
+#: because an open vocabulary would let Gemini show an unclaimed delta on every
+#: assistant turn.
+ROLES = frozenset({"user", "assistant"})
+
+#: Canonical sampling parameter names, in the Chat Completions spelling.  The
+#: first fourteen are exactly what P13 drops; ``top_k`` is carried by Gemini and
+#: Converse and has no Chat Completions spelling.  Responses'
+#: ``max_output_tokens`` normalises onto ``max_tokens`` (R8.5), but
+#: ``max_completion_tokens`` stays distinct — P13 drops it in its own right.
+SAMPLING_KEYS = frozenset(
+    {
+        "temperature",
+        "top_p",
+        "top_k",
+        "max_tokens",
+        "max_completion_tokens",
+        "frequency_penalty",
+        "presence_penalty",
+        "logprobs",
+        "top_logprobs",
+        "response_format",
+        "stop",
+        "n",
+        "stream_options",
+        "seed",
+        "logit_bias",
+    }
+)
+
+#: Canonical stop reasons for the response direction.  ``other`` is the escape:
+#: Gemini adds ``SAFETY`` and ``RECITATION``, Anthropic has added values over
+#: time, and Ollama reports ``done_reason: load``.  Without it a legitimate
+#: safety-blocked reply would fail the run instead of projecting — the mistake
+#: R9.3 avoids on the request side.  An unmapped value projects as ``other``
+#: with the original string in ``Reply.residual["stop_reason"]``.
+STOP_REASONS = frozenset({"end_turn", "max_tokens", "stop_sequence", "tool_use", "error", "other"})
+
+
+@dataclass(frozen=True)
+class Turn:
+    """One conversational turn.
+
+    Attributes:
+        role: Either ``user`` or ``assistant`` (:data:`ROLES`).
+        parts: Ordered content. A tool result is a :class:`ToolResult` part
+            inside a ``user`` turn, which is Anthropic Messages' shape; Chat
+            Completions' separate ``role: "tool"`` messages merge into one turn.
+    """
+
+    role: str
+    parts: Sequence[Part] = ()
+
+    __hash__ = None  # type: ignore[assignment]
+
+    def __post_init__(self) -> None:
+        """Validate the role and freeze the parts sequence.
+
+        Raises:
+            ValueError: When ``role`` is outside :data:`ROLES`. Construction is
+                not parsing — T-D1 builds expected conversations by hand — so
+                this is a ``ValueError`` and not :class:`UnreadableBodyError`.
+        """
+        if self.role not in ROLES:
+            raise ValueError(f"role must be one of {sorted(ROLES)}, got {self.role!r}")
+        object.__setattr__(self, "parts", tuple(self.parts))
+
+
+@dataclass(frozen=True)
+class ToolDecl:
+    """A tool the agent declared.
+
+    Attributes:
+        name: The tool's name. Paths address tools by name, not index (R7.3).
+        description: The description, or ``None`` when absent. One oracle
+            falsification case deletes it (§3.3.1).
+        schema: The parameter schema, or ``None`` when absent.
+        strict: P15 strips this on the Responses-origin path. ``None`` means
+            absent, which must stay distinct from ``False`` or that row's
+            presence and absence would be indistinguishable.
+    """
+
+    name: str
+    description: str | None = None
+    schema: Mapping[str, Any] | None = None
+    strict: bool | None = None
+
+    __hash__ = None  # type: ignore[assignment]
+
+    def __post_init__(self) -> None:
+        """Freeze the schema mapping when one is present."""
+        if self.schema is not None:
+            object.__setattr__(self, "schema", _freeze_mapping(self.schema))
+
+
+@dataclass(frozen=True)
+class Conversation:
+    """The semantic content of a request, independent of any wire format.
+
+    Attributes:
+        system: Ordered system text, lifted here from whichever of the four
+            carriers the format uses (R8.2).
+        turns: Ordered turns.
+        tools: Ordered tool declarations.
+        sampling: Sampling parameters, keyed by :data:`SAMPLING_KEYS`.
+    """
+
+    system: Sequence[Text] = ()
+    turns: Sequence[Turn] = ()
+    tools: Sequence[ToolDecl] = ()
+    sampling: Mapping[str, Any] = _frozen_field()
+
+    __hash__ = None  # type: ignore[assignment]
+
+    def __post_init__(self) -> None:
+        """Freeze every sequence and validate the sampling keys.
+
+        Raises:
+            TypeError: When ``sampling`` is not a mapping.
+            ValueError: When a sampling key is outside :data:`SAMPLING_KEYS`.
+                The set is closed (§3.3.1b), and enforcing it here is what
+                stops a reader dropping a format's own control field into
+                ``sampling`` — Gemini's ``generationConfig`` members are the
+                likely accident. Validated the way :class:`Turn` validates its
+                role, rather than left as an unenforced reader obligation.
+        """
+        object.__setattr__(self, "system", tuple(self.system))
+        object.__setattr__(self, "turns", tuple(self.turns))
+        object.__setattr__(self, "tools", tuple(self.tools))
+
+        if not isinstance(self.sampling, Mapping):
+            raise TypeError("sampling must be a mapping of canonical key to value")
+
+        unknown = sorted(set(self.sampling) - SAMPLING_KEYS)
+        if unknown:
+            raise ValueError(
+                f"sampling keys must be canonical (§3.3.1b); {unknown} are not. "
+                "A recognised control field of the format belongs in envelope.extra; "
+                "an unrecognised key belongs in the residual."
+            )
+        object.__setattr__(self, "sampling", _freeze_mapping(self.sampling))
+
+
+@dataclass(frozen=True)
+class Envelope:
+    """Routing and control fields.
+
+    Attributes:
+        model: M1 replaces this; P6 removes it from the body and P20 moves it
+            into the URL; Converse's ``modelId`` normalises onto it (R8.4).
+        stream: P17 injects it, M11 forces it false, P18 and P19 rewrite it.
+        store: P17 injects it.
+        extra: Every other control field the format defines, **keyed by the wire
+            key**, so a register row can name ``envelope.extra[thinking]``. The
+            single exception is ``tool_choice``, which unifies four wire keys
+            because they name one concept (R8.6).
+    """
+
+    model: str | None = None
+    stream: bool | None = None
+    store: bool | None = None
+    extra: Mapping[str, Any] = _frozen_field()
+
+    __hash__ = None  # type: ignore[assignment]
+
+    def __post_init__(self) -> None:
+        """Freeze the extra mapping in place."""
+        object.__setattr__(self, "extra", _freeze_mapping(self.extra))
+
+
+# --------------------------------------------------------------------------
+# Projections
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Request:
+    """A request projected into the wire-independent form.
+
+    Attributes:
+        envelope: Routing and control.
+        conversation: Semantic content.
+        residual: Paths the reader could not classify, mapped to their values.
+            A non-empty residual **fails the run** (§3.3.1).
+        consumed: Top-level body keys the reader mapped into the envelope or the
+            conversation. Without this a dropped key is undetectable — see
+            :func:`verify_total`.
+        source: The mapping the reader parsed. Carried so that
+            :func:`verify_total` needs no second parse, which could disagree
+            with the reader's about duplicate keys.
+    """
+
+    envelope: Envelope
+    conversation: Conversation
+    residual: Mapping[str, Any] = _frozen_field()
+    consumed: frozenset[str] = frozenset()
+    source: Mapping[str, Any] = _frozen_field()
+
+    __hash__ = None  # type: ignore[assignment]
+
+    def __post_init__(self) -> None:
+        """Freeze the residual and source mappings."""
+        object.__setattr__(self, "residual", _freeze_mapping(self.residual))
+        object.__setattr__(self, "source", _freeze_mapping(self.source))
+
+
+@dataclass(frozen=True)
+class Reply:
+    """A reply projected into the wire-independent form, for T-A7.
+
+    Attributes:
+        parts: Ordered content of the assistant's reply.
+        stop_reason: One of :data:`STOP_REASONS`.
+        usage: Token counts. **Carried but excluded from the fidelity diff** —
+            usage is provider-reported and never agent-supplied, so a difference
+            carries no I1 information.
+        residual: As :attr:`Request.residual`.
+        consumed: As :attr:`Request.consumed`.
+        source: As :attr:`Request.source`.
+    """
+
+    parts: Sequence[Part] = ()
+    stop_reason: str | None = None
+    usage: Mapping[str, Any] = _frozen_field()
+    residual: Mapping[str, Any] = _frozen_field()
+    consumed: frozenset[str] = frozenset()
+    source: Mapping[str, Any] = _frozen_field()
+
+    __hash__ = None  # type: ignore[assignment]
+
+    def __post_init__(self) -> None:
+        """Freeze every sequence and mapping."""
+        object.__setattr__(self, "parts", tuple(self.parts))
+        object.__setattr__(self, "usage", _freeze_mapping(self.usage))
+        object.__setattr__(self, "residual", _freeze_mapping(self.residual))
+        object.__setattr__(self, "source", _freeze_mapping(self.source))
+
+
+# --------------------------------------------------------------------------
+# The totality rule
+# --------------------------------------------------------------------------
+
+
+class UnreadableBodyError(Exception):
+    """A body a reader could not read at all.
+
+    Named here so six independently written readers raise one type. T-D1 must
+    distinguish "this body was unreadable" — T-C6 contributes a malformed entry
+    to the corpus — from "this is an I1 breach", and cannot do that against six
+    different exception types or a bare ``Exception``.
+
+    **Three failure shapes, deliberately distinct**, so a caller can tell them
+    apart:
+
+    - ``UnreadableBodyError`` — *the body* is wrong. The reader met something
+      it cannot read, such as malformed JSON or a role no format defines.
+    - ``ValueError`` — *the caller* is wrong. A projection type was constructed
+      with a bad role or a non-canonical sampling key. Raised from inside a
+      reader, it means the reader mis-routed a field: a reader bug, not a
+      transport one and not an I1 breach.
+    - :class:`ProjectionTotalityError` — the reader *read* the body but did not
+      account for all of it.
+    """
+
+
+class ProjectionTotalityError(AssertionError):
+    """A reader failed to account for the body it read.
+
+    Derives from ``AssertionError`` because it reports a failed check rather
+    than a broken program: it reads as a test failure, not as a crash.
+    """
+
+
+class DroppedFieldsError(ProjectionTotalityError):
+    """A body key the reader neither mapped nor residualised.
+
+    The dangerous case, and the one a residual-only rule cannot see.
+    """
+
+
+class ResidualFieldsError(ProjectionTotalityError):
+    """The reader could not classify something, and said so.
+
+    §3.3.1: a non-empty residual fails the run — it is not reported as a diff
+    and it is not ignored, because an unaccounted field is precisely where an
+    unregistered mutation hides.
+    """
+
+
+def verify_total(projected: Request | Reply) -> None:
+    """Assert that a reader accounted for every key in the body it read.
+
+    Two distinct failures, reported in order of danger:
+
+    1. a **dropped** key — in neither ``consumed`` nor ``residual``. The reader
+       silently ignored it. This is what :attr:`Request.consumed` exists to
+       catch: a dropping reader leaves the residual *empty*, so a
+       "residual must be empty" rule would pass it.
+    2. a **residual** — the reader could not classify it and said so.
+
+    Args:
+        projected: A :class:`Request` or a :class:`Reply`. Both carry
+            ``source``, ``consumed`` and ``residual``.
+
+    Raises:
+        DroppedFieldsError: When a top-level key of ``projected.source`` appears
+            in neither account. Any key claimed in ``consumed`` but absent from
+            the body is named in the same message, so a typo'd claim is not
+            mis-diagnosed as a drop the reader caused.
+        ResidualFieldsError: When ``residual`` is non-empty.
+    """
+    # A key claimed in both accounts counts as a residual, so it is excluded
+    # from the drop check here and caught below (R2.8).
+    accounted = set(projected.consumed) | set(projected.residual)
+    dropped = sorted(set(projected.source) - accounted)
+
+    if dropped:
+        claimed_absent = sorted(set(projected.consumed) - set(projected.source))
+        detail = f"; claimed but absent: {claimed_absent}" if claimed_absent else ""
+        raise DroppedFieldsError(
+            f"reader dropped {dropped} — every body key must map to the envelope, "
+            f"the conversation, or the residual{detail}"
+        )
+
+    if projected.residual:
+        raise ResidualFieldsError(
+            f"reader could not classify {sorted(projected.residual)} — a non-empty residual fails the run"
+        )
+
+
+# --------------------------------------------------------------------------
+# The projection protocols
+# --------------------------------------------------------------------------
+
+
+@runtime_checkable
+class Projection(Protocol):
+    """Reads one wire format's request into the common form.
+
+    Implemented by T-A1–T-A6, one reader per format, each written against that
+    format's published examples and importing nothing from ``src/kitty``.
+
+    ``isinstance`` works against this protocol; ``issubclass`` raises, because
+    of the ``wire_format`` data member. ``isinstance`` also checks member
+    *presence* only, never signatures.
+    """
+
+    wire_format: WireFormat
+
+    def read_request(self, captured: CapturedRequest) -> Request:
+        """Project a captured request.
+
+        Takes the **whole** capture, not a body: Gemini carries the model and
+        the operation in the URL path (§3.3.5), so a body-only reader could not
+        project a Gemini request at all.
+
+        Args:
+            captured: The request as observed on the wire.
+
+        Returns:
+            The wire-independent projection.
+
+        Raises:
+            UnreadableBodyError: When the body cannot be read.
+        """
+        ...
+
+
+@runtime_checkable
+class ReplyProjection(Protocol):
+    """Reads one wire format's reply into the common form.
+
+    Separate from :class:`Projection` because §3.3.1 makes response translation
+    "a different claim [that] gets a different test", and because the plan
+    splits the work as six request tasks against one reply task (T-A7) with its
+    own comparison task (T-D10).
+    """
+
+    wire_format: WireFormat
+
+    def read_reply(self, captured: CapturedReply) -> Reply:
+        """Project a captured reply.
+
+        Args:
+            captured: The reply as observed on the wire, already reassembled
+                from SSE if it was streamed — reassembly is T-A7's boundary.
+
+        Returns:
+            The wire-independent projection.
+
+        Raises:
+            UnreadableBodyError: When the body cannot be read.
+        """
+        ...
+
+
+# --------------------------------------------------------------------------
+# The path vocabulary
+# --------------------------------------------------------------------------
+
+#: Anchors for the fields the register addresses by name (§3.3.1). Spelled once
+#: here so T-W3's rows and T-D1's deltas cannot drift apart on spelling.
+ENVELOPE_MODEL = "envelope.model"
+ENVELOPE_STREAM = "envelope.stream"
+ENVELOPE_STORE = "envelope.store"
+
+#: Bare-collection anchors, for rows that change a collection as a whole: M5 and
+#: M13 rewrite the turns, P5b joins the system blocks, and §3.3.1 pins P13 and
+#: P14 to ``conversation.sampling`` rather than to one key.
+CONVERSATION_SYSTEM = "conversation.system"
+CONVERSATION_TURNS = "conversation.turns"
+CONVERSATION_TOOLS = "conversation.tools"
+CONVERSATION_SAMPLING = "conversation.sampling"
+
+#: Response-direction anchors, for M12 and T-D10.
+REPLY_STOP_REASON = "reply.stop_reason"
+REPLY_USAGE = "reply.usage"
+
+#: Route anchors (§3.3.5). M14, P20 and P21 change where a request goes, which
+#: the body cannot show.
+ROUTE_METHOD = "route.method"
+ROUTE_SCHEME = "route.scheme"
+ROUTE_HOST = "route.host"
+ROUTE_PATH = "route.path"
+ROUTE_QUERY = "route.query"
+
+#: The route components a path may name, and the fields of
+#: :class:`CapturedRequest` they correspond to.
+ROUTE_COMPONENTS = frozenset({"method", "scheme", "host", "path", "query"})
+
+#: The canonical `tool_choice` values.  Four formats spell one concept four ways
+#: — Chat Completions and Messages `tool_choice`, Converse's
+#: `toolConfig.toolChoice`, Gemini's `functionCallingConfig.mode` — so a
+#: Messages-to-CC comparison would otherwise show an unclaimed delta on every
+#: request that declares tools.  A specific tool is named `tool:<name>`.
+TOOL_CHOICE_VALUES = frozenset({"auto", "any", "none"})
+
+#: The key `tool_choice` normalises onto.  The single deliberate exception to
+#: keying :attr:`Envelope.extra` by the wire key, because the four wire keys
+#: name one concept and Gemini's is `toolConfig`.
+TOOL_CHOICE_KEY = "tool_choice"
+
+#: The value a register row carries when the projection deliberately does not
+#: model its effect. It **requires a reason**. P16 uses it (the content-type tag
+#: is redundant with the turn's role), as do the whole-body protocol
+#: translations M2, M9, P11 and P12, which change everything and so name nothing
+#: usefully. An empty cell would make those rows silently unfalsifiable.
+NOT_PROJECTABLE = "not projectable"
+
+#: The wildcard segment. §3.3.1 writes register fields with an empty index —
+#: "P15 is ``conversation.tools[].strict``" — meaning every tool.
+WILDCARD = "*"
+
+
+def extra_path(key: str) -> str:
+    """Return the path naming a format-specific control field.
+
+    Args:
+        key: The wire key, e.g. ``thinking`` for P2a.
+
+    Returns:
+        A path of the form ``envelope.extra[<key>]``.
+    """
+    return f"envelope.extra[{key}]"
+
+
+def sampling_path(key: str) -> str:
+    """Return the path naming one sampling parameter.
+
+    Args:
+        key: A member of :data:`SAMPLING_KEYS`.
+
+    Returns:
+        A path of the form ``conversation.sampling[<key>]``.
+    """
+    return f"conversation.sampling[{key}]"
+
+
+def system_path(index: int) -> str:
+    """Return the path naming one system text part.
+
+    Args:
+        index: Position in :attr:`Conversation.system`.
+
+    Returns:
+        A path of the form ``conversation.system[<i>]``.
+    """
+    return f"conversation.system[{index}]"
+
+
+def turn_path(index: int, field_name: str | None = None) -> str:
+    """Return the path naming one turn, or a field of it.
+
+    Args:
+        index: Position in :attr:`Conversation.turns`.
+        field_name: An optional field, e.g. ``role``.
+
+    Returns:
+        A path of the form ``conversation.turns[<i>]``, with ``.<field>``
+        appended when one is given.
+    """
+    base = f"conversation.turns[{index}]"
+    return f"{base}.{field_name}" if field_name else base
+
+
+def part_path(turn_index: int, part_index: int) -> str:
+    """Return the path naming one part of one turn.
+
+    §3.3.4 requires a failure to name the exact turn and part.
+
+    Args:
+        turn_index: Position in :attr:`Conversation.turns`.
+        part_index: Position in that turn's parts.
+
+    Returns:
+        A path of the form ``conversation.turns[<i>].parts[<j>]``.
+    """
+    return f"conversation.turns[{turn_index}].parts[{part_index}]"
+
+
+def tool_path(name: str, field_name: str | None = None) -> str:
+    """Return the path naming one tool declaration, or a field of it.
+
+    Tools are addressed **by name, not index**: translators reorder and filter
+    declarations, so a positional path would report a delta whenever the list
+    order changed while nothing about the declaration did.
+
+    Args:
+        name: The tool's name.
+        field_name: An optional field, e.g. ``strict`` for P15.
+
+    Returns:
+        A path of the form ``conversation.tools[<name>]``, with ``.<field>``
+        appended when one is given.
+    """
+    base = f"conversation.tools[{name}]"
+    return f"{base}.{field_name}" if field_name else base
+
+
+def header_path(name: str) -> str:
+    """Return the path naming one request header.
+
+    P9a, P9b and P9c change headers rather than the body, and §4.3 C1 asserts on
+    the exact header set.
+
+    Args:
+        name: The header name; lowercased for addressing, though the capture
+            itself preserves the original casing.
+
+    Returns:
+        A path of the form ``headers[<name>]``.
+    """
+    return f"headers[{name.lower()}]"
+
+
+def residual_path(key: str) -> str:
+    """Return the path naming one unclassified value.
+
+    Args:
+        key: The path into the body, which may itself contain dots — bracket
+            contents are literal and are never re-parsed.
+
+    Returns:
+        A path of the form ``residual[<key>]``.
+    """
+    return f"residual[{key}]"
+
+
+def reply_part_path(index: int) -> str:
+    """Return the path naming one part of a reply.
+
+    Args:
+        index: Position in :attr:`Reply.parts`.
+
+    Returns:
+        A path of the form ``reply.parts[<i>]``.
+    """
+    return f"reply.parts[{index}]"
+
+
+def reply_usage_path(key: str) -> str:
+    """Return the path naming one usage counter.
+
+    Usage is carried but **excluded from the fidelity diff** — it is
+    provider-reported and never agent-supplied. The path form exists so T-D10
+    can name a counter without hand-assembling a string.
+
+    Args:
+        key: The usage key, e.g. ``input_tokens``.
+
+    Returns:
+        A path of the form ``reply.usage[<key>]``.
+    """
+    return f"reply.usage[{key}]"
+
+
+def route_path(component: str) -> str:
+    """Return the path naming one route component.
+
+    §3.3.5: M14 replaces the destination entirely, P20 encodes the model as an
+    Azure deployment id in the path, and P21 puts the Vertex project and
+    location in the base URL. None of that is visible in the body.
+
+    Args:
+        component: One of ``method``, ``scheme``, ``host``, ``path``, ``query``.
+
+    Returns:
+        A path of the form ``route.<component>``.
+
+    Raises:
+        ValueError: When ``component`` is not a route component.
+    """
+    if component not in ROUTE_COMPONENTS:
+        raise ValueError(f"route component must be one of {sorted(ROUTE_COMPONENTS)}, got {component!r}")
+    return f"route.{component}"
+
+
+def _segments(path: str) -> list[str]:
+    """Split a path into segments, treating bracket contents as literal.
+
+    A key may contain dots — ``residual[generationConfig.topK]`` — so a naive
+    ``split(".")`` would shatter it. Brackets are tracked by depth and their
+    contents are never re-parsed.
+
+    Args:
+        path: A concrete path or a pattern.
+
+    Returns:
+        The path's segments, in order.
+
+    Raises:
+        ValueError: When brackets are unbalanced. R7.2d calls such a path "not
+            addressable"; raising makes that *visible*. Letting the depth drift
+            would silently glue the rest of the path into one segment, and
+            :func:`path_matches` would then return a confident wrong answer.
+    """
+    segments: list[str] = []
+    current: list[str] = []
+    depth = 0
+
+    for char in path:
+        if char == "[":
+            depth += 1
+        elif char == "]":
+            depth -= 1
+            if depth < 0:
+                raise ValueError(f"unbalanced ']' in path {path!r}")
+        elif char == "." and depth == 0:
+            segments.append("".join(current))
+            current = []
+            continue
+        current.append(char)
+
+    if depth != 0:
+        raise ValueError(f"unclosed '[' in path {path!r}")
+
+    segments.append("".join(current))
+    return segments
+
+
+def _segment_matches(pattern: str, concrete: str) -> bool:
+    """Return whether one pattern segment names one concrete segment.
+
+    Args:
+        pattern: A segment which may carry the ``[*]`` wildcard.
+        concrete: The corresponding concrete segment.
+
+    Returns:
+        ``True`` when the pattern names the segment.
+    """
+    if pattern == concrete:
+        return True
+
+    prefix, sep, rest = pattern.partition("[")
+    if not sep or not rest.endswith("]"):
+        return False
+
+    # `[]` is accepted as a wildcard because §3.3.1 spelled register fields that
+    # way ("P15 is conversation.tools[].strict") before this vocabulary existed.
+    # A row carried over in the old notation must not silently match nothing.
+    if rest[:-1] not in (WILDCARD, ""):
+        return False
+
+    c_prefix, c_sep, c_rest = concrete.partition("[")
+    return bool(c_sep) and c_prefix == prefix and c_rest.endswith("]")
+
+
+def path_matches(pattern: str, concrete: str) -> bool:
+    """Return whether a register row's pattern names a concrete delta path.
+
+    §3.3.2 assertion 1 — "every difference must map to a register row" — is
+    literally this match. Defining it here, rather than letting T-W3 write the
+    patterns and T-D1 write the matcher, is what stops the two agreeing only by
+    luck.
+
+    **A pattern is a prefix.** It names the location it points at and everything
+    beneath it, at any depth. So P13's anchor ``conversation.sampling`` claims a
+    delta on any key under it, and a row anchored at
+    ``conversation.turns[*].parts[*]`` claims
+    ``conversation.turns[2].parts[0].signature`` — which M8's carrier repair
+    produces. Restricting the prefix rule to bracket-free patterns would make
+    that last case unclaimed, and under §3.3.2 assertion 1 an unclaimed delta
+    fails the run: a false I1 breach manufactured by the matcher itself.
+
+    Over-claiming in the other direction costs nothing, because a register row
+    is anchored at the coarsest node it affects and every path beneath that node
+    is, by construction, part of what the row changed.
+
+    Args:
+        pattern: A path which may carry ``[*]`` wildcards.
+        concrete: A concrete path, as a delta reports it.
+
+    Returns:
+        ``True`` when the pattern names the path.
+
+    Raises:
+        ValueError: When either path has unbalanced brackets.
+    """
+    pattern_segments = _segments(pattern)
+    concrete_segments = _segments(concrete)
+
+    # A pattern may be shorter than the path it claims, never longer.
+    if len(pattern_segments) > len(concrete_segments):
+        return False
+
+    for index, pattern_segment in enumerate(pattern_segments):
+        concrete_segment = concrete_segments[index]
+
+        # A bare collection name claims a bracketed member of itself, so
+        # `sampling` claims `sampling[temperature]`.
+        if "[" not in pattern_segment and concrete_segment.startswith(f"{pattern_segment}["):
+            continue
+        if not _segment_matches(pattern_segment, concrete_segment):
+            return False
+
+    return True
+

--- a/tests/harness/contract.py
+++ b/tests/harness/contract.py
@@ -258,12 +258,19 @@ class ToolResult:
 
     def __post_init__(self) -> None:
         """Freeze the content sequence in place."""
-        object.__setattr__(self, "content", tuple(self.content))
+        object.__setattr__(
+            self, "content", _checked_members(self.content, RESULT_PART_TYPES, "ToolResult.content")
+        )
 
 
 #: Every :data:`Part` variant, as a tuple for ``isinstance`` and for the guard
 #: that asserts the union has not silently grown.
 PART_TYPES = (Text, ToolUse, ToolResult, Thinking, Image, Json, Opaque)
+
+#: What a :class:`ToolResult` may carry.  Deliberately narrower than
+#: :data:`PART_TYPES` and deliberately not recursive: no wire format nests a
+#: tool call inside a tool result.
+RESULT_PART_TYPES = (Text, Image, Json, Opaque)
 
 Part = Text | ToolUse | ToolResult | Thinking | Image | Json | Opaque
 
@@ -297,6 +304,39 @@ REDACTED_HEADERS = frozenset(
 #: Query-string keys whose values never appear in a ``repr``. Gemini carries its
 #: credential in the URL, which :attr:`CapturedRequest.query` preserves verbatim.
 REDACTED_QUERY_KEYS = frozenset({"key", "api_key", "access_token"})
+
+
+def _checked_members(values: Any, allowed: tuple[type, ...], field_name: str) -> tuple[Any, ...]:
+    """Return ``values`` as a tuple, rejecting anything outside ``allowed``.
+
+    The contract declares several closed sets — the :data:`Part` union, the
+    parts a :class:`ToolResult` may carry, the types a :class:`Conversation`
+    holds. *Closed* has meant *enforced* everywhere else in this module
+    (:data:`ROLES`, :data:`SAMPLING_KEYS`, :data:`STOP_REASONS`,
+    :data:`TOOL_CHOICE_VALUES`), and a declared-but-unchecked union is the same
+    defect: a rule that reads like a guarantee and guarantees nothing.
+
+    Args:
+        values: The sequence given for the field.
+        allowed: The types a member may be.
+        field_name: The field's name, for the error message.
+
+    Returns:
+        The members, order untouched.
+
+    Raises:
+        TypeError: When a member is outside ``allowed``.
+    """
+    # Materialise once: reading a one-shot iterable twice would leave the store
+    # empty and silent, which is the defect round 9 closed on headers.
+    members = tuple(values)
+
+    offenders = sorted({type(m).__name__ for m in members if not isinstance(m, allowed)})
+    if offenders:
+        names = ", ".join(t.__name__ for t in allowed)
+        raise TypeError(f"{field_name} accepts only {names}; got {', '.join(offenders)}")
+
+    return members
 
 
 def _normalised_headers(headers: Any) -> tuple[tuple[str, str], ...]:
@@ -334,6 +374,13 @@ def _normalised_headers(headers: Any) -> tuple[tuple[str, str], ...]:
     pairs = tuple(tuple(entry) for entry in entries)
     if any(len(pair) != 2 for pair in pairs):
         raise TypeError("each header must be a (name, value) pair")
+
+    # A `bytes` name survives a length check and then misses the credential
+    # mask outright: `b"authorization"` is not in a set of `str`, so the value
+    # is rendered in full. Checking the length without the element types is how
+    # a leak walks through a guard that looks like it covers this.
+    if any(not isinstance(part, str) for pair in pairs for part in pair):
+        raise TypeError("header names and values must both be str")
 
     return pairs
 
@@ -575,10 +622,11 @@ class Turn:
             ValueError: When ``role`` is outside :data:`ROLES`. Construction is
                 not parsing — T-D1 builds expected conversations by hand — so
                 this is a ``ValueError`` and not :class:`UnreadableBodyError`.
+            TypeError: When a member of ``parts`` is outside :data:`PART_TYPES`.
         """
         if self.role not in ROLES:
             raise ValueError(f"role must be one of {sorted(ROLES)}, got {self.role!r}")
-        object.__setattr__(self, "parts", tuple(self.parts))
+        object.__setattr__(self, "parts", _checked_members(self.parts, PART_TYPES, "Turn.parts"))
 
 
 @dataclass(frozen=True)
@@ -639,9 +687,9 @@ class Conversation:
                 likely accident. Validated the way :class:`Turn` validates its
                 role, rather than left as an unenforced reader obligation.
         """
-        object.__setattr__(self, "system", tuple(self.system))
-        object.__setattr__(self, "turns", tuple(self.turns))
-        object.__setattr__(self, "tools", tuple(self.tools))
+        object.__setattr__(self, "system", _checked_members(self.system, (Text,), "Conversation.system"))
+        object.__setattr__(self, "turns", _checked_members(self.turns, (Turn,), "Conversation.turns"))
+        object.__setattr__(self, "tools", _checked_members(self.tools, (ToolDecl,), "Conversation.tools"))
 
         if not isinstance(self.sampling, Mapping):
             raise TypeError("sampling must be a mapping of canonical key to value")
@@ -796,7 +844,7 @@ class Reply:
                 f"stop_reason_raw is only for 'other', but stop_reason is {self.stop_reason!r}"
             )
 
-        object.__setattr__(self, "parts", tuple(self.parts))
+        object.__setattr__(self, "parts", _checked_members(self.parts, PART_TYPES, "Reply.parts"))
         object.__setattr__(self, "usage", _freeze_mapping(self.usage))
         object.__setattr__(self, "residual", _freeze_mapping(self.residual))
         object.__setattr__(self, "source", _freeze_mapping(self.source))

--- a/tests/harness/contract.py
+++ b/tests/harness/contract.py
@@ -505,8 +505,15 @@ SAMPLING_KEYS = frozenset(
 #: Gemini adds ``SAFETY`` and ``RECITATION``, Anthropic has added values over
 #: time, and Ollama reports ``done_reason: load``.  Without it a legitimate
 #: safety-blocked reply would fail the run instead of projecting — the mistake
-#: R9.3 avoids on the request side.  An unmapped value projects as ``other``
-#: with the original string in ``Reply.residual["stop_reason"]``.
+#: R9.3 avoids on the request side.  An unmapped value projects as ``other``,
+#: with the wire's own string kept in :attr:`Reply.stop_reason_raw`.
+#:
+#: **Not in the residual.**  An earlier draft put it there, which defeated the
+#: escape it was meant to be: :func:`verify_total` fails the run on *any*
+#: non-empty residual, so a reader following that rule literally would have
+#: failed every safety-blocked Gemini reply.  A value mapped to ``other`` has
+#: been seen and classified — it is accounted for, not unaccounted — so the
+#: residual was the wrong home for it on the contract's own terms.
 STOP_REASONS = frozenset({"end_turn", "max_tokens", "stop_sequence", "tool_use", "error", "other"})
 
 
@@ -684,6 +691,10 @@ class Reply:
     Attributes:
         parts: Ordered content of the assistant's reply.
         stop_reason: One of :data:`STOP_REASONS`.
+        stop_reason_raw: The wire's own value when ``stop_reason`` is ``other``,
+            and ``None`` otherwise. Keeps a Gemini ``SAFETY`` distinguishable
+            from a ``RECITATION`` without failing the run, which putting it in
+            the residual would have done.
         usage: Token counts. **Carried but excluded from the fidelity diff** —
             usage is provider-reported and never agent-supplied, so a difference
             carries no I1 information.
@@ -694,6 +705,7 @@ class Reply:
 
     parts: Sequence[Part] = ()
     stop_reason: str | None = None
+    stop_reason_raw: str | None = None
     usage: Mapping[str, Any] = _frozen_field()
     residual: Mapping[str, Any] = _frozen_field()
     consumed: frozenset[str] = frozenset()

--- a/tests/harness/contract.py
+++ b/tests/harness/contract.py
@@ -278,10 +278,18 @@ Part = Text | ToolUse | ToolResult | Thinking | Image | Json | Opaque
 REDACTION_MASK = "<redacted>"
 
 #: Header names whose values never appear in a ``repr``, lowercased for
-#: case-insensitive matching. The five recorders (§7.2) will see every one of
-#: these: ``x-api-key`` from Anthropic, ``api-key`` from Azure and P9b's MiMo,
-#: ``x-goog-api-key`` from Gemini, ``authorization`` from Vertex's OAuth leg and
-#: ``proxy-authorization`` from the CONNECT legs (§5.2.1).
+#: case-insensitive matching. Seven entries, in two groups.
+#:
+#: **Five the recorders (§7.2) will actually see**, one per carrier:
+#: ``x-api-key`` from Anthropic, ``api-key`` from Azure and P9b's MiMo,
+#: ``x-goog-api-key`` from Gemini, ``authorization`` from Vertex's OAuth leg,
+#: and ``proxy-authorization`` from the CONNECT legs (§5.2.1).
+#:
+#: **Two precautionary**: ``cookie`` and ``set-cookie``. No adapter authenticates
+#: by cookie today, so nothing exercises them — they are here because a session
+#: cookie is a credential and the cost of listing one nobody sends is nil, while
+#: the cost of omitting one somebody starts sending is a leak into every CI log.
+#: :attr:`CapturedReply` is the likelier carrier of the two.
 REDACTED_HEADERS = frozenset(
     {"authorization", "proxy-authorization", "x-api-key", "api-key", "x-goog-api-key", "cookie", "set-cookie"}
 )

--- a/tests/harness/contract.py
+++ b/tests/harness/contract.py
@@ -745,15 +745,28 @@ class Reply:
         """Validate the stop reason and freeze every sequence and mapping.
 
         Raises:
-            ValueError: When ``stop_reason`` is outside :data:`STOP_REASONS`.
-                Closed means enforced, the same posture :class:`Turn` takes on
-                roles and :class:`Conversation` on sampling keys — a vocabulary
-                declared closed but checked nowhere is a comment, not a rule.
+            ValueError: When ``stop_reason`` is outside :data:`STOP_REASONS`, or
+                when it does not pair correctly with ``stop_reason_raw``. Closed
+                means enforced, the same posture :class:`Turn` takes on roles and
+                :class:`Conversation` on sampling keys — a vocabulary declared
+                closed but checked nowhere is a comment, not a rule, and the same
+                applies to an invariant written only in a docstring.
         """
         if self.stop_reason is not None and self.stop_reason not in STOP_REASONS:
             raise ValueError(
                 f"stop_reason must be one of {sorted(STOP_REASONS)}, got {self.stop_reason!r}; "
                 "an unmapped wire value projects as 'other' with the original in stop_reason_raw"
+            )
+
+        # The pairing is the escape's whole value. `other` without the wire's
+        # string discards what T-D10 needs to tell a SAFETY block from a
+        # RECITATION; a raw value beside a canonical reason means the reader
+        # mapped it and kept a stale original.
+        if self.stop_reason == "other" and self.stop_reason_raw is None:
+            raise ValueError("stop_reason 'other' must carry the wire's own value in stop_reason_raw")
+        if self.stop_reason != "other" and self.stop_reason_raw is not None:
+            raise ValueError(
+                f"stop_reason_raw is only for 'other', but stop_reason is {self.stop_reason!r}"
             )
 
         object.__setattr__(self, "parts", tuple(self.parts))

--- a/tests/harness/contract.py
+++ b/tests/harness/contract.py
@@ -386,6 +386,12 @@ class CapturedRequest:
         if isinstance(self.headers, Mapping):
             raise TypeError("headers must be a sequence of (name, value) pairs, not a mapping")
 
+        # A string is a sequence too, so `tuple("ab")` is a *valid-looking*
+        # 2-tuple of characters. Rejecting the type is the only check that
+        # catches it; a length check cannot.
+        if any(isinstance(entry, str | bytes) for entry in self.headers):
+            raise TypeError("each header must be a (name, value) pair, not a string")
+
         pairs = tuple(tuple(h) for h in self.headers)
         if any(len(pair) != 2 for pair in pairs):
             raise TypeError("each header must be a (name, value) pair")
@@ -437,6 +443,12 @@ class CapturedReply:
         """
         if isinstance(self.headers, Mapping):
             raise TypeError("headers must be a sequence of (name, value) pairs, not a mapping")
+
+        # A string is a sequence too, so `tuple("ab")` is a *valid-looking*
+        # 2-tuple of characters. Rejecting the type is the only check that
+        # catches it; a length check cannot.
+        if any(isinstance(entry, str | bytes) for entry in self.headers):
+            raise TypeError("each header must be a (name, value) pair, not a string")
 
         pairs = tuple(tuple(h) for h in self.headers)
         if any(len(pair) != 2 for pair in pairs):

--- a/tests/harness/test_contract.py
+++ b/tests/harness/test_contract.py
@@ -149,13 +149,15 @@ class TestCapturedRequestRedaction:
         `x-goog-api-key` (Gemini), `authorization` (Vertex's OAuth leg) and
         `proxy-authorization` (the CONNECT legs, §5.2.1).
         """
-        assert {
+        assert set(c.REDACTED_HEADERS) == {
             "authorization",
             "proxy-authorization",
             "x-api-key",
             "api-key",
             "x-goog-api-key",
-        } <= c.REDACTED_HEADERS
+            "cookie",
+            "set-cookie",
+        }
 
     def test_the_proxy_authorization_header_is_actually_masked(self) -> None:
         """Membership in the set is not proof the mask reaches it."""

--- a/tests/harness/test_contract.py
+++ b/tests/harness/test_contract.py
@@ -384,6 +384,20 @@ class TestEnvelopeAndConversation:
         """
         assert set(c.STOP_REASONS) == {"end_turn", "max_tokens", "stop_sequence", "tool_use", "error", "other"}
 
+    def test_the_stop_reason_escape_does_not_itself_fail_the_run(self) -> None:
+        """The escape must not be built out of the thing that fails the run.
+
+        Keeping the wire's value in the residual would have made every
+        safety-blocked Gemini reply fail `verify_total`, defeating the escape
+        entirely. A value mapped to `other` has been seen and classified, so it
+        is accounted for — `stop_reason_raw` is its home.
+        """
+        blocked = c.Reply(stop_reason="other", stop_reason_raw="SAFETY", consumed=frozenset({"finishReason"}),
+                          source={"finishReason": "SAFETY"})
+
+        c.verify_total(blocked)
+        assert blocked.stop_reason_raw == "SAFETY"
+
     def test_the_tool_choice_vocabulary_is_a_constant_not_prose(self) -> None:
         """Four formats spell one concept four ways; six readers must not each guess (R8.6)."""
         assert set(c.TOOL_CHOICE_VALUES) == {"auto", "any", "none"}
@@ -648,12 +662,16 @@ class TestTotalityFalsification:
         with pytest.raises(c.ResidualFieldsError, match="mystery"):
             c.verify_total(residualised)
 
-    def test_a_reader_that_drops_a_key_nested_under_one_it_consumed_is_caught(self) -> None:
-        """Top-level accounting alone would pass this.
+    def test_a_nested_key_the_reader_could_not_classify_fails_closed(self) -> None:
+        """A residual keyed by a *path* fails the run, not just a top-level one.
 
         Gemini puts every sampling parameter under ``generationConfig``, so a
-        reader that consumes the outer key and quietly ignores ``topK`` inside
-        it satisfies a top-level check.  Path-keyed residuals are what close it.
+        reader must be able to say "I could not classify ``topK`` inside a key
+        I did handle" and have that fail. Path-keyed residuals are what allow
+        it.
+
+        Note what this does **not** prove — see
+        :meth:`test_a_nested_key_the_reader_silently_drops_is_a_known_limit`.
         """
         nested = _project(
             consumed={"model", "mystery", "generationConfig"},
@@ -662,6 +680,26 @@ class TestTotalityFalsification:
 
         with pytest.raises(c.ResidualFieldsError, match="generationConfig.topK"):
             c.verify_total(nested)
+
+    def test_a_nested_key_the_reader_silently_drops_is_a_known_limit(self) -> None:
+        """The boundary of the totality rule, pinned so it is deliberate.
+
+        ``consumed`` holds **top-level** keys, so a reader that claims
+        ``generationConfig`` and silently ignores ``topK`` inside it passes.
+        Catching that would need the contract to walk the body itself, which
+        would make it a second reader — and the oracle must not be written in
+        terms of anything that reads bodies (§3.3.1).
+
+        What closes it instead: each reader's own L1 tests against its format's
+        published examples (§7.4), and T-D8's "residual empty across the whole
+        corpus" over all seven readers.
+
+        This test fails the day someone extends totality to nested keys — which
+        is the point. It is not an endorsement, it is a boundary marker.
+        """
+        nested_drop = _project(consumed={"model", "mystery", "generationConfig"}, residual={})
+
+        c.verify_total(nested_drop)
 
     def test_a_reader_that_accounts_for_every_key_passes(self) -> None:
         """**The control.**

--- a/tests/harness/test_contract.py
+++ b/tests/harness/test_contract.py
@@ -142,8 +142,26 @@ class TestCapturedRequestRedaction:
             assert name == name.lower()
 
     def test_the_mask_set_names_every_credential_header_the_five_recorders_will_see(self) -> None:
-        """Asserts its own subject set, so the set cannot quietly shrink (house rule)."""
-        assert {"authorization", "x-api-key", "api-key", "x-goog-api-key"} <= c.REDACTED_HEADERS
+        """Asserts its own subject set, so the set cannot quietly shrink (house rule).
+
+        One entry per carrier named in the constant's own docstring:
+        `x-api-key` (Anthropic), `api-key` (Azure and P9b's MiMo),
+        `x-goog-api-key` (Gemini), `authorization` (Vertex's OAuth leg) and
+        `proxy-authorization` (the CONNECT legs, §5.2.1).
+        """
+        assert {
+            "authorization",
+            "proxy-authorization",
+            "x-api-key",
+            "api-key",
+            "x-goog-api-key",
+        } <= c.REDACTED_HEADERS
+
+    def test_the_proxy_authorization_header_is_actually_masked(self) -> None:
+        """Membership in the set is not proof the mask reaches it."""
+        captured = _capture(headers=(("Proxy-Authorization", "Basic c2VjcmV0OnBhc3M="),))
+
+        assert "c2VjcmV0OnBhc3M=" not in repr(captured)
 
 
 class TestCapturedReply:
@@ -409,6 +427,33 @@ class TestEnvelopeAndConversation:
 
         assert c.extra_path(c.TOOL_CHOICE_KEY) == "envelope.extra[tool_choice]"
         assert envelope.extra["tool_choice"] == "auto"
+
+    def test_a_wire_spelling_of_tool_choice_is_rejected(self) -> None:
+        """Closed means enforced. Gemini's `AUTO` must be normalised, not passed through."""
+        with pytest.raises(ValueError, match="tool_choice"):
+            c.Envelope(extra={c.TOOL_CHOICE_KEY: "AUTO"})
+
+    def test_a_named_tool_selection_is_accepted(self) -> None:
+        """The control: `tool:<name>` is the fourth legal form (R8.6)."""
+        envelope = c.Envelope(extra={c.TOOL_CHOICE_KEY: "tool:get_weather"})
+
+        assert envelope.extra[c.TOOL_CHOICE_KEY] == "tool:get_weather"
+
+    def test_other_entries_in_extra_are_not_validated(self) -> None:
+        """`extra` is open by design; `tool_choice` is the one entry with a canonical value."""
+        envelope = c.Envelope(extra={"thinking": {"type": "enabled"}, "reasoning_effort": "high"})
+
+        assert envelope.extra["reasoning_effort"] == "high"
+
+    def test_a_wire_stop_reason_is_rejected_rather_than_carried_through(self) -> None:
+        """Gemini's `MAX_TOKENS` must map onto the canonical set, or the diff sees two spellings."""
+        with pytest.raises(ValueError, match="stop_reason"):
+            c.Reply(stop_reason="MAX_TOKENS")
+
+    def test_every_canonical_stop_reason_is_accepted(self) -> None:
+        """The control: the guard above would pass if construction rejected everything."""
+        for reason in c.STOP_REASONS:
+            assert c.Reply(stop_reason=reason).stop_reason == reason
 
 
 class TestPathVocabulary:
@@ -888,8 +933,8 @@ def test_unreadable_body_error_is_named_by_the_contract() -> None:
 #: dynamic forms stay unanchored, because they appear mid-expression.
 _KITTY_IMPORT = re.compile(
     r"^\s*(?:from|import)\s+(?:src\.)?kitty\b"
-    r"|import_module\(\s*[\"']kitty"
-    r"|__import__\(\s*[\"']kitty"
+    r"|import_module\(\s*[\"'](?:src\.)?kitty"
+    r"|__import__\(\s*[\"'](?:src\.)?kitty"
 )
 
 
@@ -929,6 +974,8 @@ def test_the_import_guard_actually_fires_on_every_form_it_claims_to_catch() -> N
         "from src.kitty import server",
         'mod = importlib.import_module("kitty.bridge.server")',
         '__import__("kitty")',
+        'mod = importlib.import_module("src.kitty.bridge.server")',
+        '__import__("src.kitty")',
     ]
 
     undetected = [form for form in forms if not _KITTY_IMPORT.search(form)]

--- a/tests/harness/test_contract.py
+++ b/tests/harness/test_contract.py
@@ -101,6 +101,19 @@ class TestCapturedRequestShape:
         with pytest.raises(TypeError, match="not a string"):
             _capture(headers=("Authorization",))  # type: ignore[arg-type]
 
+    def test_headers_given_as_a_generator_are_not_consumed_by_the_guard(self) -> None:
+        """A one-shot iterable must survive validation.
+
+        The guard has to look at the entries *and* store them. Reading the
+        input twice consumes a generator on the first pass, so the second sees
+        nothing and the capture is stored with **no headers at all** — no
+        error, from a guard whose whole purpose is to fail loudly. A recorder
+        streaming its headers is the realistic source.
+        """
+        captured = _capture(headers=(pair for pair in (("A", "1"), ("B", "2"))))  # type: ignore[arg-type]
+
+        assert captured.headers == (("A", "1"), ("B", "2"))
+
 
 class TestCapturedRequestRedaction:
     """Credentials must not reach a pytest diff or a CI log (R1.7)."""
@@ -232,6 +245,33 @@ class TestCapturedReply:
         reply = c.CapturedReply(status=200, headers=(("Set-Cookie", "session=secret-token"),), body=b"{}")
 
         assert "secret-token" not in repr(reply)
+
+    @pytest.mark.parametrize(
+        ("headers", "expected"),
+        [
+            ({"Set-Cookie": "session=secret"}, "mapping"),
+            ("ab", "not a string"),
+            ((("Set-Cookie",),), "pair"),
+        ],
+        ids=["mapping", "two-character-string", "wrong-length-pair"],
+    )
+    def test_it_rejects_the_same_malformed_headers_a_request_does(self, headers: object, expected: str) -> None:
+        """The reply's guard must not drift from the request's.
+
+        Both types validate headers identically, and both were previously
+        hand-copied — so a defect found in one was silently a defect in the
+        other. They now share one helper, and this exercises the reply side of
+        all three rejection paths so the shared behaviour is pinned from both
+        ends rather than assumed from one.
+        """
+        with pytest.raises(TypeError, match=expected):
+            c.CapturedReply(status=200, headers=headers)  # type: ignore[arg-type]
+
+    def test_its_headers_survive_a_generator_too(self) -> None:
+        """The one-shot case, on the second type that shares the helper."""
+        reply = c.CapturedReply(status=200, headers=(p for p in (("A", "1"),)))  # type: ignore[arg-type]
+
+        assert reply.headers == (("A", "1"),)
 
 
 class TestImmutability:

--- a/tests/harness/test_contract.py
+++ b/tests/harness/test_contract.py
@@ -185,11 +185,20 @@ class TestCapturedRequestRedaction:
             assert c.REDACTION_MASK in rendered, f"{name} masked to nothing rather than to the mask"
 
     def test_every_masked_query_key_is_actually_redacted(self) -> None:
-        """The query-side counterpart, swept the same way and for the same reason."""
+        """The query-side counterpart, swept the same way and for the same reason.
+
+        Asserts the **pair survives with the mask as its value**, not merely
+        that the secret is gone. A `repr` that dropped the pair outright, or
+        emptied it to `key=`, would satisfy an absence check while hiding a
+        missing-credential bug exactly as effectively as a leak hides a present
+        one. The header sweep already pins this; the two must not disagree.
+        """
         for key in sorted(c.REDACTED_QUERY_KEYS):
-            rendered = repr(_capture(query=f"{key.upper()}=SECRET-VALUE&alt=sse"))
+            sent = key.upper()
+            rendered = repr(_capture(query=f"{sent}=SECRET-VALUE&alt=sse"))
 
             assert "SECRET-VALUE" not in rendered, f"{key} is in the set but not masked"
+            assert f"{sent}={c.REDACTION_MASK}" in rendered, f"{key} was dropped or emptied, not masked"
             assert "alt=sse" in rendered, f"masking {key} destroyed an innocent parameter"
 
 

--- a/tests/harness/test_contract.py
+++ b/tests/harness/test_contract.py
@@ -101,6 +101,23 @@ class TestCapturedRequestShape:
         with pytest.raises(TypeError, match="not a string"):
             _capture(headers=("Authorization",))  # type: ignore[arg-type]
 
+    def test_a_bytes_header_name_is_rejected_because_it_would_bypass_the_mask(self) -> None:
+        """The pair-length check let a credential through the redaction entirely.
+
+        `b"authorization".lower()` is `b"authorization"`, which is not in a set
+        of `str` — so a bytes-named `Authorization` header missed the mask and
+        its value was rendered in full into every log and assertion diff. A
+        length check that ignores element types is how a leak walks through a
+        guard that looks like it covers this.
+        """
+        with pytest.raises(TypeError, match="both be str"):
+            _capture(headers=((b"Authorization", "Bearer sk-LEAKED"),))  # type: ignore[arg-type]
+
+    def test_a_bytes_header_value_is_rejected_too(self) -> None:
+        """The other element, so the check cannot be half-applied."""
+        with pytest.raises(TypeError, match="both be str"):
+            _capture(headers=(("Authorization", b"Bearer sk-LEAKED"),))  # type: ignore[arg-type]
+
     def test_headers_given_as_a_generator_are_not_consumed_by_the_guard(self) -> None:
         """A one-shot iterable must survive validation.
 
@@ -427,6 +444,30 @@ class TestEnvelopeAndConversation:
         assert [t.text for t in conversation.system] == ["a", "b"]
         assert [t.role for t in conversation.turns] == ["user", "assistant"]
         assert [t.name for t in conversation.tools] == ["x", "y"]
+
+    @pytest.mark.parametrize(
+        ("build", "expected"),
+        [
+            (lambda: c.Turn(role="user", parts=("not a part",)), "Turn.parts"),
+            (lambda: c.Reply(parts=(42,)), "Reply.parts"),
+            (lambda: c.ToolResult(content=(c.ToolUse(name="f"),)), "ToolResult.content"),
+            (lambda: c.Conversation(system=("plain string",)), "Conversation.system"),
+            (lambda: c.Conversation(turns=("not a turn",)), "Conversation.turns"),
+            (lambda: c.Conversation(tools=("not a tool",)), "Conversation.tools"),
+        ],
+        ids=["turn-parts", "reply-parts", "tool-result-content", "system", "turns", "tools"],
+    )
+    def test_a_closed_union_rejects_a_member_outside_it(self, build: object, expected: str) -> None:
+        """Closed means enforced — the posture the vocabularies already take.
+
+        Swept across **every** field that declares a closed set rather than the
+        one that was reported, because fixing these one at a time is what
+        produced four separate rounds of the same finding. `ToolResult.content`
+        is deliberately narrower than `Part`: a tool call cannot nest inside a
+        tool result, and that claim is now checked rather than merely written.
+        """
+        with pytest.raises(TypeError, match=expected):
+            build()  # type: ignore[operator]
 
     def test_a_role_outside_the_closed_vocabulary_is_rejected_at_construction(self) -> None:
         """Construction is not parsing, so this is a ValueError, not UnreadableBodyError (R8.1)."""

--- a/tests/harness/test_contract.py
+++ b/tests/harness/test_contract.py
@@ -85,6 +85,22 @@ class TestCapturedRequestShape:
         with pytest.raises(TypeError, match="pair"):
             _capture(headers=(("Authorization",),))  # type: ignore[arg-type]
 
+    def test_a_two_character_string_does_not_slip_through_as_a_pair(self) -> None:
+        """A string is a sequence, so `tuple("ab")` is a valid-looking 2-tuple.
+
+        A length check cannot catch this — `("a", "b")` has length 2 and would
+        be stored as a header named `a` with the value `b`. Only rejecting the
+        type does, and this is the one shape that walked through a guard whose
+        own docstring says failing loudly is the point.
+        """
+        with pytest.raises(TypeError, match="not a string"):
+            _capture(headers=("ab",))  # type: ignore[arg-type]
+
+    def test_a_longer_string_is_rejected_for_the_same_reason(self) -> None:
+        """The control: a length check alone would reject this one and miss the pair above."""
+        with pytest.raises(TypeError, match="not a string"):
+            _capture(headers=("Authorization",))  # type: ignore[arg-type]
+
 
 class TestCapturedRequestRedaction:
     """Credentials must not reach a pytest diff or a CI log (R1.7)."""

--- a/tests/harness/test_contract.py
+++ b/tests/harness/test_contract.py
@@ -141,13 +141,22 @@ class TestCapturedRequestRedaction:
         for name in c.REDACTED_HEADERS:
             assert name == name.lower()
 
-    def test_the_mask_set_names_every_credential_header_the_five_recorders_will_see(self) -> None:
-        """Asserts its own subject set, so the set cannot quietly shrink (house rule).
+    def test_the_mask_set_is_exactly_five_carriers_plus_two_precautionary(self) -> None:
+        """Asserts its own subject set exactly, so it cannot shrink *or* grow unexplained.
 
-        One entry per carrier named in the constant's own docstring:
-        `x-api-key` (Anthropic), `api-key` (Azure and P9b's MiMo),
-        `x-goog-api-key` (Gemini), `authorization` (Vertex's OAuth leg) and
+        **Five with a carrier** the recorders will meet (§7.2): `x-api-key`
+        (Anthropic), `api-key` (Azure and P9b's MiMo), `x-goog-api-key`
+        (Gemini), `authorization` (Vertex's OAuth leg) and
         `proxy-authorization` (the CONNECT legs, §5.2.1).
+
+        **Two precautionary**: `cookie` and `set-cookie`. Nothing authenticates
+        by cookie today, so nothing exercises them — kept because listing a
+        credential nobody sends costs nothing, while omitting one somebody
+        later starts sending leaks it into every CI log.
+
+        Exact, not a subset: the subset form could not notice an entry nobody
+        had explained, which is how the constant and its prose drifted apart
+        in the first place.
         """
         assert set(c.REDACTED_HEADERS) == {
             "authorization",

--- a/tests/harness/test_contract.py
+++ b/tests/harness/test_contract.py
@@ -168,11 +168,29 @@ class TestCapturedRequestRedaction:
             "set-cookie",
         }
 
-    def test_the_proxy_authorization_header_is_actually_masked(self) -> None:
-        """Membership in the set is not proof the mask reaches it."""
-        captured = _capture(headers=(("Proxy-Authorization", "Basic c2VjcmV0OnBhc3M="),))
+    def test_every_masked_header_is_actually_redacted(self) -> None:
+        """Membership in the set is not proof the mask reaches the entry.
 
-        assert "c2VjcmV0OnBhc3M=" not in repr(captured)
+        Swept over the constant itself rather than a hand-picked few, so an
+        eighth entry cannot ship asserted-but-unexercised — which is how four
+        of the seven sat untested through four review rounds.
+
+        Each is sent in **upper case** to prove the match is case-insensitive
+        per entry, not merely that the constant happens to be lowercase.
+        """
+        for name in sorted(c.REDACTED_HEADERS):
+            rendered = repr(_capture(headers=((name.upper(), "SECRET-VALUE"),)))
+
+            assert "SECRET-VALUE" not in rendered, f"{name} is in the set but not masked"
+            assert c.REDACTION_MASK in rendered, f"{name} masked to nothing rather than to the mask"
+
+    def test_every_masked_query_key_is_actually_redacted(self) -> None:
+        """The query-side counterpart, swept the same way and for the same reason."""
+        for key in sorted(c.REDACTED_QUERY_KEYS):
+            rendered = repr(_capture(query=f"{key.upper()}=SECRET-VALUE&alt=sse"))
+
+            assert "SECRET-VALUE" not in rendered, f"{key} is in the set but not masked"
+            assert "alt=sse" in rendered, f"masking {key} destroyed an innocent parameter"
 
 
 class TestCapturedReply:
@@ -462,9 +480,28 @@ class TestEnvelopeAndConversation:
             c.Reply(stop_reason="MAX_TOKENS")
 
     def test_every_canonical_stop_reason_is_accepted(self) -> None:
-        """The control: the guard above would pass if construction rejected everything."""
+        """The control: the guard above would pass if construction rejected everything.
+
+        `other` is passed with its paired raw value, because the two are only
+        meaningful together — see the pairing tests below.
+        """
         for reason in c.STOP_REASONS:
-            assert c.Reply(stop_reason=reason).stop_reason == reason
+            raw = "SAFETY" if reason == "other" else None
+            assert c.Reply(stop_reason=reason, stop_reason_raw=raw).stop_reason == reason
+
+    def test_other_without_the_wire_value_is_rejected(self) -> None:
+        """`other` alone discards the very thing the escape exists to keep.
+
+        T-D10 must be able to tell a Gemini `SAFETY` block from a `RECITATION`;
+        a reader that maps both to bare `other` has thrown that away.
+        """
+        with pytest.raises(ValueError, match="stop_reason_raw"):
+            c.Reply(stop_reason="other")
+
+    def test_a_raw_value_beside_a_canonical_reason_is_rejected(self) -> None:
+        """The other direction: a stale original left over from a mapped value."""
+        with pytest.raises(ValueError, match="only for 'other'"):
+            c.Reply(stop_reason="end_turn", stop_reason_raw="STOP")
 
 
 class TestPathVocabulary:

--- a/tests/harness/test_contract.py
+++ b/tests/harness/test_contract.py
@@ -1,0 +1,910 @@
+"""L1 tests for the input contract — the vocabulary the fidelity oracle is written in.
+
+`.system_design/TEST_SUITE.md` §3.3.1 · plan task **T-W2** (KBR-25).
+
+These tests prove the *contract*, not any reader.  Nothing here exercises
+kitty: the module under test imports nothing from ``src/kitty`` by design
+(§7.4), because an oracle written in terms of the code under test proves
+self-consistency rather than fidelity.
+
+**The falsification set is the point of this module.**  Plan §1.4 requires the
+first working version of every harness to ship with a deliberate defect it must
+detect.  :class:`TestTotalityFalsification` holds four stub readers over one
+body — one that drops an unknown key, one that residualises it, one that drops a
+key *nested* under a key it consumed, and one that accounts for everything.  The
+last is the control: without it, a :func:`verify_total` that raised
+unconditionally would satisfy the other three.
+
+**Why ``isinstance`` and never ``issubclass``.**  ``Projection`` carries a data
+member (``wire_format``), and ``issubclass`` raises ``TypeError`` on such a
+protocol.  ``isinstance`` checks member *presence* only — never signatures — so
+it cannot prove :attr:`read_request`'s parameter type; the annotation test does
+that work separately.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import hashlib
+import re
+from pathlib import Path
+from typing import get_type_hints
+
+import pytest
+
+from harness import contract as c
+
+
+class TestCapturedRequestShape:
+    """The seven ticket-named fields, in order, carried losslessly."""
+
+    def test_the_seven_named_fields_come_first_and_in_the_tickets_order(self) -> None:
+        """Downstream tasks destructure this type; the order is part of the contract."""
+        names = [f.name for f in dataclasses.fields(c.CapturedRequest)]
+
+        assert names[:7] == ["method", "scheme", "host", "path", "query", "headers", "body"]
+
+    def test_the_recorder_slots_default_to_none_so_t_w4_can_fill_them(self) -> None:
+        """§7.2's arrival time and peer port are T-W4's to populate, not fidelity's to read."""
+        captured = c.CapturedRequest(
+            method="POST", scheme="https", host="api.example.com", path="/v1/messages", query="", headers=(), body=b""
+        )
+
+        assert captured.arrival is None
+        assert captured.peer_port is None
+
+    def test_duplicate_header_names_and_original_casing_both_survive(self) -> None:
+        """§4.3 C1 asserts the exact header set, so a mapping would destroy the evidence."""
+        captured = _capture(headers=(("X-Api-Key", "k"), ("x-api-key", "j")))
+
+        assert captured.headers == (("X-Api-Key", "k"), ("x-api-key", "j"))
+
+    def test_the_query_string_is_stored_verbatim_not_reordered(self) -> None:
+        """T-W9's falsification is a recorder that drops the query; parsing is the caller's job."""
+        assert _capture(query="b=2&a=1").query == "b=2&a=1"
+
+    def test_a_body_that_is_not_valid_utf8_survives_unchanged(self) -> None:
+        """The capture is bytes: T-C6 contributes a malformed body and it must reach the reader."""
+        raw = b"\xff\xfe not json at all"
+
+        assert _capture(body=raw).body == raw
+
+    def test_headers_given_as_a_mapping_are_rejected_rather_than_shredded(self) -> None:
+        """Iterating a mapping yields its keys, so a dict would become character tuples.
+
+        R1.2 makes headers a sequence of pairs *because* someone will reach for
+        a mapping — most likely T-W4's recorder author. Silently accepting one
+        destroys the exact header evidence §4.3 C1 asserts on, and the loss
+        would surface much later as a mysterious `repr` crash.
+        """
+        with pytest.raises(TypeError, match="mapping"):
+            _capture(headers={"Authorization": "Bearer sk-LEAK"})  # type: ignore[arg-type]
+
+    def test_a_header_entry_that_is_not_a_pair_is_rejected(self) -> None:
+        """The control for the guard above, covering a malformed sequence."""
+        with pytest.raises(TypeError, match="pair"):
+            _capture(headers=(("Authorization",),))  # type: ignore[arg-type]
+
+
+class TestCapturedRequestRedaction:
+    """Credentials must not reach a pytest diff or a CI log (R1.7)."""
+
+    def test_the_authorization_header_value_is_absent_from_the_repr(self) -> None:
+        """A dataclass repr lands in every assertion failure; §7.1 flags this trap for the corpus."""
+        captured = _capture(headers=(("Authorization", "Bearer sk-secret-value"),))
+
+        assert "sk-secret-value" not in repr(captured)
+
+    def test_the_gemini_api_key_query_parameter_is_absent_from_the_repr(self) -> None:
+        """Gemini carries its credential in the URL, which R1.3 preserves verbatim."""
+        captured = _capture(query="key=AIzaSecretValue&alt=sse")
+
+        assert "AIzaSecretValue" not in repr(captured)
+
+    def test_the_query_mask_actually_matched_and_left_the_rest_alone(self) -> None:
+        """A masking rule that silently stopped matching would pass the test above.
+
+        The absence of a secret proves nothing on its own — a `repr` that
+        dropped the query entirely would also pass. This pins that the mask
+        fired *and* that the non-credential parameter survived.
+        """
+        rendered = repr(_capture(query="key=AIzaSecretValue&alt=sse"))
+
+        assert f"key={c.REDACTION_MASK}" in rendered
+        assert "alt=sse" in rendered
+
+    def test_every_masked_query_key_is_lowercase(self) -> None:
+        """Matching is case-insensitive, so the constant must not carry mixed case."""
+        for name in c.REDACTED_QUERY_KEYS:
+            assert name == name.lower()
+
+    def test_the_masked_repr_still_shows_that_a_credential_was_present(self) -> None:
+        """Masking to nothing would hide a missing-auth bug as effectively as a leak."""
+        captured = _capture(headers=(("Authorization", "Bearer sk-secret-value"),))
+
+        assert c.REDACTION_MASK in repr(captured)
+
+    def test_a_non_credential_header_is_shown_in_full(self) -> None:
+        """This is the control: a repr that masked everything would pass the two tests above."""
+        captured = _capture(headers=(("Content-Type", "application/json"),))
+
+        assert "application/json" in repr(captured)
+
+    def test_the_raw_credential_is_still_reachable_by_field_access(self) -> None:
+        """C1 asserts on the real header values; redaction is a display concern only."""
+        captured = _capture(headers=(("Authorization", "Bearer sk-secret-value"),))
+
+        assert captured.headers[0][1] == "Bearer sk-secret-value"
+
+    def test_every_masked_name_is_lowercase_so_matching_is_case_insensitive(self) -> None:
+        """A mask set holding `Authorization` would silently miss the wire's `authorization`."""
+        for name in c.REDACTED_HEADERS:
+            assert name == name.lower()
+
+    def test_the_mask_set_names_every_credential_header_the_five_recorders_will_see(self) -> None:
+        """Asserts its own subject set, so the set cannot quietly shrink (house rule)."""
+        assert {"authorization", "x-api-key", "api-key", "x-goog-api-key"} <= c.REDACTED_HEADERS
+
+
+class TestCapturedReply:
+    """The response direction's capture, for T-A7."""
+
+    def test_it_carries_status_headers_and_body(self) -> None:
+        """`ReplyProjection` reads this; `Reply` is what it produces."""
+        reply = c.CapturedReply(status=200, headers=(("Content-Type", "application/json"),), body=b"{}")
+
+        assert (reply.status, reply.body) == (200, b"{}")
+
+    def test_it_redacts_credentials_in_its_repr_too(self) -> None:
+        """A reply carries `set-cookie`; the same log-leak applies."""
+        reply = c.CapturedReply(status=200, headers=(("Set-Cookie", "session=secret-token"),), body=b"{}")
+
+        assert "secret-token" not in repr(reply)
+
+
+class TestImmutability:
+    """The oracle diffs projections and must not be able to alter what it compares (R3.8)."""
+
+    def test_rebinding_a_field_is_rejected(self) -> None:
+        """`frozen=True` blocks the obvious mutation."""
+        part = c.Text("hello")
+
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            part.text = "goodbye"  # type: ignore[misc]
+
+    def test_mutating_through_a_mapping_field_is_rejected(self) -> None:
+        """`frozen=True` alone does NOT give this — a plain dict field stays mutable."""
+        envelope = c.Envelope(model="m", extra={"thinking": {"type": "enabled"}})
+
+        with pytest.raises(TypeError):
+            envelope.extra["thinking"] = "tampered"  # type: ignore[index]
+
+    def test_no_projection_type_is_hashable(self) -> None:
+        """Forced off so hashability is deterministic, not data-dependent (R3.11).
+
+        A frozen dataclass with no mapping field would otherwise hash happily,
+        and §3.3.3's counterpart matching would pass on text-only fixtures then
+        raise on the first corpus entry carrying a ``ToolUse``.
+
+        The subject set is **derived from the module**, not hand-listed, so a
+        fourteenth projection type shipping hashable is caught — which is
+        exactly the accident this guards.
+        """
+        captures = {c.CapturedRequest, c.CapturedReply}
+        projections = [
+            obj
+            for obj in vars(c).values()
+            if dataclasses.is_dataclass(obj) and isinstance(obj, type) and obj not in captures
+        ]
+
+        assert len(projections) >= 13, f"expected the projection types, found {projections}"
+
+        for projection in projections:
+            assert projection.__hash__ is None, f"{projection.__name__} is hashable"
+
+    def test_a_capture_stays_hashable_because_recorders_key_connections_by_it(self) -> None:
+        """The asymmetry is deliberate: only *projections* are unhashable (§7.4)."""
+        assert hash(_capture()) == hash(_capture())
+
+
+class TestPartGrammar:
+    """The closed union every reader maps its format onto (R3.4)."""
+
+    def test_all_seven_variants_inhabit_the_union(self) -> None:
+        """Asserts its own subject set so a new variant cannot be added unnoticed."""
+        variants = [
+            c.Text("t"),
+            c.ToolUse(id="1", name="get_weather", arguments={"city": "Kyiv"}),
+            c.ToolResult(tool_use_id="1", content=(c.Text("sunny"),), is_error=False),
+            c.Thinking(text="hmm", signature=None),
+            c.Image(digest="d", media_type="image/png", ref=None),
+            c.Json(value={"k": "v"}),
+            c.Opaque(kind="document", digest="d"),
+        ]
+
+        for variant in variants:
+            assert isinstance(variant, c.PART_TYPES)
+        assert len(variants) == len(c.PART_TYPES)
+
+    def test_tool_arguments_are_a_parsed_mapping_never_a_json_string(self) -> None:
+        """Chat Completions encodes arguments as a string and Messages as an object (R3.5)."""
+        use = c.ToolUse(id="1", name="f", arguments={"a": 1})
+
+        assert use.arguments["a"] == 1
+
+    def test_two_tool_uses_differing_only_in_an_argument_value_are_unequal(self) -> None:
+        """Equality is by value: the diff is what the whole oracle rests on."""
+        assert c.ToolUse(id="1", name="f", arguments={"a": 1}) != c.ToolUse(id="1", name="f", arguments={"a": 2})
+
+    def test_a_tool_result_carries_ordered_mixed_content(self) -> None:
+        """Converse carries `json`, Anthropic carries `document`; `Text | Image` dropped them (R3.6)."""
+        result = c.ToolResult(
+            tool_use_id="1",
+            content=(
+                c.Text("see"),
+                c.Image(digest="d"),
+                c.Json(value={"rows": 2}),
+                c.Opaque(kind="document", digest="d"),
+            ),
+            is_error=False,
+        )
+
+        assert [type(p) for p in result.content] == [c.Text, c.Image, c.Json, c.Opaque]
+
+    def test_tool_call_ids_may_be_absent_because_gemini_carries_none(self) -> None:
+        """Gemini's functionCall/functionResponse have no id; a required one forces a fake (R3.9)."""
+        use = c.ToolUse(id=None, name="f", arguments={})
+        result = c.ToolResult(tool_use_id=None, content=(c.Text("x"),), is_error=False)
+
+        assert use.id is None and result.tool_use_id is None
+
+    def test_an_image_holds_a_digest_and_media_type_but_never_bytes(self) -> None:
+        """Carrying bytes would put megabytes into every failure message (R3.7)."""
+        names = {f.name for f in dataclasses.fields(c.Image)}
+
+        assert names == {"digest", "media_type", "ref"}
+
+    def test_the_documented_digest_is_sha256_over_the_decoded_bytes(self) -> None:
+        """Unpinned, two readers produce different digests for one image and the corpus fails."""
+        raw = b"\x89PNG\r\n\x1a\n fake image bytes"
+
+        assert c.image_digest(raw) == hashlib.sha256(raw).hexdigest()
+
+    def test_a_referenced_image_has_no_digest(self) -> None:
+        """Gemini's `fileData.fileUri` carries a URI and no bytes to digest."""
+        image = c.Image(digest=None, media_type=None, ref="gs://bucket/cat.png")
+
+        assert image.digest is None and image.ref == "gs://bucket/cat.png"
+
+    def test_an_empty_thinking_block_is_distinguishable_from_no_block(self) -> None:
+        """P5e and P8 inject empty blocks; P8's trigger is conditional, so absence must be visible."""
+        assert (c.Thinking(text="", signature=None),) != ()
+
+    def test_thinking_carries_the_signature_m8_manipulates(self) -> None:
+        """Anthropic's `signature` and Gemini's `thoughtSignature` are M8's subject."""
+        assert c.Thinking(text="t", signature="sig").signature == "sig"
+
+
+class TestEnvelopeAndConversation:
+    """The projection's two halves, and the register rows that address them."""
+
+    def test_the_three_named_control_fields_the_register_addresses(self) -> None:
+        """M1 is `envelope.model`; P17 is `envelope.stream` and `envelope.store` (§3.3.1)."""
+        envelope = c.Envelope(model="claude-opus-5", stream=True, store=False)
+
+        assert (envelope.model, envelope.stream, envelope.store) == ("claude-opus-5", True, False)
+
+    def test_a_format_specific_control_field_is_reachable_by_its_wire_key(self) -> None:
+        """P2a is `thinking`, P3 `reasoning`, P4 `reasoning_effort`, P10 `reasoning_split`."""
+        envelope = c.Envelope(extra={"thinking": {"type": "enabled"}})
+
+        assert envelope.extra["thinking"] == {"type": "enabled"}
+
+    def test_absent_is_distinguishable_from_false(self) -> None:
+        """P15 strips `strict`; if absent and False were one value the row would be untestable."""
+        assert c.ToolDecl(name="f", strict=None) != c.ToolDecl(name="f", strict=False)
+
+    def test_ordering_is_preserved_across_system_turns_and_tools(self) -> None:
+        """Order is meaning: R7's paths are index-based, so drift reports false deltas."""
+        conversation = c.Conversation(
+            system=(c.Text("a"), c.Text("b")),
+            turns=(c.Turn(role="user", parts=(c.Text("1"),)), c.Turn(role="assistant", parts=(c.Text("2"),))),
+            tools=(c.ToolDecl(name="x"), c.ToolDecl(name="y")),
+        )
+
+        assert [t.text for t in conversation.system] == ["a", "b"]
+        assert [t.role for t in conversation.turns] == ["user", "assistant"]
+        assert [t.name for t in conversation.tools] == ["x", "y"]
+
+    def test_a_role_outside_the_closed_vocabulary_is_rejected_at_construction(self) -> None:
+        """Construction is not parsing, so this is a ValueError, not UnreadableBodyError (R8.1)."""
+        with pytest.raises(ValueError):
+            c.Turn(role="system", parts=())
+
+    def test_system_is_not_a_role_because_it_lifts_into_the_conversation(self) -> None:
+        """R8.2: `system`, `developer` and Responses' `instructions` all lift, never become turns."""
+        assert set(c.ROLES) == {"user", "assistant"}
+
+    def test_the_canonical_sampling_set_holds_every_parameter_p13_drops(self) -> None:
+        """P13 drops fourteen named parameters; readers must agree all fourteen are sampling."""
+        p13 = {
+            "temperature",
+            "top_p",
+            "max_tokens",
+            "max_completion_tokens",
+            "frequency_penalty",
+            "presence_penalty",
+            "logprobs",
+            "top_logprobs",
+            "response_format",
+            "stop",
+            "n",
+            "stream_options",
+            "seed",
+            "logit_bias",
+        }
+
+        assert p13 <= c.SAMPLING_KEYS
+
+    def test_max_completion_tokens_is_not_collapsed_onto_max_tokens(self) -> None:
+        """R8.5 maps Responses' `max_output_tokens` onto `max_tokens`; this is a different field."""
+        assert {"max_tokens", "max_completion_tokens"} <= c.SAMPLING_KEYS
+        assert "max_output_tokens" not in c.SAMPLING_KEYS
+
+    def test_top_k_is_canonical_even_though_chat_completions_lacks_it(self) -> None:
+        """Gemini and Converse both carry it; a CC-only set would residualise a legitimate field."""
+        assert "top_k" in c.SAMPLING_KEYS
+
+    def test_a_non_canonical_sampling_key_is_rejected_at_construction(self) -> None:
+        """The set is closed (R9.1), and closed means enforced.
+
+        Gemini's `generationConfig` members are the likely accident: a reader
+        that tips them straight into `sampling` would otherwise be caught by
+        nothing here and nothing downstream.
+        """
+        with pytest.raises(ValueError, match="generationConfig"):
+            c.Conversation(sampling={"generationConfig": {"topK": 40}})
+
+    def test_every_canonical_sampling_key_is_accepted(self) -> None:
+        """The control: the guard above would pass if construction rejected everything."""
+        conversation = c.Conversation(sampling=dict.fromkeys(c.SAMPLING_KEYS, 1))
+
+        assert set(conversation.sampling) == set(c.SAMPLING_KEYS)
+
+    def test_sampling_given_as_something_other_than_a_mapping_is_rejected_clearly(self) -> None:
+        """A list of pairs would otherwise be reported as "these keys are not canonical"."""
+        with pytest.raises(TypeError, match="mapping"):
+            c.Conversation(sampling=[("temperature", 1)])  # type: ignore[arg-type]
+
+    def test_the_stop_reason_vocabulary_is_closed_but_has_an_escape(self) -> None:
+        """Gemini adds SAFETY and RECITATION; Ollama reports `load` (R8.7).
+
+        Without `other`, a legitimate safety-blocked reply would fail the run —
+        the mistake R9.3 avoids on the request side.
+        """
+        assert set(c.STOP_REASONS) == {"end_turn", "max_tokens", "stop_sequence", "tool_use", "error", "other"}
+
+    def test_the_tool_choice_vocabulary_is_a_constant_not_prose(self) -> None:
+        """Four formats spell one concept four ways; six readers must not each guess (R8.6)."""
+        assert set(c.TOOL_CHOICE_VALUES) == {"auto", "any", "none"}
+        assert c.TOOL_CHOICE_KEY == "tool_choice"
+
+    def test_tool_choice_lands_under_its_single_agreed_key(self) -> None:
+        """The one deliberate exception to keying `extra` by the wire key."""
+        envelope = c.Envelope(extra={c.TOOL_CHOICE_KEY: "auto"})
+
+        assert c.extra_path(c.TOOL_CHOICE_KEY) == "envelope.extra[tool_choice]"
+        assert envelope.extra["tool_choice"] == "auto"
+
+
+class TestPathVocabulary:
+    """How a delta and a register row name the same location (R7)."""
+
+    def test_the_named_envelope_roots_are_constants_not_hand_assembled_strings(self) -> None:
+        """M1's anchor is spelled once, here, so T-W3 and T-D1 cannot drift apart."""
+        assert (c.ENVELOPE_MODEL, c.ENVELOPE_STREAM, c.ENVELOPE_STORE) == (
+            "envelope.model",
+            "envelope.stream",
+            "envelope.store",
+        )
+
+    def test_a_tool_is_addressed_by_name_because_translators_reorder_them(self) -> None:
+        """A positional path would report a delta whenever the list order changed (R7.3)."""
+        assert c.tool_path("get_weather", "strict") == "conversation.tools[get_weather].strict"
+
+    def test_a_part_is_addressed_by_turn_and_part_index(self) -> None:
+        """§3.3.4: a failure must name the exact turn and part."""
+        assert c.part_path(2, 1) == "conversation.turns[2].parts[1]"
+
+    def test_the_remaining_forms_build(self) -> None:
+        """Each form exists because a register row or a design section needs it."""
+        assert c.extra_path("thinking") == "envelope.extra[thinking]"
+        assert c.sampling_path("temperature") == "conversation.sampling[temperature]"
+        assert c.system_path(0) == "conversation.system[0]"
+        assert c.residual_path("generationConfig.topK") == "residual[generationConfig.topK]"
+
+    def test_header_rows_have_a_form_because_three_register_rows_change_headers(self) -> None:
+        """P9a sets User-Agent, P9b swaps the auth scheme, P9c impersonates Codex (§4.3 C1)."""
+        assert c.header_path("User-Agent") == "headers[user-agent]"
+
+    def test_bare_collections_are_legal_paths(self) -> None:
+        """M5 and M13 change `turns` wholesale; §3.3.1 pins P13 to `conversation.sampling`.
+
+        Asserts the exact spellings, not merely a prefix: a check for
+        ``startswith("conversation.")`` would pass on ``conversation.oops``.
+        """
+        assert (c.CONVERSATION_TURNS, c.CONVERSATION_SYSTEM, c.CONVERSATION_TOOLS, c.CONVERSATION_SAMPLING) == (
+            "conversation.turns",
+            "conversation.system",
+            "conversation.tools",
+            "conversation.sampling",
+        )
+
+    def test_a_turn_role_has_a_path_of_its_own(self) -> None:
+        """R8.1 closes the role vocabulary, so a changed role is a nameable delta."""
+        assert c.turn_path(1, "role") == "conversation.turns[1].role"
+        assert c.turn_path(1) == "conversation.turns[1]"
+
+    def test_the_route_components_have_paths_because_the_body_cannot_show_them(self) -> None:
+        """M14 replaces the destination, P20 encodes Azure's deployment, P21 Vertex's project."""
+        assert (c.ROUTE_METHOD, c.ROUTE_SCHEME, c.ROUTE_HOST, c.ROUTE_PATH, c.ROUTE_QUERY) == (
+            "route.method",
+            "route.scheme",
+            "route.host",
+            "route.path",
+            "route.query",
+        )
+        assert c.route_path("host") == c.ROUTE_HOST
+
+    def test_a_route_path_rejects_a_component_that_is_not_one(self) -> None:
+        """The builder exists to stop hand-assembled strings drifting (R7.4)."""
+        with pytest.raises(ValueError):
+            c.route_path("deployment")
+
+    def test_the_reply_direction_has_its_own_root(self) -> None:
+        """M12 is a response-path row and T-D10 diffs Reply projections."""
+        assert c.reply_part_path(0) == "reply.parts[0]"
+        assert c.REPLY_STOP_REASON == "reply.stop_reason"
+        assert c.reply_usage_path("input_tokens") == "reply.usage[input_tokens]"
+        assert c.REPLY_USAGE == "reply.usage"
+
+    def test_a_tool_name_containing_a_dot_survives_the_brackets(self) -> None:
+        """Bracket contents are literal, so a dotted name is not shattered (R7.2d)."""
+        assert c.tool_path("a.b", "strict") == "conversation.tools[a.b].strict"
+        assert c.path_matches("conversation.tools[*].strict", c.tool_path("a.b", "strict"))
+
+    def test_an_unbalanced_bracket_is_rejected_rather_than_silently_mis_split(self) -> None:
+        """R7.2d calls such a path "not addressable"; a wrong answer would be worse."""
+        with pytest.raises(ValueError):
+            c.path_matches("residual[a]].b", "residual[a]")
+
+        with pytest.raises(ValueError):
+            c.path_matches("conversation.tools[abc", "conversation.tools[abc]")
+
+    def test_a_row_the_projection_does_not_model_carries_an_explicit_escape(self) -> None:
+        """M2, M9, P11, P12 and P16 change everything or nothing nameable (R7.2c)."""
+        assert c.NOT_PROJECTABLE == "not projectable"
+
+
+class TestPathMatching:
+    """A register row writes a pattern; a delta is concrete. Assertion 1 is that match (R7.5)."""
+
+    def test_a_concrete_tool_path_matches_the_wildcard_pattern_a_register_row_carries(self) -> None:
+        """§3.3.1 writes P15 as `conversation.tools[].strict` — a wildcard over every tool."""
+        assert c.path_matches("conversation.tools[*].strict", "conversation.tools[get_weather].strict")
+
+    def test_it_does_not_match_a_sibling_field(self) -> None:
+        """The control: a matcher that returned True everywhere would pass the test above."""
+        assert not c.path_matches("conversation.tools[*].strict", "conversation.tools[get_weather].description")
+
+    def test_a_wildcard_matches_any_index(self) -> None:
+        """Turn and part indices vary per corpus entry; the row is written once."""
+        assert c.path_matches("conversation.turns[*].parts[*]", "conversation.turns[3].parts[7]")
+
+    def test_a_bare_collection_pattern_matches_everything_beneath_it(self) -> None:
+        """P13 is anchored to `conversation.sampling`, and drops fourteen keys under it."""
+        assert c.path_matches("conversation.sampling", "conversation.sampling[temperature]")
+
+    def test_an_exact_path_matches_only_itself(self) -> None:
+        """M1's anchor must not accidentally claim a delta on `envelope.stream`."""
+        assert c.path_matches("envelope.model", "envelope.model")
+        assert not c.path_matches("envelope.model", "envelope.stream")
+
+    def test_bracket_contents_are_literal_so_a_dotted_key_survives(self) -> None:
+        """`residual[generationConfig.topK]` must not be re-parsed as two segments (R7.2d)."""
+        assert c.path_matches("residual[*]", "residual[generationConfig.topK]")
+
+    def test_a_literal_star_on_the_concrete_side_is_not_special(self) -> None:
+        """Wildcards live in patterns only.
+
+        A tool genuinely named `*` appearing in a *delta* must not turn that
+        delta into something that matches every pattern.
+        """
+        assert not c.path_matches("conversation.tools[x].strict", "conversation.tools[*].strict")
+
+    def test_a_pattern_claims_paths_beneath_it_even_when_it_carries_a_wildcard(self) -> None:
+        """The case that would have manufactured a false I1 breach.
+
+        T-D1 legitimately reports `conversation.turns[2].parts[0].signature` —
+        M8's carrier repair changes exactly that. A row anchored at
+        `conversation.turns[*].parts[*]` must claim it, or §3.3.2 assertion 1
+        fails the run over a mutation that *is* registered.
+        """
+        assert c.path_matches("conversation.turns[*].parts[*]", "conversation.turns[2].parts[0].signature")
+
+    def test_a_pattern_never_matches_a_shallower_path(self) -> None:
+        """The control: prefix matching runs one way only."""
+        assert not c.path_matches("conversation.turns[*].parts[*]", "conversation.turns[2]")
+
+    def test_the_old_empty_bracket_spelling_still_matches(self) -> None:
+        """§3.3.1 wrote P15 as `conversation.tools[].strict` before this vocabulary existed.
+
+        A row carried over in the old notation must not silently match nothing.
+        """
+        assert c.path_matches("conversation.tools[].strict", "conversation.tools[get_weather].strict")
+
+    def test_a_sibling_collection_is_not_claimed(self) -> None:
+        """`conversation.tools` must not claim a delta under `conversation.turns`."""
+        assert not c.path_matches(c.CONVERSATION_TOOLS, "conversation.turns[0].parts[0]")
+
+    def test_the_prefix_stops_at_a_bracket(self) -> None:
+        """The second rule sitting next to the first, and the one that surprises.
+
+        Bracket contents are literal, so a pattern naming a *parent key* does
+        not claim paths nested under it. Only the wildcard or the bare
+        collection reaches inside. A T-W3 author who has internalised "a
+        pattern is a prefix" gets this wrong once, so it is pinned.
+        """
+        assert not c.path_matches("residual[generationConfig]", "residual[generationConfig.topK]")
+        assert c.path_matches("residual[*]", "residual[generationConfig.topK]")
+        assert c.path_matches("residual", "residual[generationConfig.topK]")
+
+
+def _capture(
+    *,
+    method: str = "POST",
+    scheme: str = "https",
+    host: str = "api.example.com",
+    path: str = "/v1/messages",
+    query: str = "",
+    headers: tuple[tuple[str, str], ...] = (),
+    body: bytes = b"{}",
+) -> c.CapturedRequest:
+    """Build a capture with everything but the field under test defaulted.
+
+    Args:
+        method: HTTP method.
+        scheme: URL scheme.
+        host: URL host.
+        path: URL path.
+        query: Raw query string.
+        headers: Ordered header pairs, casing preserved.
+        body: Raw body bytes.
+
+    Returns:
+        A :class:`~harness.contract.CapturedRequest` for one assertion.
+    """
+    return c.CapturedRequest(
+        method=method, scheme=scheme, host=host, path=path, query=query, headers=headers, body=body
+    )
+
+
+#: One body, read four different ways below. ``mystery`` is the key none of the
+#: readers were written to expect; ``generationConfig`` is the nesting key that
+#: makes the nested-drop case possible.
+_BODY = {
+    "model": "claude-opus-5",
+    "mystery": "an unregistered field",
+    "generationConfig": {"topK": 40},
+}
+
+
+def _project(consumed: set[str], residual: dict[str, object], source: dict[str, object] | None = None) -> c.Request:
+    """Build a projection claiming a given account of the body.
+
+    Args:
+        consumed: Top-level body keys the stub reader claims to have mapped.
+        residual: Paths the stub reader could not classify, with their values.
+        source: The body the stub reader read; defaults to :data:`_BODY`.
+
+    Returns:
+        A :class:`~harness.contract.Request` standing in for a reader's output.
+    """
+    return c.Request(
+        envelope=c.Envelope(model="claude-opus-5"),
+        conversation=c.Conversation(),
+        residual=residual,
+        consumed=frozenset(consumed),
+        source=source if source is not None else _BODY,
+    )
+
+
+class TestTotalityFalsification:
+    """The harness rule (plan §1.4): a deliberate defect this contract must detect.
+
+    Four stub readers over one body, differing only in how they account for the
+    keys they were not written to expect.  This is why :attr:`Request.consumed`
+    exists — see :meth:`test_a_reader_that_drops_an_unknown_key_is_caught`.
+    """
+
+    def test_a_reader_that_drops_an_unknown_key_is_caught(self) -> None:
+        """**The ticket's named falsification case.**
+
+        This is the one a residual-only rule cannot catch.  The reader neither
+        maps ``mystery`` nor residualises it, so the residual is *empty* and a
+        "residual must be empty" check would pass.  Totality is decidable only
+        against the source body, which is the whole reason the projection
+        declares what it consumed.
+        """
+        dropped = _project(consumed={"model", "generationConfig"}, residual={})
+
+        with pytest.raises(c.DroppedFieldsError, match="mystery"):
+            c.verify_total(dropped)
+
+    def test_a_reader_that_residualises_an_unknown_key_is_caught(self) -> None:
+        """§3.3.1: a non-empty residual fails the run — it is neither a diff nor ignored."""
+        residualised = _project(consumed={"model", "generationConfig"}, residual={"mystery": "an unregistered field"})
+
+        with pytest.raises(c.ResidualFieldsError, match="mystery"):
+            c.verify_total(residualised)
+
+    def test_a_reader_that_drops_a_key_nested_under_one_it_consumed_is_caught(self) -> None:
+        """Top-level accounting alone would pass this.
+
+        Gemini puts every sampling parameter under ``generationConfig``, so a
+        reader that consumes the outer key and quietly ignores ``topK`` inside
+        it satisfies a top-level check.  Path-keyed residuals are what close it.
+        """
+        nested = _project(
+            consumed={"model", "mystery", "generationConfig"},
+            residual={"generationConfig.topK": 40},
+        )
+
+        with pytest.raises(c.ResidualFieldsError, match="generationConfig.topK"):
+            c.verify_total(nested)
+
+    def test_a_reader_that_accounts_for_every_key_passes(self) -> None:
+        """**The control.**
+
+        Without it, a :func:`verify_total` that raised unconditionally would
+        satisfy all three cases above — a harness that cannot pass is as useless
+        as one that cannot fail.
+        """
+        total = _project(consumed={"model", "mystery", "generationConfig"}, residual={})
+
+        c.verify_total(total)
+
+    def test_a_dropped_key_is_reported_ahead_of_a_residual(self) -> None:
+        """A silent drop is the more dangerous defect, so it names the failure (R2.6).
+
+        The message must name **every** dropped key, not just the first: a
+        checker truncating the list would leave a maintainer fixing one field
+        and re-running to discover the next.
+        """
+        both = _project(consumed=set(), residual={"mystery": "x"})
+
+        with pytest.raises(c.DroppedFieldsError, match=r"generationConfig.*model"):
+            c.verify_total(both)
+
+    def test_a_reply_that_drops_a_key_is_caught_too(self) -> None:
+        """The rule is bidirectional (R2.4), and only its *passing* case was covered.
+
+        T-A7 and T-D10 read this direction. A checker that silently returned
+        for anything that is not a ``Request`` would satisfy every other case
+        in this class — a harness blind on one side is the shape §1.4 exists to
+        prevent, and it would go unnoticed until T-D10.
+        """
+        dropped = c.Reply(consumed=frozenset({"content"}), source={"content": [], "surprise": 1})
+
+        with pytest.raises(c.DroppedFieldsError, match="surprise"):
+            c.verify_total(dropped)
+
+    def test_a_nested_residual_does_not_account_for_its_top_level_parent(self) -> None:
+        """The tempting wrong reading of this contract's own split (R2.2/R2.3).
+
+        ``consumed`` holds top-level keys while ``residual`` holds full paths,
+        which invites a checker that credits ``generationConfig.topK`` to
+        ``generationConfig``. It must not: the reader residualised something
+        *inside* the key without ever claiming the key itself, so the key is
+        still dropped.
+        """
+        nested_only = _project(
+            consumed=set(),
+            residual={"generationConfig.topK": 40},
+            source={"generationConfig": {"topK": 40}},
+        )
+
+        with pytest.raises(c.DroppedFieldsError, match="generationConfig"):
+            c.verify_total(nested_only)
+
+    def test_a_key_claimed_but_absent_from_the_body_is_named_in_the_message(self) -> None:
+        """A typo'd claim already fails as a drop; this stops it being mis-diagnosed (R2.7).
+
+        The realistic accident: a reader claims ``max_token`` while the body
+        carries ``max_tokens``.  The real key is then in neither account, so it
+        already fails as a drop — but reported alone that reads as "the reader
+        ignored max_tokens", when in fact it handled it and misspelled the
+        claim.  Naming the absent claim alongside points at the actual defect.
+
+        Claimed-but-absent is deliberately **not** its own error: on its own it
+        harms nothing, and a second error type would fire on a body that is
+        fully accounted for.
+        """
+        typo = _project(
+            consumed={"max_token"},
+            residual={},
+            source={"max_tokens": 4096},
+        )
+
+        with pytest.raises(c.DroppedFieldsError, match="claimed but absent.*max_token"):
+            c.verify_total(typo)
+
+    def test_a_claim_absent_from_the_body_does_not_fail_a_run_on_its_own(self) -> None:
+        """The control for the test above: it is a diagnostic, not a failure (R2.7)."""
+        over_claimed = _project(
+            consumed={"max_tokens", "not_in_this_body"},
+            residual={},
+            source={"max_tokens": 4096},
+        )
+
+        c.verify_total(over_claimed)
+
+    def test_a_key_in_both_accounts_is_treated_as_a_residual(self) -> None:
+        """R2.8 states the edge rather than leaving each reader to discover it."""
+        both = _project(consumed={"model", "mystery", "generationConfig"}, residual={"mystery": "x"})
+
+        with pytest.raises(c.ResidualFieldsError):
+            c.verify_total(both)
+
+    def test_it_accepts_a_reply_as_well_as_a_request(self) -> None:
+        """M12 is a response-path row and T-D10 diffs replies (R2.4)."""
+        reply = c.Reply(parts=(), stop_reason="end_turn", usage={}, residual={}, consumed=frozenset({"content"}),
+                        source={"content": []})
+
+        c.verify_total(reply)
+
+
+class TestProtocols:
+    """What the six readers implement (R4)."""
+
+    def test_a_conforming_reader_satisfies_the_request_protocol(self) -> None:
+        """`isinstance`, never `issubclass` — the latter raises on a data protocol."""
+        assert isinstance(_StubReader(), c.Projection)
+
+    def test_a_class_missing_the_method_does_not_satisfy_it(self) -> None:
+        """The control for the test above."""
+
+        class NotAReader:
+            """A class that declares the format but cannot read one."""
+
+            wire_format = c.WireFormat.GEMINI
+
+        assert not isinstance(NotAReader(), c.Projection)
+
+    def test_read_request_takes_a_whole_capture_not_a_body(self) -> None:
+        """Gemini carries the model and the operation in the URL (§3.3.5, R4.2).
+
+        `isinstance` checks member presence only, never signatures, so this
+        annotation check is what actually pins the parameter type.
+
+        Resolved with ``get_type_hints`` rather than read from
+        ``__annotations__``: the module uses ``from __future__ import
+        annotations``, so the raw attribute holds the *string*
+        ``"CapturedRequest"`` and would compare equal to a same-named class
+        from anywhere at all.
+        """
+        hints = get_type_hints(c.Projection.read_request)
+
+        assert hints["captured"] is c.CapturedRequest
+
+    def test_the_reply_protocol_is_separate_and_a_request_reader_does_not_satisfy_it(self) -> None:
+        """§3.3.1: response translation "is a different claim and it gets a different test"."""
+        assert not isinstance(_StubReader(), c.ReplyProjection)
+
+    def test_both_protocols_declare_the_wire_format_the_oracle_selects_on(self) -> None:
+        """§7.4 selects a projection by the shape observed on the wire, in both directions."""
+        assert "wire_format" in c.Projection.__annotations__
+        assert "wire_format" in c.ReplyProjection.__annotations__
+
+    def test_the_wire_format_enum_names_exactly_the_six_formats_the_design_lists(self) -> None:
+        """A bare `str` would let six authors spell one format three ways (R4.4)."""
+        assert {f.value for f in c.WireFormat} == {
+            "anthropic_messages",
+            "chat_completions",
+            "openai_responses",
+            "gemini",
+            "bedrock_converse",
+            "ollama_chat",
+        }
+
+
+class _StubReader:
+    """A minimal conforming request projection, for the protocol tests."""
+
+    wire_format = c.WireFormat.ANTHROPIC_MESSAGES
+
+    def read_request(self, captured: c.CapturedRequest) -> c.Request:
+        """Return an empty projection.
+
+        Args:
+            captured: The request as observed on the wire.
+
+        Returns:
+            A projection accounting for nothing, which is enough for a
+            protocol-conformance check.
+        """
+        return _project(consumed=set(), residual={}, source={})
+
+
+def test_unreadable_body_error_is_named_by_the_contract() -> None:
+    """Six readers would otherwise raise six types and T-D1 would catch `Exception` (R2.10)."""
+    assert issubclass(c.UnreadableBodyError, Exception)
+
+
+#: Any form of reaching into the product package. Deliberately not a
+#: ``startswith`` check: that missed ``from src.kitty import ...``, a double
+#: space after the keyword, and both dynamic forms.
+#: The static half is anchored to the start of a line (with leading whitespace
+#: allowed, so an indented import still matches) rather than floating, so prose
+#: mentioning an import in a comment or docstring cannot trip it. The two
+#: dynamic forms stay unanchored, because they appear mid-expression.
+_KITTY_IMPORT = re.compile(
+    r"^\s*(?:from|import)\s+(?:src\.)?kitty\b"
+    r"|import_module\(\s*[\"']kitty"
+    r"|__import__\(\s*[\"']kitty"
+)
+
+
+def test_the_contract_imports_nothing_from_kitty() -> None:
+    """The oracle must not be written in terms of the code under test (§3.3.1, §7.4).
+
+    This is the single structural guarantee the whole I1 claim rests on: a
+    projection that asked kitty how to read a body would inherit kitty's bugs,
+    and the oracle would prove self-consistency rather than fidelity.
+
+    Read from source rather than by inspecting imports, so an import inside a
+    function body is caught as well as a module-level one.
+    """
+    source = Path(c.__file__).read_text(encoding="utf-8")
+
+    # Assert the subject was actually read: a guard that passes on an empty
+    # string is indistinguishable from one that cannot fail (house rule,
+    # `tests/test_egress_coverage.py`).
+    assert len(source) > 1000, "read no meaningful source; the guard would pass vacuously"
+
+    offending = [line.strip() for line in source.splitlines() if _KITTY_IMPORT.search(line)]
+
+    assert offending == [], f"contract.py must not import kitty: {offending}"
+
+
+def test_the_import_guard_actually_fires_on_every_form_it_claims_to_catch() -> None:
+    """The positive control for the guard above.
+
+    Without it, a pattern that had stopped matching anything would read as a
+    clean bill of health forever.
+    """
+    forms = [
+        "from kitty.bridge import server",
+        "import kitty",
+        "from  kitty import server",
+        "import  kitty.bridge",
+        "from src.kitty import server",
+        'mod = importlib.import_module("kitty.bridge.server")',
+        '__import__("kitty")',
+    ]
+
+    undetected = [form for form in forms if not _KITTY_IMPORT.search(form)]
+
+    assert undetected == [], f"the guard would miss these: {undetected}"
+
+
+def test_the_import_guard_does_not_fire_on_innocent_text() -> None:
+    """The negative control: a pattern matching everything would also pass above."""
+    innocent = [
+        "# kitty-bridge is the product under test",
+        "from harness import contract",
+        "kitty = 1",
+        "# never write `import kitty` in this module",
+    ]
+
+    assert [line for line in innocent if _KITTY_IMPORT.search(line)] == []


### PR DESCRIPTION
Closes **[KBR-25](https://shelpuk.atlassian.net/browse/KBR-25)** — plan task **T-W2**, the input contract.

---

## Context for the Product Owner

**What this is for.** Kitty Bridge's promise to the user is that it changes nothing in their request except what we deliberately decided to change — the model, mostly. Nothing proves that today. The test-suite design (KBR-2) specifies a "transparency oracle" that takes the request the coding agent sent and the bytes we actually put on the provider's wire, translates both into one neutral form, and fails on any difference nobody registered.

Those two things are in **different languages**: the agent might speak Anthropic Messages while the provider speaks Bedrock Converse. You cannot compare them as JSON. This PR defines the neutral language both get translated into.

**What it does not do.** It tests nothing about kitty yet. It is the dictionary; the eleven tasks behind it are the translators, the recorder, and the comparison itself. Nothing user-visible changes, and no product code is touched.

**Why it matters commercially.** This is the foundation for catching a whole class of bug that is currently invisible: a provider adapter that quietly drops a tool description, rewrites a token limit, or sends a request to the wrong Azure deployment. Those degrade output quality in ways that look like the model being bad rather than the bridge being wrong.

**Cost.** The plan sized this at half a day; it took about a day and a half. Two things moved into it during design review that the plan had not anticipated (below). Because this task sits at the head of every dependency chain, **every milestone moves one day** — the programme goes 17 → 18 days. The chain table in the plan is recomputed rather than left stale.

---

## What is in the change

| File | |
|---|---|
| `tests/harness/contract.py` | The contract — types, protocols, the totality rule, the path vocabulary |
| `tests/harness/test_contract.py` | 106 tests, including the falsification set |
| `.system_design/TEST_SUITE.md` | §3.3.1 corrected; §3.3.1a and §3.3.1b added |
| `.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md` | T-W2 re-scoped and re-sized; schedule recomputed |

No file under `src/kitty/` is touched.

### The load-bearing decision

The ticket names the falsification case: *"a stub reader that drops an unknown key fails it."*

The obvious implementation — "check nothing was left unclassified" — **cannot catch that reader.** A reader that drops a field leaves nothing behind to find, so the check passes over the exact defect it was written for. Totality is only decidable against the original body, so a projection now declares what it *accounted for*, and the check compares that against the source.

### Two additions from design review

Both are here for the same reason the ticket gives for putting `CapturedRequest` here rather than in T-W4 — one contract, one reading:

- **A path vocabulary and its matcher.** The next task (KBR-26) must record, for all 35 registered mutations, which field each one touches; the oracle must emit the same strings when reporting a difference. Neither can define that vocabulary without the other agreeing.
- **Cross-format normalisation rules.** Gemini calls the assistant `model`; OpenAI puts a tool result in its own message where Anthropic nests it inside a user turn. Six readers written by six authors would each choose differently, and the oracle would then report *our own inconsistency* as a broken promise — a false alarm on every Gemini request, which is the fastest way to get a safety check ignored.

### Verified, not asserted

Plan §1.4 exists because four earlier harness designs would have passed while proving nothing. So five deliberately broken versions of the check were built, and all five are killed by the test set:

| Sabotage | |
|---|---|
| Only checks for unclassified fields | killed |
| Rejects everything, always | killed |
| Checks requests, silently skips replies | killed |
| Credits a nested field to its parent | killed |
| Reports only the first missing field | killed |

The last three came from code review — the set that shipped first missed them.

### Facts checked against vendor documentation

- Bedrock Converse tool results carry `json` (the common case), `document`, `video`, `searchResult`; Anthropic carries `document` and `search_result`. The original shape held only text and images and would have dropped all of it **silently and identically on both sides** — invisible to the check.
- Gemini's `functionCall`/`functionResponse` carry **no id**, so tool-call ids are optional and pairing falls back to name and order. Ollama is recorded as unverified and handed to KBR-38.

---

## Review trail

Three `system-design-reviewer` rounds on the requirements, two `code-reviewer` rounds on the code, and two automated review rounds on this PR. Notable outcomes:

- The reviewer showed the original scoping decision on two recorder fields was wrong — four tasks consume them, and my split would have forced them all onto a different type. Reversed.
- I declined one proposed fix and said why: it would not have fixed the case it was raised for. The reviewer agreed on re-review.
- The final blocking finding was that my own matcher fix left the **design document** describing behaviour the code no longer had — the precise failure this task exists to prevent. Corrected, along with an anchoring warning that follows from it and is now carried by KBR-26 and KBR-53.

## Verification

- `ruff check .`, `lint-imports`, `mypy src/kitty` — pass
- `mypy tests/harness/contract.py` — clean (CI does not gate `tests/`)
- Full suite — green on **Python 3.10, 3.11, 3.12 and 3.13** in CI (~19 min each), plus `ci-required`. Locally the suite ran clean at the 93-test revision (3346 passed, 37 skipped, against a 3257-passed baseline on `main`); later local re-runs were killed by machine memory pressure, so CI across all four versions is the authoritative result.
- Bare-`pytest` collection verified in the CI form, since this repo has previously had a green local run and a red CI from that difference.

## Handed on, deliberately

- The 35-row assignment goes to **KBR-26**, reading the register's own data. A copy inside this task would be a second source of truth that stays green while the register moves.
- The tool-result merge rule goes to **KBR-34**: proving it needs two independently written readers, and a contract-level test would only show the author can copy.
- Route accounting splits between **KBR-36** (reader) and **KBR-52** (assertion).
- Body-borne credentials in captures, and whether Ollama's sampling options widen the canonical set, are recorded as open scope questions rather than decided here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[KBR-25]: https://shelpuk.atlassian.net/browse/KBR-25?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ