### PR TITLE
Make a missing openssl fail the gate instead of vanishing from it

### DIFF
--- a/.system_design/TEST_SUITE.md
+++ b/.system_design/TEST_SUITE.md
@@ -1885,9 +1885,10 @@ has to keep it, and the fix for a red gate is to install `openssl`, never to rei
 resource.** §8.1's `RESOURCE_DEPENDENT_LAYERS` excludes a whole **layer** whose resource a
 developer's machine may not have — a pinned agent binary, live credentials, a load rig — so a bare
 `pytest` reports those as *deselected*, not skipped. That mechanism is layer-granular by
-construction, and `openssl` is needed by a handful of tests *inside* `l1`, spread across three
-modules. A resource used by part of a gating layer therefore has only two possible treatments:
-skip it, which §8 forbids, or require it.
+construction, and `openssl` is needed by *some tests inside* `l1` rather than by a layer — stated
+as that property rather than as a count of modules, which is the kind of number that goes stale
+silently. A resource used by part of a gating layer has only two possible treatments: skip it,
+which §8 forbids, or require it.
 The two rules are consistent, and the seam between them is worth naming because the obvious
 reading of §8.1 suggests a third option that does not exist.
 

--- a/.system_design/TEST_SUITE.md
+++ b/.system_design/TEST_SUITE.md
@@ -1861,10 +1861,43 @@ most expensive kind of false confidence.
 
 **One exception, stated so the rule is honest.** A **platform or interpreter** skip is permitted:
 `tests/test_launcher_discovery.py` skips POSIX cases on Windows, and the matrix is what covers
-them. A **resource-availability** skip is not, and the suite has one today —
-`tests/bridge/test_bridge_state.py` calls `pytest.skip("openssl not available")` inside a gating
-job, which is the exact shape this rule forbids. Filed as KBR-132 rather than quietly
-grandfathered — the rule is only worth stating if its one known breach has an owner.
+them. A **resource-availability** skip is not. The suite had one — `tests/bridge/test_bridge_state.py`
+called `pytest.skip("openssl not available")` inside a gating job, the exact shape this rule
+forbids — filed as KBR-132 rather than quietly grandfathered, and **closed on 2026-09-11**.
+
+**How it is upheld there now.** `tests/bridge/tls_certs.py` owns the certificate generation the
+bridge TLS tests need, and every non-success exit from it goes through `pytest.fail`: a missing
+binary, a non-zero exit, a timeout. `tests/bridge/test_tls_certs.py` is the check on that, and its
+falsification case — restore the skip, the test must go **red** — is what makes it a detector
+rather than a decoration. That case is written out in the module rather than left to a
+`pytest.raises`, because `Failed` and `Skipped` are *sibling* classes: `pytest.raises(Failed)` does
+not catch a `Skipped`, so the obvious spelling would have reported the reintroduced defect as a
+*skipped* test, passing the gate. A detector that fails by skipping is the defect wearing the
+uniform of its own guard.
+
+**A consequence, stated because it is now load-bearing:** `openssl` is an **environment
+prerequisite of the Fast job**, not something a test may probe for. Forbidding the
+resource-availability skip and requiring the runner to provide the resource are the same statement.
+`ubuntu-latest` ships it; a change of runner image, a container job, or a non-Ubuntu matrix entry
+has to keep it, and the fix for a red gate is to install `openssl`, never to reinstate the skip.
+
+**Why that is not handled by deselection, which is this document's other answer for a missing
+resource.** §8.1's `RESOURCE_DEPENDENT_LAYERS` excludes a whole **layer** whose resource a
+developer's machine may not have — a pinned agent binary, live credentials, a load rig — so a bare
+`pytest` reports those as *deselected*, not skipped. That mechanism is layer-granular by
+construction, and `openssl` is needed by a handful of tests *inside* `l1`, spread across three
+modules. A resource used by part of a gating layer therefore has only two possible treatments:
+skip it, which §8 forbids, or require it.
+The two rules are consistent, and the seam between them is worth naming because the obvious
+reading of §8.1 suggests a third option that does not exist.
+
+**The rule itself is still only prose.** Nothing checks that a *future* test does not do what
+`test_bridge_state.py` did. The property holds today — no test in a gating layer calls
+`pytest.skip`, and every `skipif` left there tests `sys.platform`, `os.name`, `sys.version_info` or
+`hasattr(signal, ...)` — but that is an observation about the present, not a mechanism, and it is
+the kind of observation that stops being true without anyone noticing. Filed as
+[KBR-138](https://shelpuk.atlassian.net/browse/KBR-138), by the same reasoning that filed KBR-132:
+the rule is only worth stating if the gap between it and its enforcement has an owner.
 
 ### 8.1 The selection mechanism
 
@@ -1934,6 +1967,11 @@ T-K6's business, together with the job that runs them; doing it earlier would re
 every gate. T-H1 must take that reclassification into account before it measures a mutation
 baseline, because it selects on `l1`.
 
+KBR-132 added one to that set: `tests/bridge/test_tls_certs.py` spawns a real `openssl` in one of
+its five cases. Named here rather than left for T-K6 to rediscover, since the count is what T-K6
+and T-H1 plan against. KBR-132 deliberately did **not** move it — the rule above applies to a test
+fixing a skip defect exactly as it applies to any other.
+
 **The load gate has to be wired, not merely declared.** The table above marks Load as gating a
 release, but `publish.yml` currently depends only on the reusable `tests.yml`. Putting the load
 run in "its own workflow" would leave publication free to proceed while load fails — or while it
@@ -1991,6 +2029,7 @@ does not surface work that is done. `TEST_SUITE_IMPLEMENTATION_PLAN.md` §16 mir
 | **G19** | Routing was outside the register and outside the oracle | The destination is built from the profile (M14, P20, P21); a body-only check cannot see a misrouted Azure deployment | §3.3.5 — whole-request oracle with an independently derived route | **1** |
 | **G17** | Undecided behaviour for an irreducible final turn | Compaction emits an over-budget request, or (since KBR-5) the bridge refuses it downstream; neither was designed | Answer Q10, then align M3-M7, the 6.1 properties and TR-3 together | **2** |
 | **G18** | P13-P19 - seven transport-level mutations, unregistered in the first draft | Necessary (the Codex backend and boto3 require them) but invisible above DEBUG, and unreachable by a guard placed at `translate_to_upstream` | Rows P13-P19; boundary corrected in 3.2.3; Q5 decides user visibility | **3** |
+| **G21** | §8's skip rule is stated in prose and nothing checks it — KBR-138 | Found while closing KBR-132. The known breach is fixed, and every skip left in a *gating* layer is a platform or interpreter one — but that is an observation, not a mechanism, and the next resource-availability skip written into `l1`, `l2`, `l3` or `acceptance` re-creates the same silent-green defect | A check over the collected suite that fails on a resource-availability skip in a gating layer, with a planted skip as its falsification case (§1.4). It must be **layer-aware**: `tests/integration/test_agent_e2e.py` holds three legitimate resource skips (missing credentials, profile, agent binary) that are legal only because they sit in `agent_live`, so a flat grep would report them and be turned off. Two further questions: static sweep or runtime hook, and whether a permitted skip is recognised by condition shape or declared by marker | **3** |
 | **G1** | I1 is unstated and untested | No definition of "unchanged"; mutation sites discoverable only by reading 6,463 lines | Register (§3.2) + oracle (§3.3) | **1** |
 | **G2** | No-bypass unproven **for the bridge's serving path**; no negative assertion; start-path guard is file-granular | `test_egress_https_proxy.py` proves the transports and drives `egress_cmd._probe` | Sealed-network harness (§5.2) per transport (§5.5) + AST start-path guard | **1** |
 | **G3** | I2 partially breached (F1) — KBR-8 | Identity ad hoc per adapter; the subscription adapter reports two different versions in one request | Header contract + parity baseline, then a policy and a code fix | **2** |

--- a/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
+++ b/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
@@ -522,6 +522,7 @@ merge.** So:
 | KBR-7 · **CLOSED** | G16 | T-G4 | Route taken: atomic fix + hook-level guard landed together, red evidence in the PR. T-G4 still owns the wire boundary. (Status convention: `TEST_SUITE.md` §9.2.) |
 | KBR-8 | G3 | T-G9, TR-1c | Atomic fix + test now |
 | KBR-9 | G6 | T-G1 | Atomic fix + test now |
+| KBR-132 · **CLOSED** | G21 | — | Route taken: atomic fix + regression test, red at base, evidence in the PR. The broader guard is **KBR-138**, which has no plan-task ID because it was filed after this plan was written; G21 is its design gap. (Status convention: `TEST_SUITE.md` §9.2.) |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -755,6 +755,13 @@ ruff check .
 mypy src/kitty
 ```
 
+The suite also needs `openssl` on your `PATH` — a few tests generate a throwaway TLS certificate
+with it. A missing `openssl` fails those tests rather than skipping them, deliberately: a test that
+removes itself when a resource is absent lets CI report success without having run it. That is a
+different treatment from the deselected categories described below, and the difference is the
+granularity: a resource needed by a whole *layer* is excluded by selection, while a resource needed
+by a handful of tests inside a layer CI gates on has to be present.
+
 ### Running a subset of the tests
 
 Every test carries exactly one layer marker, so you can ask for the part you need:

--- a/tests/bridge/test_bridge_state.py
+++ b/tests/bridge/test_bridge_state.py
@@ -8,10 +8,11 @@ from pathlib import Path
 
 import pytest
 
-from bridge.tls_certs import generate_self_signed_cert
 from kitty.bridge.server import BridgeServer
 from kitty.bridge.state import BridgeState, load_state, remove_state, write_state
 from kitty.providers.zai import ZaiRegularAdapter
+
+from .tls_certs import generate_self_signed_cert
 
 
 def _default_state_path() -> Path:

--- a/tests/bridge/test_bridge_state.py
+++ b/tests/bridge/test_bridge_state.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import pytest
 
+from bridge.tls_certs import generate_self_signed_cert
 from kitty.bridge.server import BridgeServer
 from kitty.bridge.state import BridgeState, load_state, remove_state, write_state
 from kitty.providers.zai import ZaiRegularAdapter
@@ -63,34 +64,10 @@ class TestBridgeStateFile:
     async def test_state_file_with_tls_flag(self, tmp_path: Path):
         """State file records tls=True when TLS is configured."""
         state_path = tmp_path / "bridge_state.json"
-        # We need a cert/key to start TLS — skip if openssl not available
-        import subprocess
-
-        try:
-            cert = tmp_path / "cert.pem"
-            key = tmp_path / "key.pem"
-            subprocess.run(
-                [
-                    "openssl",
-                    "req",
-                    "-x509",
-                    "-newkey",
-                    "rsa:2048",
-                    "-keyout",
-                    str(key),
-                    "-out",
-                    str(cert),
-                    "-days",
-                    "1",
-                    "-nodes",
-                    "-subj",
-                    "/CN=localhost",
-                ],
-                check=True,
-                capture_output=True,
-            )
-        except (FileNotFoundError, subprocess.CalledProcessError):
-            pytest.skip("openssl not available")
+        # A missing openssl fails this test rather than skipping it: this is a
+        # gating layer, and TEST_SUITE.md section 8 forbids the quiet version
+        # (KBR-132). `tls_certs` owns that behaviour.
+        cert, key = generate_self_signed_cert(tmp_path)
 
         server = BridgeServer(
             adapter=None,

--- a/tests/bridge/test_tls_certs.py
+++ b/tests/bridge/test_tls_certs.py
@@ -59,7 +59,7 @@ def _failure_message_from(tmp_path: Path) -> str:
         raise AssertionError(
             f"The helper skipped instead of failing ({skipped}). A skip inside a "
             "gating job is what KBR-132 fixed; TEST_SUITE.md section 8 forbids it."
-        ) from None
+        ) from skipped
     except pytest.fail.Exception as failed:
         return str(failed)
 
@@ -91,21 +91,24 @@ def no_openssl_on_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
 class TestMissingOpensslFailsTheRun:
     """The resource is absent: the run goes red, never green-by-omission."""
 
-    def test_missing_openssl_fails_it_does_not_skip(
-        self, tmp_path: Path, no_openssl_on_path: None
-    ) -> None:
+    @pytest.mark.usefixtures("no_openssl_on_path")
+    def test_missing_openssl_fails_it_does_not_skip(self, tmp_path: Path) -> None:
         """PATH carrying no openssl produces a failure, not a skip (AC1).
 
         This is the falsification case for the whole change: restoring the
         ``pytest.skip`` in the helper turns this test red.
+
+        The assertion names the *missing-binary* branch rather than just
+        ``"openssl"``: all three of the helper's failure messages contain that
+        word, so the looser assertion would pass on any failure at all and prove
+        only that something went wrong somewhere.
         """
         message = _failure_message_from(tmp_path)
 
-        assert "openssl" in message
+        assert "not found on PATH" in message
 
-    def test_the_failure_message_says_why_it_did_not_skip(
-        self, tmp_path: Path, no_openssl_on_path: None
-    ) -> None:
+    @pytest.mark.usefixtures("no_openssl_on_path")
+    def test_the_failure_message_says_why_it_did_not_skip(self, tmp_path: Path) -> None:
         """The message names the rule, so a CI log is self-explanatory (AC1b).
 
         Asserted rather than left to prose: a reader of a red CI job needs to

--- a/tests/bridge/test_tls_certs.py
+++ b/tests/bridge/test_tls_certs.py
@@ -1,0 +1,183 @@
+"""Tests for KBR-132: the certificate helper fails loudly, it never skips.
+
+``.system_design/TEST_SUITE.md`` §8 forbids a resource-availability skip inside
+a gating job. :mod:`bridge.tls_certs` is where that rule is kept for the bridge
+TLS tests, and this module is the check on it.
+
+🔴 **The catch shape below is the point of these tests, not ceremony.**
+``pytest.fail.Exception`` (``Failed``) and ``pytest.skip.Exception``
+(``Skipped``) are *siblings*: both derive from ``OutcomeException``, which
+derives from ``BaseException``. So ``pytest.raises(Failed)`` does **not** catch
+a ``Skipped`` — if the defect were reintroduced, the ``Skipped`` would escape
+the ``raises`` block, propagate out of the test body, and pytest would report
+these tests as **skipped**, which passes the gate. The detector would have
+reproduced the very defect it exists to detect. Every case therefore catches
+``Skipped`` *first* and converts it into an assertion failure.
+
+The two exception attributes are the most public form pytest offers; the classes
+themselves live in the private ``_pytest.outcomes``. They are undocumented but
+long-stable and widely used, which is a deliberate trade against importing a
+private module, and is recorded here because `pyproject.toml` pins
+``pytest>=8.0`` with no upper bound.
+"""
+
+from __future__ import annotations
+
+import ssl
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from bridge.tls_certs import generate_self_signed_cert
+
+# Distinctive enough that finding it in a failure message proves the helper
+# passed openssl's own diagnostics through rather than inventing a summary.
+_STDERR_SENTINEL = "problems making Certificate Request"
+
+
+def _failure_message_from(tmp_path: Path) -> str:
+    """Call the helper and return the message of the failure it must raise.
+
+    Args:
+        tmp_path: Directory handed to :func:`generate_self_signed_cert`.
+
+    Returns:
+        The text of the ``Failed`` exception the helper raised.
+
+    Raises:
+        AssertionError: When the helper skips, or returns successfully. Both are
+            the KBR-132 defect: a skip removes the test from a gating job, and a
+            success means the failure condition was not reproduced at all.
+    """
+    # `Skipped` is caught FIRST and re-raised as an ordinary assertion failure.
+    # Letting it propagate would mark this test skipped -- green, silent, and
+    # the exact outcome these tests exist to make impossible.
+    try:
+        generate_self_signed_cert(tmp_path)
+    except pytest.skip.Exception as skipped:
+        raise AssertionError(
+            f"The helper skipped instead of failing ({skipped}). A skip inside a "
+            "gating job is what KBR-132 fixed; TEST_SUITE.md section 8 forbids it."
+        ) from None
+    except pytest.fail.Exception as failed:
+        return str(failed)
+
+    raise AssertionError(
+        "The helper returned successfully where it had to fail. The failure "
+        "condition was not reproduced, so this test proves nothing."
+    )
+
+
+class TestMissingOpensslFailsTheRun:
+    """The resource is absent: the run goes red, never green-by-omission."""
+
+    def test_missing_openssl_fails_it_does_not_skip(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """PATH carrying no openssl produces a failure, not a skip (AC1).
+
+        ``PATH`` is scrubbed rather than :func:`subprocess.run` stubbed, because
+        absence of the binary is the actual CI condition being guarded and a
+        stub would prove only that the ``except`` branch is reachable.
+
+        This is also the falsification case for the whole change: restoring the
+        ``pytest.skip`` in the helper turns this test red.
+        """
+        empty = tmp_path / "no-binaries"
+        empty.mkdir()
+        monkeypatch.setenv("PATH", str(empty))
+
+        message = _failure_message_from(tmp_path)
+
+        assert "openssl" in message
+
+    def test_the_failure_message_says_why_it_did_not_skip(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The message names the rule, so a CI log is self-explanatory (AC1b).
+
+        Asserted rather than left to prose: a reader of a red CI job needs to
+        know that reinstating the skip is the one fix that is not available.
+        """
+        empty = tmp_path / "no-binaries"
+        empty.mkdir()
+        monkeypatch.setenv("PATH", str(empty))
+
+        message = _failure_message_from(tmp_path)
+
+        assert "TEST_SUITE.md" in message
+
+
+class TestOpensslMisbehaviourFailsTheRun:
+    """The resource is present but unusable: still red, and still legible."""
+
+    def test_openssl_error_fails_with_its_stderr(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A non-zero exit fails and carries openssl's own diagnostics (AC2).
+
+        Stubbed rather than shimmed onto ``PATH``: a fake executable would make
+        this case depend on the platform's script conventions, and what is under
+        test is the helper's branch, not the shell's.
+        """
+
+        def _failing_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess:
+            return subprocess.CompletedProcess(args=["openssl"], returncode=1, stdout="", stderr=_STDERR_SENTINEL)
+
+        monkeypatch.setattr(subprocess, "run", _failing_run)
+
+        message = _failure_message_from(tmp_path)
+
+        assert _STDERR_SENTINEL in message
+        assert "TEST_SUITE.md" in message
+
+    def test_openssl_timeout_fails_loudly(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A wedged openssl fails the test rather than hanging the job (AC2a).
+
+        The gate runs this on every pull request across four Python versions;
+        the job's 30-minute ceiling is a backstop for the whole run and says
+        nothing about which call stopped.
+
+        🔴 **The recorded kwargs are what make this test mean anything.** A
+        helper that catches ``TimeoutExpired`` but never passes ``timeout=`` to
+        :func:`subprocess.run` satisfies "converts the exception to a failure"
+        perfectly and still hangs forever on a real stuck process. That is one
+        of the four harnesses the plan's §1.4 rule was written about — a guard
+        proving a function was *called* when the enforcement is the argument it
+        was called with. So the bound is asserted as **armed**, not handled.
+        """
+        seen: dict[str, object] = {}
+
+        def _hanging_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess:
+            seen.update(kwargs)
+            raise subprocess.TimeoutExpired(cmd="openssl", timeout=60)
+
+        monkeypatch.setattr(subprocess, "run", _hanging_run)
+
+        message = _failure_message_from(tmp_path)
+
+        assert seen.get("timeout"), "openssl is spawned with no timeout; nothing bounds a wedged process"
+        assert seen.get("stdin") is subprocess.DEVNULL, (
+            "openssl inherits stdin; an unexpected prompt would block on the terminal, "
+            "not on the timeout above"
+        )
+        assert "did not finish" in message
+        assert "TEST_SUITE.md" in message
+
+
+class TestGeneratedMaterialIsUsable:
+    """The helper still does its job -- failing loudly is not the whole contract."""
+
+    def test_generated_cert_and_key_load_into_an_ssl_context(self, tmp_path: Path) -> None:
+        """The pair is accepted by a real server-side SSL context (AC3).
+
+        Needs a real ``openssl``, and fails loudly without one by the rule
+        above. That is the intended behaviour of this suite, not an oversight.
+        """
+        cert, key = generate_self_signed_cert(tmp_path)
+
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        context.load_cert_chain(str(cert), str(key))

--- a/tests/bridge/test_tls_certs.py
+++ b/tests/bridge/test_tls_certs.py
@@ -1,7 +1,7 @@
 """Tests for KBR-132: the certificate helper fails loudly, it never skips.
 
 ``.system_design/TEST_SUITE.md`` §8 forbids a resource-availability skip inside
-a gating job. :mod:`bridge.tls_certs` is where that rule is kept for the bridge
+a gating job. ``tls_certs`` alongside this module is where that rule is kept for the bridge
 TLS tests, and this module is the check on it.
 
 🔴 **The catch shape below is the point of these tests, not ceremony.**
@@ -29,7 +29,7 @@ from pathlib import Path
 
 import pytest
 
-from bridge.tls_certs import generate_self_signed_cert
+from .tls_certs import generate_self_signed_cert
 
 # Distinctive enough that finding it in a failure message proves the helper
 # passed openssl's own diagnostics through rather than inventing a summary.
@@ -69,41 +69,48 @@ def _failure_message_from(tmp_path: Path) -> str:
     )
 
 
+@pytest.fixture()
+def no_openssl_on_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Point ``PATH`` at an empty directory for the duration of one test.
+
+    Args:
+        tmp_path: The test's temporary directory, which also holds the empty
+            directory ``PATH`` is redirected to.
+        monkeypatch: Fixture restoring the real ``PATH`` afterwards.
+
+    The binary is made genuinely absent rather than :func:`subprocess.run` being
+    stubbed, because absence is the CI condition being guarded; a stub would
+    prove only that the ``except`` branch is reachable.
+    """
+    empty = tmp_path / "no-binaries"
+    empty.mkdir()
+
+    monkeypatch.setenv("PATH", str(empty))
+
+
 class TestMissingOpensslFailsTheRun:
     """The resource is absent: the run goes red, never green-by-omission."""
 
     def test_missing_openssl_fails_it_does_not_skip(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+        self, tmp_path: Path, no_openssl_on_path: None
     ) -> None:
         """PATH carrying no openssl produces a failure, not a skip (AC1).
 
-        ``PATH`` is scrubbed rather than :func:`subprocess.run` stubbed, because
-        absence of the binary is the actual CI condition being guarded and a
-        stub would prove only that the ``except`` branch is reachable.
-
-        This is also the falsification case for the whole change: restoring the
+        This is the falsification case for the whole change: restoring the
         ``pytest.skip`` in the helper turns this test red.
         """
-        empty = tmp_path / "no-binaries"
-        empty.mkdir()
-        monkeypatch.setenv("PATH", str(empty))
-
         message = _failure_message_from(tmp_path)
 
         assert "openssl" in message
 
     def test_the_failure_message_says_why_it_did_not_skip(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+        self, tmp_path: Path, no_openssl_on_path: None
     ) -> None:
         """The message names the rule, so a CI log is self-explanatory (AC1b).
 
         Asserted rather than left to prose: a reader of a red CI job needs to
         know that reinstating the skip is the one fix that is not available.
         """
-        empty = tmp_path / "no-binaries"
-        empty.mkdir()
-        monkeypatch.setenv("PATH", str(empty))
-
         message = _failure_message_from(tmp_path)
 
         assert "TEST_SUITE.md" in message
@@ -160,7 +167,7 @@ class TestOpensslMisbehaviourFailsTheRun:
         message = _failure_message_from(tmp_path)
 
         assert seen.get("timeout"), "openssl is spawned with no timeout; nothing bounds a wedged process"
-        assert seen.get("stdin") is subprocess.DEVNULL, (
+        assert seen.get("stdin") == subprocess.DEVNULL, (
             "openssl inherits stdin; an unexpected prompt would block on the terminal, "
             "not on the timeout above"
         )

--- a/tests/bridge/test_tls_certs.py
+++ b/tests/bridge/test_tls_certs.py
@@ -88,10 +88,14 @@ def no_openssl_on_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("PATH", str(empty))
 
 
+@pytest.mark.usefixtures("no_openssl_on_path")
 class TestMissingOpensslFailsTheRun:
-    """The resource is absent: the run goes red, never green-by-omission."""
+    """The resource is absent: the run goes red, never green-by-omission.
 
-    @pytest.mark.usefixtures("no_openssl_on_path")
+    The precondition is declared on the class because it is what the class *is*
+    -- every case here asks what happens with no ``openssl`` to find.
+    """
+
     def test_missing_openssl_fails_it_does_not_skip(self, tmp_path: Path) -> None:
         """PATH carrying no openssl produces a failure, not a skip (AC1).
 
@@ -107,7 +111,6 @@ class TestMissingOpensslFailsTheRun:
 
         assert "not found on PATH" in message
 
-    @pytest.mark.usefixtures("no_openssl_on_path")
     def test_the_failure_message_says_why_it_did_not_skip(self, tmp_path: Path) -> None:
         """The message names the rule, so a CI log is self-explanatory (AC1b).
 

--- a/tests/bridge/test_tls_support.py
+++ b/tests/bridge/test_tls_support.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 
+from bridge.tls_certs import generate_self_signed_cert
 from kitty.bridge.server import BridgeServer
 from kitty.providers.zai import ZaiRegularAdapter
 
@@ -21,42 +22,13 @@ def _make_server(**kwargs):
     )
 
 
-def _generate_self_signed_cert(tmp_path: Path) -> tuple[Path, Path]:
-    """Generate a self-signed cert+key for testing using openssl."""
-    import subprocess
-
-    cert_path = tmp_path / "cert.pem"
-    key_path = tmp_path / "key.pem"
-    subprocess.run(
-        [
-            "openssl",
-            "req",
-            "-x509",
-            "-newkey",
-            "rsa:2048",
-            "-keyout",
-            str(key_path),
-            "-out",
-            str(cert_path),
-            "-days",
-            "1",
-            "-nodes",
-            "-subj",
-            "/CN=localhost",
-        ],
-        check=True,
-        capture_output=True,
-    )
-    return cert_path, key_path
-
-
 class TestTLSSupport:
     """TLS configuration for the bridge server."""
 
     @pytest.mark.asyncio
     async def test_tls_cert_and_key_enables_https(self, tmp_path: Path):
         """Providing both cert and key enables HTTPS."""
-        cert, key = _generate_self_signed_cert(tmp_path)
+        cert, key = generate_self_signed_cert(tmp_path)
         server = _make_server(tls_cert=str(cert), tls_key=str(key))
         port = await server.start_async()
         try:
@@ -117,6 +89,6 @@ class TestTLSWarning:
         assert server._should_warn_no_tls() is False
 
     def test_non_localhost_with_tls_no_warn(self, tmp_path: Path):
-        cert, key = _generate_self_signed_cert(tmp_path)
+        cert, key = generate_self_signed_cert(tmp_path)
         server = _make_server(host="0.0.0.0", tls_cert=str(cert), tls_key=str(key))
         assert server._should_warn_no_tls() is False

--- a/tests/bridge/test_tls_support.py
+++ b/tests/bridge/test_tls_support.py
@@ -6,9 +6,10 @@ from pathlib import Path
 
 import pytest
 
-from bridge.tls_certs import generate_self_signed_cert
 from kitty.bridge.server import BridgeServer
 from kitty.providers.zai import ZaiRegularAdapter
+
+from .tls_certs import generate_self_signed_cert
 
 
 def _make_server(**kwargs):

--- a/tests/bridge/tls_certs.py
+++ b/tests/bridge/tls_certs.py
@@ -1,0 +1,112 @@
+"""Throwaway TLS certificates for the bridge tests, generated loudly.
+
+``.system_design/TEST_SUITE.md`` §8: **skips are failures in a gating job.** A
+platform or interpreter skip is permitted; a *resource-availability* skip is
+not, because a gating job that goes green after running nothing is the most
+expensive kind of false confidence.
+
+The bridge TLS tests need a certificate and a key, and generate them by spawning
+``openssl``. That binary is a resource, so this module's whole contract is that
+its absence or misbehaviour **fails** the run rather than quietly removing tests
+from it (KBR-132). Every exit from :func:`generate_self_signed_cert` other than
+success goes through :func:`pytest.fail`.
+
+**A consequence worth stating plainly:** ``openssl`` is an environment
+prerequisite of the Fast CI job, not something a test may probe for. Forbidding
+the skip is the same statement as requiring the runner to provide the binary.
+
+The sibling module ``tests/test_egress_https_proxy.py`` keeps its own generator:
+it builds a CA and two signed leaves with different extensions, which is a
+different function, and ``TEST_SUITE.md`` §8.2 names that module for relocation
+under T-K6 (KBR-115).
+
+**Import note.** Imported as ``bridge.tls_certs``: ``tests/`` has no
+``__init__.py`` but ``tests/bridge/`` has one, so pytest's ``prepend`` import
+mode puts ``tests/`` on ``sys.path`` and ``bridge`` is the package. The same
+caveat as ``tests/layers.py`` applies — adding ``tests/__init__.py`` breaks it.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+# Generous enough that a loaded CI runner never trips it, short enough that a
+# genuinely wedged `openssl` is reported as a failure rather than eating the
+# job's 30-minute ceiling. RSA-2048 keygen is milliseconds when it works at all.
+_OPENSSL_TIMEOUT_SECONDS = 60
+
+# Repeated in every failure message so a CI log says why the run did not simply
+# skip. Whoever reads it should not have to find the design document first.
+_WHY_NOT_A_SKIP = (
+    "This fails rather than skipping: TEST_SUITE.md section 8 forbids a "
+    "resource-availability skip inside a gating job, so openssl is a "
+    "prerequisite of the environment, not something a test probes for (KBR-132)."
+)
+
+
+def generate_self_signed_cert(tmp_path: Path) -> tuple[Path, Path]:
+    """Generate a throwaway self-signed certificate and key for a local server.
+
+    Spawns ``openssl req -x509`` to write a PEM certificate and an unencrypted
+    RSA key into ``tmp_path``. The certificate is valid for one day and carries
+    ``CN=localhost``, which is all the bridge's TLS tests need — nothing here
+    verifies a chain.
+
+    Args:
+        tmp_path: Directory receiving ``cert.pem`` and ``key.pem``. The caller's
+            ``tmp_path`` fixture, so the files die with the test.
+
+    Returns:
+        The ``(certificate, key)`` paths, in that order.
+
+    Raises:
+        pytest.fail.Exception: When ``openssl`` is absent from ``PATH``, exits
+            non-zero, or does not finish within
+            :data:`_OPENSSL_TIMEOUT_SECONDS`. Never
+            :func:`pytest.skip` — see this module's docstring.
+    """
+    cert_path = tmp_path / "cert.pem"
+    key_path = tmp_path / "key.pem"
+
+    # `stdin` is closed so a prompt from an unexpected openssl build blocks on
+    # nothing and surfaces as the timeout below rather than as a hung job.
+    try:
+        completed = subprocess.run(
+            [
+                "openssl",
+                "req",
+                "-x509",
+                "-newkey",
+                "rsa:2048",
+                "-keyout",
+                str(key_path),
+                "-out",
+                str(cert_path),
+                "-days",
+                "1",
+                "-nodes",
+                "-subj",
+                "/CN=localhost",
+            ],
+            capture_output=True,
+            text=True,
+            stdin=subprocess.DEVNULL,
+            timeout=_OPENSSL_TIMEOUT_SECONDS,
+        )
+    except FileNotFoundError:
+        pytest.fail(f"openssl was not found on PATH, and this test needs it. {_WHY_NOT_A_SKIP}")
+    except subprocess.TimeoutExpired:
+        pytest.fail(
+            f"openssl did not finish within {_OPENSSL_TIMEOUT_SECONDS}s. {_WHY_NOT_A_SKIP}"
+        )
+
+    if completed.returncode != 0:
+        pytest.fail(
+            f"openssl req failed (exit {completed.returncode}):\n{completed.stderr}\n"
+            f"{_WHY_NOT_A_SKIP}"
+        )
+
+    return cert_path, key_path

--- a/tests/bridge/tls_certs.py
+++ b/tests/bridge/tls_certs.py
@@ -20,10 +20,14 @@ it builds a CA and two signed leaves with different extensions, which is a
 different function, and ``TEST_SUITE.md`` §8.2 names that module for relocation
 under T-K6 (KBR-115).
 
-**Import note.** Imported as ``bridge.tls_certs``: ``tests/`` has no
-``__init__.py`` but ``tests/bridge/`` has one, so pytest's ``prepend`` import
-mode puts ``tests/`` on ``sys.path`` and ``bridge`` is the package. The same
-caveat as ``tests/layers.py`` applies — adding ``tests/__init__.py`` breaks it.
+**Import note.** Imported relatively -- ``from .tls_certs import ...`` -- which
+is how ``tests/bridge/test_tool_use_auditor.py`` already reaches its sibling,
+and which resolves through the package rather than through ``sys.path``. The
+absolute spelling works today too, but only because ``tests/`` has no
+``__init__.py`` while ``tests/bridge/`` does, so pytest's ``prepend`` import
+mode puts ``tests/`` on ``sys.path``. That is a property of the import mode, not
+of this package; ``tests/layers.py`` already rests on it once, and the relative
+form avoids adding a second place that breaks if the mode ever changes.
 """
 
 from __future__ import annotations

--- a/tests/test_egress_https_proxy.py
+++ b/tests/test_egress_https_proxy.py
@@ -60,6 +60,12 @@ _AIOHTTP_SKIP_REASON = "aiohttp requires Python 3.11 for TLS-in-TLS over stdlib 
 # ── Certificates (session-scoped, files only) ────────────────────────────
 
 
+# Matches the bound in `tests/bridge/tls_certs.py`, for the same reason: long
+# enough that a loaded runner never trips it, short enough that a stuck openssl
+# is reported rather than left to consume the job's ceiling.
+_OPENSSL_TIMEOUT_SECONDS = 60
+
+
 @dataclasses.dataclass(frozen=True)
 class _CertFiles:
     """Paths of the throwaway certificate set used by the local servers.
@@ -88,8 +94,21 @@ def _run_openssl(*args: str) -> None:
     Raises:
         pytest.fail: When openssl exits non-zero; the captured stderr is
             included so certificate-generation mistakes are readable (AC1).
+        subprocess.TimeoutExpired: When openssl does not finish within
+            ``_OPENSSL_TIMEOUT_SECONDS``. Left to propagate rather than
+            converted: it already names the command and the bound, and an
+            unhandled error is as loud as a failure.
     """
-    completed = subprocess.run(["openssl", *args], capture_output=True, text=True)
+    # Bounded, and stdin closed, for the reason `tests/bridge/tls_certs.py`
+    # gives (KBR-132): this is the single entry point for five openssl calls
+    # inside the gate, and nothing else would stop a wedged one hanging it.
+    completed = subprocess.run(
+        ["openssl", *args],
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
+        timeout=_OPENSSL_TIMEOUT_SECONDS,
+    )
     if completed.returncode != 0:
         pytest.fail(f"openssl {args[0]} failed (exit {completed.returncode}):\n{completed.stderr}")
 

--- a/tests/test_egress_https_proxy.py
+++ b/tests/test_egress_https_proxy.py
@@ -100,8 +100,10 @@ def _run_openssl(*args: str) -> None:
             unhandled error is as loud as a failure.
     """
     # Bounded, and stdin closed, for the reason `tests/bridge/tls_certs.py`
-    # gives (KBR-132): this is the single entry point for five openssl calls
-    # inside the gate, and nothing else would stop a wedged one hanging it.
+    # gives (KBR-132): this is the single entry point for every openssl process
+    # this module spawns inside the gate, and nothing else would stop a wedged
+    # one hanging it. Deliberately no count -- "call sites" and "processes
+    # spawned" differ here, because `_generate_leaf` runs twice.
     completed = subprocess.run(
         ["openssl", *args],
         capture_output=True,


### PR DESCRIPTION
Closes [KBR-132](https://shelpuk.atlassian.net/browse/KBR-132).

## Context for the Product Owner

The pull-request gate is the one checkpoint between a change and a release. This PR closes a hole in it.

One test checks that the bridge correctly reports "I am running with TLS enabled." To do that it needs a throwaway certificate, which it made by calling out to the `openssl` program. If `openssl` was not on the machine, **the test quietly removed itself and the job reported success** — a pass earned by not looking. The test suite design already had a name for this: *"a gating job that goes green because it ran nothing is the most expensive kind of false confidence."*

Nothing is broken for users today — the CI machines happen to ship `openssl`. The risk was that nothing guaranteed that, and nothing would have told us if it stopped. After this PR a missing `openssl` turns the gate **red** with a message saying exactly what is missing and why the run is not allowed to skip.

No product behaviour changes. This is entirely about whether the safety net is real.

## What changed

| | |
|---|---|
| `tests/bridge/tls_certs.py` | **New.** One place that generates the certificate, and fails loudly three ways: binary missing, binary errors, binary hangs. |
| `tests/bridge/test_tls_certs.py` | **New.** Five tests proving it fails rather than skips, and that the failure messages are usable. |
| `tests/bridge/test_bridge_state.py` | The `pytest.skip("openssl not available")` is gone. |
| `tests/bridge/test_tls_support.py` | Used a byte-identical private copy of the same generator; now uses the shared one (R5). |
| `.system_design/TEST_SUITE.md` | §8 records the breach as closed and how the rule is upheld; names `openssl` as an environment prerequisite of the Fast job; records that the rule is still unenforced. New gap row **G21**. §8.2 notes the new module for T-K6's count. |
| `.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md` | §16 defect register gains the KBR-132 row, in closed form. |
| `README.md` | `openssl` named as a prerequisite, reconciled with the deselection paragraph that follows it. |

Net effect on existing files is **−7 lines**. No `src/` change. No test changed layer.

## The part worth reviewing carefully

`Failed` and `Skipped` are **sibling** exception classes in pytest — neither inherits from the other, and both derive from `BaseException`. So the obvious way to write this regression test:

```python
with pytest.raises(pytest.fail.Exception):
    generate_self_signed_cert(tmp_path)
```

**does not work.** With the defect reinstated, the `Skipped` escapes the `raises` block, propagates out of the test, and pytest reports the test as *skipped* — which passes the gate. The detector would have reproduced the exact defect it exists to detect.

So every case catches `Skipped` **first** and converts it to an assertion failure, and the helper's `else` arm fails if nothing was raised at all. That third arm matters: it makes the harness fail **closed** if the helper is ever rewritten to bypass `subprocess.run`.

## Regression evidence (plan §16 — red at base)

Four independent mutations, all confirmed red:

| Mutation | Result |
|---|---|
| `pytest.fail` → `pytest.skip` on the missing-binary path | `2 failed, 3 passed` — reported **FAILED**, not skipped |
| delete `timeout=` from the `subprocess.run` call | `test_openssl_timeout_fails_loudly` FAILED |
| delete `stdin=subprocess.DEVNULL` | `test_openssl_timeout_fails_loudly` FAILED |
| `if completed.returncode != 0:` → `if False:` | `test_openssl_error_fails_with_its_stderr` FAILED |

The headline one, verbatim:

```
E  AssertionError: The helper skipped instead of failing (openssl not available).
   A skip inside a gating job is what KBR-132 fixed; TEST_SUITE.md section 8 forbids it.
FAILED tests/bridge/test_tls_certs.py::TestMissingOpensslFailsTheRun::test_missing_openssl_fails_it_does_not_skip
2 failed, 3 passed in 0.91s
```

The second and third matter more than they look: without them, a helper that *catches* `TimeoutExpired` but never *arms* `timeout=` would hang forever behind a green test — the failure mode the plan's §1.4 harness rule was written about.

## Verification

- `pytest -m "l1 or l2" -q --strict-markers --require-category=l1 --require-category=l2` — **3502 passed, 2 skipped, 32 deselected**, exit 0. Both skips are the Windows-only cases in `test_launcher_discovery.py`, which §8 permits.
- Collection parity against `origin/main`: 3499 → 3504 node IDs, and the difference is **exactly the 5 new tests** — nothing else added, removed, or relabelled.
- `ruff check .`, `mypy src/kitty`, `lint-imports` all clean.
- `ubuntu-latest` ships `OpenSSL 3.0.13`, confirmed against the `actions/runner-images` manifest, so the new prerequisite holds for every matrix entry.

## Deliberately not done

- **The test is not moved to `l3`.** It spawns a process and binds a socket, so `l3` is its right long-term home — but no job runs `l3` yet, and §8.2 forbids the move until the Subsystem job exists ([KBR-115](https://shelpuk.atlassian.net/browse/KBR-115)). Moving it now would take it out of every gate: a worse version of the bug being fixed.
- **Nothing enforces the rule for the next test.** §8 states it in prose; no check verifies it. That guard covers a class of defect rather than this one, so it is [KBR-138](https://shelpuk.atlassian.net/browse/KBR-138), recorded in §8 and in the gap register as **G21** rather than dropped when this breach closed.
- **The certificate is not generated in-process.** `cryptography`/`trustme` would remove the external binary entirely. Rejected here: it adds a dependency for a defect that does not need one, and the other `openssl` call site would keep shelling out, so the suite would gain a second way of doing one thing rather than replace the first. Recorded in the requirements so the next reader sees a decision, not an omission.

## Found along the way, filed not fixed

[KBR-141](https://shelpuk.atlassian.net/browse/KBR-141) — `_connect_target` is wrong on every supported Python below the December 2024 patch releases, including **Ubuntu 24.04's stock 3.12.3**, and CI cannot see it because `actions/setup-python` always resolves to the newest patch. Unrelated to this PR; untouched here. It is why a local gate run on an older interpreter shows one failure in `test_bridge_management.py` that this branch did not cause.

## Review

Reviewed by the `system-design-reviewer` (two rounds, on the requirements) and the `code-reviewer` (**APPROVE**, after two documentation corrections now applied). The code reviewer contributed the third and fourth falsification probes above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JDdNzJzvNbZzQFzkAQM8Cm


[KBR-132]: https://shelpuk.atlassian.net/browse/KBR-132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KBR-115]: https://shelpuk.atlassian.net/browse/KBR-115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ