### PR TITLE
Let one assertion be known-failing, and nothing else (KBR-30 / T-W7)

### DIFF
--- a/.github/review/rules/python-tests.md
+++ b/.github/review/rules/python-tests.md
@@ -94,8 +94,24 @@ Several tests exist specifically to hold something nothing else enforces:
 **A change that weakens one of these to make a diff pass is a critical finding**,
 and it is worth stating explicitly in the finding what invariant was being held.
 Deleting such a test, loosening its assertion, or adding a skip to it all count.
-An `xfail` or `skip` added anywhere without a stated reason and a linked issue is
-a warning at minimum.
+An `xfail` or `skip` added anywhere without a stated reason and a linked issue
+is a warning at minimum. A `ratchet` carries both by construction, so its
+trigger is different: a `ratchet` added to one of the invariant guards named
+above, or one whose registry row does not land in the same diff.
+
+**`ratchet` is the third amnesty form and has its own rule.** It exempts one
+named assertion, from a row in `tests/exemptions.py` carrying that assertion,
+its expected failure condition and its Jira key
+(`.system_design/TEST_SUITE.md` §8.3). Two things to raise:
+
+- 🔴 **More than one assertion inside a `ratchet` block.** The block must hold
+  one assertion and the statements that build its subject. A second assertion is
+  never evaluated once the first fails, so a failure it would have reported is
+  invisible — the blanket amnesty §8 rejects, in miniature. Nothing detects
+  this; review is the enforcement.
+- **A `ratchet` call passing `_registry=`.** That is the mechanism's private
+  test seam. From a guard it is a local amnesty that no one can count by reading
+  the registry, which defeats the point of having one.
 
 ## Coverage of the change itself
 

--- a/.system_design/TEST_SUITE.md
+++ b/.system_design/TEST_SUITE.md
@@ -1845,8 +1845,9 @@ The exemption is therefore narrow and accountable:
 
 - It attaches to **one assertion**, named, with its expected failure condition and its issue key
   (TR-1c's header-subset assertion → KBR-8. TR-4's no-vendor-content assertion → KBR-5 was the
-  only other entry and was **withdrawn on 2026-09-07** when KBR-5 shipped; the registry is now one
-  row long, which is the length it is supposed to trend towards).
+  only other entry and was **withdrawn on 2026-09-07** when KBR-5 shipped, which leaves the
+  registry one row long **in the state this document describes** — the length it is supposed to
+  trend towards, and not a count of what is in the file today; see §8.3).
 - **Setup and every other assertion in the scenario gate normally.** If TR-4 cannot reach the
   bridge, the job fails — that is not the known defect.
 - **An unexpected pass fails the job.** When the assertion starts passing, the defect is fixed
@@ -1963,9 +1964,10 @@ not against an empty one.
 
 ### 8.3 The exemption mechanism
 
-Delivered by T-W7 (KBR-30), ahead of the guards that need it: T-G1, T-G4, T-G5, T-G9 and T-J1
+Delivered by T-W7 (KBR-30), ahead of the guards that need it: T-G1, T-G4, T-G5, T-G9 and T-J2
 each cover a class of check broader than the one defect they happen to expose, so each is
-expected to land red on one assertion (plan §16).
+expected to land red on one assertion (plan §16). T-J1 is the blocked *dependency* rather than a
+guard — it is the pytest-bdd wiring T-J2's scenarios are written against.
 
 **`tests/exemptions.py`** holds the registry and the decisions over it, in the shape §8.1 uses
 for the selection rules: every decision is a **pure function** — `outcome_for`,
@@ -2085,9 +2087,9 @@ the same way §8.2 makes each pending layer someone's named handoff.
 assertion, KBR-8 — belongs to an acceptance scenario that does not exist yet (§6.4.1, delivered
 by T-J2 downstream of T-J1). A registry row for an assertion no test contains documents a
 fiction, and the guard against a fiction cannot be the unexpected-pass rule, because nothing ever
-runs it. Whichever of T-G1, T-G4, T-G5, T-G9 or T-J2 lands first adds the first row. §8's own
-row-count parenthetical above, §6.4.1 and §6.2.3 are not amended to say so: this document states
-the To-Be state, in which those rows exist.
+runs it. Whichever of T-G1, T-G4, T-G5, T-G9 or T-J2 lands first adds the first row. §6.4.1 and
+§6.2.3 are not amended to say so: this document states the To-Be state, in which those rows
+exist, and §8's row-count parenthetical now says which state it is counting.
 
 That makes the registry-shape check itself vulnerable to §8's own "green because it stopped
 looking": a validator run over zero rows passes perfectly. So `registry_violations` is proved

--- a/.system_design/TEST_SUITE.md
+++ b/.system_design/TEST_SUITE.md
@@ -680,7 +680,8 @@ Two further C1 assertions arising from F1:
 **C1b — Fingerprint parity (L3).** Compare kitty's header set against a captured Claude Code
 native set (§7.1 captures both). Assert kitty's is a *subset*, and report the difference. Today
 the difference is large; the test's job is to make it visible and stop it growing, not to fail
-the build on day one — a reported baseline with a ratchet, becoming a gate once G3 closes.
+the build on day one — a reported baseline with a ratchet (the monotonic kind, not the §8.3
+exemption), becoming a gate once G3 closes.
 
 **C2 — Body shape (L3).** Covered by the transparency oracle (§3.3), plus two assertions the
 oracle's projection makes possible and a flat scan cannot:
@@ -1543,7 +1544,7 @@ The exemption covers **one assertion**, never the scenario. In TR-1c it is the h
 assertion (KBR-8). Every other step in
 those scenarios — setup, the `Given` clauses, and any other `Then` — gates normally, so a broken
 fixture or an unrelated regression still fails the build. An unexpected pass also fails, forcing
-the exemption off when the defect closes. The full policy and the exemption registry are in §8;
+the exemption off when the defect closes. The full policy is in §8 and the registry in §8.3;
 this section does not restate it, so the two cannot drift apart.
 
 **Three scenarios were corrected against the implementation, not the other way round.**
@@ -1673,7 +1674,8 @@ that is a gate — it is the "as appropriate" this document forbids elsewhere. S
   window after the run, proving `force_close` and the connection-limit behave under saturation.
 
 The ceilings and floors are numbers this document does not invent: they come from a first
-baseline run, recorded and then ratcheted. **`_backend_context` isolation moved to L3** (§6.3.1)
+baseline run, recorded and then ratcheted — again the monotonic kind, not the §8.3 exemption.
+**`_backend_context` isolation moved to L3** (§6.3.1)
 — it is deterministic and does not need a load rig to prove.
 
 ## 7. Shared test infrastructure
@@ -1834,7 +1836,7 @@ release must not wait on an LLM eval. Both cannot hold. Evals and the live-agent
 **alerting**, not gating: they are nondeterministic and depend on a third party's availability,
 and a release that can be blocked by someone else's rate limiter is not a release process.
 
-**`@ratchet` exempts one named assertion, not a scenario.** A scenario-wide exemption is a
+**`ratchet` exempts one named assertion, not a scenario.** A scenario-wide exemption is a
 blanket amnesty: a broken fixture, a failure in a `Given` step, or an unrelated regression inside
 that scenario all become invisible, indistinguishable from the known defect. That is a worse
 outcome than the red gate it was meant to avoid.
@@ -1958,6 +1960,139 @@ versions. The new L3 work adds real sockets to that gate. If the fast gate stops
 people route around it, so the marker split above is also the mechanism for keeping the per-PR
 path bounded — and the mutation-cadence measurement (Q11) has to be taken against that budget,
 not against an empty one.
+
+### 8.3 The exemption mechanism
+
+Delivered by T-W7 (KBR-30), ahead of the guards that need it: T-G1, T-G4, T-G5, T-G9 and T-J1
+each cover a class of check broader than the one defect they happen to expose, so each is
+expected to land red on one assertion (plan §16).
+
+**`tests/exemptions.py`** holds the registry and the decisions over it, in the shape §8.1 uses
+for the selection rules: every decision is a **pure function** — `outcome_for`,
+`lookup_exemption`, `registry_violations`, `unexpected_pass_message` — so each can be handed a
+deliberate defect, per plan §1.4. There is no pytest hook, no plugin and no new CI flag; a test
+that uses an exemption is an ordinary test carrying its ordinary layer marker.
+
+```python
+# tests/exemptions.py — the one registry
+EXEMPTIONS: Mapping[str, Exemption] = {
+    "tr-1c-header-subset": Exemption(
+        assertion="the header set is a subset of what Claude Code sends natively",
+        condition="the bridge sends a User-Agent the agent does not",
+        issue="KBR-8",
+    ),
+}
+```
+
+```python
+# the guard. Imported as `exemptions`, not `tests.exemptions`: `tests/` has no
+# `__init__.py`, so pytest's `prepend` import mode puts it on `sys.path` —
+# `tests/layers.py` carries the same caveat in its module docstring.
+from exemptions import ratchet
+
+with ratchet("tr-1c-header-subset"):
+    assert bridge_headers <= native_headers
+```
+
+**Two words spelled the same.** `ratchet(...)` here is the **exemption**: binary, gating, and it
+fails when its assertion starts passing. A *"ratcheted baseline"* in §4.3 C1b, §6.3.1 and §6.4.4,
+and in plan tasks T-I9 and T-I12, is a **different and non-gating** mechanism: record a number,
+report it, tighten it monotonically. The collision predates this section — §8 above already calls
+the exemption `@ratchet` — and the name is kept because §8 is the section the guards are written
+against. T-I9 and T-I12 must not import this symbol; their plan rows say so.
+
+**Ids are lowercase kebab-case**, and that much is checked, because five tasks add rows
+independently. Prefixing an id with the guard or scenario it belongs to is a convention, not a
+check — see the stated limits below. **One row per assertion, not per defect:** two guards over
+KBR-8 take two rows, since each must be withdrawn on the day its own cell starts passing.
+
+**Parametrised guards.** The blocked consumers are per-adapter (T-G9) and per adapter × model ×
+transport (T-G4), and the defect is usually one cell of that matrix. Exempt the cell, not the
+parametrisation:
+
+```python
+exemption = (
+    ratchet("t-g9-openai-subscription-user-agent")
+    if adapter == "openai_subscription"
+    else nullcontext()
+)
+with exemption:
+    assert headers(adapter) <= native_headers(adapter)
+```
+
+The other adapters gate normally; the exempt one still fails the job the day it starts passing.
+The row's `condition` column names the cell in prose, because nothing else does. **In a
+parametrised guard a cell is an assertion:** three exempt cells take three rows, so each can be
+withdrawn on the day its own cell starts passing, and the count in the registry stays a count of
+outstanding defects.
+
+Six decisions in that mechanism depart from the obvious option, and are recorded because the
+obvious option is what a future reader will otherwise assume was intended:
+
+- **A context manager, not a decorator.** The paragraph above writes `@ratchet`, and a decorator
+  is what pytest's own `xfail` would give. But a decorator can only wrap a **whole test**, which
+  is exactly the scenario-wide amnesty this section rejects: it would hide a broken fixture and
+  every healthy assertion beside the exempt one. Assertion scope needs a block. The name is kept.
+- **Only `AssertionError` is amnestied; every other exception propagates.** An exemption says
+  "this claim is known to be false", not "this region of the test may do anything". A `KeyError`
+  inside the block is a broken fixture and fails the job. `pytest.fail()`, `pytest.xfail()`,
+  `pytest.skip()` and **a missed `pytest.raises()`** are not `AssertionError`s and are therefore
+  **not** amnestied — the safe direction, since an exemption that could turn a test into a skip is
+  the failure §8 names two paragraphs above, but a surprise for the author of an L2 guard that
+  reports its verdict with `pytest.fail` and a diff, which is the shape
+  `tests/test_github_actions.py` uses today. **A guard that needs an exemption states its verdict
+  as an `assert`**: catch with `try`/`except` and assert on what you caught, rather than leaning on
+  `pytest.raises` or `pytest.fail`.
+- **An unexpected pass raises a non-`AssertionError` exception.** `UnexpectedExemptionPass`
+  descends from `Exception`, deliberately not from `AssertionError`, so that a nested or adjacent
+  `ratchet` block can never swallow it. A strictness signal that another exemption can amnesty is
+  not strictness.
+- **The registry seam is private.** `ratchet` takes an underscored `_registry` keyword so that
+  this mechanism's own tests can have rows while the production registry is empty. **A guard must
+  never pass it.** A public `registry=` would be a documented back door into the one-registry
+  invariant: a local amnesty nobody can count by reading one file.
+- **No orphan-row scan.** A row whose assertion has since been deleted is stale documentation,
+  but it grants amnesty to nothing and so cannot hide a failure; the mechanism against an
+  exemption outliving its defect is the unexpected-pass rule. A text scan of `tests/**` for unused
+  ids would buy tidiness at the price of a false positive on any id named in a comment.
+  Considered and declined, not overlooked.
+- **No terminal reporting of fired exemptions.** Visibility is the registry file, which is what
+  §8 asks for — "one registry … short, visible". A per-run summary would be a `conftest.py` hook,
+  and the value of this mechanism is precisely that it changes no job's collection or selection.
+  The residual risk is real and accepted: a CI log gives no sign that an exemption fired.
+
+**Two limits the mechanism cannot enforce, stated so they are not mistaken for guarantees.**
+
+- **The block must hold exactly one assertion** and the statements that build its subject.
+  Nothing detects a second: once the first assertion fails, the second is never evaluated, and a
+  failure it would have reported is invisible — a miniature of the blanket amnesty §8 rejects.
+  The enforcement is review, and the rule is in `.github/review/rules/python-tests.md`.
+- **The `condition` column is documentation, not an assertion.** Any `AssertionError` from the
+  block is amnestied, including one raised by an unrelated regression that happens to break the
+  same assertion. The mitigation is the single-statement scope above, not the column.
+- **The id prefix is a convention.** `registry_violations` checks the casing, not that an id
+  names its guard or scenario, and it cannot check that a parametrised guard took one row per
+  exempt cell. An allow-list of permitted prefixes would need editing for every new guard, which
+  buys tidiness at the price of friction on the path this mechanism exists to keep open.
+
+**The unexpected-pass rule only fires in a job that runs the test.** A row attached to a test on
+a layer in `PENDING_ACTIVATION_LAYERS` (§8.2) — `l3` and `acceptance` today, which is where T-G4,
+T-G5 and T-J2 land — is unchecked until that job is activated, so there the exemption *can*
+outlive its defect. The task that activates the job owns re-checking the rows on its layer, in
+the same way §8.2 makes each pending layer someone's named handoff.
+
+**The registry ships empty, today.** The row this section names — TR-1c's header-subset
+assertion, KBR-8 — belongs to an acceptance scenario that does not exist yet (§6.4.1, delivered
+by T-J2 downstream of T-J1). A registry row for an assertion no test contains documents a
+fiction, and the guard against a fiction cannot be the unexpected-pass rule, because nothing ever
+runs it. Whichever of T-G1, T-G4, T-G5, T-G9 or T-J2 lands first adds the first row. §8's own
+row-count parenthetical above, §6.4.1 and §6.2.3 are not amended to say so: this document states
+the To-Be state, in which those rows exist.
+
+That makes the registry-shape check itself vulnerable to §8's own "green because it stopped
+looking": a validator run over zero rows passes perfectly. So `registry_violations` is proved
+against a **fabricated malformed registry** rather than against the production one, and the
+production registry is asserted clean as a separate, weaker claim.
 
 ## 9. Gap register
 

--- a/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
+++ b/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
@@ -175,8 +175,11 @@ fixture fails a CI lint.
 
 **T-W7 — exemption registry.** Plain pytest, not BDD-specific. An entry names **one assertion**,
 its expected failure condition and its ticket; everything else in the test gates normally; an
-unexpected pass fails (`xfail(strict=True)`). *Falsification:* a second, non-exempt failing
-assertion in the same test must still fail the job.
+unexpected pass fails (`xfail(strict=True)`). *Falsification, both required:* a second,
+non-exempt failing assertion in the same test must still fail the job; and an exempt assertion
+that starts passing must fail it. Each falsification case must assert the **exact** exception
+that escapes, through a `BaseException` guard — `pytest.raises(AssertionError)` cannot see
+`pytest.xfail`, so an implementation that amnesties the whole test reports green through it.
 
 **T-W8 — bridge fixture core and extension interface.** A profile/backend factory and a real
 `BridgeServer` started against a recorder, for the **default aiohttp transport only**, plus the
@@ -361,10 +364,10 @@ that makes *its* bytes observable. Bundled, the Ollama half would have had no ev
 | **T-I6** | Agent settings precedence | blocked Q12 | T-I5 | Three runs, three winners; every sentinel demonstrated live | §6.4.2 | M |
 | **T-I7** | Streaming recovery — content | partial Q14 | T-B4, T-G7, T-W8 | Four injection points; no duplicated text, no reused tool-call id, no spliced arguments. Positive oracle waits on Q14 | §6.3.1 | L |
 | **T-I8** | Cross-attempt content and cadence | | T-D1, T-W8, T-B4 | Blip and empty-response retries byte-identical; M6, M8, M9 and failover re-normalisation each fire only on trigger | §4.3 C3 | M |
-| **T-I9** | Connection lifecycle baseline | | T-W8, T-C7 | Distinct connections per session vs the native capture; ratcheted | §4.3 C5 | M |
+| **T-I9** | Connection lifecycle baseline | | T-W8, T-C7 | Distinct connections per session vs the native capture; ratcheted — a **reported baseline**, not `exemptions.ratchet`, which is the unrelated gating mechanism of §8.3 | §4.3 C5 | M |
 | **T-I10** | `_backend_context` isolation | | T-W8 | Deterministic; belongs here, not in load | §6.3.1 | S |
 | **T-I11** | Failover, disconnect, error envelopes | | T-B4, T-W8 | Mid-stream failover; disconnect releases upstream without marking unhealthy; 503 in each native envelope; oversized in the protocol's error shape | §6.3.1 | M |
-| **T-I12** | Fingerprint parity report | | T-C7, T-W8, T-G9 | Header set vs the native baseline; **reported with a ratchet, not gating**, until gap G3 closes | §4.3 C1b | M |
+| **T-I12** | Fingerprint parity report | | T-C7, T-W8, T-G9 | Header set vs the native baseline; **reported with a ratchet, not gating**, until gap G3 closes. The ratchet here is a monotonic baseline; do **not** import `exemptions.ratchet`, which gates and fails when parity improves (§8.3) | §4.3 C1b | M |
 | **T-I13** | Side traffic | | T-W8 | `/healthz` and `/stats` cause no upstream request; pre-flight pinned as a declared exception; `--no-validate` removes it | §4.3 C6 | M |
 | **T-I14** | **Expand live-agent coverage to five Claude Code scenarios** | | — | Plain turn, tool-using turn, multi-turn with tool results, extended thinking, and a session crossing the compaction threshold. The existing file has two cases; scheduling it nightly does not expand it | §6.4.2 | M |
 
@@ -510,8 +513,13 @@ merge.** So:
   PR that the test fails at the base revision and passes with the fix. A guard written after the
   fix with no such evidence is still not acceptable — that is what the rule exists to prevent.
 - **Exemption path** only where the fix must genuinely follow later, or where the guard's scope is
-  broader than one defect. T-G1, T-G3, T-G4, T-G5 and T-G9 each cover a class of check beyond a
-  single defect, so they may land first with a single-assertion exemption.
+  broader than one defect. T-G1, T-G4, T-G5 and T-G9 each cover a class of check beyond a
+  single defect, so they may land first with a single-assertion exemption. (T-G3 was on this list
+  until KBR-6 fixed its defect and landed the guard green; its row in §10 records the dropped
+  dependency.) **A guard taking that
+  path states its verdict as an `assert`**, not `pytest.fail` — only `AssertionError` is
+  amnestied, and the established shape in this repo is `pytest.fail` with a diff, so this is the
+  one thing to get right before writing the guard. Design §8.3.
 - **Later acceptance scenarios pass normally** if the defect is already fixed. T-J2 does not need
   TR-1c and TR-4 to be red; it needs them to be correct.
 
@@ -563,6 +571,7 @@ Every design requirement has an owner. "Existing" means the current suite alread
 | §6.4.4 | Load rig and gate | T-K4, T-K5 |
 | §7.1–§7.4 | Corpus, recorders, proxy, oracle | T-W6/Epic C, T-W4/Epic B, T-W5, T-W2/T-D1 |
 | §8 | Markers, selection, job activation | T-W1, T-K6–T-K12 |
+| §8, §8.3 | Assertion exemption policy and registry | T-W7 |
 | §5.1 | Real-socket transport proof across three stacks | **Existing** — `tests/test_egress_https_proxy.py`, extended by T-W5 |
 | §6.2.3 | A structural scan that asserts its own positives | **Existing** — `tests/test_egress_coverage.py`, the pattern T-E7 copies |
 

--- a/README.md
+++ b/README.md
@@ -778,6 +778,25 @@ pytest -m agent_live  # launches real agent CLIs against live credentials
 The marker is assigned automatically from the file's path; a test only declares its own layer
 where that default is wrong. `.system_design/TEST_SUITE.md` §8 has the full matrix.
 
+### Exempting a known-failing assertion
+
+A guard sometimes covers a class of check broader than the one defect it happens to expose, so it
+would land red on a single assertion. `tests/exemptions.py` exempts **that one assertion** and
+nothing else:
+
+```python
+from exemptions import ratchet
+
+with ratchet("tr-1c-header-subset"):
+    assert bridge_headers <= native_headers
+```
+
+Every other assertion in the test, and all of its setup, still gates. A broken fixture inside the
+block still fails. And when the assertion starts passing, the run **fails** and tells you to
+delete the row -- so an exemption cannot outlive the defect it describes. Each row names the
+assertion, the condition it is expected to fail under, and its Jira key; the registry is one file
+and is meant to trend towards empty. `.system_design/TEST_SUITE.md` §8.3 has the reasoning.
+
 ## License
 
 MIT

--- a/tests/exemptions.py
+++ b/tests/exemptions.py
@@ -42,7 +42,7 @@ import re
 from collections.abc import Mapping
 from dataclasses import dataclass
 from enum import Enum
-from types import TracebackType
+from types import MappingProxyType, TracebackType
 
 # Every failure this module raises is prefixed with this, so a CI summary can
 # tell an exemption problem apart from the ordinary assertion failures around
@@ -93,7 +93,13 @@ class Exemption:
 # contains documents a fiction, and the unexpected-pass rule cannot catch that
 # one, because nothing ever runs it. Whichever of T-G1, T-G4, T-G5, T-G9 or
 # T-J2 lands first adds the first row.
-EXEMPTIONS: Mapping[str, Exemption] = {}
+#
+# A `MappingProxyType`, not a bare dict, so the value matches the read-only
+# annotation at runtime as well as to a type checker. `EXEMPTIONS[...] = ...`
+# from a guard would otherwise pass `mypy` and register a row nobody can find by
+# reading this file -- the one-registry invariant defeated by one line. Rows are
+# added by editing the literal below.
+EXEMPTIONS: Mapping[str, Exemption] = MappingProxyType({})
 
 
 class UnknownExemption(Exception):

--- a/tests/exemptions.py
+++ b/tests/exemptions.py
@@ -1,0 +1,356 @@
+"""The assertion exemption registry, and the decisions taken over it.
+
+``.system_design/TEST_SUITE.md`` §8 states the policy: a guard whose scope is
+broader than the one defect it exposes may exempt **one named assertion** from a
+gating job, and nothing else.  §8.3 specifies this mechanism.  Four contract
+guards and one acceptance scenario (plan §16) are designed to land red on a
+single assertion each, and none of them can land without it.
+
+Three rules carry the whole of it:
+
+* the exemption attaches to **one assertion**, delimited by a ``with`` block —
+  setup, every ``Given`` step and every other assertion in the same test gate
+  normally;
+* only a failed assertion is amnestied — a broken fixture is not the known
+  defect and fails the job;
+* an **unexpected pass fails the job**, so an exemption cannot outlive the defect
+  it describes.
+
+Usage::
+
+    from exemptions import ratchet
+
+    with ratchet("tr-1c-header-subset"):
+        assert bridge_headers <= native_headers
+
+Every decision is a pure function — :func:`outcome_for`,
+:func:`lookup_exemption`, :func:`registry_violations`,
+:func:`unexpected_pass_message` — so each can be handed a deliberate defect, as
+the implementation plan's §1.4 harness rule requires.  There is no pytest hook,
+plugin or CI flag here: a test that uses an exemption is an ordinary test
+carrying its ordinary layer marker, and no job's selection changes.
+
+**Import note.** Imported as ``exemptions``, not ``tests.exemptions``: ``tests/``
+has no ``__init__.py``, so pytest's ``prepend`` import mode puts that directory
+on ``sys.path``.  :mod:`tests.layers` and ``tests/internal_key_scan.py`` are
+imported the same way and the same caveat applies.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import Enum
+from types import TracebackType
+
+# Every failure this module raises is prefixed with this, so a CI summary can
+# tell an exemption problem apart from the ordinary assertion failures around
+# it -- all of which pytest reports the same way.
+EXEMPTION_PREFIX = "assertion-exemption:"
+
+# Jira keys in this project. Checked as a shape rather than against Jira: the
+# suite must run offline, and a typo in the project prefix is the realistic
+# mistake, not a well-formed key pointing at a closed ticket.
+# `\Z`, not `$`: in Python `$` also matches before a trailing newline, so
+# `"KBR-8\n"` would pass a `$`-anchored check.
+_ISSUE_KEY = re.compile(r"^KBR-\d+\Z")
+
+# Lowercase kebab-case. Enforced because five downstream tasks add rows
+# independently and a registry whose ids are in three casings is a registry
+# nobody greps successfully. Prefixing an id with its guard or scenario
+# (`tr-1c-header-subset`, `t-g9-bedrock-user-agent`) is a convention and is NOT
+# checked: an allow-list of prefixes would need editing for every new guard.
+# TEST_SUITE.md §8.3 records that as a stated limit rather than a gap.
+_EXEMPTION_ID = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*\Z")
+
+
+@dataclass(frozen=True)
+class Exemption:
+    """One exempt assertion, and the reason it is exempt.
+
+    Attributes:
+        assertion: What the assertion claims, in the words a product owner would
+            use — not its source text, which moves.
+        condition: The condition under which it is expected to fail. This is the
+            field that makes the row reviewable: a reader can ask whether the
+            defect described is still the defect observed.
+        issue: The Jira key of the defect, as ``KBR-<digits>``. An exemption
+            without a ticket is an amnesty nobody owns.
+    """
+
+    assertion: str
+    condition: str
+    issue: str
+
+
+# 🔴 The registry of ACKNOWLEDGED DEBT. One row per exempt assertion, and the
+# list is supposed to trend towards zero.
+#
+# It ships EMPTY, deliberately. TEST_SUITE.md §8 names one row -- TR-1c's
+# header-subset assertion, KBR-8 -- but TR-1c is an acceptance scenario that
+# does not exist yet (§6.4.1, plan task T-J2). A row for an assertion no test
+# contains documents a fiction, and the unexpected-pass rule cannot catch that
+# one, because nothing ever runs it. Whichever of T-G1, T-G4, T-G5, T-G9 or
+# T-J2 lands first adds the first row.
+EXEMPTIONS: Mapping[str, Exemption] = {}
+
+
+class UnknownExemption(Exception):
+    """Raised when a ``ratchet`` block names an id the registry does not hold.
+
+    Descends from :class:`Exception` and deliberately not from
+    :class:`AssertionError`, for the same reason as
+    :class:`UnexpectedExemptionPass`: :func:`ratchet` resolves the row *outside*
+    its own block, so an enclosing ``ratchet`` would otherwise classify a
+    registry miss as its own expected failure and suppress it.
+    """
+
+
+class UnexpectedExemptionPass(Exception):
+    """Raised when an exempt assertion passes, meaning its defect is fixed.
+
+    Descends from :class:`Exception` and deliberately **not** from
+    :class:`AssertionError`: were it an ``AssertionError``, a nested or adjacent
+    ``ratchet`` block would classify it as its own expected failure and suppress
+    it.  A strictness signal another exemption can swallow is not strictness.
+    """
+
+
+class Outcome(Enum):
+    """What happened inside a ``ratchet`` block."""
+
+    EXPECTED_FAILURE = "expected failure"
+    UNEXPECTED_PASS = "unexpected pass"
+    PROPAGATE = "propagate"
+
+
+def outcome_for(error: BaseException | None) -> Outcome:
+    """Classify what left a ``ratchet`` block.
+
+    Args:
+        error: The exception the block raised, or ``None`` when it completed.
+
+    Returns:
+        :attr:`Outcome.EXPECTED_FAILURE` for a failed assertion,
+        :attr:`Outcome.UNEXPECTED_PASS` when nothing was raised, and
+        :attr:`Outcome.PROPAGATE` for anything else.
+
+    Only ``AssertionError`` is amnestied.  An exemption says "this claim is known
+    to be false", not "this region of the test may do anything": a ``KeyError``
+    raised while the assertion's subject is being built is a broken fixture, and
+    suppressing it would let a guard report its known defect while proving
+    nothing at all.  Subclasses count — pytest's rewriting and several libraries
+    raise them, and an identity check would classify the same defect two
+    different ways depending on who reported it.
+
+    ``pytest.fail(...)``, ``pytest.xfail(...)`` and ``pytest.skip(...)`` are
+    **not** amnestied: each raises a ``BaseException`` that is not an
+    ``AssertionError``, so each propagates and fails the job.  That is the safe
+    direction — an exemption must not be able to turn a test into a skip — but it
+    surprises the author of a guard that reports its verdict with ``pytest.fail``
+    and a diff, which is the established shape of the L2 guards in
+    ``tests/test_github_actions.py`` and ``tests/test_pypi_packaging.py``.  A
+    guard that needs an exemption states its verdict as an ``assert``.
+    """
+    if error is None:
+        return Outcome.UNEXPECTED_PASS
+
+    if isinstance(error, AssertionError):
+        return Outcome.EXPECTED_FAILURE
+
+    return Outcome.PROPAGATE
+
+
+def lookup_exemption(exemption_id: str, registry: Mapping[str, Exemption]) -> Exemption:
+    """Return the registry row an exemption names.
+
+    Args:
+        exemption_id: The id given to :func:`ratchet`.
+        registry: The registry to resolve against.
+
+    Returns:
+        The matching :class:`Exemption`.
+
+    Raises:
+        UnknownExemption: When the registry holds no such id.
+
+    An exemption that is not in the registry is precisely the scattered amnesty
+    §8 forbids — it would grant cover with no ticket, no stated condition and
+    nowhere to read how many are outstanding.  The message lists the ids that do
+    exist, because the realistic cause is a typo or a row someone has already
+    withdrawn.
+    """
+    if exemption_id in registry:
+        return registry[exemption_id]
+
+    # "known ids: " followed by nothing reads as a broken lookup. The registry
+    # ships empty, so this is the message the first person to mistype an id
+    # actually sees.
+    known = ", ".join(sorted(registry)) if registry else "the registry is empty"
+
+    raise UnknownExemption(
+        f"{EXEMPTION_PREFIX} {exemption_id!r} is not in the registry, so it "
+        f"exempts nothing. Known ids: {known}."
+    )
+
+
+def registry_violations(registry: Mapping[str, Exemption]) -> list[str]:
+    """Return one human-readable line per malformed registry row.
+
+    Args:
+        registry: The registry to check.
+
+    Returns:
+        A message per offending row, naming the row and the field at fault.
+        Empty when every row is complete.
+
+    Every offender is reported rather than the first: a check that surfaces one
+    problem per CI round is a check people stop running.
+    """
+    violations: list[str] = []
+
+    for exemption_id, entry in registry.items():
+        # The id is a row's only handle: it is what the `ratchet` call names and
+        # what a maintainer greps for when the unexpected-pass failure fires.
+        if not _EXEMPTION_ID.match(exemption_id):
+            violations.append(
+                f"{exemption_id!r} is not a usable exemption id; ids are "
+                "lowercase kebab-case (and by convention, though not by this "
+                "check, prefixed with the guard or scenario they belong to)"
+            )
+
+        if not entry.assertion.strip():
+            violations.append(f"{exemption_id!r} names no assertion")
+
+        # The condition is what makes the row reviewable later: without it a
+        # reader cannot ask whether the defect described is still the one seen.
+        if not entry.condition.strip():
+            violations.append(f"{exemption_id!r} states no expected failure condition")
+
+        if not _ISSUE_KEY.match(entry.issue):
+            violations.append(
+                f"{exemption_id!r} carries {entry.issue!r}, which is not a "
+                "KBR-<number> issue key; an exemption without a ticket is an "
+                "amnesty nobody owns"
+            )
+
+    return violations
+
+
+def unexpected_pass_message(exemption_id: str, exemption: Exemption) -> str:
+    """Build the failure text for an exempt assertion that has started passing.
+
+    Args:
+        exemption_id: The id the ``ratchet`` block named.
+        exemption: Its registry row.
+
+    Returns:
+        The message :class:`UnexpectedExemptionPass` carries.
+
+    Whoever reads this in CI did not write the exemption and may never have seen
+    the ticket, so it states the assertion, the condition that was expected to
+    break it, the issue, and the one action that clears it.
+    """
+    return (
+        f"{EXEMPTION_PREFIX} the exempt assertion {exemption_id!r} passed. It "
+        f"claims: {exemption.assertion}. It was expected to fail while: "
+        f"{exemption.condition} ({exemption.issue}). The defect is fixed, so "
+        "delete the row from the registry in tests/exemptions.py and let the "
+        "assertion gate normally."
+    )
+
+
+class _Ratchet:
+    """The context manager :func:`ratchet` returns.
+
+    Written as an explicit ``__enter__``/``__exit__`` pair rather than with
+    ``contextlib.contextmanager`` so that the three outcomes map one-to-one onto
+    the return of :meth:`__exit__`: suppression is a returned ``True``, not a
+    generator that happens not to re-raise.
+    """
+
+    def __init__(self, exemption_id: str, exemption: Exemption) -> None:
+        """Store the resolved exemption.
+
+        Args:
+            exemption_id: The id the caller named.
+            exemption: Its registry row, already resolved by :func:`ratchet`.
+        """
+        self._exemption_id = exemption_id
+        self._exemption = exemption
+
+    def __enter__(self) -> None:
+        """Enter the exempt block.
+
+        Returns:
+            Nothing. The row is not handed back: no guard needs it, and a
+            ``ratchet(...) as row`` form would invite the block to grow a second
+            statement, which is the one thing the block must not do.
+        """
+        return None
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> bool:
+        """Apply the exemption to whatever left the block.
+
+        Args:
+            exc_type: The exception class, or ``None``.
+            exc: The exception instance, or ``None``.
+            traceback: The traceback, or ``None``.
+
+        Returns:
+            ``True`` to suppress the known defect, ``False`` to let anything else
+            propagate.
+
+        Raises:
+            UnexpectedExemptionPass: When the block raised nothing, meaning the
+                defect is fixed and the row must come out.
+        """
+        outcome = outcome_for(exc)
+
+        if outcome is Outcome.UNEXPECTED_PASS:
+            raise UnexpectedExemptionPass(
+                unexpected_pass_message(self._exemption_id, self._exemption)
+            )
+
+        return outcome is Outcome.EXPECTED_FAILURE
+
+
+def ratchet(exemption_id: str, *, _registry: Mapping[str, Exemption] | None = None) -> _Ratchet:
+    """Exempt the single assertion inside the ``with`` block that follows.
+
+    Args:
+        exemption_id: The registry id of the assertion being exempted.
+        _registry: The registry to resolve against, defaulting to
+            :data:`EXEMPTIONS`. Underscored because it is a seam for this
+            mechanism's own tests, which need rows while the production registry
+            is empty. **A guard must never pass it**: a locally-supplied registry
+            is an amnesty that no one can count by reading one file, which is the
+            state §8 exists to prevent. Resolved in the body rather than as a
+            default argument, so that rebinding :data:`EXEMPTIONS` takes effect
+            instead of silently doing nothing.
+
+    Returns:
+        A context manager that suppresses the named assertion's failure and
+        fails the test if it passes.
+
+    Raises:
+        UnknownExemption: When ``exemption_id`` is not in the registry. Raised
+            **here**, before the block runs, rather than on the way out: a
+            deferred lookup would let an exemption naming a row that does not
+            exist pass silently for as long as its assertion kept failing.
+
+    ``TEST_SUITE.md`` §8 writes this as ``@ratchet``, and pytest's own ``xfail``
+    is a decorator.  A decorator is the wrong shape here, because it can only
+    wrap a **whole test** — the scenario-wide amnesty §8 rejects, under which a
+    broken fixture and every healthy assertion beside the exempt one all become
+    invisible.  Assertion scope needs a block; the name is kept.
+    """
+    registry = EXEMPTIONS if _registry is None else _registry
+
+    return _Ratchet(exemption_id, lookup_exemption(exemption_id, registry))

--- a/tests/test_assertion_exemptions.py
+++ b/tests/test_assertion_exemptions.py
@@ -307,6 +307,22 @@ def test_registry_violations_reports_every_offender() -> None:
     assert len(violations) == 2
 
 
+def test_the_production_registry_cannot_be_added_to_at_runtime() -> None:
+    """A guard cannot register its own row by assigning into the registry.
+
+    The annotation says :class:`~collections.abc.Mapping`, which a type checker
+    enforces and a plain ``dict`` does not. Rows are added by editing the
+    literal in ``tests/exemptions.py``, where the list stays readable in one
+    place — §8's whole reason for having a registry.
+    """
+    with pytest.raises(TypeError):
+        EXEMPTIONS["smuggled-in"] = Exemption(  # type: ignore[index]
+            assertion="an assertion", condition="a condition", issue="KBR-8"
+        )
+
+    assert "smuggled-in" not in EXEMPTIONS
+
+
 def test_the_production_registry_is_well_formed() -> None:
     """Whatever rows the registry carries today, they are complete.
 
@@ -489,11 +505,13 @@ def test_ratchet_defaults_to_the_production_registry() -> None:
     """The registry argument is a private test seam, not the calling convention.
 
     Guards write ``with ratchet("some-id"):`` and get the one registry §8
-    requires; only this module passes its own, and the underscore says so. The
-    id below is one no production row is expected to take — the assertion
-    states that rather than assuming it, so this stays true as rows come and go.
+    requires; only this module passes its own, and the underscore says so.
+
+    The precondition is derived from :data:`SAMPLE_REGISTRY` rather than written
+    as a literal, so it keeps holding when a sample row is renamed and covers
+    every sample row rather than this one.
     """
-    assert "sample-only-header-subset" not in EXEMPTIONS
+    assert not (SAMPLE_REGISTRY.keys() & EXEMPTIONS.keys())
 
     def a_guard_using_the_calling_convention() -> None:
         """Stand in for a guard, which never passes a registry of its own."""

--- a/tests/test_assertion_exemptions.py
+++ b/tests/test_assertion_exemptions.py
@@ -1,0 +1,503 @@
+"""Tests for the assertion exemption registry.
+
+``.system_design/TEST_SUITE.md`` §8.3 specifies a mechanism that exempts **one
+named assertion** from a gating job, so that a guard whose scope is broader than
+the one defect it exposes can land without turning the whole gate red.
+
+The two cases the plan calls falsification (§1.4, plan task T-W7) are the pair
+that separate this mechanism from the blanket amnesty §8 rejects:
+
+* :func:`test_ratchet_does_not_suppress_a_later_failing_assertion` — an exempt
+  assertion beside a second, healthy one must still fail the job;
+* :func:`test_ratchet_fails_when_the_exempt_assertion_passes` — an exemption
+  that has outlived its defect must fail the job.
+
+Both are asserted **in process** rather than through a ``pytester`` sub-run. The
+claim is "the exemption suppresses only what is inside its block", and an
+exception escaping the block *is* how pytest fails a test; a second interpreter
+would prove nothing further and would couple these tests to pytest's own plugin
+loading.
+
+This module is ``l1`` by the path default — pure functions and a context manager
+over them, no sockets, no files, no clock. It declares no layer marker because
+the default is right.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+
+import pytest
+from exemptions import (
+    EXEMPTION_PREFIX,
+    EXEMPTIONS,
+    Exemption,
+    Outcome,
+    UnexpectedExemptionPass,
+    UnknownExemption,
+    lookup_exemption,
+    outcome_for,
+    ratchet,
+    registry_violations,
+    unexpected_pass_message,
+)
+
+# A stand-in for the production registry. The falsification cases need rows, and
+# the production registry ships empty (§8.3); tying these tests to whatever the
+# first real row happens to be would make them fail the day that row is
+# withdrawn, which is the opposite of what this mechanism is for.
+SAMPLE_REGISTRY: Mapping[str, Exemption] = {
+    "sample-only-header-subset": Exemption(
+        assertion="the header set is a subset of what the agent sends natively",
+        condition="the bridge adds a header the agent does not send",
+        issue="KBR-8",
+    ),
+    "sample-only-inner": Exemption(
+        assertion="the bridge opens one connection per session",
+        condition="connection reuse differs from the native baseline",
+        issue="KBR-8",
+    ),
+}
+
+# Shaped like the real TR-1c assertion, so the tests below read as the thing
+# being exempted rather than as `assert False` with extra steps. `assert False`
+# is also a ruff B011 finding.
+BRIDGE_ONLY_HEADERS = frozenset({"x-kitty-title"})
+NATIVE_HEADERS: frozenset[str] = frozenset()
+
+
+# ── The decisions, as pure functions ───────────────────────────────────────
+
+
+def test_outcome_for_no_error_is_an_unexpected_pass() -> None:
+    """An exempt assertion that raises nothing has outlived its defect."""
+    assert outcome_for(None) is Outcome.UNEXPECTED_PASS
+
+
+def test_outcome_for_an_assertion_error_is_the_expected_failure() -> None:
+    """A failed assertion inside the block is the known defect."""
+    assert outcome_for(AssertionError("the known defect")) is Outcome.EXPECTED_FAILURE
+
+
+def test_outcome_for_an_assertion_error_subclass_is_the_expected_failure() -> None:
+    """A subclass is still a failed assertion.
+
+    pytest's assertion rewriting and several libraries raise subclasses of
+    ``AssertionError``; an identity check on the type would amnesty the bare
+    class and propagate every one of those, which is the same defect reported
+    two different ways depending on who raised it.
+    """
+
+    class _RewrittenAssertionError(AssertionError):
+        """A stand-in for a library's own ``AssertionError`` subclass."""
+
+    assert outcome_for(_RewrittenAssertionError()) is Outcome.EXPECTED_FAILURE
+
+
+@pytest.mark.parametrize(
+    "error",
+    [KeyError("headers"), RuntimeError("the bridge never started"), TypeError("bad fixture")],
+    ids=["KeyError", "RuntimeError", "TypeError"],
+)
+def test_outcome_for_any_other_exception_propagates(error: Exception) -> None:
+    """Anything that is not a failed assertion is not the known defect.
+
+    Args:
+        error: An exception a broken fixture might raise inside the block.
+    """
+    assert outcome_for(error) is Outcome.PROPAGATE
+
+
+def test_unexpected_exemption_pass_is_not_an_assertion_error() -> None:
+    """The strictness signal must not be amnestiable by another exemption.
+
+    ``UnexpectedExemptionPass`` descends from ``Exception`` deliberately: were it
+    an ``AssertionError``, a nested or adjacent ``ratchet`` block would classify
+    it as its own expected failure and suppress it. A strictness signal that
+    another exemption can swallow is not strictness.
+    """
+    assert not issubclass(UnexpectedExemptionPass, AssertionError)
+    # And the registry miss, for the same reason: `ratchet()` resolves the row
+    # outside its own block, so an enclosing exemption would otherwise amnesty
+    # an unknown id and the registry would stop being the only source of them.
+    assert not issubclass(UnknownExemption, AssertionError)
+
+
+def test_the_unexpected_pass_message_names_the_id_the_issue_and_the_remedy() -> None:
+    """The failure has to tell a maintainer with no context what to do.
+
+    Whoever reads this in CI did not write the exemption and may never have seen
+    the ticket. Naming only the id would send them grepping.
+    """
+    row = SAMPLE_REGISTRY["sample-only-header-subset"]
+
+    message = unexpected_pass_message("sample-only-header-subset", row)
+
+    # The literal, not `EXEMPTION_PREFIX in message`: that form is satisfied by
+    # a prefix someone has emptied out.
+    assert message.startswith("assertion-exemption:")
+    assert EXEMPTION_PREFIX == "assertion-exemption:"
+    assert "sample-only-header-subset" in message
+    assert "KBR-8" in message
+    assert "the header set is a subset of what the agent sends natively" in message
+    # The remedy, not just the diagnosis, and named precisely: `"registry" in
+    # message` is satisfied by any sentence that happens to use the word.
+    assert "delete the row" in message
+    assert "tests/exemptions.py" in message
+
+
+def test_lookup_exemption_returns_the_named_row() -> None:
+    """A known id resolves to its row."""
+    row = SAMPLE_REGISTRY["sample-only-header-subset"]
+
+    assert lookup_exemption("sample-only-header-subset", SAMPLE_REGISTRY) is row
+
+
+def test_lookup_exemption_rejects_an_unknown_id() -> None:
+    """An exemption that is not in the registry is a scattered amnesty.
+
+    The message lists the ids that do exist, because the overwhelmingly likely
+    cause is a typo or a row someone has already withdrawn.
+    """
+    with pytest.raises(UnknownExemption) as caught:
+        lookup_exemption("no-such-id", SAMPLE_REGISTRY)
+
+    assert "no-such-id" in str(caught.value)
+    assert "sample-only-header-subset" in str(caught.value)
+
+
+def test_lookup_exemption_says_so_when_the_registry_is_empty() -> None:
+    """An empty registry is the goal state, and must read as one.
+
+    Listing "known ids: " and nothing else invites the reader to conclude the
+    lookup is broken. The registry ships empty (§8.3), so this is the message
+    the first person to mistype an id will actually see.
+    """
+    with pytest.raises(UnknownExemption) as caught:
+        lookup_exemption("sample-only-header-subset", {})
+
+    assert "empty" in str(caught.value)
+
+
+# ── The registry's own shape ───────────────────────────────────────────────
+
+
+def test_registry_violations_passes_a_well_formed_registry() -> None:
+    """A registry whose rows are all complete has no violations."""
+    assert registry_violations(SAMPLE_REGISTRY) == []
+
+
+@pytest.mark.parametrize(
+    ("exemption_id", "row", "expected_fragment"),
+    [
+        (
+            "sample-only-a",
+            Exemption(assertion="  ", condition="a condition", issue="KBR-8"),
+            "assertion",
+        ),
+        (
+            "sample-only-b",
+            Exemption(assertion="an assertion", condition="", issue="KBR-8"),
+            "condition",
+        ),
+        (
+            "no-ticket",
+            Exemption(assertion="an assertion", condition="a condition", issue=""),
+            "issue key",
+        ),
+        (
+            "wrong-project",
+            Exemption(assertion="an assertion", condition="a condition", issue="JIRA-8"),
+            "issue key",
+        ),
+        (
+            "   ",
+            Exemption(assertion="an assertion", condition="a condition", issue="KBR-8"),
+            "id",
+        ),
+        (
+            "TR_1c_Header_Subset",
+            Exemption(assertion="an assertion", condition="a condition", issue="KBR-8"),
+            "kebab-case",
+        ),
+        (
+            "sample-only-c",
+            Exemption(
+                assertion="an assertion", condition="a condition", issue="KBR-8 (wontfix)"
+            ),
+            "issue key",
+        ),
+        (
+            "sample-only-d",
+            Exemption(assertion="an assertion", condition="a condition", issue="KBR-8\n"),
+            "issue key",
+        ),
+        (
+            "t-g9-ok\n",
+            Exemption(assertion="an assertion", condition="a condition", issue="KBR-8"),
+            "id",
+        ),
+    ],
+    ids=[
+        "blank assertion",
+        "blank condition",
+        "no ticket",
+        "wrong project",
+        "blank id",
+        "id in another convention",
+        "issue key with trailing text",
+        "issue key with a trailing newline",
+        "id with a trailing newline",
+    ],
+)
+def test_registry_violations_flags_a_malformed_row(
+    exemption_id: str, row: Exemption, expected_fragment: str
+) -> None:
+    """Every field an entry must carry is checked, and named when it is missing.
+
+    Args:
+        exemption_id: The row's key in the registry.
+        row: A row with exactly one thing wrong with it.
+        expected_fragment: The word the violation line must contain, so that the
+            test fails when the checker reports the wrong field. The ids are
+            deliberately anonymous: every violation line embeds the id, so an id
+            like ``"blank-condition"`` would satisfy the fragment on its own and
+            a checker naming the wrong field would pass. The two trailing-newline
+            rows are not padding: Python's ``$`` matches *before* a trailing
+            newline, so a ``$``-anchored pattern accepts ``"KBR-8\n"``.
+
+    This is deliberately proved against a **fabricated** malformed registry. The
+    production registry ships empty, and a validator run over zero rows passes
+    perfectly — §8's "green because it stopped looking", reproduced inside the
+    check meant to prevent it.
+    """
+    violations = registry_violations({exemption_id: row})
+
+    assert len(violations) == 1
+    assert expected_fragment in violations[0]
+
+
+def test_registry_violations_accepts_an_id_that_names_no_guard() -> None:
+    """The prefix convention is not a check, and the suite says which it is.
+
+    ``TEST_SUITE.md`` §8.3 lists it among the limits the mechanism cannot
+    enforce. Without this test the omission reads as an oversight in
+    ``registry_violations`` rather than as the recorded decision it is.
+    """
+    unprefixed = {
+        "header-subset": Exemption(assertion="a", condition="c", issue="KBR-8"),
+    }
+
+    assert registry_violations(unprefixed) == []
+
+
+def test_registry_violations_reports_every_offender() -> None:
+    """All of them, not the first.
+
+    At ~18 minutes a CI round, a check that surfaces one problem per round is a
+    check people stop running.
+    """
+    violations = registry_violations(
+        {
+            "blank-assertion": Exemption(assertion="", condition="c", issue="KBR-8"),
+            "no-ticket": Exemption(assertion="a", condition="c", issue=""),
+        }
+    )
+
+    assert len(violations) == 2
+
+
+def test_the_production_registry_is_well_formed() -> None:
+    """Whatever rows the registry carries today, they are complete.
+
+    A weaker claim than the test above and deliberately separate from it: this
+    one passes vacuously while the registry is empty, which is exactly why it
+    cannot be the only place the checker is exercised.
+    """
+    assert registry_violations(EXEMPTIONS) == []
+
+
+# ── The mechanism ──────────────────────────────────────────────────────────
+#
+# Every case below asserts the EXACT type of what escapes, through a
+# `BaseException` guard rather than through `pytest.raises`. That is not
+# pedantry. `pytest.xfail()`, `pytest.skip()` and `pytest.fail()` raise
+# `BaseException` subclasses that `pytest.raises(AssertionError)` does not
+# catch, and the first two turn the surrounding test GREEN. A plausible wrong
+# implementation -- suppress the assertion, then call `pytest.xfail()` -- is a
+# test-wide amnesty, exactly what this mechanism exists to forbid, and it was
+# observed passing an earlier version of these tests with the suite reporting
+# "23 passed, 2 xfailed" and exit code 0.
+
+
+def escaping_exception(body: Callable[[], None]) -> BaseException | None:
+    """Run ``body`` and return whatever left it, including pytest's outcomes.
+
+    Args:
+        body: A zero-argument callable standing in for a guard's test body.
+
+    Returns:
+        The exception that escaped, or ``None`` when the body returned
+        normally.
+
+    Catches ``BaseException`` deliberately: ``pytest.xfail`` and ``pytest.skip``
+    are how a wrong implementation would make a failing job look green, and a
+    narrower guard cannot see them.
+    """
+    try:
+        body()
+    except BaseException as error:
+        return error
+
+    return None
+
+
+def test_ratchet_suppresses_the_failure_of_the_assertion_it_names() -> None:
+    """The known defect does not fail the job, and does not skip it either."""
+
+    def a_guard_whose_only_failing_assertion_is_exempt() -> None:
+        """Stand in for a guard that has caught nothing but its known defect."""
+        with ratchet("sample-only-header-subset", _registry=SAMPLE_REGISTRY):
+            assert BRIDGE_ONLY_HEADERS <= NATIVE_HEADERS, "the known defect"
+
+    assert escaping_exception(a_guard_whose_only_failing_assertion_is_exempt) is None
+
+
+def test_ratchet_does_not_suppress_a_later_failing_assertion() -> None:
+    """Falsification 1 — an exemption covers one assertion, not the test.
+
+    A scenario-wide exemption would make a broken fixture, a failing ``Given``
+    step and an unrelated regression all invisible, indistinguishable from the
+    known defect. That is worse than the red gate it was meant to avoid, so the
+    mechanism is not fit to use until this case is observed failing.
+    """
+
+    def a_guard_with_one_exempt_and_one_healthy_assertion() -> None:
+        """Stand in for a T-G9-shaped guard that has caught a real regression."""
+        with ratchet("sample-only-header-subset", _registry=SAMPLE_REGISTRY):
+            assert BRIDGE_ONLY_HEADERS <= NATIVE_HEADERS, "the known defect"
+
+        assert [] == ["the turn"], "an unrelated regression"
+
+    escaped = escaping_exception(a_guard_with_one_exempt_and_one_healthy_assertion)
+
+    # The exact type, not `pytest.raises(AssertionError)`: an implementation
+    # that xfailed the whole test would raise `XFailed`, which is not an
+    # `AssertionError` and which reports the job green.
+    assert type(escaped) is AssertionError
+    assert "an unrelated regression" in str(escaped)
+
+
+def test_ratchet_does_not_suppress_a_broken_fixture_inside_the_block() -> None:
+    """An exemption says a claim is known false, not that anything may happen.
+
+    A ``KeyError`` raised where the assertion's subject is being built is a
+    broken fixture. Amnestying it would let the guard report the known defect
+    while proving nothing at all.
+    """
+    captured: dict[str, str] = {}
+
+    def a_guard_whose_fixture_is_broken() -> None:
+        """Stand in for a guard whose capture never arrived."""
+        with ratchet("sample-only-header-subset", _registry=SAMPLE_REGISTRY):
+            assert captured["x-kitty-title"] == "absent"
+
+    assert type(escaping_exception(a_guard_whose_fixture_is_broken)) is KeyError
+
+
+def test_ratchet_does_not_amnesty_a_pytest_fail_verdict() -> None:
+    """``pytest.fail`` is not an ``AssertionError``, so it is not exempt.
+
+    The L2 guards this mechanism was built for report their verdict with
+    ``pytest.fail`` and a diff today. The safe direction is the one taken — an
+    exemption must never be able to convert a verdict into a pass — but the
+    behaviour is pinned here so a downstream author finds it stated rather than
+    discovers it in CI.
+    """
+
+    def a_guard_that_reports_its_verdict_with_fail() -> None:
+        """Stand in for a T-G1-shaped README guard."""
+        with ratchet("sample-only-header-subset", _registry=SAMPLE_REGISTRY):
+            pytest.fail("the README table and the code disagree")
+
+    assert type(escaping_exception(a_guard_that_reports_its_verdict_with_fail)) is pytest.fail.Exception
+
+
+def test_ratchet_fails_when_the_exempt_assertion_passes() -> None:
+    """Falsification 2 — an exemption cannot outlive the defect it describes.
+
+    ``xfail(strict=True)`` semantics: when the assertion starts passing, the
+    defect is fixed, and nobody has to remember to take the row out.
+    """
+
+    def a_guard_whose_defect_has_been_fixed() -> None:
+        """Stand in for a guard the day its ticket closes."""
+        with ratchet("sample-only-header-subset", _registry=SAMPLE_REGISTRY):
+            assert NATIVE_HEADERS <= BRIDGE_ONLY_HEADERS, "the defect is fixed"
+
+    escaped = escaping_exception(a_guard_whose_defect_has_been_fixed)
+
+    assert type(escaped) is UnexpectedExemptionPass
+    assert "KBR-8" in str(escaped)
+
+
+def test_an_outer_exemption_cannot_swallow_an_inner_unexpected_pass() -> None:
+    """The strictness signal survives being nested inside another exemption.
+
+    This is the behaviour :func:`test_unexpected_exemption_pass_is_not_an_assertion_error`
+    pins the type relationship for. Were ``UnexpectedExemptionPass`` an
+    ``AssertionError``, the outer block would classify it as its own expected
+    failure and suppress it — one fixed defect would hide another's exemption.
+    """
+
+    def two_nested_exemptions() -> None:
+        """Stand in for a guard whose inner defect closed first."""
+        with ratchet("sample-only-header-subset", _registry=SAMPLE_REGISTRY):
+            with ratchet("sample-only-inner", _registry=SAMPLE_REGISTRY):
+                assert NATIVE_HEADERS <= BRIDGE_ONLY_HEADERS, "the inner defect is fixed"
+
+            assert BRIDGE_ONLY_HEADERS <= NATIVE_HEADERS, "the outer known defect"
+
+    escaped = escaping_exception(two_nested_exemptions)
+
+    assert type(escaped) is UnexpectedExemptionPass
+    assert "sample-only-inner" in str(escaped)
+
+
+def test_ratchet_rejects_an_unknown_id_before_running_the_block() -> None:
+    """A registry miss must not be masked by the assertion failing anyway.
+
+    Were the lookup deferred to the end of the block, an exemption naming a row
+    that does not exist would pass silently for as long as its assertion kept
+    failing — an amnesty granted by nothing, which is the state the registry
+    exists to make impossible.
+    """
+    entered = False
+
+    def a_guard_naming_a_row_that_does_not_exist() -> None:
+        """Stand in for a guard whose exemption was withdrawn under it."""
+        nonlocal entered
+        with ratchet("no-such-id", _registry=SAMPLE_REGISTRY):
+            entered = True
+            assert BRIDGE_ONLY_HEADERS <= NATIVE_HEADERS, "the known defect"
+
+    assert type(escaping_exception(a_guard_naming_a_row_that_does_not_exist)) is UnknownExemption
+    assert not entered
+
+
+def test_ratchet_defaults_to_the_production_registry() -> None:
+    """The registry argument is a private test seam, not the calling convention.
+
+    Guards write ``with ratchet("some-id"):`` and get the one registry §8
+    requires; only this module passes its own, and the underscore says so. The
+    id below is one no production row is expected to take — the assertion
+    states that rather than assuming it, so this stays true as rows come and go.
+    """
+    assert "sample-only-header-subset" not in EXEMPTIONS
+
+    def a_guard_using_the_calling_convention() -> None:
+        """Stand in for a guard, which never passes a registry of its own."""
+        with ratchet("sample-only-header-subset"):
+            pass
+
+    assert type(escaping_exception(a_guard_using_the_calling_convention)) is UnknownExemption


### PR DESCRIPTION
Closes [KBR-30](https://shelpuk.atlassian.net/browse/KBR-30) — plan task **T-W7**, the last Milestone 0 contract with tasks waiting on it.

## Context for the Product Owner

The test suite is being rebuilt so that a green build means something. Part of that work is five new **guards** — automated checks that hold a promise nothing else enforces (that the bridge is invisible to the provider, that the README matches the code, that no request escapes the configured gateway).

Each of those five guards has a problem in common: it checks a whole *class* of thing, and in each case one item in that class is a bug we already know about and have already ticketed. So each guard, the day it is switched on, goes red for a reason we already understand.

That leaves a bad choice. Ship the guards and the build is permanently red — and a permanently red build gets ignored, then switched off, taking the working checks down with it. Or hold the guards back until every known bug is fixed, and get no protection in the meantime.

**This change is the third option.** It lets a guard mark exactly one line as "known to be failing, tracked as KBR-8", while every other check in that same guard still protects us normally. And the moment someone fixes the underlying bug, **the build fails on purpose** — telling us to remove the marker. An excuse cannot quietly outlive the problem it was written for.

Concretely: this unblocks **KBR-76, KBR-77, KBR-80, KBR-81 and KBR-107**. It changes no product behaviour and ships no `src/` code — it is test-suite tooling.

The list of active exemptions lives in one file, each entry naming its Jira ticket, so "how much known-broken are we carrying?" is answered by reading one short list. **It ships with zero entries.**

## What is in the change

- `tests/exemptions.py` — the registry plus a `ratchet(...)` block that exempts one assertion.
- `tests/test_assertion_exemptions.py` — 32 tests.
- `TEST_SUITE.md` §8.3, `TEST_SUITE_IMPLEMENTATION_PLAN.md`, `README.md`, and the repo's own review rules.

Three rules carry it: the exemption attaches to **one assertion**, not a test; only a failed assertion is excused (a broken fixture still fails); and **an unexpected pass fails the job**.

## Evidence

**22 deliberate defects were applied to the mechanism and each was observed failing.** Three are worth calling out, because two reviewers found them and they changed the design:

1. **The first version of these tests could not tell a failing job from a green one.** An implementation that excuses the assertion and then calls `pytest.xfail()` is a *test-wide* amnesty — the exact thing this forbids — and it **passed**, with the suite reporting `23 passed, 2 xfailed` and exit code 0. `XFailed` and `Skipped` descend from `BaseException`, so `pytest.raises(AssertionError)` cannot see them. Every mechanism test now asserts the *exact* type of what escapes.
2. **A checker that named the wrong malformed field passed**, because the violation message embeds the row id and two test ids supplied the expected word themselves.
3. **Python's `$` matches before a trailing newline**, so `"KBR-8\n"` passed the ticket-key check. Both patterns now anchor with `\Z`.

Reviewed twice by `system-design-reviewer` and once by `code-reviewer`; every blocker they raised is fixed in this branch.

## Decisions worth a second opinion

- **The name `ratchet` is kept.** `TEST_SUITE.md` §8 calls this mechanism `@ratchet`, but the same document uses "ratcheted" in four other places for the *opposite* kind of thing — a monotonic, non-gating baseline (T-I9, T-I12). I kept the design's word and added an explicit disambiguation plus warnings on both plan rows. Renaming to `exempt_assertion` would remove the trap outright; say the word and I will.
- **The registry ships empty.** §8 names one row (TR-1c → KBR-8), but that acceptance scenario does not exist yet. A row for an assertion no test contains documents a fiction.
- **Four limits are recorded rather than solved**, next to what the mechanism does enforce: one assertion per block is convention (a second is never reached once the first fails); the "condition" column is documentation; the id prefix is a convention and only the casing is checked; and the unexpected-pass rule only fires in a job that actually runs the test, leaving `l3` and `acceptance` rows unchecked until T-K6 and T-K9 turn those jobs on.

## Also filed

[KBR-150](https://shelpuk.atlassian.net/browse/KBR-150) — not fixed here. `tests/bridge/test_bridge_management.py` fails on stock Ubuntu 24.04 while CI is green: `ipaddress.IPv6Address.is_unspecified` gained a delegation to the mapped IPv4 address in the 3.12.4-era stdlib fixes, so `_connect_target`'s result depends on a patch level `requires-python` does not constrain. My first diagnosis of it was wrong; the ticket records the correction and the measurements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019QjGt96ao62Hcf21R4n28G


[KBR-30]: https://shelpuk.atlassian.net/browse/KBR-30?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KBR-150]: https://shelpuk.atlassian.net/browse/KBR-150?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ