### PR TITLE
Accept a base URL that already carries the endpoint path (KBR-134)

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,6 +439,9 @@ Use the `custom_openai` provider to connect to **any** service that exposes an O
 This works with DeepSeek, Together AI, Groq, vLLM, LM Studio, and any other service that accepts
 `POST /v1/chat/completions` with Bearer auth and SSE streaming.
 
+**The base URL ends at the API root** — Kitty appends `/chat/completions` itself. Give it
+`https://api.mistral.ai/v1`, not `https://api.mistral.ai/v1/chat/completions`.
+
 ```bash
 $ kitty setup
   ? Provider: Custom OpenAI-Compatible
@@ -459,6 +462,7 @@ $ kitty claude
 | Together AI  | `https://api.together.xyz/v1`           |
 | Groq         | `https://api.groq.com/openai/v1`        |
 | Fireworks    | `https://api.fireworks.ai/inference/v1` |
+| Mistral      | `https://api.mistral.ai/v1`             |
 | vLLM (local) | `http://localhost:8000/v1`              |
 | LM Studio    | `http://localhost:1234/v1`              |
 

--- a/src/kitty/bridge/server.py
+++ b/src/kitty/bridge/server.py
@@ -20,6 +20,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from types import TracebackType
 from typing import TYPE_CHECKING, NoReturn, TextIO, TypedDict, cast
+from urllib.parse import urlsplit, urlunsplit
 
 import aiohttp
 from aiohttp import web
@@ -6335,11 +6336,30 @@ class BridgeServer:
         return False
 
     @staticmethod
-    def _translate_upstream_error(status: int, body: object) -> str:
+    def _translate_upstream_error_text(
+        status: int,
+        body: object,
+        custom_url: str | None = None,
+        appended_path: str | None = None,
+    ) -> str:
         """Translate an upstream HTTP error into a user-friendly message.
 
         For auth errors (401/403), returns a clear message indicating the
         API key issue.
+
+        Args:
+            status: The upstream HTTP status code.
+            body: The upstream error body, as a dict or a raw string.
+            custom_url: The URL the bridge requested, already redacted, when the
+                profile supplied it.  ``None`` for fixed-endpoint providers,
+                which disables the 404 branch — advising those users to check a
+                base URL they never set would be wrong.
+            appended_path: The endpoint path the bridge appended to the
+                configured base URL, named in the 404 message so a doubled path
+                is self-evident.
+
+        Returns:
+            The message shown to the agent.
         """
         if isinstance(body, dict):
             details = json.dumps(body, ensure_ascii=False)
@@ -6397,7 +6417,71 @@ class BridgeServer:
                 prefix = "Upstream provider temporary internal failure (HTTP 500). Please retry shortly."
             return f"{prefix} Details: {details}" if details else prefix
 
+        # KBR-134: the profile supplied this address, so a 404 is as likely to be
+        # the URL as the model. Sits below the branches above deliberately -- a
+        # 404 carrying a context-window or tool-pairing body has more actionable
+        # advice than "check your base URL".
+        if status == 404 and custom_url and appended_path:
+            prefix = (
+                f"Upstream returned HTTP 404 for {custom_url}. Either the model is not available "
+                f"at that endpoint, or this profile's base URL is wrong: Kitty appends "
+                f'"{appended_path}" to the base URL itself, so the base URL must end at the API root.'
+            )
+            return f"{prefix} Details: {details}" if details else prefix
+
         return details
+
+    @staticmethod
+    def _redact_userinfo(url: str) -> str:
+        """Strip any ``user:password@`` component from a URL.
+
+        The 404 message travels into the agent transcript and the access log, and
+        userinfo is never needed to diagnose a wrong endpoint.
+
+        Args:
+            url: The URL to redact.
+
+        Returns:
+            The URL without its userinfo component, unchanged when it has none.
+        """
+        # No "@" anywhere means no userinfo, so the common case never parses. That
+        # also keeps this off `urlsplit`, which raises on a malformed IPv6 literal
+        # -- unreachable here, since such a URL cannot have produced an HTTP status
+        # for us to format, but not worth depending on.
+        if "@" not in url:
+            return url
+        parts = urlsplit(url)
+        if "@" not in parts.netloc:
+            return url
+        host = parts.netloc.rsplit("@", 1)[1]
+        return urlunsplit(parts._replace(netloc=host))
+
+    def _translate_upstream_error(self, status: int, body: object) -> str:
+        """Translate an upstream error, supplying this request's endpoint context.
+
+        An instance method rather than a static one so that every existing call
+        site — all twelve already call it on ``self`` — gains the 404 context
+        without being edited.  The static core remains available for unit tests
+        that have no server.
+
+        Args:
+            status: The upstream HTTP status code.
+            body: The upstream error body.
+
+        Returns:
+            The message shown to the agent.
+        """
+        # Only a provider whose URL the user configured can have a wrong one, and
+        # only a 404 reads it. Narrow on both counts because `build_base_url` is a
+        # documented raiser: rebuilding the URL while *formatting* an error would
+        # let a bad base_url replace an upstream error with an unhandled one.
+        provider = self._active_provider
+        custom_url: str | None = None
+        path: str | None = None
+        if status == 404 and provider.requires_custom_url:
+            custom_url = self._redact_userinfo(self._build_upstream_url())
+            path = provider.get_upstream_path(self._active_model or "")
+        return self._translate_upstream_error_text(status, body, custom_url=custom_url, appended_path=path)
 
     @staticmethod
     def _map_provider_error(exc: Exception) -> tuple[int, str]:

--- a/src/kitty/cli/profile_cmd.py
+++ b/src/kitty/cli/profile_cmd.py
@@ -168,7 +168,7 @@ def _create_profile_flow(store: ProfileStore, cred_store: CredentialStore) -> Pr
     provider_config: dict = {}
     if provider_adapter.requires_custom_url:
         while True:
-            base_url = prompt_text("API base URL (e.g. https://api.deepseek.com/v1): ")
+            base_url = prompt_text("API base URL — the API root, e.g. https://api.deepseek.com/v1: ")
             if base_url and base_url.strip():
                 provider_config = {"base_url": base_url.strip()}
                 break

--- a/src/kitty/cli/setup_cmd.py
+++ b/src/kitty/cli/setup_cmd.py
@@ -76,7 +76,7 @@ def run_setup_wizard(store: ProfileStore, cred_store: CredentialStore) -> Profil
     provider_config: dict = {}
     if provider_adapter.requires_custom_url:
         while True:
-            base_url = prompt_text("API base URL (e.g. https://api.deepseek.com/v1): ")
+            base_url = prompt_text("API base URL — the API root, e.g. https://api.deepseek.com/v1: ")
             if base_url and base_url.strip():
                 provider_config = {"base_url": base_url.strip()}
                 break

--- a/src/kitty/providers/base.py
+++ b/src/kitty/providers/base.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Awaitable, Callable
+from urllib.parse import urlsplit, urlunsplit
 
 
 class ProviderAdapter(ABC):
@@ -93,6 +94,59 @@ class ProviderAdapter(ABC):
             Base URL string (without the endpoint path).
         """
         return self.default_base_url
+
+    @staticmethod
+    def _strip_endpoint_suffix(url: str, suffix: str) -> str:
+        """Remove one trailing copy of ``suffix`` from a base URL's path.
+
+        The bridge composes every request as ``base_url + endpoint path``, so a
+        base URL that already ends in that endpoint produces a doubled path and
+        a 404 from the upstream.  Users paste the full endpoint routinely —
+        it is the form every provider's documentation shows — so the redundant
+        tail is removed here rather than rejected (KBR-134).
+
+        The suffix is a **parameter rather than** :attr:`upstream_path` so that a
+        caller always supplies the same path composition will use.  Adapters
+        that route per model through :meth:`get_upstream_path` (Azure, Vertex,
+        OpenCode) would otherwise be normalised against a path they never
+        request.
+
+        Args:
+            url: The configured base URL, already validated as ``http(s)``.
+            suffix: The endpoint path that will be appended to the result,
+                leading slash included — for example ``"/chat/completions"``.
+
+        Returns:
+            ``url`` with one trailing ``suffix`` removed from its path, or
+            ``url`` unchanged when removing it would alter the address the
+            bridge ends up requesting, or when it cannot be parsed at all.
+        """
+        # Match the parsed path, never the raw string: "https://chat/completions"
+        # ends with "/chat/completions" as text, and stripping that eats the host.
+        # `urlsplit`, not `urlparse` -- the latter splits a trailing ";params" off
+        # the last path segment and reattaches it to whichever segment ends up last.
+        #
+        # An unparseable URL is returned untouched rather than allowed to raise:
+        # `urlsplit` rejects a malformed IPv6 literal such as "https://[::1/v1", and
+        # this helper runs inside `build_base_url`, which pre-flight validation calls
+        # OUTSIDE its own try block. Raising here would turn a bad stored profile into
+        # a traceback at launch, where it previously produced an error message.
+        try:
+            parts = urlsplit(url)
+        except ValueError:
+            return url
+        path = parts.path.rstrip("/")
+        if not path.endswith(suffix):
+            return url
+
+        # Self-check: keep the candidate only if composing the endpoint back onto
+        # it reproduces the caller's own URL. A query, a fragment or a doubled
+        # slash all survive the match above but would move or change the address,
+        # and this one comparison rejects every such shape without enumerating them.
+        candidate = urlunsplit(parts._replace(path=path[: -len(suffix)]))
+        if candidate.rstrip("/") + suffix == url.rstrip("/"):
+            return candidate
+        return url
 
     def get_upstream_path(self, model: str) -> str:
         """Build the upstream path for a specific model.

--- a/src/kitty/providers/custom_anthropic.py
+++ b/src/kitty/providers/custom_anthropic.py
@@ -66,7 +66,9 @@ class CustomAnthropicAdapter(AnthropicAdapter):
                 raise ValueError(
                     f"Invalid base_url in provider_config: {url!r}. Must be a non-empty http:// or https:// URL."
                 )
-            return str(url)
+            # KBR-134: a pasted full endpoint would otherwise be composed into a
+            # doubled path and rejected upstream as a missing model.
+            return self._strip_endpoint_suffix(str(url), self.upstream_path)
         return self.default_base_url
 
     def translate_to_upstream(self, cc_request: dict) -> dict:

--- a/src/kitty/providers/custom_openai.py
+++ b/src/kitty/providers/custom_openai.py
@@ -45,7 +45,9 @@ class CustomOpenAIAdapter(ProviderAdapter):
                 raise ValueError(
                     f"Invalid base_url in provider_config: {url!r}. Must be a non-empty http:// or https:// URL."
                 )
-            return str(url)
+            # KBR-134: a pasted full endpoint would otherwise be composed into a
+            # doubled path and rejected upstream as a missing model.
+            return self._strip_endpoint_suffix(str(url), self.upstream_path)
         return self.default_base_url
 
     def build_upstream_headers(self, api_key: str) -> dict[str, str]:

--- a/tests/bridge/test_bridge_server.py
+++ b/tests/bridge/test_bridge_server.py
@@ -761,7 +761,7 @@ class TestCloudflareDetection:
         assert BridgeServer._is_cloudflare_block(403, "<html>Forbidden</html>") is False
 
     def test_translate_upstream_error_cloudflare(self) -> None:
-        msg = BridgeServer._translate_upstream_error(
+        msg = BridgeServer._translate_upstream_error_text(
             403,
             "<html>cf-browser-verification window._cf_chl_opt = {};</html>",
         )

--- a/tests/bridge/test_custom_url_404.py
+++ b/tests/bridge/test_custom_url_404.py
@@ -1,0 +1,163 @@
+"""KBR-134 — the 404 diagnostic, wired to a real server rather than a bare function.
+
+`tests/bridge/test_upstream_error_translation.py` proves the message text.  This
+file proves the other half: that a ``BridgeServer`` built from a profile actually
+reaches that text, with the URL it would really have requested, and that a
+fixed-endpoint provider is left alone.
+
+L1 by the path default in ``tests/layers.py``.  It needs no sockets — the same
+construction the rest of ``tests/bridge/`` uses — and `TEST_SUITE.md` §2.2 puts a
+claim at the lowest layer that can prove it, which for "the instance method reads
+the active provider" is here.
+"""
+
+from __future__ import annotations
+
+import aiohttp
+import pytest
+
+from kitty.bridge.server import BridgeServer
+from kitty.providers.custom_openai import CustomOpenAIAdapter
+from kitty.providers.openai import OpenAIAdapter
+
+
+def _server(provider, provider_config: dict | None) -> BridgeServer:
+    """Build a bridge server for one provider without starting it.
+
+    Args:
+        provider: The provider adapter under test.
+        provider_config: The profile's provider configuration.
+
+    Returns:
+        An unstarted :class:`BridgeServer`.
+    """
+    return BridgeServer(
+        None,  # type: ignore[arg-type]
+        provider,
+        "test-key",
+        model="mistral-large-latest",
+        provider_config=provider_config,
+    )
+
+
+class TestCustomUrl404Wiring:
+    """The message reaches a server-formatted error, carrying the real URL."""
+
+    def test_reporters_configuration_produces_the_diagnostic(self):
+        """The reporter's stored profile, had it not been normalised, explains itself.
+
+        The base URL here is deliberately the *already-normalised* root: the point
+        is that whatever URL the bridge composes is the one the user is shown, so
+        a future doubling is visible rather than reported as a missing model.
+        """
+        server = _server(CustomOpenAIAdapter(), {"base_url": "https://api.mistral.ai/v1"})
+
+        message = server._translate_upstream_error(404, {"detail": "Not Found"})
+
+        assert "https://api.mistral.ai/v1/chat/completions" in message
+        assert "must end at the API root" in message
+        assert '"/chat/completions"' in message
+
+    def test_message_names_the_doubled_path_when_one_survives(self):
+        """A base URL normalisation cannot repair still shows the address in full."""
+        server = _server(
+            CustomOpenAIAdapter(),
+            {"base_url": "https://gw.example/v1/chat/completions?tenant=x"},
+        )
+
+        message = server._translate_upstream_error(404, {"detail": "Not Found"})
+
+        # The query-bearing URL is left alone by normalisation (D10), so the
+        # malformed composition is what the user sees -- which is the point.
+        assert "https://gw.example/v1/chat/completions?tenant=x/chat/completions" in message
+
+    def test_userinfo_never_reaches_the_message(self):
+        """Credentials in the configured URL are stripped before it is echoed."""
+        server = _server(
+            CustomOpenAIAdapter(),
+            {"base_url": "https://someone:hunter2@gw.example/v1"},
+        )
+
+        message = server._translate_upstream_error(404, {"detail": "Not Found"})
+
+        assert "hunter2" not in message
+        assert "someone" not in message
+        assert "https://gw.example/v1/chat/completions" in message
+
+    def test_fixed_endpoint_provider_is_untouched(self):
+        """A provider whose URL the user never set keeps the old passthrough."""
+        server = _server(OpenAIAdapter(), None)
+
+        message = server._translate_upstream_error(404, {"detail": "Not Found"})
+
+        assert "base URL" not in message
+        assert message == '{"detail": "Not Found"}'
+
+
+class TestCustomUrl404ReachesTheClient:
+    """The diagnostic must survive into what the agent actually receives.
+
+    The class above proves the message is built correctly.  This proves the far
+    more important thing: that a real request, against a real upstream returning
+    404, puts that text in front of the user.  Without it the feature could be
+    perfect and invisible.
+    """
+
+    @staticmethod
+    def _messages_request(stream: bool) -> dict:
+        """Return a minimal Anthropic Messages request.
+
+        Args:
+            stream: Whether to ask for an SSE response.
+
+        Returns:
+            The JSON body to POST to ``/v1/messages``.
+        """
+        return {
+            "model": "mistral-large-latest",
+            "max_tokens": 64,
+            "messages": [{"role": "user", "content": "2+2"}],
+            "stream": stream,
+        }
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("stream", [False, True], ids=["non-streaming", "streaming"])
+    async def test_404_diagnostic_reaches_the_agent(self, stream: bool):
+        """A 404 from a user-configured endpoint reaches the agent as the §2.3 text.
+
+        The base URL here is the *normalised* one the reporter's profile now
+        resolves to, because that is what the bridge really requests after this
+        change — a test pinned to the doubled path would be asserting against a
+        URL the fix has already eliminated.  What is proven is the half the unit
+        tests cannot see: the message survives the handler and lands in the
+        client's payload.
+
+        Args:
+            stream: Whether the agent asked for SSE, parametrised because the
+                streaming and non-streaming handlers format errors separately.
+        """
+        from aioresponses import aioresponses
+
+        requested = "https://api.mistral.ai/v1/chat/completions"
+        server = _server(CustomOpenAIAdapter(), {"base_url": "https://api.mistral.ai/v1"})
+        port = await server.start_async()
+        try:
+            with aioresponses(passthrough=["http://127.0.0.1"]) as upstream:
+                upstream.post(requested, status=404, body=b'{"detail": "Not Found"}', repeat=True)
+                async with (
+                    aiohttp.ClientSession() as session,
+                    session.post(
+                        f"http://127.0.0.1:{port}/v1/messages",
+                        json=self._messages_request(stream),
+                        headers={"content-type": "application/json"},
+                    ) as resp,
+                ):
+                    payload = await resp.text()
+        finally:
+            await server.stop_async()
+
+        assert requested in payload, payload
+        assert "must end at the API root" in payload, payload
+        # Not the quoted path itself: the payload is JSON (or SSE-wrapped JSON),
+        # so the quotes around it are escaped and matching them is brittle.
+        assert "to the base URL itself" in payload, payload

--- a/tests/bridge/test_upstream_error_translation.py
+++ b/tests/bridge/test_upstream_error_translation.py
@@ -10,11 +10,15 @@ from kitty.bridge.server import BridgeServer
 
 
 class TestTranslateUpstreamError:
-    """Unit tests for BridgeServer._translate_upstream_error."""
+    """Unit tests for the static core, ``BridgeServer._translate_upstream_error_text``.
+
+    The same-named instance method wraps this to supply the endpoint context; it
+    is exercised in ``tests/bridge/test_custom_url_404.py``.
+    """
 
     @staticmethod
     def _call(status: int, body: object) -> str:
-        return BridgeServer._translate_upstream_error(status, body)
+        return BridgeServer._translate_upstream_error_text(status, body)
 
     # ── Z.AI code 1261: Prompt exceeds max length ─────────────────────────
 
@@ -305,3 +309,86 @@ class TestTranslateUpstreamError:
         assert "/clear" in result
         # Tool-call-specific phrasing, not the context-window hint
         assert "broken tool_use/tool_result pairing" in result
+
+
+class TestCustomUrl404Message:
+    """KBR-134 — a 404 from a user-configured endpoint must name the address.
+
+    Claude Code renders any 404 on a model request as "that model may not
+    exist", which sent the reporter hunting for a model problem that did not
+    exist.  When the profile supplied the URL, the bridge says so instead.
+    """
+
+    # The text pinned in the requirements document, spelled out rather than
+    # imported: an assertion that reads the implementation's own constant
+    # proves only that the constant equals itself.
+    EXPECTED = (
+        'Upstream returned HTTP 404 for https://api.mistral.ai/v1/chat/completions/chat/completions. '
+        "Either the model is not available at that endpoint, or this profile's base URL is wrong: "
+        'Kitty appends "/chat/completions" to the base URL itself, so the base URL must end at the '
+        'API root. Details: {"detail": "Not Found"}'
+    )
+
+    def test_names_the_requested_url_and_the_rule(self):
+        """The reporter's exact failure produces the pinned message."""
+        result = BridgeServer._translate_upstream_error_text(
+            404,
+            {"detail": "Not Found"},
+            custom_url="https://api.mistral.ai/v1/chat/completions/chat/completions",
+            appended_path="/chat/completions",
+        )
+        assert result == self.EXPECTED
+
+    def test_omits_details_when_body_is_empty(self):
+        """An empty upstream body drops the trailing clause rather than dangling."""
+        result = BridgeServer._translate_upstream_error_text(
+            404, None, custom_url="https://gw.example/v1/chat/completions", appended_path="/chat/completions"
+        )
+        assert result.endswith("must end at the API root.")
+        assert "Details:" not in result
+
+    def test_fixed_endpoint_provider_is_unaffected(self):
+        """Without a custom URL the 404 body passes through exactly as before."""
+        result = BridgeServer._translate_upstream_error_text(404, {"x": 1})
+        assert result == json.dumps({"x": 1}, ensure_ascii=False)
+
+    def test_context_window_error_still_wins(self):
+        """A 404 carrying a context-window body keeps the more actionable /clear advice."""
+        body = {"error": {"code": "1261", "message": "Prompt exceeds max length"}}
+        result = BridgeServer._translate_upstream_error_text(
+            404, body, custom_url="https://gw.example/v1/chat/completions", appended_path="/chat/completions"
+        )
+        assert "/clear" in result
+        assert "base URL" not in result
+
+    def test_auth_error_still_wins(self):
+        """The 404 branch does not disturb the auth branch it sits below."""
+        result = BridgeServer._translate_upstream_error_text(
+            401, {"error": "Unauthorized"}, custom_url="https://gw.example/v1", appended_path="/chat/completions"
+        )
+        assert "authentication failed" in result.lower()
+
+
+class TestUserinfoRedaction:
+    """A URL echoed into an error message must not carry credentials."""
+
+    def test_userinfo_is_removed(self):
+        """The message travels into the agent transcript and the access log."""
+        redacted = BridgeServer._redact_userinfo("https://u:p@gw.example/v1/chat/completions")
+        assert redacted == "https://gw.example/v1/chat/completions"
+
+    def test_url_without_userinfo_is_unchanged(self):
+        """Redaction is a no-op for the ordinary case."""
+        url = "https://gw.example:8443/v1/chat/completions"
+        assert BridgeServer._redact_userinfo(url) == url
+
+    def test_redacted_url_reaches_the_message(self):
+        """Neither the password nor the ``user:pass@`` form survives into the text."""
+        result = BridgeServer._translate_upstream_error_text(
+            404,
+            {},
+            custom_url=BridgeServer._redact_userinfo("https://u:hunter2@gw.example/v1/chat/completions"),
+            appended_path="/chat/completions",
+        )
+        assert "hunter2" not in result
+        assert "u:" not in result

--- a/tests/bridge/test_vendor_token_guard.py
+++ b/tests/bridge/test_vendor_token_guard.py
@@ -89,6 +89,15 @@ _ALLOWLIST: dict[str, str] = {
         "contains a tool result whose matching tool call was lost. Start a new conversation "
         "(/clear), or switch to a model with a larger context window."
     ): "downstream 400 body for an irreducible conversation (KBR-5)",
+    # KBR-134's 404 diagnostic. Downstream only, by construction: it is built by
+    # _translate_upstream_error_text() and every caller writes the result into a
+    # response to the agent. No build_upstream_headers() or translate_to_upstream()
+    # can reach it -- the function is only ever called with an upstream status in
+    # hand, i.e. after the request has already gone out.
+    (
+        '. Either the model is not available at that endpoint, or this profile\'s '
+        'base URL is wrong: Kitty appends "'
+    ): "downstream error body: how the user fixes a wrong base URL (KBR-134)",
 }
 
 #: The string this ticket deleted. The scanner must still be able to see it.

--- a/tests/test_custom_url_docs.py
+++ b/tests/test_custom_url_docs.py
@@ -1,0 +1,90 @@
+"""KBR-134 — the documentation and the prompts must not teach the broken URL form.
+
+The reporter did exactly what Mistral's own documentation shows: he pasted the
+full endpoint.  Normalisation now rescues that, but the places where a user reads
+or types the value are what stop the mistake being made at all, and they are
+edited separately from the code that consumes it.  This is the §6.2 case — two
+artifacts that must agree, both readable statically.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from kitty.providers.custom_openai import CustomOpenAIAdapter
+
+pytestmark = pytest.mark.l2
+
+_ROOT = Path(__file__).resolve().parents[1]
+_README = _ROOT / "README.md"
+_PROMPT_FILES = (
+    _ROOT / "src" / "kitty" / "cli" / "setup_cmd.py",
+    _ROOT / "src" / "kitty" / "cli" / "profile_cmd.py",
+)
+
+# The "Common endpoints" table rows: | Service | `URL` |
+_TABLE_ROW = re.compile(r"^\|\s*[^|]+\|\s*`(https?://[^`]+)`\s*\|", re.MULTILINE)
+
+
+def _documented_base_urls() -> list[str]:
+    """Return every base URL the README's common-endpoints table lists.
+
+    Returns:
+        The URLs, in document order.
+    """
+    section = _README.read_text(encoding="utf-8").split("**Common endpoints:**", 1)
+    assert len(section) == 2, "README no longer has a '**Common endpoints:**' table"
+    return _TABLE_ROW.findall(section[1].split("\n\n## ", 1)[0])
+
+
+def test_scan_finds_the_known_positives():
+    """The scan must find the rows it exists to check, or it is a no-op.
+
+    Per `TEST_SUITE.md` §6.2, a structural guard asserts its own scan works.
+    Without this, a README reshuffle that broke the regex would leave every
+    assertion below vacuously true.
+    """
+    urls = _documented_base_urls()
+
+    assert len(urls) >= 5, f"expected the endpoints table to have several rows, found {urls}"
+    assert "https://api.deepseek.com/v1" in urls
+
+
+def test_mistral_is_documented():
+    """The service that produced KBR-134 is listed, at its API root."""
+    assert "https://api.mistral.ai/v1" in _documented_base_urls()
+
+
+def test_no_documented_url_teaches_the_broken_form():
+    """Every listed URL is already an API root — normalising it changes nothing.
+
+    This is the check that matters: a future row pasted as a full endpoint would
+    be an instruction to reproduce the reported bug.
+    """
+    adapter = CustomOpenAIAdapter()
+
+    for url in _documented_base_urls():
+        assert adapter.build_base_url({"base_url": url}) == url, url
+
+
+def test_readme_states_the_rule():
+    """The section says where the base URL ends, not only what one looks like."""
+    text = _README.read_text(encoding="utf-8")
+
+    assert "The base URL ends at the API root" in text
+
+
+@pytest.mark.parametrize("path", _PROMPT_FILES, ids=lambda p: p.name)
+def test_wizard_prompt_names_the_api_root(path: Path):
+    """Both places a user types the value say what the value is.
+
+    Args:
+        path: The CLI module carrying the prompt.
+    """
+    text = path.read_text(encoding="utf-8")
+
+    assert "API base URL" in text, f"{path.name} no longer prompts for a base URL"
+    assert "the API root" in text, f"{path.name} prompt does not name the API root"

--- a/tests/test_layer_selection.py
+++ b/tests/test_layer_selection.py
@@ -403,6 +403,7 @@ class TestTheWholeSuiteIsCoherent:
             "tests/test_github_actions.py",
             "tests/test_layer_markers.py",
             "tests/test_layer_selection.py",
+            "tests/test_custom_url_docs.py",
         }
 
         actual = {

--- a/tests/test_provider_custom_anthropic.py
+++ b/tests/test_provider_custom_anthropic.py
@@ -392,3 +392,91 @@ class TestCustomAnthropicBuildRequest:
         req = adapter.build_request("claude-sonnet-4-6", [], temperature=None, max_tokens=None)
         assert "temperature" not in req
         assert "max_tokens" not in req
+
+
+class TestCustomAnthropicBaseUrlEndpointSuffix:
+    """KBR-134 — the same trap, with ``/v1/messages`` as the endpoint path.
+
+    Not reported by a customer; found by reading the code while fixing the
+    OpenAI-compatible case.  A user pasting ``https://api.anthropic.com/v1/messages``
+    would otherwise reach ``.../v1/messages/v1/messages``.
+    """
+
+    @staticmethod
+    def _build(url: str) -> str:
+        """Return the base URL the adapter derives from ``url``.
+
+        Args:
+            url: The value stored in ``provider_config["base_url"]``.
+
+        Returns:
+            The normalised base URL.
+        """
+        return CustomAnthropicAdapter().build_base_url({"base_url": url})
+
+    def test_strips_messages_endpoint(self):
+        """A pasted Messages endpoint resolves to the API root."""
+        assert self._build("https://api.anthropic.com/v1/messages") == "https://api.anthropic.com"
+
+    def test_strips_messages_endpoint_with_trailing_slash(self):
+        """A trailing slash belongs to the match, not to the returned value."""
+        assert self._build("https://api.anthropic.com/v1/messages/") == "https://api.anthropic.com"
+
+    def test_leaves_api_root_untouched(self):
+        """The documented form is returned byte-identical."""
+        assert self._build("https://api.anthropic.com") == "https://api.anthropic.com"
+
+    def test_leaves_other_providers_endpoint_untouched(self):
+        """A Chat Completions path is not this adapter's endpoint and is left alone."""
+        url = "https://api.anthropic.com/v1/chat/completions"
+        assert self._build(url) == url
+
+    def test_does_not_consume_the_host(self):
+        """``https://v1/messages`` ends with the suffix as a *string* only."""
+        assert self._build("https://v1/messages") == "https://v1/messages"
+
+    def test_leaves_query_bearing_url_untouched(self):
+        """Stripping would move the query ahead of the appended path (D10)."""
+        url = "https://gw.example/v1/messages?tenant=x"
+        assert self._build(url) == url
+
+    def test_composition_is_never_changed(self):
+        """Normalisation never alters the URL the bridge ends up requesting."""
+        suffix = CustomAnthropicAdapter().upstream_path
+        for path in (
+            "",
+            "/",
+            "/v1/messages",
+            "/v1/messages/",
+            "/v1/messages/v1/messages",
+            "//v1/messages",
+            "/v1/messages?q=1",
+            "/v1/messages#f",
+            "/proxy/v1/messages",
+        ):
+            url = f"https://gw.example{path}"
+            result = self._build(url)
+            if result == url:
+                continue
+            assert result.rstrip("/") + suffix == url.rstrip("/"), url
+
+    def test_rejects_empty_url(self):
+        """An empty base URL still raises, with the existing message."""
+        import pytest
+
+        with pytest.raises(ValueError, match="Invalid base_url"):
+            self._build("")
+
+    def test_rejects_non_http_scheme(self):
+        """A non-HTTP scheme still raises before normalisation is reached."""
+        import pytest
+
+        with pytest.raises(ValueError, match="Invalid base_url"):
+            self._build("ftp://x")
+
+    def test_rejects_schemeless_url(self):
+        """A bare host still raises before normalisation is reached."""
+        import pytest
+
+        with pytest.raises(ValueError, match="Invalid base_url"):
+            self._build("api.anthropic.com")

--- a/tests/test_provider_custom_openai.py
+++ b/tests/test_provider_custom_openai.py
@@ -310,3 +310,174 @@ class TestCustomOpenAINormalizeModel:
         req = {"model": "deepseek-chat", "messages": []}
         adapter.normalize_request(req)
         assert req == {"model": "deepseek-chat", "messages": []}
+
+
+class TestCustomOpenAIBaseUrlEndpointSuffix:
+    """KBR-134 — a base URL that already carries ``/chat/completions``.
+
+    The bridge composes ``base_url + upstream_path``, so a user who pastes the
+    full endpoint (which is what every provider's documentation shows) gets a
+    doubled path and a 404.  ``build_base_url`` strips the redundant suffix.
+    """
+
+    @staticmethod
+    def _build(url: str) -> str:
+        """Return the base URL the adapter derives from ``url``.
+
+        Args:
+            url: The value stored in ``provider_config["base_url"]``.
+
+        Returns:
+            The normalised base URL.
+        """
+        return CustomOpenAIAdapter().build_base_url({"base_url": url})
+
+    # ── The reported defect ────────────────────────────────────────────────
+
+    def test_strips_endpoint_suffix(self):
+        """The reporter's exact input resolves to Mistral's API root."""
+        assert self._build("https://api.mistral.ai/v1/chat/completions") == "https://api.mistral.ai/v1"
+
+    def test_strips_endpoint_suffix_with_trailing_slash(self):
+        """A trailing slash belongs to the match, not to the returned value."""
+        assert self._build("https://api.mistral.ai/v1/chat/completions/") == "https://api.mistral.ai/v1"
+
+    def test_strips_when_suffix_is_the_whole_path(self):
+        """A base URL that is nothing but the endpoint leaves a bare origin."""
+        assert self._build("https://api.example.com/chat/completions") == "https://api.example.com"
+
+    def test_strips_exactly_one_occurrence(self):
+        """Stripping once keeps the composed URL identical to the input (D4)."""
+        assert self._build("https://gw/chat/completions/chat/completions") == "https://gw/chat/completions"
+
+    # ── Correctly configured URLs are untouched ────────────────────────────
+
+    def test_leaves_api_root_untouched(self):
+        """The documented form is returned byte-identical."""
+        assert self._build("https://api.deepseek.com/v1") == "https://api.deepseek.com/v1"
+
+    def test_leaves_local_http_url_untouched(self):
+        """A loopback vLLM or LM Studio endpoint is unaffected."""
+        assert self._build("http://localhost:8000/v1") == "http://localhost:8000/v1"
+
+    def test_leaves_trailing_slash_untouched(self):
+        """A non-matching URL keeps its trailing slash (R5)."""
+        assert self._build("https://gw.example:8443/api/v1/") == "https://gw.example:8443/api/v1/"
+
+    # ── Shapes where a naive strip would corrupt the address ───────────────
+
+    def test_does_not_consume_the_host(self):
+        """``https://chat/completions`` ends with the suffix as a *string* only."""
+        assert self._build("https://chat/completions") == "https://chat/completions"
+
+    def test_leaves_path_parameters_untouched(self):
+        """``urlsplit`` keeps ``;x=1`` in the path, so the match correctly fails."""
+        assert self._build("https://host/v1/chat/completions;x=1") == "https://host/v1/chat/completions;x=1"
+
+    def test_leaves_query_bearing_url_untouched(self):
+        """Stripping would move the query ahead of the appended path (D10)."""
+        assert self._build("https://gw/v1/chat/completions?tenant=x") == "https://gw/v1/chat/completions?tenant=x"
+
+    def test_leaves_fragment_bearing_url_untouched(self):
+        """Same defect as the query case, via the fragment (D10)."""
+        assert self._build("https://gw/v1/chat/completions#frag") == "https://gw/v1/chat/completions#frag"
+
+    def test_leaves_doubled_slash_untouched(self):
+        """Stripping would yield a different address, not a shorter one (D10)."""
+        assert self._build("https://gw//chat/completions") == "https://gw//chat/completions"
+
+    def test_leaves_azure_style_endpoint_untouched(self):
+        """Azure's documented endpoint carries a query and cannot be composed at all."""
+        azure = "https://res.openai.azure.com/openai/deployments/d/chat/completions?api-version=2024-02-01"
+        assert self._build(azure) == azure
+
+    def test_match_is_case_sensitive(self):
+        """URL paths are case-sensitive by specification, so an upper-case path is left alone."""
+        assert self._build("https://gw/V1/CHAT/COMPLETIONS") == "https://gw/V1/CHAT/COMPLETIONS"
+
+    # ── The property the strip must never violate ──────────────────────────
+
+    def test_composition_is_never_changed(self):
+        """Normalisation never alters the URL the bridge ends up requesting.
+
+        For every input, either the value is returned unchanged — in which case
+        the composed URL is what it always was — or composing the endpoint back
+        onto the result reproduces the caller's own URL exactly.  This is the
+        invariant the self-check in ``_strip_endpoint_suffix`` enforces, and it
+        is what makes "strip the suffix" safe without a list of special cases.
+        """
+        suffix = CustomOpenAIAdapter().upstream_path
+        urls = [
+            f"{scheme}://{host}{path}"
+            for scheme in ("http", "https")
+            for host in ("gw", "gw.example", "gw.example:8443", "u:p@gw.example")
+            for path in (
+                "",
+                "/",
+                "/v1",
+                "/v1/",
+                "/chat/completions",
+                "/chat/completions/",
+                "/v1/chat/completions",
+                "/v1/chat/completions/",
+                "/v1/chat/completions/chat/completions",
+                "//chat/completions",
+                "/v1/chat/completions;x=1",
+                "/v1/chat/completions?q=1",
+                "/v1/chat/completions#f",
+                "/openai/deployments/d/chat/completions?api-version=2024-02-01",
+            )
+        ]
+        for url in urls:
+            result = self._build(url)
+            if result == url:
+                continue
+            assert result.rstrip("/") + suffix == url.rstrip("/"), url
+
+    def test_scheme_and_host_are_preserved(self):
+        """Normalisation touches the path and nothing else."""
+        from urllib.parse import urlsplit
+
+        for url in (
+            "https://api.mistral.ai/v1/chat/completions",
+            "http://localhost:8000/v1",
+            "https://chat/completions",
+            "https://gw.example:8443/api/v1/",
+        ):
+            before, after = urlsplit(url), urlsplit(self._build(url))
+            assert (after.scheme, after.netloc) == (before.scheme, before.netloc), url
+
+    def test_unparseable_url_is_returned_untouched(self):
+        """A URL ``urlsplit`` cannot read must not become an exception.
+
+        ``urlsplit`` raises on a malformed IPv6 literal, and this helper runs
+        inside ``build_base_url`` — which ``kitty.validation.validate_api_key``
+        calls *outside* its own ``try``.  Raising here would turn a bad stored
+        profile into a traceback at launch instead of an error message, which is
+        a regression this normalisation introduced and must not reintroduce.
+        """
+        assert self._build("https://[::1/v1") == "https://[::1/v1"
+        assert self._build("https://[::1/v1/chat/completions") == "https://[::1/v1/chat/completions"
+
+    # ── Existing validation is unchanged ───────────────────────────────────
+
+    def test_rejects_empty_url(self):
+        """An empty base URL still raises, with the existing message."""
+        import pytest
+
+        with pytest.raises(ValueError, match="Invalid base_url"):
+            self._build("")
+
+    def test_rejects_non_http_scheme(self):
+        """A non-HTTP scheme still raises before normalisation is reached."""
+        import pytest
+
+        with pytest.raises(ValueError, match="Invalid base_url"):
+            self._build("ftp://x")
+
+    def test_rejects_schemeless_url(self):
+        """A bare host still raises before normalisation is reached."""
+        import pytest
+
+        with pytest.raises(ValueError, match="Invalid base_url"):
+            self._build("api.mistral.ai/v1")

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -194,3 +194,55 @@ async def test_validate_dirty_key_returns_invalid(mock_session_cls):
     assert result.valid is False
     assert "invalid characters" in result.reason
     assert "kitty setup" in result.reason
+
+
+@pytest.mark.asyncio
+@patch("kitty.validation.aiohttp.ClientSession")
+async def test_preflight_probes_the_normalised_url(mock_session_cls):
+    """KBR-134 — pre-flight inherits the base-URL fix, because it composes the same way.
+
+    ``validate_api_key`` builds its probe URL through ``build_base_url``, so the
+    reporter's stored profile is probed at Mistral's real endpoint rather than at
+    the doubled path that produced the original 404.  Nothing in
+    ``validation.py`` changed to achieve this; the test pins the consequence so a
+    later refactor cannot quietly undo it.
+    """
+    from kitty.providers.custom_openai import CustomOpenAIAdapter
+
+    provider = CustomOpenAIAdapter()
+    mock_response = AsyncMock()
+    mock_response.status = 200
+    mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_response.__aexit__ = AsyncMock(return_value=False)
+
+    mock_session = AsyncMock()
+    mock_session.post = MagicMock(return_value=mock_response)
+    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = AsyncMock(return_value=False)
+    mock_session_cls.return_value = mock_session
+
+    result = await validate_api_key(
+        provider,
+        "any-key",
+        {"base_url": "https://api.mistral.ai/v1/chat/completions"},
+    )
+
+    assert result.valid is True
+    assert mock_session.post.call_args.args[0] == "https://api.mistral.ai/v1/chat/completions"
+
+
+@pytest.mark.asyncio
+async def test_preflight_does_not_raise_on_an_unparseable_base_url():
+    """A malformed stored base URL yields a result, not a traceback.
+
+    ``validate_api_key`` builds its probe URL *before* its own ``try`` block, and
+    ``launcher.py`` does not wrap the call, so anything ``build_base_url`` raises
+    reaches the user as a Python traceback at launch.  Normalisation parses the
+    URL where nothing did before, which made that reachable; this pins the
+    graceful path.
+    """
+    from kitty.providers.custom_openai import CustomOpenAIAdapter
+
+    result = await validate_api_key(CustomOpenAIAdapter(), "any-key", {"base_url": "https://[::1/v1"})
+
+    assert result.valid is False


### PR DESCRIPTION
Closes [KBR-134](https://shelpuk.atlassian.net/browse/KBR-134).

## Context for the Product Owner

**The complaint.** A customer set up a custom OpenAI-compatible profile for Mistral, asked it "2+2", and was told:

> There's an issue with the selected model (mistral-large-latest). It may not exist or you may not have access to it.

The model exists. His key was fine. Mistral works with Kitty today, unchanged.

**What actually happened.** Kitty asks for the *address of the API* and adds the specific endpoint onto it. He pasted the *full endpoint* — which is what Mistral's documentation, and every other provider's, shows you. Kitty stacked one on the other, the request landed nowhere, and the provider returned a generic "not found". Claude Code turns any "not found" into "that model may not exist", so the customer spent his time hunting a model problem that never existed.

**What this changes for customers.**

1. **The paste now just works.** Kitty recognises a duplicated endpoint and trims it. The reporter's existing profile starts working with no edit on his part — no support round-trip, no "please reconfigure".
2. **The same protection for Anthropic-compatible endpoints.** The identical flaw was sitting there unreported. Closed in the same change.
3. **A dead-end address now says so**, and prints the address Kitty actually called, so the next person diagnoses it in seconds instead of an afternoon.
4. **The documentation and the setup prompts now state the rule**, so the mistake is less likely to be made at all.

**What this does not fix, deliberately.** Azure OpenAI still cannot be used through this provider. Its documented endpoint carries a `?api-version=` parameter, and Kitty cannot assemble such an address at all — a separate, pre-existing defect that touches every provider and needs its own design decision. Filed as [KBR-143](https://shelpuk.atlassian.net/browse/KBR-143), and this change at least makes the failure legible rather than silent.

## Root cause, established on the wire

Not reasoned about — measured, using the key the reporter supplied. Four candidate causes, each settled:

| Hypothesis | Verdict | Evidence |
|---|---|---|
| The base URL is concatenated with the endpoint path, producing a doubled path | **Confirmed** | The doubled URL returns `HTTP 404 {"detail":"Not Found"}`; the correct one returns `HTTP 200` |
| Kitty's request shape is incompatible with Mistral | **Falsified** | A real bridge against Mistral served a full streaming session — system prompt, tool declarations, SSE — 200 and a correct answer |
| Pre-flight key validation should have caught it | **Confirmed as contributing** | It treats everything except 401/403 as "key valid", so the 404 sailed through |
| The models he named do not exist on Mistral | **Falsified** | Both return 200 |

## How the fix is built

`build_base_url` removes one trailing copy of the provider's own endpoint path. The interesting part is what stops that being dangerous.

**The strip is guarded by a self-check, not a list of special cases.** It composes the endpoint back onto the candidate and keeps it only if that reproduces the caller's own URL. Two rounds of design review produced four URL shapes that break unguarded stripping — a query string, a fragment, a doubled slash, and `https://chat/completions`, whose *string* ends with the suffix and whose **host** would be eaten, leaving `https:/`. One comparison rejects all four, with no branch of their own. The code reviewer fuzzed the property over **64,736 generated URLs**: zero violations.

**Exactly one occurrence is stripped.** Once leaves the composed address byte-identical to what the customer configured, so it cannot break a gateway that genuinely routes at that path. A loop would not have that property.

**A 404 from a customer-supplied endpoint now explains itself**, naming the URL requested and stating that the base URL ends at the API root. Credentials embedded in a URL are stripped before it is echoed, since the message reaches the agent transcript and the access log. Fixed-endpoint providers keep the old behaviour — telling those users to check a base URL they never set would be wrong.

**One regression found and fixed during self-review.** Normalisation parses the URL, which nothing did before, and Python's parser rejects a malformed IPv6 literal. Pre-flight validation builds its probe URL outside its own error handling, with nothing above it catching — so a bad stored profile would have produced a raw traceback at launch. Proved both ways on the machine. An unparseable URL is now returned untouched: we must not rewrite what we cannot read. Two regression tests pin it.

## Tests

48 new tests, all at the layers CI actually runs. Per `TEST_SUITE.md` §2.2, each claim sits at the lowest layer that can prove it.

- **L1 — normalisation.** The reported defect, the four hostile shapes above, an Azure-style endpoint, case sensitivity, the `urlparse`-vs-`urlsplit` `;params` trap, and the composition property over a generated set. Both custom providers.
- **L1 — the 404 message.** Exact text, empty-body handling, credential redaction, and that a 404 carrying a context-window body still yields the more useful `/clear` advice.
- **L1 — wiring.** A real bridge against a stub upstream answering 404, streaming and non-streaming, asserting the text reaches the client's payload. Added after code review pointed out that calling the internal function directly proved only half of what was claimed.
- **L1 — pre-flight** inherits the fix, and no longer crashes on an unparseable URL.
- **L2 — contract.** The README and both wizard prompts state the rule, and every URL the README lists normalises to itself, so the documentation cannot teach the broken form. Self-checking, per §6.2.

Two suite guards required registration, both working as designed: the vendor-token guard refused the new message until it was classified as downstream-only (it says "Kitty", and the suite will not let a product name near anything that could reach a provider), and the layer registry required the new contract test be declared.

## Verification

All four CI gates green locally on the merged tree: `ruff`, `mypy`, `lint-imports`, and `pytest -m "l1 or l2"` — **3,430 passed, 0 failed**, up from 3,378 on the baseline.

Reviewed by `system-design-reviewer` twice — the first pass falsified the property I had written, the second caught that it was still false for query-bearing URLs — and by `code-reviewer`, whose one blocking finding is addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VMeBsTCWi33JzGFU8RLB1k


[KBR-134]: https://shelpuk.atlassian.net/browse/KBR-134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KBR-143]: https://shelpuk.atlassian.net/browse/KBR-143?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ