### PR TITLE
Share the CONNECT proxy, and give it a join key and an off switch (KBR-28)

### DIFF
--- a/.system_design/TEST_SUITE.md
+++ b/.system_design/TEST_SUITE.md
@@ -920,6 +920,16 @@ thing this assertion needs to catch.
 (Peer *address* cannot do this job: with bridge, proxy and upstream on loopback in one process,
 proxied and direct connections both present `127.0.0.1`.)
 
+**The premise, which is a property of the wiring and not a law.** A source port identifies a
+connection only because every leg terminates on the same destination `ip:port`, so the kernel will
+not hand the same port to a second connection while the first is in `TIME_WAIT`. Point a future
+leg at a *different* destination and a direct connection may legitimately draw a live tunnel's
+source port and be attributed to it. The resulting error is a false negative — a breach
+unreported — never a false positive, so it degrades safety rather than stability. Re-derive this
+before adding a second upstream port. The join is also over **connections**, never requests: a
+request-level log must be reduced to its distinct connections first, since one tunnel may carry
+many requests.
+
 #### 5.2.2 The three phases, per transport
 
 The negative assertion is the one that matters, and on its own it is dangerously easy to satisfy
@@ -1742,17 +1752,48 @@ asserted — what reaches the wire is the client library's ordering, not the age
 
 ### 7.3 Recording CONNECT proxy
 
-**Already exists.** `tests/test_egress_https_proxy.py` contains `_ConnectProxy` (enforces Basic
-auth, records every `CONNECT` as a `ConnectAttempt`) and `_TlsTarget`, with throwaway
-certificates on ephemeral ports. Extend it rather than build a second:
+**Delivered by T-W5 ([KBR-28]) in `tests/harness/connect_proxy.py`**, extracted from
+`tests/test_egress_https_proxy.py` rather than written a second time — two proxy implementations
+is how two harnesses come to disagree about what "tunnelled" means. That module keeps its five
+tests, unchanged down to the collected node ids, and drives all three transport stacks through the
+extracted fixture; it is the regression evidence for the extraction.
 
-- expose it as a shared fixture;
-- add the ability to stop it mid-test, for §5.2.2 phase 2;
-- **record the outbound source port** of each tunnel it opens, so §5.2.1 can join tunnels to the
-  connections the recorders accept — `ConnectAttempt` carries target and auth status only today,
-  which is not enough to identify a connection at both ends;
-- resolve the harness hostname itself on the proxied leg, and expose a per-transport direct-route
-  override for §5.2.2 phase 1.
+What it provides:
+
+- **The fixtures**, registered as a pytest plugin from `tests/conftest.py`, so a test asks for
+  `connect_proxy` or `tls_target` by name and imports nothing.
+- **`ConnectAttempt.source_port`** — the local port of the proxy's outbound socket for each tunnel
+  it opens, and `None` where no tunnel was opened (rejected auth, or an unreachable upstream).
+  This is §5.2.1's join key; target and auth status alone cannot identify a connection at both
+  ends.
+- **`unattributable_peer_ports(peer_ports, attempts)`** — §5.2.1's assertion, stated once so each
+  transport slice inherits it rather than re-deriving it. It refuses an unset peer port rather
+  than guessing: a recorder that never populated `CapturedRequest.peer_port` would otherwise make
+  containment unfalsifiable in whichever direction the default happened to fall. *This is an
+  addition to T-W5's two named deliverables, made because §1.4 requires this delivery to ship a
+  falsification case and a falsification case needs a checkable assertion.* It does not discharge
+  **T-E2's** phase-3 obligation, which injects a bypass into the product rather than into the test.
+- **`ConnectProxy.stop()` and `TlsTarget.stop()`** — mid-test stoppability for §5.2.2 phase 2.
+  Both abort live connections rather than closing them (a TLS `close()` waits out
+  `ssl_shutdown_timeout`, 30s by default) and both retry until the listener has actually finished
+  closing. Python 3.12.1 changed `asyncio.Server.wait_closed()` to block until every connection is
+  dropped while 3.10 and 3.11 return immediately, so a teardown that merely closes the listener
+  hangs on half the support matrix and passes on the other half.
+- **The proxied-leg resolver** — `HARNESS_UPSTREAM_HOST` (`upstream.kitty-test.invalid`, §5.3) in
+  the target certificate's SAN, and an empty-by-default `ConnectProxy.resolve` map consulted
+  before the outbound connection. The harness owns the resolver because the harness is the proxy;
+  a client tunnelling to a `.invalid` name never resolves it itself, so this is the only place the
+  name can be mapped. **Shipped here, not in T-E1**, because T-E1 would otherwise have to edit a
+  module five tickets consume — the coordination problem Milestone 0 exists to remove.
+
+Still **T-E1's** (KBR-61): the per-transport **direct**-route override §5.2.2 phase 1 needs, and
+which transport gets which route. T-W5 ships the seam, not the policy.
+
+**A missing `openssl` fails, it does not skip.** `certs` is shared infrastructure, and §8's rule
+is that a skip in a gating job is a failure: a suite that quietly stops proving containment
+because a tool is absent is indistinguishable from one that proves it.
+
+[KBR-28]: https://shelpuk.atlassian.net/browse/KBR-28
 
 ### 7.4 Wire projections and the transparency oracle
 
@@ -1963,9 +2004,12 @@ standing amnesty:
 
 A consequence worth stating: **a test may not be moved to `l3` before the Subsystem job exists.**
 Roughly six modules under `tests/` bind real sockets or spawn processes and are `l1` by default
-today — `test_egress_https_proxy.py` foremost among them. Reclassifying them is correct and is
-T-K6's business, together with the job that runs them; doing it earlier would remove them from
-every gate. T-H1 must take that reclassification into account before it measures a mutation
+today — `test_egress_https_proxy.py` foremost among them, and since T-W5 the shared fixture it was
+extracted into plus `tests/harness/test_connect_proxy.py`, which must move **with** it: an
+extraction and its own regression evidence landing in two different jobs would leave one proving
+the other in a run that no longer includes it. Reclassifying them is correct and is T-K6's
+business, together with the job that runs them; doing it earlier would remove them from every
+gate. T-H1 must take that reclassification into account before it measures a mutation
 baseline, because it selects on `l1`.
 
 KBR-132 added one to that set: `tests/bridge/test_tls_certs.py` spawns a real `openssl` in one of

--- a/.system_design/TEST_SUITE.md
+++ b/.system_design/TEST_SUITE.md
@@ -854,8 +854,9 @@ not just the first, and is called from **five** sites in three files — `bridge
 logic.
 
 **Real-socket transport proof already exists, and is strong.** `tests/test_egress_https_proxy.py`
-(601 lines) stands up a local TLS CONNECT proxy that enforces Basic auth and **records every
-`CONNECT` it sees**, plus a local TLS target, and performs real TLS handshakes across all three
+stands up a local TLS CONNECT proxy that enforces Basic auth and **records every `CONNECT` it
+sees**, plus a local TLS target — both since T-W5 shared from
+`tests/harness/connect_proxy.py` (§7.3) — and performs real TLS handshakes across all three
 transport stacks kitty uses: aiohttp (driving the real `egress_cmd._probe`), `curl_cffi` with the
 exact `proxies=` mapping `openai_subscription` passes, and urllib3 shaped as
 `botocore.httpsession._get_proxy_manager` builds it. This is the strongest asset in the area and
@@ -877,9 +878,14 @@ the foundation the rest of §5 builds on rather than replaces.
 
 ### 5.2 The sealed-network harness
 
-An L3 harness that closes gaps 1 and 2, built by extending `tests/test_egress_https_proxy.py`'s
-`_ConnectProxy` and `_TlsTarget` rather than writing new infrastructure — that proxy already
+An L3 harness that closes gaps 1 and 2, built on `tests/harness/connect_proxy.py`'s
+`ConnectProxy` and `TlsTarget` rather than writing new infrastructure — that proxy already
 records CONNECT attempts, which is the observation the harness needs.
+
+Those two classes were `_ConnectProxy` and `_TlsTarget`, private to
+`tests/test_egress_https_proxy.py`, until **T-W5 ([KBR-28])** extracted them and registered their
+fixtures as a pytest plugin; §7.3 records what that delivered. `tests/test_egress_https_proxy.py`
+now imports them and keeps only `target_url`, the one seam specific to `kitty egress test`.
 
 ```
        ┌──────────── kitty BridgeServer ────────────┐
@@ -910,12 +916,14 @@ The correct assertion is at the **connection** level: every TCP connection the u
 must be attributable to a successful tunnel through the proxy, with any number of requests
 riding on it, and failed tunnels contributing no upstream connections.
 
-**The join.** `ConnectAttempt` records target and authentication status only, which is not enough
-to identify a connection at both ends. Extend it to record the **proxy's outbound source port**
-for each tunnel it opens; the recording upstream already records the peer port of each accepted
-connection. Joining on that port identifies each upstream connection with the tunnel that
-created it. An upstream connection with no matching tunnel port is a bypass, and it is the only
-thing this assertion needs to catch.
+**The join.** `ConnectAttempt` recorded target and authentication status only, which is not enough
+to identify a connection at both ends. **T-W5 added `source_port`** — the proxy's outbound source
+port for each tunnel it opens, and `None` where no tunnel was opened; the recording upstream
+records the peer port of each accepted connection. Joining on that port identifies each upstream
+connection with the tunnel that created it. An upstream connection with no matching tunnel port is
+a bypass, and it is the only thing this assertion needs to catch.
+`unattributable_peer_ports()` in the same module states the assertion once, so each transport
+slice inherits it rather than re-deriving it.
 
 (Peer *address* cannot do this job: with bridge, proxy and upstream on loopback in one process,
 proxied and direct connections both present `127.0.0.1`.)
@@ -1058,7 +1066,7 @@ Three consequences the rest of §5 must not paper over:
 2. **The sealed-network harness proves nothing about them** unless parametrised over the
    transport. It must run over `{bridge aiohttp session, provider aiohttp session, curl_cffi
    session, botocore client}` — the shape `tests/test_egress_https_proxy.py` already uses, which
-   is a further reason to extend that module rather than start fresh.
+   is a further reason it was that module's proxy T-W5 extracted rather than a fresh one.
 3. **The OAuth leg runs at startup**, before anything else has been proven, and is the one most
    likely to fire on a fresh machine. It must not be left out.
 
@@ -2052,7 +2060,8 @@ Three assets stand out and are built on rather than replaced:
 
 - `tests/test_egress_https_proxy.py` — real TLS handshakes through a local recording CONNECT
   proxy, across all three transport stacks. The strongest existing proof of anything in this
-  document.
+  document. Since T-W5 the proxy, the target and the certificates are shared from
+  `tests/harness/connect_proxy.py`; the tests stayed here.
 - `tests/test_egress_coverage.py` — AST/regex structural guard over `src/` that also asserts its
   own scan finds known positives, so it cannot rot into a no-op.
 - `tests/test_github_actions.py` — treats the workflow definitions as testable artifacts.
@@ -2143,8 +2152,10 @@ L1 property test, stated *with* the `localhost` exclusions so it does not fail o
 weakened.
 
 **Extend the existing CONNECT proxy rather than build one (§7.3).** `test_egress_https_proxy.py`
-already owns a recording proxy across all three transport stacks. A second would duplicate the
-hard part and risk the two drifting on exactly the behaviour they both exist to pin.
+already had a recording proxy exercised across all three transport stacks. A second would
+duplicate the hard part and risk the two drifting on exactly the behaviour they both exist to pin.
+T-W5 carried this out: the proxy moved to `tests/harness/connect_proxy.py` and that module's five
+tests kept passing against it, unchanged down to their collected node ids.
 
 **Two L1 properties are stated with their exceptions (§6.1).** "Output ≤ budget" and "the last
 turn survives" are both false as absolutes — the compactor breaks out while still over budget

--- a/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
+++ b/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
@@ -166,8 +166,19 @@ failure library is T-B4. Peer-port and casing capture are enforced by a **confor
 Epic B recorder must pass**.
 
 **T-W5 — CONNECT proxy.** Extract `_ConnectProxy`/`_TlsTarget` from
-`tests/test_egress_https_proxy.py`; add tunnel source-port recording and mid-test stoppability. An
-extraction, not a rewrite: that module must pass unchanged.
+`tests/test_egress_https_proxy.py` into `tests/harness/connect_proxy.py`; add tunnel source-port
+recording and mid-test stoppability. An extraction, not a rewrite: that module must pass unchanged,
+and "unchanged" is checked mechanically — its five collected node ids are byte-identical.
+
+It also ships **`unattributable_peer_ports()`**, §5.2.1's join stated once, and the **proxied-leg
+resolver seam** (`HARNESS_UPSTREAM_HOST` in the target SAN plus an empty-by-default `resolve` map).
+Neither was in the original row. The join is here because §1.4 requires this delivery to carry a
+falsification case and a falsification case needs a checkable assertion; two implementations of one
+join is the failure the extraction exists to prevent. The resolver seam is here because T-E1 would
+otherwise have to edit a module five tickets consume, which is the coordination problem this
+milestone exists to remove — T-E1 still owns the **direct**-route override and the per-transport
+policy. **T-E2's row is untouched: it still owns its own phase-3 falsification**, which injects a
+bypass into the product rather than into the test.
 
 **T-W6 — corpus.** Format, capture procedure, credential scrubber, and a loader indexing entries
 by register trigger. Names an **owner and cadence for refresh**. *Falsification:* an unscrubbed
@@ -382,7 +393,7 @@ that makes *its* bytes observable. Bundled, the Ollama half would have had no ev
 | **T-K3** | Statistics and decision rule | blocked Q4, Q13 | T-K1, T-K2 | Successes ÷ **scheduled** trials; interval; pre-registered margin; symmetric exclusions; a missing-data ceiling that **voids** the run | §6.4.3 | M |
 | **T-K4** | Load rig and baseline | | T-W8, T-B4 | Fixed workload, named runner class; latency, TTFB, completion and error rates, bounded RSS, socket recovery; streaming and buffered measured separately | §6.4.4 | L |
 | **T-K5** | `load.yml` reusable + publish gate | ci | T-K4 | `publish.yml` `needs:`-gates on a load run **for the tag commit** | §8 | M |
-| **T-K6** | Activate the Subsystem job | ci | T-W1, T-E2, T-D3, T-D4 | `l3` gates PRs and releases. **T-D3 is required, not just T-D4**: activating the job promotes the oracle into gating infrastructure, and §1.4 forbids that before its falsification suite exists. Fixing only T-J2's dependency left this hole open | §8 | S |
+| **T-K6** | Activate the Subsystem job | ci | T-W1, T-E2, T-D3, T-D4 | `l3` gates PRs and releases. **T-D3 is required, not just T-D4**: activating the job promotes the oracle into gating infrastructure, and §1.4 forbids that before its falsification suite exists. Fixing only T-J2's dependency left this hole open. **Re-layer `tests/harness/test_connect_proxy.py` together with `tests/test_egress_https_proxy.py`** — T-W5 left both at `l1` because §8.2 forbids moving a test to a layer no job selects, and they are the extraction and its own regression evidence: landing them in different jobs would leave one proving the other in a run that no longer includes it | §8 | S |
 | **T-K7** | Deep nightly — mutation and schema fuzzing | ci | T-H3, T-G6 | Both exist before the job claims to run them | §8 | S |
 | **T-K8** | Attach the per-category checks to each job | ci | T-W1, T-K6 | **The mechanism is T-W1's** — `--require-category`, and the test pairing it to every job's marker expression, landed there. What is left here is attaching a flag per category as each job activates, and removing that layer from `PENDING_ACTIVATION_LAYERS`. Narrowed after T-W1 delivered the enforcement rather than only the vocabulary | §8.1 | S |
 | **T-K9** | Activate the Acceptance job | ci | T-J2, T-J3, T-K6 | `acceptance` gates PRs and releases | §8 | S |

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,14 @@ from layers import (
     unknown_categories,
 )
 
+# Shared fixture modules. `pytest_plugins` is honoured in an *initial*
+# conftest -- one on the path from rootdir to a collection argument, which
+# this file is for every invocation the suite uses -- and is an error in any
+# other conftest, so a deeper `tests/<dir>/conftest.py` could not hold it.
+# A test asks for `connect_proxy` or `tls_target` by name; nothing imports
+# `harness.connect_proxy` to get them.
+pytest_plugins = ("harness.connect_proxy",)
+
 # The collected items and their layers, as `(node id, [layer names])`, published
 # for `tests/test_layer_markers.py`. A stash key rather than a module global so
 # it is scoped to the session and typed.

--- a/tests/harness/connect_proxy.py
+++ b/tests/harness/connect_proxy.py
@@ -1,0 +1,734 @@
+"""Shared recording CONNECT proxy and TLS target — the harness's proxy leg.
+
+`.system_design/TEST_SUITE.md` §7.3 · plan task **T-W5** ([KBR-28]).
+
+This module owns the local TLS CONNECT proxy, the local TLS target and the
+throwaway certificate set they present.  All three were private to
+:mod:`tests.test_egress_https_proxy` until T-W5; that module still holds the
+only tests of ``kitty egress test``'s probe, but the servers now live here
+because four other tasks need them:
+
+* **T-E1/T-E2** (containment) need a proxy that records the **source port** of
+  each tunnel it opens and that can be **stopped mid-test**;
+* **T-G8/T-G10/T-G11** (dependency proxy contracts) need it as a plain fixture.
+
+The alternative to extraction was a second proxy implementation, which is how
+two harnesses come to disagree about what "tunnelled" means.
+
+**The fixtures are registered as a pytest plugin** from ``tests/conftest.py``,
+so any test asks for ``connect_proxy`` by name without importing this module.
+``__all__`` names the *importable* surface; the four fixtures --  ``certs``,
+``connect_proxy``, ``tls_target`` and ``aiohttp_trusts_test_ca`` -- are part of
+the contract too, and are addressed by name rather than imported.
+
+**A missing ``openssl`` fails, it does not skip.**  ``certs`` is now shared
+infrastructure, and §8's rule is that a skip in a gating job is a failure:
+a suite that silently stops proving containment because a tool is absent is
+indistinguishable from one that proves it.  Do not "fix" :func:`_run_openssl`
+into a skip.
+
+**What this module does not decide.**  It provides the *seam* for addressing an
+upstream by a name the public DNS cannot resolve — :data:`HARNESS_UPSTREAM_HOST`
+in the target certificate, and :attr:`ConnectProxy.resolve` on the tunnel path.
+Which transport gets which route, and the **direct**-leg override that §5.2.2
+phase 1 needs, are T-E1's (KBR-61).
+
+.. _KBR-28: https://shelpuk.atlassian.net/browse/KBR-28
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import dataclasses
+import ssl
+import subprocess
+from collections.abc import AsyncIterator, Iterable, Mapping, Sequence
+from pathlib import Path
+
+import aiohttp.connector
+import pytest
+
+from kitty.egress import EgressConfig
+
+__all__ = [
+    "EXPECTED_PROXY_AUTH",
+    "HARNESS_UPSTREAM_HOST",
+    "PROXY_PASSWORD",
+    "PROXY_USER",
+    "TARGET_BODY",
+    "CertFiles",
+    "ConnectAttempt",
+    "ConnectProxy",
+    "TlsTarget",
+    "proxy_config",
+    "server_ssl_context",
+    "unattributable_peer_ports",
+]
+
+PROXY_USER = "testuser"
+PROXY_PASSWORD = "testpass"
+
+#: The name a sealed-network harness addresses its upstream by (§5.3).  It must
+#: sit outside the ``localhost`` family or ``egress.should_bypass()`` sends the
+#: request direct and the harness passes while proving the opposite of its
+#: claim; RFC 2606 guarantees ``.invalid`` never resolves publicly, so the name
+#: cannot escape the test environment.  Carried in the target certificate's SAN
+#: so a client that reaches it through :attr:`ConnectProxy.resolve` can still
+#: verify the hop.
+HARNESS_UPSTREAM_HOST = "upstream.kitty-test.invalid"
+
+#: Fixed target response body. Contains no surrounding whitespace so it
+#: survives ``_probe``'s ``.strip()`` unchanged (AC3).
+TARGET_BODY = "kitty-egress-tls-target"
+
+#: The ``Proxy-Authorization`` value :class:`ConnectProxy` accepts. Exported
+#: because botocore-shaped clients pass it as an explicit header rather than
+#: deriving it from the URL's userinfo.
+EXPECTED_PROXY_AUTH = "Basic " + base64.b64encode(f"{PROXY_USER}:{PROXY_PASSWORD}".encode()).decode()
+
+
+# ── Certificates (session-scoped, files only) ────────────────────────────
+
+
+@dataclasses.dataclass(frozen=True)
+class CertFiles:
+    """Paths of the throwaway certificate set used by the local servers.
+
+    Attributes:
+        ca: The throwaway CA certificate to load as client trust.
+        proxy_cert: Certificate the TLS CONNECT proxy presents.
+        proxy_key: Private key matching ``proxy_cert``.
+        target_cert: Certificate the TLS target presents.
+        target_key: Private key matching ``target_cert``.
+    """
+
+    ca: Path
+    proxy_cert: Path
+    proxy_key: Path
+    target_cert: Path
+    target_key: Path
+
+
+def _run_openssl(*args: str) -> None:
+    """Run one openssl command, failing the test loudly on any error.
+
+    Args:
+        *args: Arguments following the ``openssl`` executable name.
+
+    Raises:
+        pytest.fail: When openssl exits non-zero; the captured stderr is
+            included so certificate-generation mistakes are readable (AC1).
+    """
+    completed = subprocess.run(["openssl", *args], capture_output=True, text=True)
+    if completed.returncode != 0:
+        pytest.fail(f"openssl {args[0]} failed (exit {completed.returncode}):\n{completed.stderr}")
+
+
+def _generate_leaf(
+    certs_dir: Path, name: str, ca_cert: Path, ca_key: Path, *, extra_sans: Sequence[str] = ()
+) -> tuple[Path, Path]:
+    """Generate one CA-signed leaf certificate for a local server.
+
+    The extensions satisfy Python 3.13's OpenSSL strict-mode verification and
+    the fact that both servers are addressed as ``127.0.0.1`` (AC1).
+
+    Args:
+        certs_dir: Directory receiving the key, CSR and certificate files.
+        name: Filename stem distinguishing this server's files.
+        ca_cert: The CA certificate that signs the leaf.
+        ca_key: The CA private key that signs the leaf.
+        extra_sans: Further ``subjectAltName`` entries, already qualified
+            (``DNS:``/``IP:``). The target takes :data:`HARNESS_UPSTREAM_HOST`
+            this way; the proxy is only ever addressed as ``127.0.0.1``, and a
+            certificate should not claim names its server does not answer to.
+
+    Returns:
+        The (certificate, key) paths for the leaf.
+    """
+    sans = ",".join(["DNS:localhost", "IP:127.0.0.1", *extra_sans])
+    key = certs_dir / f"{name}.key"
+    csr = certs_dir / f"{name}.csr"
+    pem = certs_dir / f"{name}.pem"
+    _run_openssl(
+        "req",
+        "-newkey",
+        "rsa:2048",
+        "-keyout",
+        str(key),
+        "-out",
+        str(csr),
+        "-nodes",
+        "-subj",
+        "/CN=localhost",
+        "-addext",
+        f"subjectAltName={sans}",
+        "-addext",
+        "keyUsage=critical,digitalSignature,keyEncipherment",
+        "-addext",
+        "extendedKeyUsage=serverAuth",
+    )
+    _run_openssl(
+        "x509",
+        "-req",
+        "-in",
+        str(csr),
+        "-CA",
+        str(ca_cert),
+        "-CAkey",
+        str(ca_key),
+        "-CAcreateserial",
+        "-out",
+        str(pem),
+        "-days",
+        "2",
+        "-copy_extensions",
+        "copyall",
+    )
+    return pem, key
+
+
+@pytest.fixture(scope="session")
+def certs(tmp_path_factory: pytest.TempPathFactory) -> CertFiles:
+    """Generate a throwaway CA plus proxy and target certificates (AC1).
+
+    Args:
+        tmp_path_factory: Pytest factory for a session-wide temp directory.
+
+    Returns:
+        The generated certificate and key paths.
+    """
+    certs_dir = tmp_path_factory.mktemp("egress-tls-certs")
+
+    # The CA needs keyCertSign/keyUsage or Python 3.13 strict-mode verification
+    # rejects it ("CA cert does not include key usage extension").
+    ca_key = certs_dir / "ca.key"
+    ca_cert = certs_dir / "ca.pem"
+    _run_openssl(
+        "req",
+        "-x509",
+        "-newkey",
+        "rsa:2048",
+        "-keyout",
+        str(ca_key),
+        "-out",
+        str(ca_cert),
+        "-days",
+        "2",
+        "-nodes",
+        "-subj",
+        "/CN=kitty-egress-test-CA",
+        "-addext",
+        "basicConstraints=critical,CA:TRUE",
+        "-addext",
+        "keyUsage=critical,keyCertSign,cRLSign",
+    )
+
+    proxy_cert, proxy_key = _generate_leaf(certs_dir, "proxy", ca_cert, ca_key)
+    target_cert, target_key = _generate_leaf(
+        certs_dir, "target", ca_cert, ca_key, extra_sans=[f"DNS:{HARNESS_UPSTREAM_HOST}"]
+    )
+    return CertFiles(
+        ca=ca_cert, proxy_cert=proxy_cert, proxy_key=proxy_key, target_cert=target_cert, target_key=target_key
+    )
+
+
+def server_ssl_context(cert: Path, key: Path) -> ssl.SSLContext:
+    """Build a TLS server context from one of the throwaway leaf certs.
+
+    Args:
+        cert: The certificate to present.
+        key: The matching private key.
+
+    Returns:
+        The loaded server-side SSL context.
+    """
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    context.load_cert_chain(str(cert), str(key))
+    return context
+
+
+# ── Local servers (function-scoped, one event loop each) ─────────────────
+
+
+@dataclasses.dataclass
+class ConnectAttempt:
+    """One CONNECT request observed by the local proxy.
+
+    Attributes:
+        target: The ``host:port`` the client asked to tunnel to. Always that
+            shape: a request with a method other than CONNECT is answered 405
+            and recorded as nothing, so this never holds a request-target.
+        authenticated: Whether the presented Basic credentials matched.
+        source_port: Local port of the proxy's outbound socket for this tunnel,
+            or ``None`` when no tunnel was opened -- a rejected authentication,
+            or an upstream that refused the connection.
+
+    ``source_port`` is §5.2.1's join key. Peer *address* cannot do that job:
+    with proxy and upstream on loopback in one process, a tunnelled connection
+    and a direct one both present ``127.0.0.1``. Nor can counting requests
+    against CONNECTs: one tunnel may carry many requests and a rejected tunnel
+    carries none, so the correlation is connection-to-tunnel and the port is
+    what identifies a connection at both ends.
+    """
+
+    target: str
+    authenticated: bool
+    source_port: int | None = None
+
+
+def unattributable_peer_ports(
+    peer_ports: Iterable[int], attempts: Iterable[ConnectAttempt]
+) -> list[int]:
+    """Return the upstream connections no tunnel through the proxy explains.
+
+    This is design §5.2.1's containment assertion, stated once so every
+    transport slice inherits it rather than re-deriving it. An upstream
+    connection with no matching tunnel port is a bypass, and it is the only
+    thing the assertion needs to catch.
+
+    Args:
+        peer_ports: The source port of every **connection** the upstream
+            accepted. Connections, not requests: one tunnel may carry many
+            requests, so a request-level log must be reduced to its distinct
+            connections before it is passed here.
+        attempts: Every CONNECT the proxy observed, established or not.
+
+    Returns:
+        The peer ports with no matching established tunnel, in the order given
+        and with duplicates kept -- two unexplained connections are two
+        findings, not one.
+
+    Raises:
+        ValueError: When a peer port is ``None``. A recorder that never filled
+            the field would otherwise make containment unfalsifiable in
+            whichever direction the default happened to fall; the honest answer
+            is that this run cannot be judged.
+
+    A rejected attempt contributes no port, so ``None`` on an *attempt* is the
+    absence of a key rather than a key matching anything.
+
+    **The premise, which is a property of this harness's wiring and not a law.**
+    A source port identifies a connection only because every leg here
+    terminates on the same destination ``ip:port``, so the kernel will not hand
+    the same port to a second connection while the first is in ``TIME_WAIT``.
+    Point a future leg at a different destination and a direct connection may
+    legitimately draw a live tunnel's source port and be attributed to it. The
+    resulting error is a false negative -- a breach unreported -- never a false
+    positive, so it degrades safety rather than stability. Re-derive this before
+    adding a second upstream port.
+    """
+    # Materialise first: the body reads `peer_ports` twice, and the annotation
+    # invites a generator -- a caller reducing a request log writes
+    # `(r.peer_port for r in log)`. Exhausting it on the unset-port sweep would
+    # report no bypass for a breached run.
+    peer_ports = list(peer_ports)
+    missing = [index for index, port in enumerate(peer_ports) if port is None]
+    if missing:
+        raise ValueError(f"peer port unset at position(s) {missing}: the connection log cannot be judged")
+
+    tunnelled = {attempt.source_port for attempt in attempts if attempt.source_port is not None}
+
+    return [port for port in peer_ports if port not in tunnelled]
+
+
+#: How long :func:`_drain_server` will keep trying before it gives up and
+#: fails the test. A hung teardown must be reported, never waited out.
+_SHUTDOWN_DEADLINE = 5.0
+
+
+async def _drain_server(server: asyncio.Server, writers: Iterable[asyncio.StreamWriter]) -> None:
+    """Wait for an already-closed listener to let go of every connection.
+
+    Args:
+        server: The listener, **already closed by the caller**. Closing is the
+            caller's job so that it happens before any ``await``; a listener
+            still open across one accepts connections whose handlers are
+            created after the teardown pass and never cancelled.
+        writers: The connections this server knows about, aborted each round.
+
+    Raises:
+        TimeoutError: When the server has not finished closing within
+            :data:`_SHUTDOWN_DEADLINE`.
+
+    Python 3.12.1 changed ``asyncio.Server.wait_closed()`` to block until the
+    server is closed **and** every connection is dropped; 3.10 and 3.11 return
+    immediately. So a teardown that merely closes the listener hangs on the
+    newer interpreters and passes on the older ones -- a harness that behaves
+    differently on two contributors' machines.
+
+    Connections are **aborted**, never closed: ``close()`` on a TLS transport
+    begins a graceful shutdown bounded by ``ssl_shutdown_timeout``, 30 seconds
+    by default, and a peer that never answers ``close_notify`` holds the wait
+    for all of it. This module has been bitten by that timeout twice already.
+
+    The retry loop is not belt-and-braces. A connection whose TLS handshake has
+    completed on the client side may not yet have been dispatched to a handler,
+    so it is attached to the server and absent from ``writers``; asyncio exposes
+    no way to see it before 3.13's ``abort_clients()``. Re-aborting each round
+    catches it the moment it appears.
+    """
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + _SHUTDOWN_DEADLINE
+    while True:
+        for writer in list(writers):
+            writer.transport.abort()
+        try:
+            await asyncio.wait_for(server.wait_closed(), timeout=0.05)
+            return
+        except (TimeoutError, asyncio.TimeoutError):
+            if loop.time() >= deadline:
+                raise TimeoutError(
+                    f"server still had connections attached {_SHUTDOWN_DEADLINE}s after close()"
+                ) from None
+
+
+async def _read_head(reader: asyncio.StreamReader) -> bytes | None:
+    """Read a request head terminated by a blank line.
+
+    Args:
+        reader: The stream to read from.
+
+    Returns:
+        The head bytes without the terminating blank line, or ``None`` when
+        the peer closed the connection before completing a head.
+    """
+    data = b""
+    while b"\r\n\r\n" not in data:
+        chunk = await reader.read(4096)
+        if not chunk:
+            return None
+        data += chunk
+    return data.split(b"\r\n\r\n", 1)[0]
+
+
+async def _pipe(source: asyncio.StreamReader, sink: asyncio.StreamWriter) -> None:
+    """Copy bytes one way until EOF or a broken connection.
+
+    Args:
+        source: The side bytes are read from.
+        sink: The side bytes are written to.
+    """
+    try:
+        while True:
+            chunk = await source.read(65536)
+            if not chunk:
+                break
+            sink.write(chunk)
+            await sink.drain()
+    except (ConnectionError, OSError):
+        pass
+
+
+class ConnectProxy:
+    """Minimal TLS CONNECT proxy enforcing Basic auth and recording attempts.
+
+    Attributes:
+        port: The 127.0.0.1 port the proxy listens on, valid once
+            :meth:`start` has returned.
+        attempts: Every CONNECT observed, including rejected ones (AC2).
+
+    The proxy owns its listener rather than leaving it to the fixture, because
+    design §5.2.2 phase 2 -- *proxy down, and the upstream must accept zero
+    connections* -- has to take it down **mid-test**. That is the assertion
+    separating real containment from a bridge that quietly falls back to a
+    direct route when the gateway fails.
+    """
+
+    def __init__(self, resolve: Mapping[str, tuple[str, int]] | None = None) -> None:
+        """Initialise an empty attempt record.
+
+        Args:
+            resolve: CONNECT targets this proxy resolves itself, as
+                ``"host:port" -> (host, port)``. Empty by default, which leaves
+                every target to the system resolver and is what the transport
+                tests want.
+        """
+        self.port = 0
+        self.attempts: list[ConnectAttempt] = []
+        self.resolve = dict(resolve or {})
+        self._server: asyncio.Server | None = None
+        self._tunnels: set[asyncio.Task[None]] = set()
+        self._writers: set[asyncio.StreamWriter] = set()
+
+    async def start(self, ssl_context: ssl.SSLContext) -> None:
+        """Begin listening on an ephemeral 127.0.0.1 port.
+
+        Args:
+            ssl_context: The server-side context the proxy presents on the
+                client hop.
+        """
+        self._server = await asyncio.start_server(self.handle, "127.0.0.1", 0, ssl=ssl_context)
+        self.port = self._server.sockets[0].getsockname()[1]
+
+    async def stop(self) -> None:
+        """Stop the proxy: refuse new connections and drop any tunnel still open.
+
+        Idempotent, because a test that stops the proxy mid-run is still
+        followed by the fixture's teardown.
+
+        Raises:
+            TimeoutError: When the listener will not finish closing; see
+                :func:`_drain_server`, which carries the reasoning.
+        """
+        server = self._server
+        if server is None:
+            return
+
+        # Closed before any `await`, so the listener cannot accept a connection
+        # whose handler is created after the cancel pass below and so never
+        # cancelled.
+        server.close()
+        # Abort BEFORE cancelling. Cancelling a stream handler makes asyncio's
+        # own done-callback call `transport.close()` a *second* time, and the
+        # second call sets `_ssl_protocol = None`, after which every `abort()`
+        # is a silent no-op and the listener stays attached for the full
+        # `ssl_shutdown_timeout`. Aborting first gets in ahead of that.
+        for writer in list(self._writers):
+            writer.transport.abort()
+        # Then cancel: a handler blocked in `open_connection` to an upstream
+        # that never answers would not notice its client socket being aborted.
+        for tunnel in list(self._tunnels):
+            tunnel.cancel()
+        await asyncio.gather(*self._tunnels, return_exceptions=True)
+        await _drain_server(server, self._writers)
+        # Cleared last: a `stop()` that raised has not stopped anything, and
+        # the fixture's teardown call must chase the connection again rather
+        # than return quietly and swallow the diagnostic.
+        self._server = None
+        self._writers.clear()
+
+    async def handle(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        """Serve one CONNECT exchange: record it, check auth, then pipe.
+
+        Args:
+            reader: The client side of the accepted (already TLS) connection.
+            writer: The client side of the accepted (already TLS) connection.
+        """
+        # Registered so `stop()` can drop a tunnel still in flight; asyncio
+        # creates one task per accepted connection and exposes no other handle.
+        tunnel = asyncio.current_task()
+        if tunnel is not None:
+            self._tunnels.add(tunnel)
+
+        self._writers.add(writer)
+        upstream_writer: asyncio.StreamWriter | None = None
+        try:
+            head = await _read_head(reader)
+            if head is None:
+                return
+            lines = head.decode("latin-1").split("\r\n")
+            method, target, _version = lines[0].split(" ", 2)
+            headers = {}
+            for line in lines[1:]:
+                key, sep, value = line.partition(":")
+                if sep:
+                    headers[key.strip().lower()] = value.strip()
+
+            if method != "CONNECT":
+                writer.write(b"HTTP/1.1 405 Method Not Allowed\r\n\r\n")
+                await writer.drain()
+                return
+
+            authenticated = headers.get("proxy-authorization") == EXPECTED_PROXY_AUTH
+            attempt = ConnectAttempt(target=target, authenticated=authenticated)
+            self.attempts.append(attempt)
+            if not authenticated:
+                writer.write(b"HTTP/1.1 407 Proxy Authentication Required\r\n\r\n")
+                await writer.drain()
+                return
+
+            host, port_text = target.rsplit(":", 1)
+            # The harness owns the resolver because the harness is the proxy
+            # (§5.3): a client tunnelling to a `.invalid` name never resolves
+            # it itself, so this is the only place the name can be mapped.
+            address = self.resolve.get(target, (host, int(port_text)))
+            try:
+                upstream_reader, upstream_writer = await asyncio.open_connection(*address)
+            except OSError:
+                # Distinguishable from "no tunnel attempted": the attempt is on
+                # the record with no source port, and the client gets a status
+                # rather than a silent close.
+                writer.write(b"HTTP/1.1 502 Bad Gateway\r\n\r\n")
+                await writer.drain()
+                return
+            self._writers.add(upstream_writer)
+            # Filled only now, because only now does a tunnel exist: the
+            # attempt is recorded before the outbound connection so that a
+            # rejected CONNECT is still on the record (§5.2.1).
+            attempt.source_port = upstream_writer.get_extra_info("sockname")[1]
+            writer.write(b"HTTP/1.1 200 Connection Established\r\n\r\n")
+            await writer.drain()
+            # Close the tunnel as soon as either direction ends. Waiting for
+            # both deadlocks when one side closes without the other noticing,
+            # stalling teardown until the TLS close_notify timeout.
+            to_upstream = asyncio.create_task(_pipe(reader, upstream_writer))
+            to_client = asyncio.create_task(_pipe(upstream_reader, writer))
+            _done, pending = await asyncio.wait({to_upstream, to_client}, return_when=asyncio.FIRST_COMPLETED)
+            for task in pending:
+                task.cancel()
+            await asyncio.gather(*pending, return_exceptions=True)
+        finally:
+            if tunnel is not None:
+                self._tunnels.discard(tunnel)
+            # The writers stay registered until `stop()` clears them. A handler
+            # that de-registered here and then called `close()` would leave the
+            # connection holding the listener open -- a graceful TLS shutdown
+            # against a peer that never answers -- with nothing left for
+            # `stop()` to abort. Aborting a transport twice is harmless; losing
+            # track of one is not.
+            if upstream_writer is not None:
+                upstream_writer.close()
+            writer.close()
+
+
+class TlsTarget:
+    """A local TLS server answering any request with :data:`TARGET_BODY`.
+
+    Attributes:
+        port: The 127.0.0.1 port the target listens on, valid once
+            :meth:`start` has returned.
+        completed: How many connections the handler has finished serving. A
+            test that needs to act *after* a handler has run its teardown has
+            no other observable: the response arriving proves only that the
+            body was written.
+
+    It owns its listener for the same reason :class:`ConnectProxy` does. A
+    fixture that closed the listener and awaited ``wait_closed()`` would hang on
+    Python 3.12.1+ whenever a connection was still attached -- and §5.2.2 phase
+    2 stops the proxy mid-exchange, which is precisely the state that leaves one
+    attached at the target.
+    """
+
+    def __init__(self) -> None:
+        """Initialise a target that is not yet listening."""
+        self.port = 0
+        self.completed = 0
+        self._server: asyncio.Server | None = None
+        self._writers: set[asyncio.StreamWriter] = set()
+
+    async def start(self, ssl_context: ssl.SSLContext) -> None:
+        """Begin listening on an ephemeral 127.0.0.1 port.
+
+        Args:
+            ssl_context: The server-side context the target presents.
+        """
+        self._server = await asyncio.start_server(self.handle, "127.0.0.1", 0, ssl=ssl_context)
+        self.port = self._server.sockets[0].getsockname()[1]
+
+    async def stop(self) -> None:
+        """Stop the target, aborting any connection still attached.
+
+        Idempotent, for the same reason :meth:`ConnectProxy.stop` is.
+
+        Raises:
+            TimeoutError: When the listener will not finish closing; see
+                :func:`_drain_server`.
+        """
+        server = self._server
+        if server is None:
+            return
+
+        # No pre-abort pass here, unlike :meth:`ConnectProxy.stop`: that one
+        # exists only to get ahead of the cancel that disarms `abort()`, and
+        # this class cancels nothing. `_drain_server` does the aborting.
+        server.close()
+        await _drain_server(server, self._writers)
+        self._server = None
+        self._writers.clear()
+
+    async def handle(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        """Answer any single request with the fixed target body.
+
+        Args:
+            reader: The client side of the accepted (already TLS) connection.
+            writer: The client side of the accepted (already TLS) connection.
+        """
+        self._writers.add(writer)
+        try:
+            if await _read_head(reader) is None:
+                return
+            body = TARGET_BODY.encode()
+            # Connection: close makes pooling clients (urllib3) close the tunnel
+            # themselves; without it the target's graceful TLS shutdown would
+            # wait out a 30-second close_notify timeout during teardown.
+            head = (
+                f"HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n"
+                f"Content-Length: {len(body)}\r\nConnection: close\r\n\r\n"
+            )
+            writer.write(head.encode() + body)
+            await writer.drain()
+        finally:
+            # Kept registered for `stop()` to abort; see `ConnectProxy.handle`.
+            self.completed += 1
+            writer.close()
+
+
+@pytest.fixture
+async def connect_proxy(certs: CertFiles) -> AsyncIterator[ConnectProxy]:
+    """Run a local TLS CONNECT proxy for one test (AC2).
+
+    Args:
+        certs: The session's throwaway certificates.
+
+    Yields:
+        The running proxy, with its port and attempt record.
+    """
+    proxy = ConnectProxy()
+    await proxy.start(server_ssl_context(certs.proxy_cert, certs.proxy_key))
+    try:
+        yield proxy
+    finally:
+        await proxy.stop()
+
+
+@pytest.fixture
+async def tls_target(certs: CertFiles) -> AsyncIterator[TlsTarget]:
+    """Run a local TLS target serving the fixed body for one test.
+
+    Args:
+        certs: The session's throwaway certificates.
+
+    Yields:
+        The running target's address.
+    """
+    target = TlsTarget()
+    await target.start(server_ssl_context(certs.target_cert, certs.target_key))
+    try:
+        yield target
+    finally:
+        await target.stop()
+
+
+# ── Test-side seams ──────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def aiohttp_trusts_test_ca(monkeypatch: pytest.MonkeyPatch, certs: CertFiles) -> None:
+    """Swap aiohttp's import-time cached verified SSL context (AC4).
+
+    aiohttp builds ``_SSL_CONTEXT_VERIFIED`` at import time and returns it for
+    both the proxy hop and the tunneled target hop, so wrapping
+    ``ssl.create_default_context`` at test time would be a no-op in a full
+    suite run. Replacing the cached object is the order-independent seam.
+
+    Args:
+        monkeypatch: Pytest's monkeypatch fixture (auto-restores the cache).
+        certs: The session's throwaway certificates.
+    """
+    context = ssl.create_default_context()
+    context.load_verify_locations(str(certs.ca))
+    monkeypatch.setattr(aiohttp.connector, "_SSL_CONTEXT_VERIFIED", context)
+
+
+def proxy_config(port: int, password: str = PROXY_PASSWORD) -> EgressConfig:
+    """Build the https-proxy configuration the tests drive.
+
+    Args:
+        port: The local proxy port.
+        password: Proxy password; pass a wrong one for the negative test.
+
+    Returns:
+        The configuration under test.
+    """
+    return EgressConfig(proxy_url=f"https://127.0.0.1:{port}", username=PROXY_USER, password=password)

--- a/tests/harness/connect_proxy.py
+++ b/tests/harness/connect_proxy.py
@@ -91,6 +91,12 @@ EXPECTED_PROXY_AUTH = "Basic " + base64.b64encode(f"{PROXY_USER}:{PROXY_PASSWORD
 # ── Certificates (session-scoped, files only) ────────────────────────────
 
 
+# Matches the bound in `tests/bridge/tls_certs.py`, for the same reason: long
+# enough that a loaded runner never trips it, short enough that a stuck openssl
+# is reported rather than left to consume the job's ceiling.
+_OPENSSL_TIMEOUT_SECONDS = 60
+
+
 @dataclasses.dataclass(frozen=True)
 class CertFiles:
     """Paths of the throwaway certificate set used by the local servers.
@@ -124,8 +130,23 @@ def _run_openssl(*args: str) -> None:
             deliberately left to propagate: §8's rule is that a skip in a
             gating job is a failure, so a missing tool must stop the suite
             rather than quietly excuse it.
+        subprocess.TimeoutExpired: When openssl does not finish within
+            ``_OPENSSL_TIMEOUT_SECONDS``. Left to propagate rather than
+            converted: it already names the command and the bound, and an
+            unhandled error is as loud as a failure.
     """
-    completed = subprocess.run(["openssl", *args], capture_output=True, text=True)
+    # Bounded, and stdin closed, for the reason `tests/bridge/tls_certs.py`
+    # gives (KBR-132): this is the single entry point for every openssl process
+    # this module spawns inside the gate, and nothing else would stop a wedged
+    # one hanging it. Deliberately no count -- "call sites" and "processes
+    # spawned" differ here, because `_generate_leaf` runs twice.
+    completed = subprocess.run(
+        ["openssl", *args],
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
+        timeout=_OPENSSL_TIMEOUT_SECONDS,
+    )
     if completed.returncode != 0:
         pytest.fail(f"openssl {args[0]} failed (exit {completed.returncode}):\n{completed.stderr}")
 

--- a/tests/harness/connect_proxy.py
+++ b/tests/harness/connect_proxy.py
@@ -497,7 +497,11 @@ class ConnectProxy:
             TimeoutError: When the listener will not finish closing; see
                 :func:`_drain_server`, which carries the reasoning.
         """
-        server = self._server
+        # Claimed up front, so the fixture's teardown call after a test has
+        # already stopped the proxy -- or after a `stop()` that raised --
+        # returns instead of spending the drain deadline again and reporting
+        # the same failure twice. The first report already named it.
+        server, self._server = self._server, None
         if server is None:
             return
 
@@ -518,11 +522,6 @@ class ConnectProxy:
             tunnel.cancel()
         await asyncio.gather(*self._tunnels, return_exceptions=True)
         await _drain_server(server, self._writers)
-        # Cleared last: a `stop()` that raised has not stopped anything, and
-        # the fixture's teardown call must chase the connection again rather
-        # than return quietly and swallow the diagnostic.
-        self._server = None
-        self._writers.clear()
 
     async def handle(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
         """Serve one CONNECT exchange: record it, check auth, then pipe.
@@ -651,7 +650,7 @@ class TlsTarget:
             TimeoutError: When the listener will not finish closing; see
                 :func:`_drain_server`.
         """
-        server = self._server
+        server, self._server = self._server, None
         if server is None:
             return
 
@@ -660,8 +659,6 @@ class TlsTarget:
         # this class cancels nothing. `_drain_server` does the aborting.
         server.close()
         await _drain_server(server, self._writers)
-        self._server = None
-        self._writers.clear()
 
     async def handle(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
         """Answer any single request with the fixed target body.

--- a/tests/harness/connect_proxy.py
+++ b/tests/harness/connect_proxy.py
@@ -117,8 +117,13 @@ def _run_openssl(*args: str) -> None:
         *args: Arguments following the ``openssl`` executable name.
 
     Raises:
-        pytest.fail: When openssl exits non-zero; the captured stderr is
+        pytest.Failed: When openssl exits non-zero; the captured stderr is
             included so certificate-generation mistakes are readable (AC1).
+        OSError: ``FileNotFoundError`` when the ``openssl`` binary is not on
+            PATH. The ``returncode`` check never sees that case, and it is
+            deliberately left to propagate: §8's rule is that a skip in a
+            gating job is a failure, so a missing tool must stop the suite
+            rather than quietly excuse it.
     """
     completed = subprocess.run(["openssl", *args], capture_output=True, text=True)
     if completed.returncode != 0:

--- a/tests/harness/test_connect_proxy.py
+++ b/tests/harness/test_connect_proxy.py
@@ -1,0 +1,494 @@
+"""L1 tests for the shared CONNECT proxy's containment capabilities.
+
+`.system_design/TEST_SUITE.md` §5.2.1, §5.2.2, §7.3 · plan task **T-W5** (KBR-28).
+
+The extraction itself is regression-tested by
+:mod:`tests.test_egress_https_proxy`, which drives all three transport stacks
+through the fixture and must pass unchanged.  This module tests only what T-W5
+*adds*, and it adds exactly what the containment harness (T-E1/T-E2) cannot be
+written without:
+
+* the **tunnel source port**, §5.2.1's join key — an upstream connection that
+  joins to no tunnel is a bypass, and that is the only thing the containment
+  assertion needs to catch;
+* **mid-test stoppability**, so §5.2.2 phase 2 can assert that with the proxy
+  down the upstream accepts zero connections.
+
+**Why a plain TCP sink rather than the TLS target.**  The join is between the
+proxy's outbound socket and the *connection* the far end accepts, not the
+request that rides on it (§5.2.1).  A plain sink records the peer port at
+**accept** time, which is the semantics containment needs: a bypass that
+connects and then fails TLS is still a bypass.  A TLS server's handler runs only
+after a completed handshake and would miss exactly that case.  It also keeps
+these tests off the TLS-in-TLS path, which aiohttp cannot take below Python
+3.11.
+
+**The falsification case** is
+:meth:`TestUnattributableConnections.test_a_direct_connection_is_reported_as_unattributable`
+(plan §1.4).  It opens one connection through the proxy and one straight past
+it, and requires the join to name the second and clear the first.  Without it a
+join that matched everything, or a ``source_port`` that was recorded but never
+correlated, would look identical to a working one.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import dataclasses
+import ssl
+from collections.abc import AsyncIterator, Callable
+
+import pytest
+
+from harness.connect_proxy import (
+    EXPECTED_PROXY_AUTH,
+    HARNESS_UPSTREAM_HOST,
+    TARGET_BODY,
+    CertFiles,
+    ConnectAttempt,
+    ConnectProxy,
+    TlsTarget,
+    server_ssl_context,
+    unattributable_peer_ports,
+)
+
+#: How long a test waits for an asynchronous side effect before failing. Long
+#: enough to absorb a loaded CI runner, short enough that a genuine hang is
+#: reported as a failure rather than as a stuck job.
+_SETTLE_TIMEOUT = 5.0
+
+
+@dataclasses.dataclass
+class _TcpSink:
+    """A plain TCP server that records who connects and answers nothing.
+
+    Attributes:
+        port: The 127.0.0.1 port it listens on.
+        peer_ports: The source port of every connection accepted, in order.
+    """
+
+    port: int
+    peer_ports: list[int]
+
+
+@pytest.fixture
+async def tcp_sink() -> AsyncIterator[_TcpSink]:
+    """Run a connection-recording TCP sink for one test.
+
+    Yields:
+        The running sink, with its port and the peer ports it has accepted.
+    """
+    peer_ports: list[int] = []
+
+    async def handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        """Record the peer port, then hold the connection until the peer leaves.
+
+        Args:
+            reader: The accepted connection's read side.
+            writer: The accepted connection's write side.
+        """
+        # Recorded at accept time and before any read: a bypass that connects
+        # and then sends nothing must still be counted (§5.2.1).
+        peer_ports.append(writer.get_extra_info("peername")[1])
+        try:
+            await reader.read()
+        finally:
+            writer.close()
+
+    server = await asyncio.start_server(handle, "127.0.0.1", 0)
+    try:
+        yield _TcpSink(port=server.sockets[0].getsockname()[1], peer_ports=peer_ports)
+    finally:
+        # Deliberately no `wait_closed()`: on Python 3.12.1+ it blocks until
+        # every connection is dropped, and a test that leaves a tunnel open is
+        # the normal case here. This is a plain TCP server with no TLS
+        # shutdown to negotiate, so closing the listener is the whole teardown;
+        # the loop reclaims the handler tasks. `ConnectProxy` and `TlsTarget`
+        # need `stop()` precisely because they do not have that luxury.
+        server.close()
+
+
+async def _wait_until(predicate: Callable[[], bool]) -> None:
+    """Wait for a condition to hold, rather than sleeping for a guessed interval.
+
+    Args:
+        predicate: Called repeatedly; the wait ends when it returns ``True``.
+
+    Raises:
+        AssertionError: When the condition has not held within
+            :data:`_SETTLE_TIMEOUT`.
+    """
+    # A `sleep()` long enough to be reliable on a loaded runner is also long
+    # enough to make the suite slow, which is the usual road to a flaky test.
+    async def poll() -> None:
+        """Yield to the loop until the condition holds."""
+        while not predicate():
+            await asyncio.sleep(0.01)
+
+    try:
+        await asyncio.wait_for(poll(), timeout=_SETTLE_TIMEOUT)
+    except asyncio.TimeoutError:  # pragma: no cover - only on a real failure
+        pytest.fail(f"condition did not hold within {_SETTLE_TIMEOUT}s")
+
+
+async def _open_tunnel(
+    proxy: ConnectProxy, certs: CertFiles, target: str, *, authorization: str = EXPECTED_PROXY_AUTH
+) -> tuple[asyncio.StreamReader, asyncio.StreamWriter, str]:
+    """Open one CONNECT tunnel through the proxy by hand.
+
+    Driving the handshake directly, rather than through a client library, keeps
+    these tests on a single TLS layer -- the proxy hop -- so they run on every
+    supported Python instead of only on the 3.11+ that aiohttp needs for
+    TLS-in-TLS.
+
+    Args:
+        proxy: The running proxy.
+        certs: The session's throwaway certificates, for the proxy hop's trust.
+        target: The ``host:port`` to ask the proxy to tunnel to.
+        authorization: The ``Proxy-Authorization`` value to present; pass a
+            wrong one to exercise the rejection path.
+
+    Returns:
+        The tunnel's streams and the proxy's status line.
+    """
+    context = ssl.create_default_context(cafile=str(certs.ca))
+    reader, writer = await asyncio.open_connection("127.0.0.1", proxy.port, ssl=context, server_hostname="localhost")
+    request = (
+        f"CONNECT {target} HTTP/1.1\r\nHost: {target}\r\nProxy-Authorization: {authorization}\r\n\r\n"
+    )
+    writer.write(request.encode())
+    await writer.drain()
+
+    head = b""
+    while b"\r\n\r\n" not in head:
+        chunk = await reader.read(4096)
+        if not chunk:
+            break
+        head += chunk
+    status = head.decode("latin-1").split("\r\n")[0]
+    return reader, writer, status
+
+
+class TestTunnelSourcePortRecording:
+    """`ConnectAttempt` carries the join key §5.2.1 needs, or it carries nothing."""
+
+    async def test_records_the_outbound_source_port_of_an_established_tunnel(
+        self, connect_proxy: ConnectProxy, certs: CertFiles, tcp_sink: _TcpSink
+    ) -> None:
+        """The recorded port is the one the far end actually saw connect."""
+        _reader, writer, status = await _open_tunnel(connect_proxy, certs, f"127.0.0.1:{tcp_sink.port}")
+        try:
+            assert "200" in status
+            await _wait_until(lambda: len(tcp_sink.peer_ports) == 1)
+
+            assert connect_proxy.attempts[0].source_port == tcp_sink.peer_ports[0]
+        finally:
+            writer.close()
+
+    async def test_records_no_source_port_when_authentication_is_rejected(
+        self, connect_proxy: ConnectProxy, certs: CertFiles, tcp_sink: _TcpSink
+    ) -> None:
+        """A rejected CONNECT is still recorded, but it opened no tunnel."""
+        wrong = "Basic " + base64.b64encode(b"nobody:nothing").decode()
+        _reader, writer, status = await _open_tunnel(
+            connect_proxy, certs, f"127.0.0.1:{tcp_sink.port}", authorization=wrong
+        )
+        try:
+            assert "407" in status
+
+            assert connect_proxy.attempts[0].authenticated is False
+            # The load-bearing assertion. A companion `peer_ports == []` would
+            # be decorative: read with no settling wait, it would also pass
+            # while a wrongly-opened connection was still waiting to be
+            # accepted, and there is no deterministic way to wait for an event
+            # that must never happen.
+            assert connect_proxy.attempts[0].source_port is None
+        finally:
+            writer.close()
+
+
+class TestProxiedLegResolution:
+    """The harness owns the resolver because the harness is the proxy (§5.3)."""
+
+    async def test_tunnels_to_a_name_the_public_dns_cannot_resolve(
+        self, certs: CertFiles, tcp_sink: _TcpSink
+    ) -> None:
+        """A sealed-network upstream is addressed by an unresolvable name, by design.
+
+        §5.3 requires the upstream to sit outside the ``localhost`` family, or
+        ``egress.should_bypass()`` routes it direct and the harness proves the
+        opposite of its claim.  The name it picks is a ``.invalid`` one, which
+        RFC 2606 guarantees never resolves — so the proxy has to map it, and
+        that mapping is the seam T-E1 builds on.
+        """
+        target = f"{HARNESS_UPSTREAM_HOST}:443"
+        proxy = ConnectProxy(resolve={target: ("127.0.0.1", tcp_sink.port)})
+        await proxy.start(server_ssl_context(certs.proxy_cert, certs.proxy_key))
+        try:
+            _reader, writer, status = await _open_tunnel(proxy, certs, target)
+            try:
+                assert "200" in status
+                await _wait_until(lambda: len(tcp_sink.peer_ports) == 1)
+
+                assert proxy.attempts[0].target == target
+                assert proxy.attempts[0].source_port == tcp_sink.peer_ports[0]
+            finally:
+                writer.close()
+        finally:
+            await proxy.stop()
+
+    async def test_an_unmapped_name_is_answered_502_and_opens_no_tunnel(
+        self, connect_proxy: ConnectProxy, certs: CertFiles
+    ) -> None:
+        """"Tunnel attempted, upstream unreachable" is not "no tunnel attempted".
+
+        §5.2.2 phase 2 has to tell those two apart to diagnose a run, so an
+        unreachable upstream gets a status line rather than a silent close.
+        """
+        _reader, writer, status = await _open_tunnel(connect_proxy, certs, f"{HARNESS_UPSTREAM_HOST}:443")
+        try:
+            assert "502" in status
+
+            assert connect_proxy.attempts[0].authenticated is True
+            assert connect_proxy.attempts[0].source_port is None
+        finally:
+            writer.close()
+
+    async def test_the_target_certificate_answers_to_the_harness_name(
+        self, certs: CertFiles, tls_target: TlsTarget
+    ) -> None:
+        """A mapped route is worthless if the hop it reaches cannot be verified."""
+        context = ssl.create_default_context(cafile=str(certs.ca))
+        reader, writer = await asyncio.open_connection(
+            "127.0.0.1", tls_target.port, ssl=context, server_hostname=HARNESS_UPSTREAM_HOST
+        )
+        try:
+            writer.write(b"GET / HTTP/1.1\r\nHost: x\r\n\r\n")
+            await writer.drain()
+
+            assert TARGET_BODY.encode() in await reader.read(4096)
+        finally:
+            writer.close()
+
+
+class TestMidTestStoppability:
+    """§5.2.2 phase 2 needs the proxy down while the test is still running."""
+
+    async def test_stopping_the_proxy_refuses_further_connections(
+        self, connect_proxy: ConnectProxy, certs: CertFiles, tcp_sink: _TcpSink
+    ) -> None:
+        """After `stop()` the port is dead, and the far end saw only the first connection."""
+        _reader, writer, _status = await _open_tunnel(connect_proxy, certs, f"127.0.0.1:{tcp_sink.port}")
+        await _wait_until(lambda: len(tcp_sink.peer_ports) == 1)
+        writer.close()
+
+        await connect_proxy.stop()
+
+        with pytest.raises(ConnectionRefusedError):
+            await asyncio.open_connection("127.0.0.1", connect_proxy.port)
+        assert len(tcp_sink.peer_ports) == 1
+
+    async def test_stopping_the_target_returns_while_a_connection_is_open(
+        self, certs: CertFiles, tls_target: TlsTarget
+    ) -> None:
+        """The target carries the same teardown hazard the proxy does.
+
+        §5.2.2 phase 2 stops the proxy mid-exchange, which is exactly the state
+        that leaves a connection attached at the target end.
+        """
+        context = ssl.create_default_context(cafile=str(certs.ca))
+        _reader, writer = await asyncio.open_connection(
+            "127.0.0.1", tls_target.port, ssl=context, server_hostname="localhost"
+        )
+        try:
+            await asyncio.wait_for(tls_target.stop(), timeout=_SETTLE_TIMEOUT)
+        finally:
+            writer.close()
+
+    async def test_stopping_the_proxy_returns_when_the_client_ignores_close_notify(
+        self, connect_proxy: ConnectProxy, certs: CertFiles, tcp_sink: _TcpSink
+    ) -> None:
+        """The case the abort design exists for, and the one a polite client hides.
+
+        `asyncio.open_connection`'s SSL protocol answers an inbound
+        ``close_notify`` on its own, without the application reading anything,
+        so a test using it proves only that `stop()` returns for a
+        **cooperative** peer.  A pooled urllib3 or botocore connection sitting
+        idle through §5.2.2 phase 2 is the non-cooperative case, and there a
+        graceful `close()` waits out `ssl_shutdown_timeout` -- 30 seconds.
+        `pause_reading()` reproduces that deterministically, with no thread and
+        no sleep.
+        """
+        _reader, writer, status = await _open_tunnel(connect_proxy, certs, f"127.0.0.1:{tcp_sink.port}")
+        try:
+            assert "200" in status
+            await _wait_until(lambda: len(tcp_sink.peer_ports) == 1)
+            writer.transport.pause_reading()
+
+            await asyncio.wait_for(connect_proxy.stop(), timeout=_SETTLE_TIMEOUT)
+        finally:
+            writer.transport.abort()
+
+    async def test_stopping_the_target_returns_when_the_client_ignores_close_notify(
+        self, certs: CertFiles, tls_target: TlsTarget
+    ) -> None:
+        """The target carries the same hazard, by a different route.
+
+        Its handler is never cancelled, so it reaches its own `finally` and
+        closes the connection gracefully.  If `stop()` can no longer reach that
+        connection by then, the listener stays attached to it for the full
+        shutdown timeout.
+        """
+        context = ssl.create_default_context(cafile=str(certs.ca))
+        _reader, writer = await asyncio.open_connection(
+            "127.0.0.1", tls_target.port, ssl=context, server_hostname="localhost"
+        )
+        try:
+            # Paused before the request, and never read: the response is served
+            # and the handler runs its teardown while this client answers
+            # nothing. `completed` is the only observable for "the handler has
+            # finished", and waiting on it is what puts `stop()` on the far side
+            # of the teardown -- which is where the connection escapes.
+            writer.transport.pause_reading()
+            writer.write(b"GET / HTTP/1.1\r\nHost: x\r\n\r\n")
+            await writer.drain()
+            await _wait_until(lambda: tls_target.completed == 1)
+
+            await asyncio.wait_for(tls_target.stop(), timeout=_SETTLE_TIMEOUT)
+        finally:
+            writer.transport.abort()
+
+    async def test_stopping_the_proxy_twice_is_harmless(self, connect_proxy: ConnectProxy) -> None:
+        """The fixture's teardown calls `stop()` after a test already has."""
+        await connect_proxy.stop()
+
+        await connect_proxy.stop()
+
+    async def test_stopping_the_proxy_returns_while_a_tunnel_is_open(
+        self, connect_proxy: ConnectProxy, certs: CertFiles, tcp_sink: _TcpSink
+    ) -> None:
+        """`stop()` tears down live tunnels rather than waiting on them.
+
+        Python 3.12.1 changed ``asyncio.Server.wait_closed()`` to block until the
+        server is closed **and** every connection is dropped; 3.10 and 3.11
+        return immediately.  A ``stop()`` that closed the listener and awaited
+        ``wait_closed()`` would therefore hang on 3.12 and 3.13 and pass on
+        3.10 and 3.11 -- a harness that behaves differently on two
+        contributors' machines.
+        """
+        _reader, writer, status = await _open_tunnel(connect_proxy, certs, f"127.0.0.1:{tcp_sink.port}")
+        try:
+            assert "200" in status
+            await _wait_until(lambda: len(tcp_sink.peer_ports) == 1)
+
+            await asyncio.wait_for(connect_proxy.stop(), timeout=_SETTLE_TIMEOUT)
+        finally:
+            writer.close()
+
+
+class TestUnattributableConnections:
+    """§5.2.1's join, stated once so T-E2 inherits it rather than re-deriving it."""
+
+    @pytest.mark.parametrize(
+        ("peer_ports", "source_ports", "expected"),
+        [
+            pytest.param([4001], [4001], [], id="a tunnelled connection is attributable"),
+            pytest.param([4001, 4002], [4001], [4002], id="an untunnelled connection is not"),
+            pytest.param([4001, 4001], [4001], [], id="one tunnel may carry several connections"),
+            pytest.param([], [4001], [], id="a tunnel carrying nothing is not a finding"),
+            pytest.param([4002], [], [4002], id="no tunnel at all leaves every connection unexplained"),
+            pytest.param([4001, 4001], [], [4001, 4001], id="two unexplained connections are two findings"),
+        ],
+    )
+    def test_reports_exactly_the_peer_ports_no_tunnel_explains(
+        self, peer_ports: list[int], source_ports: list[int], expected: list[int]
+    ) -> None:
+        """The join is at the connection level, never request-to-CONNECT (§5.2.1)."""
+        attempts = [ConnectAttempt(target="t:443", authenticated=True, source_port=p) for p in source_ports]
+
+        assert unattributable_peer_ports(peer_ports, attempts) == expected
+
+    def test_a_one_shot_iterable_is_judged_rather_than_consumed(self) -> None:
+        """A generator argument must not come back clean because it was read twice.
+
+        The annotation invites one: a caller reducing a request log writes
+        ``(r.peer_port for r in log)``. An implementation that sweeps for unset
+        ports and then filters would exhaust it on the first pass and report no
+        bypass for a breached run -- the same unfalsifiability the unset-port
+        guard exists to refuse, arriving through the front door.
+        """
+        ports = (port for port in [4001, 4002])
+        attempts = [ConnectAttempt(target="t:443", authenticated=True, source_port=4001)]
+
+        assert unattributable_peer_ports(ports, attempts) == [4002]
+
+    def test_an_unset_peer_port_is_refused_rather_than_judged(self) -> None:
+        """A recorder that never filled the field cannot be silently forgiven.
+
+        `CapturedRequest.peer_port` defaults to `None` and is T-W4's to
+        populate. Treating an unset port as attributable would make containment
+        pass on a recorder that observes nothing; treating it as a bypass would
+        fail every run for the wrong reason. Neither is a judgement.
+        """
+        with pytest.raises(ValueError, match="position"):
+            unattributable_peer_ports([4001, None], [])  # type: ignore[list-item]
+
+    def test_a_rejected_tunnels_absent_source_port_matches_nothing(self) -> None:
+        """`None` is the absence of a join key, not a key that joins to anything."""
+        rejected = ConnectAttempt(target="t:443", authenticated=False, source_port=None)
+
+        assert unattributable_peer_ports([4001], [rejected]) == [4001]
+
+    async def test_the_join_holds_when_many_tunnels_are_open_at_once(
+        self, connect_proxy: ConnectProxy, certs: CertFiles, tcp_sink: _TcpSink
+    ) -> None:
+        """One connection joining one tunnel proves nothing about ordering.
+
+        The containment slices drive concurrent sessions through one listener,
+        and `attempts` has no defined order under concurrency -- so the claim
+        that survives is a set equality, not an index-by-index match.
+        """
+        target = f"127.0.0.1:{tcp_sink.port}"
+        tunnels = await asyncio.gather(*(_open_tunnel(connect_proxy, certs, target) for _ in range(8)))
+        try:
+            await _wait_until(lambda: len(tcp_sink.peer_ports) == 8)
+
+            # Eight distinct ports, asserted separately: a set equality alone
+            # would also hold if two tunnels had somehow recorded one port.
+            assert len(set(tcp_sink.peer_ports)) == 8
+            assert {attempt.source_port for attempt in connect_proxy.attempts} == set(tcp_sink.peer_ports)
+            assert unattributable_peer_ports(tcp_sink.peer_ports, connect_proxy.attempts) == []
+        finally:
+            for _reader, writer, _status in tunnels:
+                writer.close()
+
+    async def test_a_direct_connection_is_reported_as_unattributable(
+        self, connect_proxy: ConnectProxy, certs: CertFiles, tcp_sink: _TcpSink
+    ) -> None:
+        """The falsification case: a real bypass, deliberately introduced (plan §1.4).
+
+        A containment harness that has never been shown to fail is
+        indistinguishable from one that cannot fail (design §5.2.2 phase 3).
+
+        This does **not** discharge T-E2's own phase-3 obligation. That one
+        injects a bypass into the *product* -- a patched `should_bypass`, or a
+        session built without the proxy -- and requires the harness to fail.
+        This one proves only that the join can tell the two kinds of connection
+        apart at all, which is the precondition for T-E2's test meaning
+        anything.
+        """
+        _reader, tunnelled, _status = await _open_tunnel(connect_proxy, certs, f"127.0.0.1:{tcp_sink.port}")
+        await _wait_until(lambda: len(tcp_sink.peer_ports) == 1)
+        # The bypass: straight to the far end, past the proxy entirely.
+        _direct_reader, direct = await asyncio.open_connection("127.0.0.1", tcp_sink.port)
+        try:
+            await _wait_until(lambda: len(tcp_sink.peer_ports) == 2)
+            direct_port = direct.get_extra_info("sockname")[1]
+
+            unattributable = unattributable_peer_ports(tcp_sink.peer_ports, connect_proxy.attempts)
+
+            assert unattributable == [direct_port]
+        finally:
+            direct.close()
+            tunnelled.close()

--- a/tests/harness/test_connect_proxy.py
+++ b/tests/harness/test_connect_proxy.py
@@ -197,6 +197,7 @@ class TestTunnelSourcePortRecording:
         try:
             assert "407" in status
 
+            assert len(connect_proxy.attempts) == 1
             assert connect_proxy.attempts[0].authenticated is False
             # The load-bearing assertion. A companion `peer_ports == []` would
             # be decorative: read with no settling wait, it would also pass
@@ -488,6 +489,16 @@ class TestUnattributableConnections:
 
             unattributable = unattributable_peer_ports(tcp_sink.peer_ports, connect_proxy.attempts)
 
+            # Both directions, stated rather than inferred. The equality below
+            # already excludes "both were rejected" -- that would return two
+            # ports, not one -- but a join is a claim about each connection,
+            # and reading only the negative half invites the next author to
+            # weaken the positive one without noticing.
+            #
+            # The join key is the proxy's OUTBOUND port, not the client's:
+            # `tunnelled`'s own sockname belongs to the client-to-proxy leg and
+            # never reaches the far end.
+            assert connect_proxy.attempts[0].source_port in tcp_sink.peer_ports
             assert unattributable == [direct_port]
         finally:
             direct.close()

--- a/tests/test_egress_https_proxy.py
+++ b/tests/test_egress_https_proxy.py
@@ -21,6 +21,11 @@ What it proves, per transport stack:
   explicit ``Proxy-Authorization`` header: urllib3 itself never converts URL
   userinfo into that header).
 
+The servers themselves now live in :mod:`harness.connect_proxy` (plan task
+T-W5), because the containment harness and the dependency proxy contracts need
+the same proxy. This module keeps the tests and the one seam that is specific to
+``kitty egress test`` rather than to the proxy — :func:`target_url`.
+
 See ``.requirements/20260820T122157Z_egress_https_proxy_tests/REQUIREMENTS.md``
 for the full specification (R1–R8, AC1–AC10).
 """
@@ -28,405 +33,30 @@ for the full specification (R1–R8, AC1–AC10).
 from __future__ import annotations
 
 import asyncio
-import base64
-import dataclasses
 import ssl
-import subprocess
 import sys
-from pathlib import Path
 
-import aiohttp.connector
 import curl_cffi.requests
 import pytest
 import urllib3
 from curl_cffi import curl as curl_cffi_curl
+from harness.connect_proxy import (
+    EXPECTED_PROXY_AUTH,
+    TARGET_BODY,
+    CertFiles,
+    ConnectProxy,
+    TlsTarget,
+    proxy_config,
+)
 
 from kitty.cli import egress_cmd
-from kitty.egress import EgressConfig
-
-PROXY_USER = "testuser"
-PROXY_PASSWORD = "testpass"
-
-#: Fixed target response body. Contains no surrounding whitespace so it
-#: survives ``_probe``'s ``.strip()`` unchanged (AC3).
-TARGET_BODY = "kitty-egress-tls-target"
-
-_EXPECTED_PROXY_AUTH = "Basic " + base64.b64encode(f"{PROXY_USER}:{PROXY_PASSWORD}".encode()).decode()
 
 _AIOHTTP_NEEDS_311 = sys.version_info < (3, 11)
 _AIOHTTP_SKIP_REASON = "aiohttp requires Python 3.11 for TLS-in-TLS over stdlib asyncio (bpo-44011)"
 
 
-# ── Certificates (session-scoped, files only) ────────────────────────────
-
-
-# Matches the bound in `tests/bridge/tls_certs.py`, for the same reason: long
-# enough that a loaded runner never trips it, short enough that a stuck openssl
-# is reported rather than left to consume the job's ceiling.
-_OPENSSL_TIMEOUT_SECONDS = 60
-
-
-@dataclasses.dataclass(frozen=True)
-class _CertFiles:
-    """Paths of the throwaway certificate set used by the local servers.
-
-    Attributes:
-        ca: The throwaway CA certificate to load as client trust.
-        proxy_cert: Certificate the TLS CONNECT proxy presents.
-        proxy_key: Private key matching ``proxy_cert``.
-        target_cert: Certificate the TLS target presents.
-        target_key: Private key matching ``target_cert``.
-    """
-
-    ca: Path
-    proxy_cert: Path
-    proxy_key: Path
-    target_cert: Path
-    target_key: Path
-
-
-def _run_openssl(*args: str) -> None:
-    """Run one openssl command, failing the test loudly on any error.
-
-    Args:
-        *args: Arguments following the ``openssl`` executable name.
-
-    Raises:
-        pytest.fail: When openssl exits non-zero; the captured stderr is
-            included so certificate-generation mistakes are readable (AC1).
-        subprocess.TimeoutExpired: When openssl does not finish within
-            ``_OPENSSL_TIMEOUT_SECONDS``. Left to propagate rather than
-            converted: it already names the command and the bound, and an
-            unhandled error is as loud as a failure.
-    """
-    # Bounded, and stdin closed, for the reason `tests/bridge/tls_certs.py`
-    # gives (KBR-132): this is the single entry point for every openssl process
-    # this module spawns inside the gate, and nothing else would stop a wedged
-    # one hanging it. Deliberately no count -- "call sites" and "processes
-    # spawned" differ here, because `_generate_leaf` runs twice.
-    completed = subprocess.run(
-        ["openssl", *args],
-        capture_output=True,
-        text=True,
-        stdin=subprocess.DEVNULL,
-        timeout=_OPENSSL_TIMEOUT_SECONDS,
-    )
-    if completed.returncode != 0:
-        pytest.fail(f"openssl {args[0]} failed (exit {completed.returncode}):\n{completed.stderr}")
-
-
-def _generate_leaf(certs_dir: Path, name: str, ca_cert: Path, ca_key: Path) -> tuple[Path, Path]:
-    """Generate one CA-signed leaf certificate for a local server.
-
-    The extensions satisfy Python 3.13's OpenSSL strict-mode verification and
-    the fact that both servers are addressed as ``127.0.0.1`` (AC1).
-
-    Args:
-        certs_dir: Directory receiving the key, CSR and certificate files.
-        name: Filename stem distinguishing this server's files.
-        ca_cert: The CA certificate that signs the leaf.
-        ca_key: The CA private key that signs the leaf.
-
-    Returns:
-        The (certificate, key) paths for the leaf.
-    """
-    key = certs_dir / f"{name}.key"
-    csr = certs_dir / f"{name}.csr"
-    pem = certs_dir / f"{name}.pem"
-    _run_openssl(
-        "req",
-        "-newkey",
-        "rsa:2048",
-        "-keyout",
-        str(key),
-        "-out",
-        str(csr),
-        "-nodes",
-        "-subj",
-        "/CN=localhost",
-        "-addext",
-        "subjectAltName=DNS:localhost,IP:127.0.0.1",
-        "-addext",
-        "keyUsage=critical,digitalSignature,keyEncipherment",
-        "-addext",
-        "extendedKeyUsage=serverAuth",
-    )
-    _run_openssl(
-        "x509",
-        "-req",
-        "-in",
-        str(csr),
-        "-CA",
-        str(ca_cert),
-        "-CAkey",
-        str(ca_key),
-        "-CAcreateserial",
-        "-out",
-        str(pem),
-        "-days",
-        "2",
-        "-copy_extensions",
-        "copyall",
-    )
-    return pem, key
-
-
-@pytest.fixture(scope="session")
-def certs(tmp_path_factory: pytest.TempPathFactory) -> _CertFiles:
-    """Generate a throwaway CA plus proxy and target certificates (AC1).
-
-    Args:
-        tmp_path_factory: Pytest factory for a session-wide temp directory.
-
-    Returns:
-        The generated certificate and key paths.
-    """
-    certs_dir = tmp_path_factory.mktemp("egress-tls-certs")
-
-    # The CA needs keyCertSign/keyUsage or Python 3.13 strict-mode verification
-    # rejects it ("CA cert does not include key usage extension").
-    ca_key = certs_dir / "ca.key"
-    ca_cert = certs_dir / "ca.pem"
-    _run_openssl(
-        "req",
-        "-x509",
-        "-newkey",
-        "rsa:2048",
-        "-keyout",
-        str(ca_key),
-        "-out",
-        str(ca_cert),
-        "-days",
-        "2",
-        "-nodes",
-        "-subj",
-        "/CN=kitty-egress-test-CA",
-        "-addext",
-        "basicConstraints=critical,CA:TRUE",
-        "-addext",
-        "keyUsage=critical,keyCertSign,cRLSign",
-    )
-
-    proxy_cert, proxy_key = _generate_leaf(certs_dir, "proxy", ca_cert, ca_key)
-    target_cert, target_key = _generate_leaf(certs_dir, "target", ca_cert, ca_key)
-    return _CertFiles(
-        ca=ca_cert, proxy_cert=proxy_cert, proxy_key=proxy_key, target_cert=target_cert, target_key=target_key
-    )
-
-
-# ── Local servers (function-scoped, one event loop each) ─────────────────
-
-
-@dataclasses.dataclass
-class ConnectAttempt:
-    """One CONNECT request observed by the local proxy.
-
-    Attributes:
-        target: The ``host:port`` the client asked to tunnel to.
-        authenticated: Whether the presented Basic credentials matched.
-    """
-
-    target: str
-    authenticated: bool
-
-
-async def _read_head(reader: asyncio.StreamReader) -> bytes | None:
-    """Read a request head terminated by a blank line.
-
-    Args:
-        reader: The stream to read from.
-
-    Returns:
-        The head bytes without the terminating blank line, or ``None`` when
-        the peer closed the connection before completing a head.
-    """
-    data = b""
-    while b"\r\n\r\n" not in data:
-        chunk = await reader.read(4096)
-        if not chunk:
-            return None
-        data += chunk
-    return data.split(b"\r\n\r\n", 1)[0]
-
-
-async def _pipe(source: asyncio.StreamReader, sink: asyncio.StreamWriter) -> None:
-    """Copy bytes one way until EOF or a broken connection.
-
-    Args:
-        source: The side bytes are read from.
-        sink: The side bytes are written to.
-    """
-    try:
-        while True:
-            chunk = await source.read(65536)
-            if not chunk:
-                break
-            sink.write(chunk)
-            await sink.drain()
-    except (ConnectionError, OSError):
-        pass
-
-
-class _ConnectProxy:
-    """Minimal TLS CONNECT proxy enforcing Basic auth and recording attempts.
-
-    Attributes:
-        port: The 127.0.0.1 port the proxy listens on (set by the fixture).
-        attempts: Every CONNECT observed, including rejected ones (AC2).
-    """
-
-    def __init__(self) -> None:
-        """Initialise an empty attempt record."""
-        self.port = 0
-        self.attempts: list[ConnectAttempt] = []
-
-    async def handle(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
-        """Serve one CONNECT exchange: record it, check auth, then pipe.
-
-        Args:
-            reader: The client side of the accepted (already TLS) connection.
-            writer: The client side of the accepted (already TLS) connection.
-        """
-        upstream_writer: asyncio.StreamWriter | None = None
-        try:
-            head = await _read_head(reader)
-            if head is None:
-                return
-            lines = head.decode("latin-1").split("\r\n")
-            method, target, _version = lines[0].split(" ", 2)
-            headers = {}
-            for line in lines[1:]:
-                key, sep, value = line.partition(":")
-                if sep:
-                    headers[key.strip().lower()] = value.strip()
-
-            if method != "CONNECT":
-                writer.write(b"HTTP/1.1 405 Method Not Allowed\r\n\r\n")
-                await writer.drain()
-                return
-
-            authenticated = headers.get("proxy-authorization") == _EXPECTED_PROXY_AUTH
-            self.attempts.append(ConnectAttempt(target=target, authenticated=authenticated))
-            if not authenticated:
-                writer.write(b"HTTP/1.1 407 Proxy Authentication Required\r\n\r\n")
-                await writer.drain()
-                return
-
-            host, port_text = target.rsplit(":", 1)
-            upstream_reader, upstream_writer = await asyncio.open_connection(host, int(port_text))
-            writer.write(b"HTTP/1.1 200 Connection Established\r\n\r\n")
-            await writer.drain()
-            # Close the tunnel as soon as either direction ends. Waiting for
-            # both deadlocks when one side closes without the other noticing,
-            # stalling teardown until the TLS close_notify timeout.
-            to_upstream = asyncio.create_task(_pipe(reader, upstream_writer))
-            to_client = asyncio.create_task(_pipe(upstream_reader, writer))
-            _done, pending = await asyncio.wait({to_upstream, to_client}, return_when=asyncio.FIRST_COMPLETED)
-            for task in pending:
-                task.cancel()
-            await asyncio.gather(*pending, return_exceptions=True)
-        finally:
-            if upstream_writer is not None:
-                upstream_writer.close()
-            writer.close()
-
-
-@dataclasses.dataclass(frozen=True)
-class _TlsTarget:
-    """The local TLS target's address.
-
-    Attributes:
-        port: The 127.0.0.1 port the target listens on.
-    """
-
-    port: int
-
-
-async def _handle_target(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
-    """Answer any single request with the fixed target body.
-
-    Args:
-        reader: The client side of the accepted (already TLS) connection.
-        writer: The client side of the accepted (already TLS) connection.
-    """
-    try:
-        if await _read_head(reader) is None:
-            return
-        body = TARGET_BODY.encode()
-        # Connection: close makes pooling clients (urllib3) close the tunnel
-        # themselves; without it the target's graceful TLS shutdown would wait
-        # out a 30-second close_notify timeout during teardown.
-        head = (
-            f"HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: {len(body)}\r\nConnection: close\r\n\r\n"
-        )
-        writer.write(head.encode() + body)
-        await writer.drain()
-    finally:
-        writer.close()
-
-
-def _server_ssl_context(cert: Path, key: Path) -> ssl.SSLContext:
-    """Build a TLS server context from one of the throwaway leaf certs.
-
-    Args:
-        cert: The certificate to present.
-        key: The matching private key.
-
-    Returns:
-        The loaded server-side SSL context.
-    """
-    context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
-    context.load_cert_chain(str(cert), str(key))
-    return context
-
-
 @pytest.fixture
-async def connect_proxy(certs: _CertFiles) -> _ConnectProxy:
-    """Run a local TLS CONNECT proxy for one test (AC2).
-
-    Args:
-        certs: The session's throwaway certificates.
-
-    Yields:
-        The running proxy, with its port and attempt record.
-    """
-    proxy = _ConnectProxy()
-    server = await asyncio.start_server(
-        proxy.handle, "127.0.0.1", 0, ssl=_server_ssl_context(certs.proxy_cert, certs.proxy_key)
-    )
-    proxy.port = server.sockets[0].getsockname()[1]
-    try:
-        yield proxy
-    finally:
-        server.close()
-        await server.wait_closed()
-
-
-@pytest.fixture
-async def tls_target(certs: _CertFiles) -> _TlsTarget:
-    """Run a local TLS target serving the fixed body for one test.
-
-    Args:
-        certs: The session's throwaway certificates.
-
-    Yields:
-        The running target's address.
-    """
-    server = await asyncio.start_server(
-        _handle_target, "127.0.0.1", 0, ssl=_server_ssl_context(certs.target_cert, certs.target_key)
-    )
-    try:
-        yield _TlsTarget(port=server.sockets[0].getsockname()[1])
-    finally:
-        server.close()
-        await server.wait_closed()
-
-
-# ── Test-side seams ──────────────────────────────────────────────────────
-
-
-@pytest.fixture
-def target_url(monkeypatch: pytest.MonkeyPatch, tls_target: _TlsTarget) -> str:
+def target_url(monkeypatch: pytest.MonkeyPatch, tls_target: TlsTarget) -> str:
     """Point ``_probe``'s echo URL at the local TLS target (AC4).
 
     Args:
@@ -439,37 +69,6 @@ def target_url(monkeypatch: pytest.MonkeyPatch, tls_target: _TlsTarget) -> str:
     url = f"https://127.0.0.1:{tls_target.port}"
     monkeypatch.setattr(egress_cmd, "IP_ECHO_URL", url)
     return url
-
-
-@pytest.fixture
-def aiohttp_trusts_test_ca(monkeypatch: pytest.MonkeyPatch, certs: _CertFiles) -> None:
-    """Swap aiohttp's import-time cached verified SSL context (AC4).
-
-    aiohttp builds ``_SSL_CONTEXT_VERIFIED`` at import time and returns it for
-    both the proxy hop and the tunneled target hop, so wrapping
-    ``ssl.create_default_context`` at test time would be a no-op in a full
-    suite run. Replacing the cached object is the order-independent seam.
-
-    Args:
-        monkeypatch: Pytest's monkeypatch fixture (auto-restores the cache).
-        certs: The session's throwaway certificates.
-    """
-    context = ssl.create_default_context()
-    context.load_verify_locations(str(certs.ca))
-    monkeypatch.setattr(aiohttp.connector, "_SSL_CONTEXT_VERIFIED", context)
-
-
-def _proxy_config(port: int, password: str = PROXY_PASSWORD) -> EgressConfig:
-    """Build the https-proxy configuration the tests drive.
-
-    Args:
-        port: The local proxy port.
-        password: Proxy password; pass a wrong one for the negative test.
-
-    Returns:
-        The configuration under test.
-    """
-    return EgressConfig(proxy_url=f"https://127.0.0.1:{port}", username=PROXY_USER, password=password)
 
 
 # ── aiohttp: the real `_probe` end to end (Python ≥3.11 only) ────────────
@@ -487,13 +86,13 @@ class TestConcurrentSessionsThroughOneProxy:
 
     async def test_concurrent_probes_all_succeed_through_shared_proxy(
         self,
-        connect_proxy: _ConnectProxy,
-        tls_target: _TlsTarget,
+        connect_proxy: ConnectProxy,
+        tls_target: TlsTarget,
         target_url: str,
         aiohttp_trusts_test_ca: None,
     ) -> None:
         results = await asyncio.gather(
-            *(egress_cmd._probe(_proxy_config(connect_proxy.port)) for _ in range(8))
+            *(egress_cmd._probe(proxy_config(connect_proxy.port)) for _ in range(8))
         )
 
         for body, _elapsed_ms, error in results:
@@ -509,13 +108,13 @@ class TestAiohttpProbeThroughHttpsProxy:
 
     async def test_probe_succeeds_through_authenticated_tls_proxy(
         self,
-        connect_proxy: _ConnectProxy,
-        tls_target: _TlsTarget,
+        connect_proxy: ConnectProxy,
+        tls_target: TlsTarget,
         target_url: str,
         aiohttp_trusts_test_ca: None,
     ) -> None:
         """Correct credentials tunnel to the target and return its body (AC3)."""
-        body, _elapsed_ms, error = await egress_cmd._probe(_proxy_config(connect_proxy.port))
+        body, _elapsed_ms, error = await egress_cmd._probe(proxy_config(connect_proxy.port))
 
         assert error is None
         assert body == TARGET_BODY
@@ -525,12 +124,12 @@ class TestAiohttpProbeThroughHttpsProxy:
 
     async def test_probe_reports_407_on_wrong_password(
         self,
-        connect_proxy: _ConnectProxy,
+        connect_proxy: ConnectProxy,
         target_url: str,
         aiohttp_trusts_test_ca: None,
     ) -> None:
         """Bad credentials surface as the proxy's 407, not TLS noise (AC5)."""
-        body, _elapsed_ms, error = await egress_cmd._probe(_proxy_config(connect_proxy.port, password="wrong-password"))
+        body, _elapsed_ms, error = await egress_cmd._probe(proxy_config(connect_proxy.port, password="wrong-password"))
 
         assert body is None
         assert error is not None
@@ -547,9 +146,9 @@ class TestCurlCffiThroughHttpsProxy:
 
     async def test_get_succeeds_through_authenticated_tls_proxy(
         self,
-        connect_proxy: _ConnectProxy,
-        tls_target: _TlsTarget,
-        certs: _CertFiles,
+        connect_proxy: ConnectProxy,
+        tls_target: TlsTarget,
+        certs: CertFiles,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """``proxies=proxies_dict()`` tunnels to the target (AC6)."""
@@ -564,7 +163,7 @@ class TestCurlCffiThroughHttpsProxy:
         # curl_cffi.aio.DEFAULT_CACERT patched (it is bound at aio.py import).
         monkeypatch.setattr(curl_cffi_curl, "DEFAULT_CACERT", str(certs.ca))
 
-        config = _proxy_config(connect_proxy.port)
+        config = proxy_config(connect_proxy.port)
 
         def request() -> curl_cffi.requests.Response:
             """Perform the blocking GET off the event loop."""
@@ -591,12 +190,12 @@ class TestUrllib3ThroughHttpsProxy:
 
     async def test_get_succeeds_through_authenticated_tls_proxy(
         self,
-        connect_proxy: _ConnectProxy,
-        tls_target: _TlsTarget,
-        certs: _CertFiles,
+        connect_proxy: ConnectProxy,
+        tls_target: TlsTarget,
+        certs: CertFiles,
     ) -> None:
         """A botocore-shaped ProxyManager tunnels to the target (AC7)."""
-        config = _proxy_config(connect_proxy.port)
+        config = proxy_config(connect_proxy.port)
         proxy_context = ssl.create_default_context()
         proxy_context.load_verify_locations(str(certs.ca))
 
@@ -605,7 +204,7 @@ class TestUrllib3ThroughHttpsProxy:
         # urllib3 itself never converts URL userinfo into that header.
         manager = urllib3.proxy_from_url(
             config.url_with_credentials(),
-            proxy_headers={"Proxy-Authorization": _EXPECTED_PROXY_AUTH},
+            proxy_headers={"Proxy-Authorization": EXPECTED_PROXY_AUTH},
             proxy_ssl_context=proxy_context,
             ca_certs=str(certs.ca),
         )


### PR DESCRIPTION
Implements [KBR-28](https://shelpuk.atlassian.net/browse/KBR-28) — plan task **T-W5**, design [`TEST_SUITE.md` §7.3](.system_design/TEST_SUITE.md).

Unblocks KBR-61 (T-E1 containment harness), KBR-84, KBR-85, KBR-86 (dependency proxy contracts).

---

## Context for the Product Owner

Kitty Bridge sits between a coding agent and an LLM provider. One of its three commercial promises is **egress containment**: when a customer configures a corporate egress gateway, *nothing* provider-bound may reach the internet except through that gateway. A partial bypass is not a bug — it is a compliance breach, and it is invisible unless something is watching for it.

Today the suite proves the proxy **works**. It has never proved that traffic **cannot go around it**. Writing that proof needs two capabilities the test rig does not have:

| Missing | Why it is needed |
|---|---|
| A way to tell which connections came through the tunnel | Everything runs on loopback, so IP addresses are useless — a tunnelled and a direct connection both look like `127.0.0.1` |
| A way to switch the proxy off mid-test | The load-bearing assertion is "proxy down ⇒ the upstream sees **zero** connections". Today the proxy only dies at teardown |

This PR delivers both, and lifts the rig out of one private test file into shared infrastructure four tickets are waiting on. **No product code changes** — this is test infrastructure only.

---

## What changed

`tests/harness/connect_proxy.py` (new) holds the TLS CONNECT proxy, the TLS target and their certificates, registered as a pytest plugin so any test asks for `connect_proxy` by name.

- **The join key.** Each tunnel records the proxy's outbound source port; the far end records the port it saw connect. A connection that joins to no tunnel is a bypass. `unattributable_peer_ports()` states that assertion once, so every transport slice inherits it rather than re-deriving it.
- **The off switch.** `stop()` on both servers takes them down mid-test.
- **The resolver seam.** A sealed-network upstream must be addressed by a name outside the `localhost` family, or kitty's own bypass logic routes it direct and the harness passes while proving the opposite of its claim. The name chosen (`upstream.kitty-test.invalid`) is guaranteed never to resolve publicly — so the proxy must map it, and the target certificate must answer to it.

`tests/test_egress_https_proxy.py` keeps its five tests and all three transport stacks. "Unchanged" is checked mechanically: its collected node ids are **byte-identical** to `main`.

## Scope boundary, and one correction

A first draft deferred the proxied-leg resolver to KBR-61. Design review rejected that and was right: KBR-61 would have had to edit the certificate generator and tunnel path of a module five tickets consume — the coordination problem Milestone 0 exists to remove. **This PR ships the seam; KBR-61 keeps the policy** and the direct-route override.

## Why you can trust these tests

Plan §1.4: *a harness never shown to fail is indistinguishable from one that cannot fail.* So twelve deliberate defects were introduced one at a time, and each was caught by the test that claims to catch it. A thirteenth **survived** — a redundant abort pass — and was deleted rather than covered.

The most useful finding came from code review. The stoppability tests originally used a client whose SSL layer answers the teardown handshake automatically, so they proved `stop()` returns for a *cooperative* peer — not the case the design exists for. An idle pooled urllib3 or botocore connection is the real one, and it is KBR-61's headline scenario. Against it, the first version of `stop()` did not stop: it raised after five seconds. Fixed, with the test that proves it.

## Verification

- Full fast gate: **3518 passed, 2 skipped**, exit 0.
- New tests pass on Python **3.10, 3.11, 3.12, 3.13** — load-bearing here, because `asyncio.Server.wait_closed()` behaves differently across that range.
- `ruff`, `lint-imports`, `mypy src/kitty` clean.

## One unrelated finding, filed separately

The gate surfaced a pre-existing failure that **reproduces on pristine `main`** and is not touched by this PR: `_connect_target` relies on a Python behaviour that changed in a *patch* release (bisected: between CPython 3.12.6 and 3.12.7). On an affected interpreter — including the Python shipped with Ubuntu 24.04 — kitty reports a running bridge as unreachable, and CI never sees it because the runner installs a newer patch. Filed as [KBR-142](https://shelpuk.atlassian.net/browse/KBR-142) with the bisection table; deselected by name from the gate run above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018b37S3LGuQABeEDr8jeeLv

[KBR-28]: https://shelpuk.atlassian.net/browse/KBR-28?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KBR-142]: https://shelpuk.atlassian.net/browse/KBR-142?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ