### PR TITLE
Give the suite an upstream that records what really went out (KBR-27)

### DIFF
--- a/.system_design/TEST_SUITE.md
+++ b/.system_design/TEST_SUITE.md
@@ -609,6 +609,17 @@ rule §3.3.1 applies to bodies.
 deployment segment in the captured path while leaving the body byte-identical. The oracle must
 fail. Without this case there is no evidence the routing assertion is wired to anything.
 
+**T-D2 must normalise the authority and scheme before comparing, and this is not optional.**
+A published URL shape is `https://…` on the provider's own hostname; the harness serves
+`http://127.0.0.1:<ephemeral>`. T-W4's recorder captures the `Host` header **verbatim,
+port included** — correct, because that is what the client sent, and because the ephemeral
+port is the only thing distinguishing one recorder from another. The consequence is that
+`route.host` and `route.scheme` mismatch **by construction** on every comparison unless the
+expectation is rewritten with the harness's own authority and scheme. Path and query need no
+such treatment, and they are where the Azure case lives. Stated here because nothing else
+assigns this, and a reader discovering it at T-D2 time would reasonably conclude the recorder
+was wrong.
+
 The recorders already capture method, path and query (§7.2). The gap was that the assertion did
 not consume them.
 
@@ -1740,6 +1751,69 @@ context-too-large rejections, and disconnects at each of §6.3.1's four injectio
 asserted — what reaches the wire is the client library's ordering, not the agent's. Peer
 *address* is deliberately not used for containment (§5.2.1).
 
+#### 7.2.1 What T-W4 settled — read this before writing another recorder
+
+The primary recorder is `tests/harness/recorder.py`; the contract every recorder is
+judged against is `tests/harness/recorder_conformance.py`, and plan §5 requires T-B1–T-B3 to
+pass it. The following were established by probe on the pinned stack (aiohttp 3.13.5) and are
+not matters of taste — each is a way a recorder can look correct and lie.
+
+| Field | Read it from | Never from |
+|---|---|---|
+| Headers | `raw_headers`, decoded **latin-1** | `request.headers`; and never `utf-8`, which refuses obs-text |
+| Path | `rel_url.raw_path` | `request.path` — percent-**decoded** |
+| Query | `rel_url.raw_query_string` | `request.query_string` — percent-**decoded** |
+| Authority | the `Host` header itself; `""` when absent | `request.host` — falls back to `socket.getfqdn()`, **inventing the build machine's name**, and that fallback differs across the `>=3.11,<3.14` pin range. `request.url` lower-cases the host |
+| Peer port | `transport.get_extra_info("peername")[1]` | `request.remote` — address only |
+
+Three server-construction facts, each of which fails as a bare client-side
+`ConnectionResetError` with no traceback if got wrong:
+
+- **`client_max_size=0`**, supplied through a `request_factory` — it is a `BaseRequest`
+  argument, *not* a `Server`/`RequestHandler` one. The 1 MiB default turns §7.1's
+  over-budget corpus entries into a harness **413**, which is M6's own trigger, so the
+  harness would manufacture the compaction the oracle exists to detect. Zero disables the
+  check outright; a fixed ceiling is something a later corpus entry outgrows, and the
+  comparison is `>=`. The recorder then buffers bodies unbounded, which is acceptable only
+  because it is a loopback double whose clients are the harness's own.
+- **`auto_decompress=False`**. Left on, a `Content-Encoding: gzip` body is captured
+  decompressed *beside a header saying it is compressed* — an internally inconsistent
+  capture, and C1 asserts on that header.
+- **Connection logging via `web.Server.connection_made(handler, transport)`**, which is the
+  only public seam that sees a connection carrying **no** request — §5.2.1's bypass shape,
+  and structurally invisible in any request list. Wrapping the protocol object is
+  impossible: `RequestHandler` defines `__slots__`. Key the log on the **handler object**;
+  never on `id(handler)`, whose addresses CPython reuses, which would reintroduce the
+  port-reuse aliasing one level down, and never on a `WeakKeyDictionary`, because
+  `RequestHandler` is not weak-referenceable.
+
+**Limitation.** With a TLS-terminating site, `connection_made` fires *after* the handshake,
+so a connection that fails negotiation is not logged — and §5.2.1 names a failed TLS
+negotiation as a real bypass. **T-B2 and T-E2 must observe at socket level or accept this
+explicitly.**
+
+**A recorder produces no `CapturedReply`.** The reply is the script; the test already knows
+it. T-A7 and T-D10 need not reopen this contract to ask for one.
+
+**The reply's format is chosen by a path *suffix*** — `/v1/messages` or `/messages` for
+Anthropic Messages, `/chat/completions` for Chat Completions — because a recorder is
+impersonating a provider and providers dispatch on the URL. An exact match would serve
+`anthropic` and `custom_anthropic` and get Azure, vertex, ollama, opencode and
+zai_anthropic wrong. §3.3.4's "select by the shape observed on the wire" governs the
+**oracle's** choice of projection and must not be wired to this decision. An unmatched path
+falls back to a declared default and is **recorded**, failing the fixture at teardown: a
+wrong-format reply is not a loud failure but an apparently empty response, and that costs
+the 80-second retry ladder.
+
+**One thing no bridge-side judgement checks.** §4.3 C3's emptiness oracles are keyed on the
+**upstream** format: `_is_empty_cc_response` for non-streaming, `translator.response_was_empty`
+plus the `has_content` byte flag for Chat Completions streams — and **nothing at all** for a
+native Anthropic Messages stream, which `server.py:3616` forwards to the client byte-for-byte.
+A recorder's Anthropic SSE success is therefore guarded only by §6.2.2's grammar. That is a
+property of the product, not of the harness: an upstream returning a well-formed but
+contentless Anthropic stream reaches Claude Code with none of the retry the Chat Completions
+path has.
+
 ### 7.3 Recording CONNECT proxy
 
 **Already exists.** `tests/test_egress_https_proxy.py` contains `_ConnectProxy` (enforces Basic
@@ -1933,6 +2007,13 @@ today — `test_egress_https_proxy.py` foremost among them. Reclassifying them i
 T-K6's business, together with the job that runs them; doing it earlier would remove them from
 every gate. T-H1 must take that reclassification into account before it measures a mutation
 baseline, because it selects on `l1`.
+
+**T-W4 added two more, and they are named here so T-K6 inherits a list rather than a search:**
+`tests/harness/test_recorder.py` and `tests/harness/test_recorder_falsification.py` both bind
+real sockets and are `l1` by default for exactly the reason above.
+`tests/harness/test_recorder_conformance.py` is genuinely `l1` — its checks are pure functions
+over data and it opens nothing. The two socket-binding modules together run in **~1 second**,
+measured, which is the number the fast-gate budget should carry until T-K6 moves them.
 
 **The load gate has to be wired, not merely declared.** The table above marks Load as gating a
 release, but `publish.yml` currently depends only on the reusable `tests.yml`. Putting the load

--- a/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
+++ b/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
@@ -96,7 +96,7 @@ After Milestone 0, seven streams advance independently, each owning its own modu
 | **T-W1** | Layer markers, CI selection rules, per-category collection checks | — | §8, §8.1, §8.2 | M |
 | **T-W2** | **The input contract** — request/capture types, the projection protocol, the path vocabulary and the normalisation rules | — | §3.3.1, §3.3.1a, §3.3.1b | ~~S~~ **M** |
 | **T-W3** | Register schema and data | T-W2 | §3.2 | M |
-| **T-W4** | Recorder implementation — primary aiohttp recorder | T-W2 | §7.2 | M |
+| **T-W4** | Recorder implementation — primary aiohttp recorder | T-W2 | §7.2, §7.2.1 | ~~M~~ **L** |
 | **T-W5** | Shared CONNECT proxy fixture | — | §7.3 | M |
 | **T-W6** | Corpus format, capture procedure, scrubber, loader | T-W3 | §7.1 | M |
 | **T-W7** | Assertion exemption registry | T-W1 | §8 | M |
@@ -160,10 +160,21 @@ fails.
 **T-W4 — recorder implementation.** Implements T-W2's `CapturedRequest` — original casing and order,
 arrival timestamp, and **the peer port of the accepted connection** — for the primary aiohttp
 recorder. It consumes the contract rather than defining it. Ships **one minimal valid success
-response per protocol** — without it any request
-driven through a real bridge falls into the retry paths, which are themselves body-mutating. The
-failure library is T-B4. Peer-port and casing capture are enforced by a **conformance test every
-Epic B recorder must pass**.
+response per protocol, per stream mode** — Claude Code sends `"stream": true`, and a streaming
+request answered with a JSON body is not a success. The failure library is T-B4. Peer-port and
+casing capture are enforced by a **conformance test every Epic B recorder must pass**, and it
+also records every **accepted connection**, including one that carries no request — §5.2.1's
+bypass shape, which no request list can express.
+
+~~without it any request driven through a real bridge falls into the retry paths, which are
+themselves body-mutating~~ — **this was wrong, and §4.3 C3 says the opposite**: transport-blip
+and empty-response retries are "the two that repeat a request unchanged" and must be
+byte-identical; the four mutating paths are M6, M8, M9 and failover. The two real reasons an
+empty or mis-shaped reply is unacceptable are sharper: it costs **80 seconds** of real
+`asyncio.sleep` per affected test (`_EMPTY_RETRY_DELAYS` + `_EMPTY_FINAL_DELAYS`) in a gating
+job, and on a **balancing** profile it fails over — and failover *is* body-mutating, so the
+harness would manufacture a delta no product code caused. A harness **413** is the same family:
+it is M6's own trigger. See §7.2.1.
 
 **T-W5 — CONNECT proxy.** Extract `_ConnectProxy`/`_TlsTarget` from
 `tests/test_egress_https_proxy.py`; add tunnel source-port recording and mid-test stoppability. An
@@ -189,7 +200,23 @@ core.
 and assert the capture is complete and **type-compatible with T-W2's declared contract** — the
 recorder's output must satisfy what a projection expects to read. Small, but it is the first
 moment the contracts are known to compose rather than merely to exist.
-*Falsification:* a recorder that drops the query string fails it.
+*Falsification:* a recorder that drops the query string fails it. T-W4 ships its **own**
+query-drop case against the recorder in isolation; this one is the end-to-end claim, and the two
+must not be collapsed.
+
+**T-W9 inherits three obligations T-W4 could not discharge**, because T-W4 starts no
+`BridgeServer` and they are only observable with one running:
+
+1. **Exactly one upstream request per inbound request.** T-W4 proves its replies are non-empty by
+   the judgements it can call directly; that is necessary and not sufficient. A second capture in
+   the recording is the only real evidence the retry ladder never fired.
+2. **The `has_content` cell of §7.2.1's table.** It is a local flag in the pass-through streaming
+   loop (`server.py:5145`), not a function — unreachable except by driving a bridge. T-W4's
+   streams satisfy its precondition by construction; nothing has confirmed it.
+3. **The empty-ladder timing.** `_EMPTY_RETRY_DELAYS` + `_EMPTY_FINAL_DELAYS` is 80 seconds of
+   real sleep. The slice should assert its own wall-clock bound, so a regression that
+   reintroduces the ladder fails rather than merely slowing the gate — the defect commit
+   `691e974` fixed once already.
 
 ---
 

--- a/tests/harness/recorder.py
+++ b/tests/harness/recorder.py
@@ -1,0 +1,768 @@
+"""The primary aiohttp recording upstream.
+
+`.system_design/TEST_SUITE.md` §7.2 · plan task **T-W4** (KBR-27).
+
+A real HTTP server that stands in for a provider. It records what the bridge put
+on the wire with enough fidelity to answer §4.3 C1 (the exact header set),
+§3.3.5 (routing, which on Azure lives only in the URL) and §5.2.1 (which TCP
+connection carried it), and it replies with a minimal valid success so that a
+request driven through a real bridge completes in **one** upstream attempt.
+
+**It imports nothing from ``src/kitty``, and must not.** §3.3.1's
+independent-oracle rule governs everything the fidelity claim rests on, and a
+recorder that asked kitty how to read a request would inherit kitty's bugs.
+``test_recorder.py`` asserts the absence structurally, sharing
+``test_contract.py``'s guard.
+
+**Why the low-level ``web.Server`` and not ``web.Application``.** Two things this
+recorder must do are unreachable from the high-level route:
+
+* **Connections that carry no request.** ``Server.connection_made(handler,
+  transport)`` is the only public seam that sees them, and §5.2.1 says an
+  upstream connection with no matching tunnel *"is the only thing this assertion
+  needs to catch"*. Wrapping the protocol object instead is impossible:
+  ``RequestHandler`` defines ``__slots__``, so assigning to
+  ``proto.connection_made`` raises, and the symptom is a bare
+  ``ConnectionResetError`` at the client with no traceback.
+* **Unbounded request bodies.** ``client_max_size`` is a ``BaseRequest``
+  argument, not a ``Server`` one, so it is supplied through
+  ``request_factory``. See :data:`_CLIENT_MAX_SIZE`.
+
+Routing is not needed — a recorder answers every path — so the low-level server
+costs nothing else.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from collections.abc import Awaitable, Callable, Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any, ClassVar
+
+from aiohttp import web
+
+from harness.contract import CapturedRequest, WireFormat
+
+__all__ = [
+    "RecordingUpstream",
+    "ConnectionRecord",
+    "Responder",
+    "Reply",
+    "minimal_success_body",
+    "minimal_success_stream",
+    "UnmatchedPathError",
+]
+
+#: Disables aiohttp's request-body ceiling outright. ``BaseRequest.read()``
+#: guards on ``if self._client_max_size:``, so zero switches the check off —
+#: deliberately, rather than picking a large number.
+#:
+#: The default is 1 MiB, and §7.1's corpus is specified to contain transcripts
+#: *over the compaction budget*. At the default those arrive as a harness **413**,
+#: which is M6's own trigger ("body re-compacted at half budget") — so the
+#: harness would manufacture the mutation the oracle exists to detect. A fixed
+#: ceiling has the same failure later, and the comparison is ``>=``, so a limit
+#: equal to an entry's exact size still raises.
+_CLIENT_MAX_SIZE = 0
+
+#: Path suffixes that select the wire format of the reply. A **suffix** match,
+#: because almost no adapter posts to a bare path: Azure sends
+#: ``/openai/deployments/{id}/chat/completions``, vertex
+#: ``/endpoints/openapi/chat/completions``, zai_anthropic
+#: ``/api/anthropic/v1/messages``, and ollama ``/v1/chat/completions``. An exact
+#: match would have selected correctly for three adapters and wrongly for the
+#: rest. A bare ``/messages`` entry is deliberately absent: no shipped adapter
+#: posts to one, and zai_anthropic's path already ends in ``/v1/messages``.
+_FORMAT_SUFFIXES: tuple[tuple[str, WireFormat], ...] = (
+    ("/chat/completions", WireFormat.CHAT_COMPLETIONS),
+    ("/v1/messages", WireFormat.ANTHROPIC_MESSAGES),
+)
+
+#: The formats §7.2 assigns to the primary recorder. The other three — OpenAI
+#: Responses, Bedrock Converse, Ollama ``/api/chat`` — belong to T-B1–T-B3,
+#: whose transports this recorder never sees.
+_SERVED_FORMATS = frozenset({WireFormat.ANTHROPIC_MESSAGES, WireFormat.CHAT_COMPLETIONS})
+
+#: The text every minimal success carries. Non-empty deliberately: every
+#: emptiness judgement in `server.py` keys on content being present, and an
+#: empty reply costs 80 seconds of retry ladder.
+_REPLY_TEXT = "ok"
+
+
+class UnmatchedPathError(AssertionError):
+    """Raised when a recorder is asked about requests that took the fallback.
+
+    A request whose path matched no suffix is answered in the recorder's
+    declared default format, which may be the wrong one. That failure is silent
+    and expensive rather than loud: the adapter parses nothing out of the reply,
+    the bridge judges the response empty, and the test pays the retry ladder. So
+    the fallback is recorded and :meth:`RecordingUpstream.assert_all_paths_matched`
+    turns it into a failure at teardown.
+    """
+
+
+@dataclass(frozen=True)
+class ConnectionRecord:
+    """One accepted TCP connection.
+
+    Keyed on the ``RequestHandler`` the aiohttp seam already hands us rather
+    than on the peer port, because §4.3 C5 counts *distinct connections* and a
+    port-deduplicated count is wrong once the kernel reuses a source port. The
+    port stays on the record as §5.2.1's cross-process join key against the
+    proxy's tunnel log.
+
+    Attributes:
+        connection_id: Identity of the connection within this recorder,
+            assigned in accept order.
+        peer_port: The peer's port — the client's own source port.
+        requests: How many requests rode on this connection. Zero is the
+            interesting value: §5.2.1's bypass is a connection that carries
+            none, and nothing in the request list can express it.
+    """
+
+    connection_id: int
+    peer_port: int
+    requests: int = 0
+
+
+#: What a recorder replies with. Handed the capture and an unprepared
+#: ``StreamResponse``, so it owns status, headers, body **and** the decision to
+#: abort mid-stream. §7.2 requires every recorder to replay "error statuses,
+#: Cloudflare blocks, empty responses, context-too-large rejections, and
+#: disconnects at each of §6.3.1's four injection points"; a hook that returned a
+#: finished response could express none of the last. T-B4 builds its failure
+#: library on this signature rather than by editing this module.
+Responder = Callable[[CapturedRequest, "Reply"], Awaitable[None]]
+
+
+def minimal_success_body(fmt: WireFormat) -> dict[str, Any]:
+    """Return the smallest non-streaming success body for ``fmt``.
+
+    "Minimal" means the fewest keys that still read as a success to the bridge —
+    not a faithful sample of a provider's response. What a *valid* body of each
+    format is belongs to the wire readers (T-A1, T-A2), which are written against
+    each format's published examples; duplicating that judgement here would
+    create a second source of truth for it.
+
+    Args:
+        fmt: The wire format to answer in.
+
+    Returns:
+        The response body, ready to serialize.
+
+    Raises:
+        ValueError: When ``fmt`` is not one of the two formats §7.2 assigns to
+            the primary recorder.
+    """
+    if fmt is WireFormat.ANTHROPIC_MESSAGES:
+        return {
+            "id": "msg_recorder",
+            "type": "message",
+            "role": "assistant",
+            "model": "recorder-model",
+            "content": [{"type": "text", "text": _REPLY_TEXT}],
+            "stop_reason": "end_turn",
+            "usage": {"input_tokens": 1, "output_tokens": 1},
+        }
+    if fmt is WireFormat.CHAT_COMPLETIONS:
+        return {
+            "id": "chatcmpl-recorder",
+            "object": "chat.completion",
+            "created": 0,
+            "model": "recorder-model",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": _REPLY_TEXT},
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+        }
+    raise ValueError(f"the primary recorder serves {sorted(f.value for f in _SERVED_FORMATS)}, not {fmt.value}")
+
+
+def minimal_success_stream(fmt: WireFormat) -> tuple[bytes, ...]:
+    """Return the smallest valid SSE success stream for ``fmt``.
+
+    Streaming is in scope because Claude Code sends ``"stream": true``, and a
+    streaming request answered with a JSON body is not a success — it lands in
+    the same retry ladder the non-streaming case would.
+
+    For Anthropic Messages the sequence follows §6.2.2's grammar —
+    ``message_start`` … ``content_block_start`` / ``content_block_delta`` /
+    ``content_block_stop`` … ``message_delta``, ``message_stop``. That grammar
+    is the *only* guard on this path: verified at ``server.py:3616``, a native
+    Messages stream is forwarded to the client byte-for-byte and never reaches a
+    translator, so no bridge-side emptiness judgement sees it.
+
+    Args:
+        fmt: The wire format to answer in.
+
+    Returns:
+        The SSE chunks, in order, each already terminated.
+
+    Raises:
+        ValueError: When ``fmt`` is not one of the two formats §7.2 assigns to
+            the primary recorder.
+    """
+    if fmt is WireFormat.ANTHROPIC_MESSAGES:
+        events = [
+            ("message_start", {
+                "type": "message_start",
+                "message": {
+                    "id": "msg_recorder", "type": "message", "role": "assistant",
+                    "model": "recorder-model", "content": [], "stop_reason": None,
+                    "usage": {"input_tokens": 1, "output_tokens": 1},
+                },
+            }),
+            ("content_block_start", {
+                "type": "content_block_start", "index": 0,
+                "content_block": {"type": "text", "text": ""},
+            }),
+            ("content_block_delta", {
+                "type": "content_block_delta", "index": 0,
+                "delta": {"type": "text_delta", "text": _REPLY_TEXT},
+            }),
+            ("content_block_stop", {"type": "content_block_stop", "index": 0}),
+            ("message_delta", {
+                "type": "message_delta",
+                "delta": {"stop_reason": "end_turn", "stop_sequence": None},
+                "usage": {"output_tokens": 1},
+            }),
+            ("message_stop", {"type": "message_stop"}),
+        ]
+        return tuple(
+            f"event: {name}\ndata: {json.dumps(payload)}\n\n".encode() for name, payload in events
+        )
+
+    if fmt is WireFormat.CHAT_COMPLETIONS:
+        chunks = [
+            {
+                "id": "chatcmpl-recorder", "object": "chat.completion.chunk", "created": 0,
+                "model": "recorder-model",
+                "choices": [{"index": 0, "delta": {"role": "assistant", "content": _REPLY_TEXT},
+                             "finish_reason": None}],
+            },
+            {
+                "id": "chatcmpl-recorder", "object": "chat.completion.chunk", "created": 0,
+                "model": "recorder-model",
+                "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+            },
+        ]
+        return tuple(f"data: {json.dumps(chunk)}\n\n".encode() for chunk in chunks) + (
+            b"data: [DONE]\n\n",
+        )
+
+    raise ValueError(f"the primary recorder serves {sorted(f.value for f in _SERVED_FORMATS)}, not {fmt.value}")
+
+
+def _wants_stream(body: bytes) -> bool:
+    """Return whether the request asked for a streamed reply.
+
+    Args:
+        body: The raw request body.
+
+    Returns:
+        True when the body is JSON with ``"stream": true``. A body that will not
+        parse is not an error here — see :meth:`RecordingUpstream._format_for`.
+    """
+    try:
+        parsed = json.loads(body)
+    except (ValueError, UnicodeDecodeError):
+        return False
+    return isinstance(parsed, dict) and parsed.get("stream") is True
+
+
+@dataclass
+class RecordingUpstream:
+    """An HTTP server that records what reaches it and replies with a success.
+
+    Bind it, point a bridge at :attr:`base_url`, then read :attr:`requests` and
+    :attr:`connections`.
+
+    One instance per test. A shared instance mixes captures across tests, and
+    the ordering claim in the conformance suite is only meaningful per-instance.
+
+    Attributes:
+        default_format: The format used when a request's path matches no suffix.
+            Required, with no implicit default: choosing one silently is how a
+            wrong-format reply reaches a bridge, and that failure is not loud —
+            the adapter parses nothing, the reply reads as empty, and the test
+            pays the retry ladder.
+        host: The bind address. Loopback is correct here and for T-W8; it is
+            **not** a containment decision. §5.3 requires the sealed-network
+            harness to address the upstream by a non-loopback name, and T-E2
+            supplies that name and the per-transport resolver override.
+        responder: What to reply with. Defaults to the minimal success.
+        requests: Captures, in arrival order.
+        connections: One :class:`ConnectionRecord` per accepted connection.
+        unmatched: Paths that fell through to :attr:`default_format`.
+    """
+
+    default_format: WireFormat
+    host: str = "127.0.0.1"
+    responder: Responder | None = None
+    connections: list[ConnectionRecord] = field(default_factory=list)
+    unmatched: list[str] = field(default_factory=list)
+    #: Arrival-ordered slots. A slot is reserved at handler entry and filled
+    #: once the body has been read, so that a short request cannot overtake a
+    #: long one in the published order. A slot whose request never completed --
+    #: a client that disconnected mid-body, which section 6.3.1 injects
+    #: deliberately -- keeps its sentinel and is filtered out by
+    #: :attr:`requests`; publishing it would put a request that never happened
+    #: into the evidence every oracle reads.
+    _slots: list[CapturedRequest] = field(default_factory=list, repr=False)
+
+    #: The `web.Server` subclass to bind. A seam so a deliberately defective
+    #: recorder can supply its own without patching a module global across an
+    #: await -- which would leak the defect into any other recorder started
+    #: concurrently on the same loop.
+    _server_class: ClassVar[type[web.Server]]
+
+    _runner: web.ServerRunner | None = field(default=None, init=False, repr=False)
+    _port: int = field(default=0, init=False, repr=False)
+    #: Connection id per ``RequestHandler``, keyed on the **object** and held for
+    #: the recorder's lifetime. Never on ``id(handler)``: CPython reuses
+    #: addresses after collection, so an id-keyed map that forgot entries could
+    #: attribute a later connection's request to an earlier connection — which is
+    #: the port-reuse failure R1.10 exists to eliminate, reintroduced one level
+    #: down. A ``WeakKeyDictionary`` is not an option either: ``RequestHandler``
+    #: omits ``__weakref__`` from ``__slots__``, so it cannot be weakly
+    #: referenced (verified). The strong reference is bounded by this recorder
+    #: being per-test.
+    _by_handler: dict[Any, int] = field(default_factory=dict, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        """Reject a format this recorder does not serve.
+
+        Raises:
+            ValueError: When ``default_format`` is outside the two §7.2 assigns
+                to the primary recorder. Failing at construction beats replying
+                in a format no adapter asked for.
+        """
+        if self.default_format not in _SERVED_FORMATS:
+            raise ValueError(
+                f"the primary recorder serves "
+                f"{sorted(f.value for f in _SERVED_FORMATS)}, not {self.default_format.value}"
+            )
+
+    # -- lifecycle ---------------------------------------------------------
+
+    async def start(self) -> None:
+        """Bind an ephemeral port and begin accepting.
+
+        Raises:
+            RuntimeError: When called on an already-started recorder.
+        """
+        if self._runner is not None:
+            raise RuntimeError("recorder already started")
+
+        server = self._server_class(
+            self._handle,
+            recorder=self,
+            auto_decompress=False,
+            request_factory=_request_factory,
+        )
+        self._runner = web.ServerRunner(server)
+        await self._runner.setup()
+        site = web.TCPSite(self._runner, self.host, 0)
+        await site.start()
+        # Port 0 means the kernel chose one. `BaseRunner.addresses` is the
+        # public way to read it back; the socket underneath is not.
+        self._port = int(self._runner.addresses[0][1])
+
+    async def stop(self) -> None:
+        """Stop accepting and release the port."""
+        if self._runner is not None:
+            await self._runner.cleanup()
+            self._runner = None
+
+    async def __aenter__(self) -> RecordingUpstream:
+        """Start the recorder.
+
+        Returns:
+            The started recorder.
+        """
+        await self.start()
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        """Stop the recorder.
+
+        Args:
+            *exc: The exception triple, unused; the port is released either way.
+        """
+        await self.stop()
+
+    # -- addressing --------------------------------------------------------
+
+    @property
+    def requests(self) -> list[CapturedRequest]:
+        """Return the completed captures, in arrival order.
+
+        A slot reserved for a request that never finished — a client that
+        disconnected mid-body, which §6.3.1 injects at four points — is not
+        published. Publishing it would put a request that never happened into
+        the evidence every oracle reads, beside real ones, and the failure would
+        surface as a confusing "capture nobody sent" rather than as a disconnect.
+
+        Returns:
+            The captures whose requests completed.
+        """
+        return [c for c in self._slots if c is not _PENDING]
+
+    @property
+    def port(self) -> int:
+        """Return the bound port.
+
+        Returns:
+            The ephemeral port chosen by the kernel.
+
+        Raises:
+            RuntimeError: When the recorder has not been started.
+        """
+        if self._runner is None:
+            raise RuntimeError("recorder is not running; call start() first")
+        return self._port
+
+    @property
+    def scheme(self) -> str:
+        """Return the scheme this recorder serves.
+
+        Returns:
+            ``"http"``. Declared rather than assumed by the conformance suite,
+            because §7.2's curl_cffi recorder terminates TLS.
+        """
+        return "http"
+
+    @property
+    def base_url(self) -> str:
+        """Return the URL a provider adapter should be pointed at.
+
+        Returns:
+            The scheme, host and port, with no trailing slash.
+        """
+        return f"{self.scheme}://{self.host}:{self.port}"
+
+    # -- assertions --------------------------------------------------------
+
+    def assert_all_paths_matched(self) -> None:
+        """Fail when any request was answered in the fallback format.
+
+        Raises:
+            UnmatchedPathError: When at least one path matched no suffix. Call
+                this at teardown; a test that means to exercise the fallback
+                clears :attr:`unmatched` instead.
+        """
+        if self.unmatched:
+            raise UnmatchedPathError(
+                f"answered in the fallback format {self.default_format.value} for "
+                f"{self.unmatched}; the reply may be the wrong shape, and a "
+                "wrong-shaped reply reads as an empty response rather than an error"
+            )
+
+    # -- request handling --------------------------------------------------
+
+    def _format_for(self, path: str) -> WireFormat:
+        """Return the wire format to answer a request at ``path`` in.
+
+        Dispatches on the path because that is what a real provider does, and
+        because bodies do not always distinguish the formats. Note this decides
+        only what the recorder *replies*; the oracle still selects projections
+        by the shape observed on the wire (§3.3.4), and nothing may route this
+        decision into it.
+
+        Args:
+            path: The request's raw path.
+
+        Returns:
+            The matched format, or :attr:`default_format` — recording the miss.
+        """
+        for suffix, fmt in _FORMAT_SUFFIXES:
+            if path.endswith(suffix):
+                return fmt
+        self.unmatched.append(path)
+        return self.default_format
+
+    async def _handle(self, request: web.BaseRequest) -> web.StreamResponse:
+        """Record one request and reply to it.
+
+        Args:
+            request: The inbound aiohttp request.
+
+        Returns:
+            The response, already prepared and written by the responder.
+        """
+        # Stamp arrival and reserve the slot before anything can await. Reading
+        # the body first would let a short later request overtake a long earlier
+        # one, and the recorded order would stop being the arrival order.
+        arrival = time.monotonic()
+        index = len(self._slots)
+        self._slots.append(_PENDING)
+
+        connection_id = self._by_handler.get(request.protocol, -1)
+        if 0 <= connection_id < len(self.connections):
+            existing = self.connections[connection_id]
+            self.connections[connection_id] = ConnectionRecord(
+                existing.connection_id, existing.peer_port, existing.requests + 1
+            )
+
+        body = await request.read()
+        captured = self.capture(request, body, arrival)
+        self.store(index, captured)
+
+        response = Reply(request)
+        responder = self.responder or self._default_responder
+        await responder(captured, response)
+        return response
+
+    def capture(
+        self, request: web.BaseRequest, body: bytes, arrival: float
+    ) -> CapturedRequest:
+        """Build the record of one request.
+
+        The single point where an observation becomes evidence, and therefore
+        the single point a **defective** recorder has to override. The
+        falsification suite subclasses this and nothing else, so a deliberate
+        defect in what is captured cannot disturb the connection log or the
+        recorded ordering — which is what lets each defect be attributed to one
+        conformance check.
+
+        Args:
+            request: The inbound aiohttp request.
+            body: The entity body, already read.
+            arrival: The timestamp taken at handler entry.
+
+        Returns:
+            The capture.
+        """
+        return CapturedRequest(
+            method=request.method,
+            scheme=self.scheme,
+            # Read the authority out of the headers. `request.host` falls back
+            # to `socket.getfqdn()` when the client sent no Host, inventing the
+            # machine's own name — and that fallback differs across the versions
+            # pyproject allows.
+            host=_host_header(request.raw_headers),
+            # `rel_url.raw_path` / `raw_query_string`, never `path` /
+            # `query_string`: the latter are percent-decoded.
+            path=str(request.rel_url.raw_path),
+            query=request.rel_url.raw_query_string,
+            headers=_decode_headers(request.raw_headers),
+            body=body,
+            arrival=arrival,
+            peer_port=_peer_port(request),
+        )
+
+    def store(self, index: int, captured: CapturedRequest) -> None:
+        """File a capture in the slot reserved for it at handler entry.
+
+        Separate from :meth:`capture` so that an ordering defect and a capture
+        defect are distinct overrides, and so neither can be mistaken for the
+        other when the falsification suite attributes a failure.
+
+        Args:
+            index: The slot reserved when the request arrived.
+            captured: The capture to file.
+        """
+        self._slots[index] = captured
+
+    async def _default_responder(
+        self, captured: CapturedRequest, response: Reply
+    ) -> None:
+        """Reply with the minimal success for the request's format.
+
+        Args:
+            captured: The recorded request.
+            response: The unprepared response to write through.
+        """
+        fmt = self._format_for(captured.path)
+
+        if _wants_stream(captured.body):
+            await response.begin(200, {"Content-Type": "text/event-stream"})
+            for chunk in minimal_success_stream(fmt):
+                await response.write(chunk)
+            await response.write_eof()
+            return
+
+        payload = json.dumps(minimal_success_body(fmt)).encode()
+        response.content_length = len(payload)
+        await response.begin(200, {"Content-Type": "application/json"})
+        await response.write(payload)
+        await response.write_eof()
+
+
+#: Placeholder occupying a request's slot between arrival and the body being
+#: read. It is always overwritten before `_handle` returns; it exists so the
+#: recorded order is arrival order even when two requests overlap.
+_PENDING = CapturedRequest(method="", scheme="", host="", path="", query="")
+
+
+def _request_factory(
+    message: Any, payload: Any, protocol: Any, writer: Any, task: Any
+) -> web.BaseRequest:
+    """Build a request with the body ceiling disabled.
+
+    ``client_max_size`` is a ``BaseRequest`` argument, not a ``Server`` one;
+    passing it to ``web.Server`` forwards it to ``RequestHandler``, which does
+    not accept it, and the only symptom is a connection reset at the client.
+
+    Args:
+        message: The parsed request line and headers.
+        payload: The body stream.
+        protocol: The owning ``RequestHandler``.
+        writer: The payload writer.
+        task: The handler task.
+
+    Returns:
+        The request, with no size ceiling.
+    """
+    return web.BaseRequest(
+        message, payload, protocol, writer, task, protocol._loop,
+        client_max_size=_CLIENT_MAX_SIZE,
+    )
+
+
+class _ConnectionLoggingServer(web.Server):
+    """A ``web.Server`` that records every connection it accepts.
+
+    Overriding ``Server.connection_made`` is the only public way to see a
+    connection that carries **no** request — §5.2.1's bypass shape. Wrapping the
+    ``RequestHandler`` is not an option: it defines ``__slots__``, so assigning
+    to ``proto.connection_made`` raises ``AttributeError`` inside the protocol
+    factory, and the client sees only a connection reset.
+
+    A caveat worth stating where the next reader will find it: with a
+    TLS-terminating site this fires **after** the handshake, so a connection
+    that fails negotiation is not logged. §5.2.1 names a failed TLS negotiation
+    as a real bypass, so T-B2 and T-E2 must observe at socket level or accept
+    the limitation explicitly.
+    """
+
+    def __init__(self, handler: Any, *, recorder: RecordingUpstream, **kwargs: Any) -> None:
+        """Bind the server to the recorder it logs into.
+
+        Args:
+            handler: The request handler coroutine.
+            recorder: The recorder owning the connection log.
+            **kwargs: Forwarded to ``web.Server``.
+        """
+        super().__init__(handler, **kwargs)
+        self._recorder = recorder
+
+    def connection_made(self, handler: Any, transport: Any) -> None:
+        """Log the accepted connection, then hand off to aiohttp.
+
+        Args:
+            handler: The ``RequestHandler`` serving this connection; its
+                identity is the connection's key, because ``BaseRequest.protocol``
+                is the same object and a peer port is not unique over time.
+            transport: The connection's transport.
+        """
+        peer = transport.get_extra_info("peername")
+        connection_id = len(self._recorder.connections)
+        self._recorder.connections.append(
+            ConnectionRecord(connection_id, peer[1] if peer else -1)
+        )
+        self._recorder._by_handler[handler] = connection_id
+        super().connection_made(handler, transport)
+
+
+def _decode_headers(raw: Sequence[tuple[bytes, bytes]]) -> tuple[tuple[str, str], ...]:
+    """Decode aiohttp's raw header bytes, preserving casing, order and repeats.
+
+    ``latin-1`` rather than ``utf-8``: header values may carry obs-text, which
+    ``utf-8`` refuses and ``latin-1`` never does, and T-W2's contract types the
+    field ``str``. A decode error here would be a capture that fails rather than
+    a capture that lies, but it would still lose the evidence.
+
+    Args:
+        raw: ``request.raw_headers``.
+
+    Returns:
+        The pairs, untouched but for the decode.
+    """
+    return tuple((name.decode("latin-1"), value.decode("latin-1")) for name, value in raw)
+
+
+def _host_header(raw: Sequence[tuple[bytes, bytes]]) -> str:
+    """Return the ``Host`` header as sent, or ``""`` when it was not sent.
+
+    Args:
+        raw: ``request.raw_headers``.
+
+    Returns:
+        The first ``Host`` value with its original casing, or the empty string.
+    """
+    for name, value in raw:
+        if name.lower() == b"host":
+            return value.decode("latin-1")
+    return ""
+
+
+def _peer_port(request: web.BaseRequest) -> int | None:
+    """Return the peer port of the connection this request arrived on.
+
+    Args:
+        request: The inbound request.
+
+    Returns:
+        The port, or ``None`` when the transport is already gone.
+    """
+    transport = request.transport
+    if transport is None:
+        return None
+    peer = transport.get_extra_info("peername")
+    return peer[1] if peer else None
+
+
+class Reply(web.StreamResponse):
+    """A response that knows the request it answers.
+
+    ``StreamResponse.prepare`` needs the request, and ``_req`` is only set *by*
+    ``prepare`` — so a responder handed a bare ``StreamResponse`` has no way to
+    start writing. Carrying the request on the response keeps the hook's
+    signature to two arguments while leaving it full control of status, headers,
+    body and abort.
+
+    Attributes:
+        request: The request being answered.
+    """
+
+    def __init__(self, request: web.BaseRequest) -> None:
+        """Bind the response to its request.
+
+        Args:
+            request: The request being answered.
+        """
+        super().__init__()
+        self.request = request
+
+    async def begin(self, status: int = 200, headers: Mapping[str, str] | None = None) -> None:
+        """Send the status line and headers, opening the body for writing.
+
+        Args:
+            status: The HTTP status to send.
+            headers: Response headers, if any.
+        """
+        self.set_status(status)
+        for name, value in (headers or {}).items():
+            self.headers[name] = value
+        await self.prepare(self.request)
+
+    async def abort(self) -> None:
+        """Drop the connection without finishing the response.
+
+        §6.3.1 injects a disconnect at four points, one of them part-way through
+        a stream. T-B4 builds those on this.
+        """
+        transport = self.request.transport
+        if transport is not None:
+            transport.abort()
+
+
+# Bound after the class is defined, because the server subclass needs to refer
+# to `RecordingUpstream` in its own annotations.
+RecordingUpstream._server_class = _ConnectionLoggingServer

--- a/tests/harness/recorder.py
+++ b/tests/harness/recorder.py
@@ -503,13 +503,17 @@ class RecordingUpstream:
         self._slots.append(_PENDING)
 
         connection_id = self._by_handler.get(request.protocol, -1)
-        if 0 <= connection_id < len(self.connections):
-            existing = self.connections[connection_id]
-            self.connections[connection_id] = ConnectionRecord(
-                existing.connection_id, existing.peer_port, existing.requests + 1
-            )
 
+        # Read the body before counting it. A client that disconnects mid-body
+        # leaves its slot unfilled and therefore out of `requests` -- so counting
+        # at handler entry would leave the connection log claiming a request the
+        # request list does not have, and `check_connection_logged`'s
+        # `carried == len(sent)` half would fail for a disconnect rather than for
+        # a defect. Section 6.3.1 injects exactly that disconnect at four points.
         body = await request.read()
+
+        self.count_on_connection(connection_id)
+
         captured = self.capture(request, body, arrival)
         self.store(index, captured)
 
@@ -517,6 +521,29 @@ class RecordingUpstream:
         responder = self.responder or self._default_responder
         await responder(captured, response)
         return response
+
+    def count_on_connection(self, connection_id: int) -> None:
+        """Attribute one completed request to the connection that carried it.
+
+        The second half of R1.10: §4.3 C5 counts distinct connections, and a
+        capture has to be attributable to one of them. A seam of its own, beside
+        :meth:`capture` and :meth:`store`, so a falsification recorder can
+        miscount without also disturbing what was captured or where it was
+        filed.
+
+        Args:
+            connection_id: The connection's id, or a negative value when the
+                connection is already gone.
+        """
+        if not 0 <= connection_id < len(self.connections):
+            return
+
+        existing = self.connections[connection_id]
+        # Read-modify-write with no `await` between the read and the write, so
+        # the event loop cannot interleave another handler here.
+        self.connections[connection_id] = ConnectionRecord(
+            existing.connection_id, existing.peer_port, existing.requests + 1
+        )
 
     def capture(
         self, request: web.BaseRequest, body: bytes, arrival: float

--- a/tests/harness/recorder_conformance.py
+++ b/tests/harness/recorder_conformance.py
@@ -1,0 +1,893 @@
+"""What every recording upstream must do, and the driver that proves it.
+
+`.system_design/TEST_SUITE.md` §7.2 · plan task **T-W4** (KBR-27).
+
+§7.2 assigns one recorder per transport — four of them — and plan §5 says each
+"must pass T-W4's conformance test". This module is that test, expressed as
+**pure functions over data** so that every one of them can be handed a
+deliberately wrong :class:`~harness.contract.CapturedRequest` and asked whether
+it notices. Plan §1.4 makes that mandatory, not stylistic.
+
+**Why a raw socket and not a client library.**  A client library reorders,
+re-cases, adds and drops headers; aiohttp's client does several of those. A test
+that sends through one cannot distinguish a recorder that *loses* casing from a
+client that never *sent* mixed casing. The same reasoning is what makes this
+driver shared rather than per-recorder: botocore's SigV4 canonicalises the path
+and owns the header set, and curl injects ``Host``, ``Accept``, ``User-Agent``
+and ``Expect: 100-continue`` — so a conformance check driven through either
+library would assert only that the recorder captured whatever the library chose
+to send, which is equally true of a recorder that lower-cases everything the
+library had already lower-cased. All four recorders in §7.2 are HTTP servers the
+harness itself runs; TLS is the only difference, and an
+:class:`ssl.SSLContext` covers it.
+
+**Captures are correlated to sends by a marker, never by position.**  Order is
+then a separate assertion (:func:`check_request_order`) instead of an assumption
+baked into the other thirteen checks. Without that, a recorder that merely
+*reorders* its list would fail every per-exchange check as well, and the
+falsification suite could not say which defect it had caught.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+import ssl
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+from harness.contract import CapturedRequest
+
+__all__ = [
+    "SentRequest",
+    "Recording",
+    "send_raw",
+    "send",
+    "open_only",
+    "open_connection_only",
+    "correlate",
+    "marker_of",
+    "MARKER_HEADER",
+    "recording_of",
+    "probe",
+    "RICH_PROBE",
+    "RICH_BODY",
+    "NO_HOST_PROBE",
+    "LATIN_PROBE",
+    "LATIN_BODY",
+    "PER_EXCHANGE_CHECKS",
+    "PER_SESSION_CHECKS",
+    "CHECK_NAMES",
+    "check_method",
+    "check_scheme",
+    "check_host",
+    "check_path",
+    "check_query",
+    "check_body",
+    "check_header_casing",
+    "check_header_order",
+    "check_header_duplicates",
+    "check_peer_port",
+    "check_arrival_increases",
+    "check_request_order",
+    "check_request_count",
+    "check_connection_logged",
+]
+
+#: How long the driver waits on a probe before giving up. A hung probe must fail
+#: fast and loudly: these tests run in the `l1` gate, where a socket that never
+#: answers would otherwise stall the job rather than fail it.
+PROBE_TIMEOUT = 5.0
+
+#: The header every probe request carries its correlation marker in. See
+#: :func:`marker_of` for why it must be a header and nothing else.
+MARKER_HEADER = "X-Probe-Marker"
+
+
+@dataclass(frozen=True)
+class SentRequest:
+    """Exactly what the driver put on the wire, and what it can be read as.
+
+    Every field but :attr:`raw` and :attr:`source_port` is **derived from**
+    :attr:`raw` by :func:`_parse_sent`, never declared alongside it. A driver
+    that reported what it *intended* to send rather than what it actually wrote
+    is the classic harness lie — all fourteen checks compare a capture against
+    this object, so a discrepancy between intent and wire would be invisible in
+    every one of them.
+
+    Attributes:
+        raw: The bytes written to the socket, in full.
+        source_port: The driver socket's own port, which a conforming recorder
+            reports as :attr:`~harness.contract.CapturedRequest.peer_port`.
+        marker: The unique value identifying this request among a probe's
+            several, used to correlate captures to sends without relying on
+            position.
+        method: The request method, parsed from :attr:`raw`.
+        path: The target's path component.
+        query: The target's query component, ``""`` when absent.
+        headers: Header pairs in wire order, casing and duplicates preserved,
+            decoded ``latin-1``.
+        body: The entity body.
+    """
+
+    raw: bytes
+    source_port: int
+    marker: str
+    method: str
+    path: str
+    query: str
+    headers: tuple[tuple[str, str], ...]
+    body: bytes
+
+    def header(self, name: str) -> str | None:
+        """Return the first value for ``name``, matched case-insensitively.
+
+        Args:
+            name: The header name to look for.
+
+        Returns:
+            The value, or ``None`` when the header was not sent.
+        """
+        lowered = name.lower()
+        for sent_name, value in self.headers:
+            if sent_name.lower() == lowered:
+                return value
+        return None
+
+
+@dataclass
+class Recording:
+    """What a recorder observed during one probe session.
+
+    The two lists are separate because §5.2.1 needs them to be: a bypass that
+    opens a TCP connection and sends no HTTP request at all is invisible in
+    :attr:`requests`, and that connection is *"the only thing this assertion
+    needs to catch"*.
+
+    Attributes:
+        requests: Captures, in the order the recorder recorded them.
+        connections: One entry per accepted connection, as
+            ``(connection_id, peer_port, carried_requests)``.
+    """
+
+    requests: list[CapturedRequest] = field(default_factory=list)
+    connections: list[tuple[int, int, int]] = field(default_factory=list)
+
+
+def _parse_sent(raw: bytes, source_port: int, marker: str) -> SentRequest:
+    """Read back the bytes the driver wrote, as a recorder should read them.
+
+    Deliberately a hand-written parser rather than a call into any HTTP library:
+    this is the reference the recorder is judged against, so it must not share
+    an implementation — or a bug — with the thing under test.
+
+    Args:
+        raw: The exact bytes written to the socket.
+        source_port: The driver socket's own port.
+        marker: The correlation marker carried by this request.
+
+    Returns:
+        The parsed :class:`SentRequest`.
+
+    Raises:
+        ValueError: When ``raw`` is not a well-formed HTTP/1.x request. The
+            driver builds these bytes itself, so this is a defect in the probe,
+            never in the recorder.
+    """
+    head, separator, body = raw.partition(b"\r\n\r\n")
+    if not separator:
+        raise ValueError("probe bytes contain no header terminator")
+
+    lines = head.split(b"\r\n")
+    request_line = lines[0].decode("latin-1")
+    try:
+        method, target, _version = request_line.split(" ", 2)
+    except ValueError as exc:
+        raise ValueError(f"malformed request line: {request_line!r}") from exc
+
+    # latin-1 throughout: header bytes may carry obs-text that utf-8 refuses,
+    # and the contract's `headers` field is typed `str`.
+    headers: list[tuple[str, str]] = []
+    for line in lines[1:]:
+        name, header_separator, value = line.decode("latin-1").partition(":")
+        if not header_separator:
+            raise ValueError(f"malformed header line: {line!r}")
+        headers.append((name, value.lstrip(" ")))
+
+    path, _, query = target.partition("?")
+    return SentRequest(
+        raw=raw,
+        source_port=source_port,
+        marker=marker,
+        method=method,
+        path=path,
+        query=query,
+        headers=tuple(headers),
+        body=body,
+    )
+
+
+def send_raw(
+    host: str,
+    port: int,
+    raw: bytes,
+    *,
+    marker: str,
+    ssl_context: ssl.SSLContext | None = None,
+) -> SentRequest:
+    """Write ``raw`` to a recorder and report what was written.
+
+    Args:
+        host: The recorder's bind address.
+        port: The recorder's listening port.
+        raw: The complete request bytes, headers and body.
+        marker: The unique value identifying this request within a probe.
+        ssl_context: Wraps the socket when given, which is how the same driver
+            reaches T-B2's TLS-terminating recorder (§7.2).
+
+    Returns:
+        The :class:`SentRequest`, carrying the socket's own source port.
+    """
+    sock = socket.create_connection((host, port), timeout=PROBE_TIMEOUT)
+    try:
+        if ssl_context is not None:
+            sock = ssl_context.wrap_socket(sock, server_hostname=host)
+        # Read the source port from the socket itself. Under TLS this must come
+        # after the wrap, because `wrap_socket` returns a different object.
+        source_port = sock.getsockname()[1]
+        sock.sendall(raw)
+        # Wait for the reply before closing: it is the only signal that the
+        # recorder has finished handling the request, so the capture is
+        # guaranteed to exist by the time this returns.
+        _drain(sock)
+    finally:
+        sock.close()
+
+    return _parse_sent(raw, source_port, marker)
+
+
+async def send(
+    host: str,
+    port: int,
+    raw: bytes,
+    *,
+    marker: str,
+    ssl_context: ssl.SSLContext | None = None,
+) -> SentRequest:
+    """Send a probe from a worker thread, so the recorder can serve it.
+
+    :func:`send_raw` uses blocking sockets, and a recorder under test runs on
+    the **same event loop** as the test that drives it. Calling it inline would
+    block that loop for the whole exchange: the server could never accept the
+    connection, the read would time out, and the recording would come back empty
+    — a failure that looks like a broken recorder rather than a broken probe.
+
+    Args:
+        host: The recorder's bind address.
+        port: The recorder's listening port.
+        raw: The complete request bytes.
+        marker: The unique value identifying this request within a probe.
+        ssl_context: Wraps the socket when given.
+
+    Returns:
+        The :class:`SentRequest`, carrying the socket's own source port.
+    """
+    return await asyncio.to_thread(
+        send_raw, host, port, raw, marker=marker, ssl_context=ssl_context,
+    )
+
+
+def open_only(host: str, port: int, *, ssl_context: ssl.SSLContext | None = None) -> int:
+    """Open a connection, send nothing, close it, and report its source port.
+
+    This is §5.2.1's bypass shape as a probe. It produces no
+    :class:`SentRequest`, because nothing was sent — which is precisely why
+    :func:`check_connection_logged` takes the opened ports separately.
+
+    Args:
+        host: The recorder's bind address.
+        port: The recorder's listening port.
+        ssl_context: Wraps the socket when given.
+
+    Returns:
+        The source port of the connection that was opened.
+    """
+    sock = socket.create_connection((host, port), timeout=PROBE_TIMEOUT)
+    try:
+        if ssl_context is not None:
+            sock = ssl_context.wrap_socket(sock, server_hostname=host)
+        return int(sock.getsockname()[1])
+    finally:
+        sock.close()
+
+
+async def open_connection_only(
+    host: str, port: int, *, ssl_context: ssl.SSLContext | None = None
+) -> int:
+    """Open a silent connection from a worker thread.
+
+    Args:
+        host: The recorder's bind address.
+        port: The recorder's listening port.
+        ssl_context: Wraps the socket when given.
+
+    Returns:
+        The source port of the connection that was opened.
+    """
+    return await asyncio.to_thread(open_only, host, port, ssl_context=ssl_context)
+
+
+def _drain(sock: socket.socket) -> bytes:
+    """Read one chunk of the reply, or give up at the timeout.
+
+    Args:
+        sock: The connected socket.
+
+    Deliberately **not** a read to end-of-connection: aiohttp holds a
+    connection open for ``keepalive_timeout`` (3630 seconds by default), so
+    reading to EOF would stall for the socket timeout on every probe.
+
+    Returns:
+        Whatever arrived; the content is not inspected, because what the
+        recorder *replies* is the script's business and not a conformance
+        property.
+    """
+    chunks: list[bytes] = []
+    try:
+        while True:
+            chunk = sock.recv(65536)
+            if not chunk:
+                break
+            chunks.append(chunk)
+            # One read is enough to know the recorder answered. Looping to EOF
+            # would block for the whole keep-alive timeout on a connection the
+            # recorder is entitled to hold open.
+            break
+    except (TimeoutError, OSError):
+        pass
+    return b"".join(chunks)
+
+
+def recording_of(upstream: Any) -> Recording:
+    """Adapt a recorder's own observations to what the checks read.
+
+    Duck-typed on ``requests`` and ``connections`` rather than typed against
+    :class:`~harness.recorder.RecordingUpstream`, so this module stays free of
+    any particular recorder — T-B1, T-B2 and T-B3 each bring their own and all
+    four are judged here.
+
+    Args:
+        upstream: Any recorder exposing ``requests`` and ``connections``.
+
+    Returns:
+        The :class:`Recording` the checks consume.
+    """
+    return Recording(
+        requests=list(upstream.requests),
+        connections=[(c.connection_id, c.peer_port, c.requests) for c in upstream.connections],
+    )
+
+
+def probe(marker: str, *, path: str = "/v1/chat/completions", body: bytes = b"{}") -> bytes:
+    """Build a plain, well-formed probe request.
+
+    Args:
+        marker: The correlation marker; travels in a header, because every other
+            location is destroyed by one of the falsification defects.
+        path: The request target.
+        body: The entity body.
+
+    Returns:
+        The complete request bytes.
+    """
+    return (
+        f"POST {path} HTTP/1.1\r\n"
+        f"Host: upstream.test\r\n"
+        f"{MARKER_HEADER}: {marker}\r\n"
+        f"Content-Length: {len(body)}\r\n"
+        f"\r\n"
+    ).encode() + body
+
+
+#: The body of :data:`RICH_PROBE`. Non-ASCII so a recorder that round-trips the
+#: body through ``str`` has something to lose.
+RICH_BODY = b'{"stream": false, "note": "\xc2\xa0"}'
+
+#: The probe every per-exchange check is run against: mixed header casing, a
+#: duplicated header, an obs-text value that ``utf-8`` would refuse, a
+#: percent-encoded path whose two escapes differ in case, and a query that is
+#: neither sorted nor decodable without changing it.
+#:
+#: The path ends in ``/chat/completions`` deliberately. The encoded segments are
+#: what :func:`check_path` reads; the *suffix* is what the recorder dispatches
+#: on, and a probe that matched no suffix would silently exercise the
+#: wrong-format fallback in every test that used it.
+RICH_PROBE = (
+    b"POST /v1/mess%61ges/a%2Fb%2fc/chat/completions?Beta=A%20B&key=k&beta=c HTTP/1.1\r\n"
+    b"Host: Upstream.Example:443\r\n"
+    b"X-Api-Key: secret\r\n"
+    b"anthropic-version: 2023-06-01\r\n"
+    b"ANTHROPIC-BETA: one\r\n"
+    b"anthropic-beta: two\r\n"
+    b"X-Weird: caf\xe9\r\n"
+    b"X-Probe-Marker: rich\r\n"
+    b"Content-Length: " + str(len(RICH_BODY)).encode() + b"\r\n"
+    b"\r\n" + RICH_BODY
+)
+
+#: HTTP/1.0 with no ``Host`` header. The only probe on which a recorder reading
+#: aiohttp's ``request.host`` is distinguishable from a correct one.
+NO_HOST_PROBE = (
+    b"POST /v1/chat/completions HTTP/1.0\r\n"
+    b"X-Probe-Marker: nohost\r\n"
+    b"Content-Length: 2\r\n"
+    b"\r\n{}"
+)
+
+#: The body of :data:`LATIN_PROBE`, high bytes declared ``latin-1``.
+LATIN_BODY = b'{"n":"caf\xe9"}'
+
+#: A body that survives ``decode`` but not ``decode`` + ``encode("utf-8")``. The
+#: only probe on which a recorder recording ``request.text()`` re-encoded is
+#: distinguishable from a correct one — on valid UTF-8 that defect is a no-op,
+#: and on undeclared binary it raises instead of mis-capturing.
+LATIN_PROBE = (
+    b"POST /v1/chat/completions HTTP/1.1\r\n"
+    b"Host: h\r\n"
+    b"X-Probe-Marker: latin\r\n"
+    b"Content-Type: application/json; charset=latin-1\r\n"
+    b"Content-Length: " + str(len(LATIN_BODY)).encode() + b"\r\n"
+    b"\r\n" + LATIN_BODY
+)
+
+
+def marker_of(captured: CapturedRequest) -> str | None:
+    """Return the probe marker a capture carries, or ``None``.
+
+    The marker travels in a **header**, looked up case-insensitively and
+    compared on its *value*. Every other location is destroyed by one of the
+    defects the falsification suite deliberately introduces: a marker in the
+    query dies to the query-dropping and query-decoding defects, one in the path
+    dies to the path-decoding defect, and one in the body dies to the
+    re-encoding defect. Correlation would then fail with "no capture found"
+    instead of the named check failing — a check failing for the wrong reason,
+    which R4.2 exists to forbid.
+
+    Case-insensitive on the *name* so the name-lower-casing defect does not
+    break correlation either.
+
+    Args:
+        captured: A recorded request.
+
+    Returns:
+        The marker value, or ``None`` when the header is absent.
+    """
+    for name, value in captured.headers:
+        if name.lower() == MARKER_HEADER.lower():
+            return value
+    return None
+
+
+def correlate(recording: Recording, sent: SentRequest) -> CapturedRequest:
+    """Return the capture matching ``sent``, found by its marker header.
+
+    Args:
+        recording: What the recorder observed.
+        sent: The request to find.
+
+    Returns:
+        The single capture carrying ``sent``'s marker.
+
+    Raises:
+        AssertionError: When no capture, or more than one, carries the marker.
+            Matching by marker rather than by position is what keeps a
+            *reordering* defect from failing every per-exchange check as well as
+            the ordering one. Refusing an ambiguous match rather than taking the
+            first is what stops a request-duplicating recorder passing silently.
+    """
+    matches = [c for c in recording.requests if marker_of(c) == sent.marker]
+    assert len(matches) == 1, (
+        f"expected exactly one capture carrying marker {sent.marker!r}, found {len(matches)}"
+    )
+    return matches[0]
+
+
+# --------------------------------------------------------------------------
+# Per-exchange checks — one capture against the request that produced it
+# --------------------------------------------------------------------------
+
+
+def check_method(captured: CapturedRequest, sent: SentRequest, *, scheme: str) -> None:
+    """Assert the method survived.
+
+    Args:
+        captured: What the recorder recorded.
+        sent: What the driver wrote.
+        scheme: The scheme the recorder declares it serves; unused here, present
+            so every per-exchange check shares one signature.
+
+    Raises:
+        AssertionError: When the recorded method differs from the one sent.
+    """
+    assert captured.method == sent.method, (
+        f"method: recorded {captured.method!r}, sent {sent.method!r}"
+    )
+
+
+def check_scheme(captured: CapturedRequest, sent: SentRequest, *, scheme: str) -> None:
+    """Assert the scheme matches the one the recorder declares it serves.
+
+    Compared against a declared value rather than a literal ``"http"``: §7.2's
+    curl_cffi recorder terminates TLS, so a literal would fail T-B2 on the day
+    it is written.
+
+    Args:
+        captured: What the recorder recorded.
+        sent: What the driver wrote; unused.
+        scheme: The scheme the recorder declares it serves.
+
+    Raises:
+        AssertionError: When the recorded scheme differs.
+    """
+    assert captured.scheme == scheme, (
+        f"scheme: recorded {captured.scheme!r}, recorder declares {scheme!r}"
+    )
+
+
+def check_host(captured: CapturedRequest, sent: SentRequest, *, scheme: str) -> None:
+    """Assert the authority is the ``Host`` header as sent, or empty when absent.
+
+    A recorder reading aiohttp's ``request.host`` passes this on any probe that
+    sends a ``Host`` — and fabricates the machine's own FQDN on one that does
+    not, which is why the falsification suite aims this check at the no-``Host``
+    probe specifically.
+
+    Args:
+        captured: What the recorder recorded.
+        sent: What the driver wrote.
+        scheme: Unused.
+
+    Raises:
+        AssertionError: When the recorded host is not what was sent, or when a
+            host was invented for a request that carried no ``Host`` header.
+    """
+    expected = sent.header("Host") or ""
+    assert captured.host == expected, (
+        f"host: recorded {captured.host!r}, sent {expected!r}"
+        + ("; a host was invented for a request that sent none" if not expected else "")
+    )
+
+
+def check_path(captured: CapturedRequest, sent: SentRequest, *, scheme: str) -> None:
+    """Assert the path survived percent-encoded and un-normalised.
+
+    Args:
+        captured: What the recorder recorded.
+        sent: What the driver wrote.
+        scheme: Unused.
+
+    Raises:
+        AssertionError: When the recorded path differs from the one sent —
+            decoded, case-folded in its escapes, or re-split.
+    """
+    assert captured.path == sent.path, (
+        f"path: recorded {captured.path!r}, sent {sent.path!r}"
+    )
+
+
+def check_query(captured: CapturedRequest, sent: SentRequest, *, scheme: str) -> None:
+    """Assert the query string survived raw, unordered and unparsed.
+
+    Args:
+        captured: What the recorder recorded.
+        sent: What the driver wrote.
+        scheme: Unused.
+
+    Raises:
+        AssertionError: When the recorded query differs from the one sent.
+    """
+    assert captured.query == sent.query, (
+        f"query: recorded {captured.query!r}, sent {sent.query!r}"
+    )
+
+
+def check_body(captured: CapturedRequest, sent: SentRequest, *, scheme: str) -> None:
+    """Assert the entity body survived byte-for-byte.
+
+    Args:
+        captured: What the recorder recorded.
+        sent: What the driver wrote.
+        scheme: Unused.
+
+    Raises:
+        AssertionError: When the recorded body differs from the one sent.
+    """
+    assert captured.body == sent.body, (
+        f"body: recorded {captured.body!r}, sent {sent.body!r}"
+    )
+
+
+def check_header_casing(captured: CapturedRequest, sent: SentRequest, *, scheme: str) -> None:
+    """Assert every recorded header name is spelled as some sent name was.
+
+    §4.3 C1 asserts on the exact header set, so a recorder that normalises
+    casing destroys the evidence before the assertion runs.
+
+    **Containment, not equality** — deliberately. The three header checks have to
+    be orthogonal, or R4.2's "no other check fails" is unreachable: a recorder
+    that *drops* a duplicate would fail an equality-based casing check too, and
+    the falsification matrix could no longer say which defect was caught. Here,
+    dropping leaves every surviving spelling correct, so only
+    :func:`check_header_duplicates` fires.
+
+    Args:
+        captured: What the recorder recorded.
+        sent: What the driver wrote.
+        scheme: Unused.
+
+    Raises:
+        AssertionError: When a recorded name is spelled in a way nothing sent.
+    """
+    sent_spellings = {name for name, _ in sent.headers}
+    wrong = sorted({name for name, _ in captured.headers if name not in sent_spellings})
+    assert not wrong, (
+        f"header casing: recorded {wrong}, which no sent header is spelled as; "
+        f"sent {sorted(sent_spellings)}"
+    )
+
+
+def check_header_order(captured: CapturedRequest, sent: SentRequest, *, scheme: str) -> None:
+    """Assert headers kept their relative order.
+
+    Recorded for the C1b baseline report rather than asserted against a vendor
+    baseline (§7.2) — but a recorder that cannot preserve order cannot produce
+    that report at all.
+
+    **An order-preserving subsequence of the lower-cased names**, for the same
+    orthogonality reason as :func:`check_header_casing`: comparing the sequences
+    for equality would make this fire on a *dropped* header and on a *re-cased*
+    one as well as on a reordered one. Lower-casing here leaves casing entirely
+    to that check; allowing a subsequence leaves drops entirely to
+    :func:`check_header_duplicates`.
+
+    Args:
+        captured: What the recorder recorded.
+        sent: What the driver wrote.
+        scheme: Unused.
+
+    Raises:
+        AssertionError: When the recorded names are not in sent relative order.
+    """
+    recorded = [name.lower() for name, _ in captured.headers]
+    expected = [name.lower() for name, _ in sent.headers]
+
+    remaining = iter(expected)
+    in_order = all(any(candidate == name for candidate in remaining) for name in recorded)
+    assert in_order, f"header order: recorded {recorded} is not in the sent order {expected}"
+
+
+def check_header_duplicates(captured: CapturedRequest, sent: SentRequest, *, scheme: str) -> None:
+    """Assert each header name kept all its values, in order.
+
+    A mapping-shaped recorder loses exactly this: ``anthropic-beta`` sent twice
+    becomes one entry in a dict. Grouped by lower-cased name so that re-casing
+    and reordering — which this check must stay silent about — do not disturb
+    it.
+
+    Args:
+        captured: What the recorder recorded.
+        sent: What the driver wrote.
+        scheme: Unused.
+
+    Raises:
+        AssertionError: When any name's sequence of values differs from what was
+            sent.
+    """
+    recorded = _values_by_name(captured.headers)
+    expected = _values_by_name(sent.headers)
+    assert recorded == expected, (
+        f"header values per name: recorded {recorded}, sent {expected}"
+    )
+
+
+def _values_by_name(headers: Sequence[tuple[str, str]]) -> dict[str, list[str]]:
+    """Group header values by lower-cased name, preserving their order.
+
+    Args:
+        headers: Header pairs in wire order.
+
+    Returns:
+        A mapping from lower-cased name to its values, in the order they
+        appeared.
+    """
+    grouped: dict[str, list[str]] = {}
+    for name, value in headers:
+        grouped.setdefault(name.lower(), []).append(value)
+    return grouped
+
+
+def check_peer_port(captured: CapturedRequest, sent: SentRequest, *, scheme: str) -> None:
+    """Assert the peer port is the client's own, not the recorder's.
+
+    §5.2.1 joins the proxy's tunnel log on this value, so a recorder reporting
+    its own listening port produces a join that succeeds against the wrong
+    connection.
+
+    Args:
+        captured: What the recorder recorded.
+        sent: What the driver wrote.
+        scheme: Unused.
+
+    Raises:
+        AssertionError: When the recorded port is not the driver's source port.
+    """
+    assert captured.peer_port == sent.source_port, (
+        f"peer_port: recorded {captured.peer_port!r}, client sent from {sent.source_port!r}"
+    )
+
+
+# --------------------------------------------------------------------------
+# Per-session checks — the recording as a whole
+# --------------------------------------------------------------------------
+
+
+def check_arrival_increases(
+    recording: Recording, sent: Sequence[SentRequest], opened_ports: Sequence[int]
+) -> None:
+    """Assert ``arrival`` moves forward, and is stamped before the reply.
+
+    Driven against a probe whose responder is deliberately slow, so a recorder
+    that stamps ``arrival`` *after* producing the response cannot pass by luck.
+
+    **Arrivals are read in sent order, not in recorded order.** Walking the
+    recorded list would make this fire on a recorder whose only fault is
+    *appending out of order* — the defect :func:`check_request_order` owns — and
+    R4.2 would be unreachable for both.
+
+    Args:
+        recording: What the recorder observed.
+        sent: The requests that produced it, in the order they were sent.
+        opened_ports: Unused; present so all four session checks share one
+            signature and can be run from a single loop.
+
+    Raises:
+        AssertionError: When any timestamp is missing, not a float, or not
+            strictly greater than that of the request sent before it.
+    """
+    by_marker = {marker_of(c): c for c in recording.requests}
+    arrivals = [by_marker[s.marker].arrival for s in sent if s.marker in by_marker]
+
+    assert all(isinstance(a, float) for a in arrivals), f"arrival must be float, got {arrivals}"
+
+    for earlier, later in zip(arrivals, arrivals[1:], strict=False):
+        assert later is not None and earlier is not None and later > earlier, (
+            f"arrival must strictly increase in sent order; got {arrivals}. A constant "
+            "clock, or a timestamp taken after the response, produces this."
+        )
+
+
+def check_request_order(
+    recording: Recording, sent: Sequence[SentRequest], opened_ports: Sequence[int]
+) -> None:
+    """Assert the captures that exist are in the order they were sent.
+
+    Phrased over request **identity**, never over ``arrival``, and as an
+    order-preserving **subsequence** rather than an equality. Both choices exist
+    to keep R4.2 reachable: identity keeps a clock defect out of this check, and
+    subsequence keeps a *dropped* request out of it —
+    :func:`check_request_count` owns that one.
+
+    Args:
+        recording: What the recorder observed.
+        sent: The requests that produced it, in the order they were sent.
+        opened_ports: Unused; see :func:`check_arrival_increases`.
+
+    Raises:
+        AssertionError: When the recorded captures are not in sent relative
+            order.
+    """
+    recorded = [marker_of(c) for c in recording.requests]
+    expected = [s.marker for s in sent]
+
+    remaining = iter(expected)
+    in_order = all(any(candidate == marker for candidate in remaining) for marker in recorded)
+    assert in_order, f"request order: recorded {recorded} is not in the sent order {expected}"
+
+
+def check_request_count(
+    recording: Recording, sent: Sequence[SentRequest], opened_ports: Sequence[int]
+) -> None:
+    """Assert every request that was sent has a capture.
+
+    Phrased as coverage rather than as a length comparison, so a recorder that
+    merely *reorders* passes here and fails only
+    :func:`check_request_order`. A recorder that silently drops a request is
+    caught here and by nothing else — §4.3 C6's "``/healthz`` never causes an
+    upstream request" will lean on exactly this claim.
+
+    Args:
+        recording: What the recorder observed.
+        sent: The requests that produced it.
+        opened_ports: Unused; see :func:`check_arrival_increases`.
+
+    Raises:
+        AssertionError: When a sent request has no capture, or when the recorder
+            produced captures nobody sent.
+    """
+    recorded = [marker_of(c) for c in recording.requests]
+    missing = [s.marker for s in sent if s.marker not in recorded]
+    assert not missing, f"no capture for {missing}; recorded {recorded}"
+
+    unexpected = [m for m in recorded if m not in {s.marker for s in sent}]
+    assert not unexpected, f"recorded captures nobody sent: {unexpected}"
+
+
+def check_connection_logged(
+    recording: Recording, sent: Sequence[SentRequest], opened_ports: Sequence[int]
+) -> None:
+    """Assert every connection the driver opened was logged, requests or not.
+
+    §5.2.1's load-bearing negative is an upstream connection with no matching
+    tunnel — *"the only thing this assertion needs to catch"*. Such a connection
+    carries no HTTP request, so it is invisible in ``sent`` as well as in the
+    request list. **That is why this check needs ``opened_ports``**: judged
+    against ``sent`` alone it could only ever ask whether request-bearing
+    connections were logged, which is the one thing a lazily-logging recorder
+    gets right. An earlier version did exactly that and could not fail for the
+    defect it names.
+
+    Args:
+        recording: What the recorder observed.
+        sent: The requests that produced it.
+        opened_ports: Every source port the driver opened, including ones that
+            sent nothing.
+
+    Raises:
+        AssertionError: When a connection the driver opened has no record, or
+            when the records do not account for every request.
+    """
+    logged_ports = {peer_port for _, peer_port, _ in recording.connections}
+
+    unlogged = [port for port in opened_ports if port not in logged_ports]
+    assert not unlogged, (
+        f"connections opened but never logged: {unlogged}; logged {sorted(logged_ports)}. "
+        "A connection that carries no request is still a connection, and a bypass "
+        "looks exactly like one."
+    )
+
+    # Per-connection request counts are the other half of R1.10: a capture must
+    # be attributable to the connection that carried it.
+    carried = sum(count for _, _, count in recording.connections)
+    assert carried == len(sent), (
+        f"connection log accounts for {carried} requests, {len(sent)} were sent"
+    )
+
+
+#: The ten checks that judge one capture against the request that produced it.
+PER_EXCHANGE_CHECKS: tuple[Callable[..., None], ...] = (
+    check_method,
+    check_scheme,
+    check_host,
+    check_path,
+    check_query,
+    check_body,
+    check_header_casing,
+    check_header_order,
+    check_header_duplicates,
+    check_peer_port,
+)
+
+#: The four checks that judge a recording as a whole.
+PER_SESSION_CHECKS: tuple[Callable[..., None], ...] = (
+    check_arrival_increases,
+    check_request_order,
+    check_request_count,
+    check_connection_logged,
+)
+
+#: Every check by name, so a falsification case can name the one it must trip
+#: and the suite can assert the list is the fourteen the design specifies.
+CHECK_NAMES: tuple[str, ...] = tuple(
+    check.__name__ for check in PER_EXCHANGE_CHECKS + PER_SESSION_CHECKS
+)

--- a/tests/harness/test_recorder.py
+++ b/tests/harness/test_recorder.py
@@ -27,6 +27,7 @@ from pathlib import Path
 import pytest
 
 import harness.recorder as recorder_module
+import harness.recorder_conformance as conformance_module
 from harness.contract import CapturedRequest, WireFormat
 from harness.recorder import (
     RecordingUpstream,
@@ -40,6 +41,7 @@ from harness.recorder_conformance import (
     PER_EXCHANGE_CHECKS,
     PER_SESSION_CHECKS,
     RICH_PROBE,
+    check_connection_logged,
     correlate,
     probe,
     recording_of,
@@ -322,18 +324,26 @@ class TestCaptureFidelity:
             b"X-Probe-Marker: gone\r\nContent-Length: 50\r\n\r\nx"
         )
         sock = socket.create_connection((recorder.host, recorder.port))
+        aborted_port = sock.getsockname()[1]
         try:
             await asyncio.to_thread(sock.sendall, truncated)
             await _until(lambda: bool(recorder.connections), what="the connection to be accepted")
         finally:
             sock.close()
 
-        await send(recorder.host, recorder.port, probe("real"), marker="real")
+        sent = await send(recorder.host, recorder.port, probe("real"), marker="real")
 
         assert [c.path for c in recorder.requests] == ["/v1/chat/completions"]
         assert all(c.method for c in recorder.requests), (
             f"a slot for an incomplete request was published: {recorder.requests}"
         )
+
+        # The connection log has to agree with the request list, not merely be
+        # populated. Filtering the unfilled slot out of `requests` while still
+        # counting it on its connection would leave the two halves of R1.10
+        # contradicting each other — and `check_connection_logged` is the thing
+        # that would notice, so it is what this asserts through.
+        check_connection_logged(recording_of(recorder), [sent], [aborted_port, sent.source_port])
 
 
 class TestTheConnectionLog:
@@ -702,17 +712,32 @@ class TestTheRecorderStaysIndependentOfKitty:
     nothing"*.
     """
 
-    def test_the_recorder_imports_nothing_from_kitty(self) -> None:
-        """Assert the recorder is not written in terms of the code under test.
+    @pytest.mark.parametrize(
+        "module", [recorder_module, conformance_module], ids=lambda m: m.__name__
+    )
+    def test_it_imports_nothing_from_kitty(self, module) -> None:
+        """Assert a support module is not written in terms of the code under test.
 
         A recorder that asked kitty how to read a request would inherit kitty's
         bugs, and the fidelity claim would reduce to self-consistency.
+
+        **Both** support modules are guarded, not just the recorder. The
+        conformance module happens to import nothing from kitty today, and
+        nothing would have noticed if that changed: none of its checks touch a
+        translator, so adding one would pass every test here while quietly
+        taking on the dependency the recorder forbids. The two *test* modules
+        are deliberately not guarded — ``test_recorder.py`` imports kitty on
+        purpose, to ask the bridge's own judgement whether a reply reads as
+        empty.
+
+        Args:
+            module: The support module whose source is read.
         """
-        source = Path(recorder_module.__file__).read_text(encoding="utf-8")
+        source = Path(module.__file__).read_text(encoding="utf-8")
         assert len(source) > 1000, "read no meaningful source; the guard would pass vacuously"
 
         offending = [line.strip() for line in source.splitlines() if _KITTY_IMPORT.search(line)]
-        assert offending == [], f"recorder.py must not import kitty: {offending}"
+        assert offending == [], f"{module.__name__} must not import kitty: {offending}"
 
 
 async def _until(predicate: Callable[[], bool], *, what: str) -> None:

--- a/tests/harness/test_recorder.py
+++ b/tests/harness/test_recorder.py
@@ -1,0 +1,877 @@
+"""The primary aiohttp recorder, against real sockets.
+
+`.system_design/TEST_SUITE.md` §7.2 · plan task **T-W4** (KBR-27).
+
+Every probe here writes its request bytes itself. A client library is free to
+reorder, re-case, add and drop headers — aiohttp's own client does several of
+those — so a test that sent through one could not tell a recorder that *loses*
+casing from a client that never *sent* mixed casing.
+
+**Layer.** These bind real sockets and read as `l3`, but they carry the `l1`
+path default deliberately: §8.2 states *"a test may not be moved to `l3` before
+the Subsystem job exists"*, and today no job selects `l3`, so an `l3` marker
+would remove them from every gate. `tests/test_egress_https_proxy.py` is `l1` for
+the same reason, and T-K6 owns the reclassification together with the job that
+runs it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import gzip
+import json
+import socket
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+import harness.recorder as recorder_module
+from harness.contract import CapturedRequest, WireFormat
+from harness.recorder import (
+    RecordingUpstream,
+    Reply,
+    UnmatchedPathError,
+    minimal_success_body,
+    minimal_success_stream,
+)
+from harness.recorder_conformance import (
+    NO_HOST_PROBE,
+    PER_EXCHANGE_CHECKS,
+    PER_SESSION_CHECKS,
+    RICH_PROBE,
+    correlate,
+    probe,
+    recording_of,
+    send,
+)
+from harness.test_contract import _KITTY_IMPORT
+
+
+@pytest.fixture
+async def recorder():
+    """Start a recorder on an ephemeral loopback port, and stop it after.
+
+    One instance per test, deliberately: a shared recorder mixes captures across
+    tests, and the ordering claims are only meaningful per-instance.
+
+    Yields:
+        The running :class:`RecordingUpstream`.
+    """
+    upstream = RecordingUpstream(default_format=WireFormat.CHAT_COMPLETIONS)
+    await upstream.start()
+    try:
+        yield upstream
+    finally:
+        await upstream.stop()
+        # R2.2's loud fallback, enforced structurally rather than by each test
+        # remembering to ask. A wrong-format reply is not a loud failure on its
+        # own -- the adapter parses nothing out of it, the bridge reads the
+        # response as empty, and the test pays the 80-second retry ladder.
+        upstream.assert_all_paths_matched()
+
+
+#: The condition wait: 400 steps of 5 ms, so a genuinely stuck test fails in
+#: about two seconds instead of hanging the gate, while a healthy one returns
+#: on the first poll.
+_SETTLE_ATTEMPTS = 400
+_SETTLE_STEP = 0.005
+
+#: How long to wait for a reply before giving up on it.
+_REPLY_TIMEOUT = 5.0
+
+
+class TestTheRecorderPassesEveryConformanceCheck:
+    """R3.3 — the primary recorder satisfies the contract Epic B inherits."""
+
+    @pytest.mark.parametrize("check", PER_EXCHANGE_CHECKS, ids=lambda c: c.__name__)
+    async def test_per_exchange_check(self, recorder: RecordingUpstream, check) -> None:
+        """Assert one capture matches the request that produced it.
+
+        Args:
+            recorder: The running recorder.
+            check: One of the ten per-exchange checks.
+        """
+        sent = await send(recorder.host, recorder.port, RICH_PROBE, marker="rich")
+        captured = correlate(recording_of(recorder), sent)
+        check(captured, sent, scheme=recorder.scheme)
+
+    @pytest.mark.parametrize("check", PER_SESSION_CHECKS, ids=lambda c: c.__name__)
+    async def test_per_session_check(self, recorder: RecordingUpstream, check) -> None:
+        """Assert the recording as a whole is faithful.
+
+        Args:
+            recorder: The running recorder.
+            check: One of the four per-session checks.
+        """
+        sent = [
+            await send(recorder.host, recorder.port, probe(marker), marker=marker)
+            for marker in ("first", "second")
+        ]
+        check(recording_of(recorder), sent, [s.source_port for s in sent])
+
+
+class TestCaptureFidelity:
+    """R1 — the specific things §4.3 C1, §3.3.5 and §5.2.1 read."""
+
+    async def test_it_records_the_percent_encoded_path_undecoded(
+        self, recorder: RecordingUpstream
+    ) -> None:
+        """Assert the path keeps its escapes, and their casing.
+
+        ``request.path`` decodes and would render this ``/v1/messages/a/b/c``.
+        §3.3.5 asserts on routing, and on Azure the deployment id in the path is
+        the only thing distinguishing two byte-identical bodies.
+
+        Args:
+            recorder: The running recorder.
+        """
+        await send(recorder.host, recorder.port, RICH_PROBE, marker="rich")
+        assert recorder.requests[0].path == "/v1/mess%61ges/a%2Fb%2fc/chat/completions"
+
+    async def test_it_records_the_raw_query_unreordered(
+        self, recorder: RecordingUpstream
+    ) -> None:
+        """Assert the query survives undecoded and in the order it was sent.
+
+        Args:
+            recorder: The running recorder.
+        """
+        await send(recorder.host, recorder.port, RICH_PROBE, marker="rich")
+        assert recorder.requests[0].query == "Beta=A%20B&key=k&beta=c"
+
+    async def test_it_records_an_absent_query_as_empty(
+        self, recorder: RecordingUpstream
+    ) -> None:
+        """Assert no query is recorded as the empty string, not ``None``.
+
+        Args:
+            recorder: The running recorder.
+        """
+        await send(recorder.host, recorder.port, probe("q"), marker="q")
+        assert recorder.requests[0].query == ""
+
+    async def test_it_records_headers_with_casing_order_and_duplicates(
+        self, recorder: RecordingUpstream
+    ) -> None:
+        """Assert the exact header evidence §4.3 C1 asserts on survives.
+
+        Args:
+            recorder: The running recorder.
+        """
+        await send(recorder.host, recorder.port, RICH_PROBE, marker="rich")
+        headers = list(recorder.requests[0].headers)
+
+        assert ("ANTHROPIC-BETA", "one") in headers
+        assert ("anthropic-beta", "two") in headers
+        assert [n for n, _ in headers][:4] == [
+            "Host", "X-Api-Key", "anthropic-version", "ANTHROPIC-BETA",
+        ]
+
+    async def test_it_decodes_obs_text_header_values_rather_than_failing(
+        self, recorder: RecordingUpstream
+    ) -> None:
+        """Assert a `latin-1`-only header value survives.
+
+        ``utf-8`` refuses ``caf\\xe9``, so a recorder decoding with it would lose
+        the request entirely rather than record it.
+
+        Args:
+            recorder: The running recorder.
+        """
+        await send(recorder.host, recorder.port, RICH_PROBE, marker="rich")
+        assert ("X-Weird", "café") in list(recorder.requests[0].headers)
+
+    async def test_it_records_the_host_header_verbatim(
+        self, recorder: RecordingUpstream
+    ) -> None:
+        """Assert the authority keeps its casing and its port.
+
+        ``request.url`` lower-cases the host.
+
+        Args:
+            recorder: The running recorder.
+        """
+        await send(recorder.host, recorder.port, RICH_PROBE, marker="rich")
+        assert recorder.requests[0].host == "Upstream.Example:443"
+
+    async def test_it_records_no_host_rather_than_inventing_one(
+        self, recorder: RecordingUpstream
+    ) -> None:
+        """Assert an absent ``Host`` is recorded as absent.
+
+        This is the defect aiohttp's ``request.host`` produces unaided: with no
+        ``Host`` header it returns ``socket.getfqdn()`` — the build machine's own
+        name — and which value that is differs across the aiohttp versions
+        ``pyproject.toml`` allows.
+
+        Args:
+            recorder: The running recorder.
+        """
+        await send(recorder.host, recorder.port, NO_HOST_PROBE, marker="nohost")
+        assert recorder.requests[0].host == ""
+
+    async def test_it_records_the_peer_port_not_its_own(
+        self, recorder: RecordingUpstream
+    ) -> None:
+        """Assert the recorded port is the client's, §5.2.1's join key.
+
+        Args:
+            recorder: The running recorder.
+        """
+        sent = await send(recorder.host, recorder.port, probe("p"), marker="p")
+        assert recorder.requests[0].peer_port == sent.source_port
+        assert recorder.requests[0].peer_port != recorder.port
+
+    async def test_it_captures_a_body_above_aiohttps_default_ceiling(
+        self, recorder: RecordingUpstream
+    ) -> None:
+        """Assert a 2 MiB body is captured whole.
+
+        aiohttp caps request bodies at 1 MiB by default, above which it raises
+        **413** — which is M6's own trigger, so the harness would manufacture the
+        compaction the fidelity oracle exists to detect. §7.1's corpus is
+        specified to contain transcripts over the compaction budget.
+
+        Args:
+            recorder: The running recorder.
+        """
+        body = b"x" * (2 * 1024 * 1024)
+        await send(recorder.host, recorder.port, probe("big", body=body), marker="big")
+        assert recorder.requests[0].body == body
+
+    async def test_it_captures_a_chunked_body_dechunked(
+        self, recorder: RecordingUpstream
+    ) -> None:
+        """Assert transfer-coding is undone, which is the level a projection reads at.
+
+        Args:
+            recorder: The running recorder.
+        """
+        raw = (
+            b"POST /v1/chat/completions HTTP/1.1\r\nHost: h\r\nX-Probe-Marker: ch\r\n"
+            b"Transfer-Encoding: chunked\r\n\r\n3\r\nabc\r\n2\r\nde\r\n0\r\n\r\n"
+        )
+        await send(recorder.host, recorder.port, raw, marker="ch")
+        assert recorder.requests[0].body == b"abcde"
+
+    async def test_it_captures_a_gzip_body_still_compressed(
+        self, recorder: RecordingUpstream
+    ) -> None:
+        """Assert content-coding is *not* undone.
+
+        aiohttp decompresses by default, which would leave the capture carrying a
+        plaintext body beside a ``Content-Encoding: gzip`` header claiming
+        otherwise — an internally inconsistent capture, read by the header
+        assertion in §4.3 C1.
+
+        Args:
+            recorder: The running recorder.
+        """
+        payload = gzip.compress(b"hello-compressed")
+        raw = (
+            b"POST /v1/chat/completions HTTP/1.1\r\nHost: h\r\nX-Probe-Marker: gz\r\n"
+            b"Content-Encoding: gzip\r\nContent-Length: "
+            + str(len(payload)).encode() + b"\r\n\r\n" + payload
+        )
+        await send(recorder.host, recorder.port, raw, marker="gz")
+
+        captured = recorder.requests[0]
+        assert captured.body == payload
+        assert ("Content-Encoding", "gzip") in list(captured.headers)
+
+    async def test_arrival_increases_across_requests(
+        self, recorder: RecordingUpstream
+    ) -> None:
+        """Assert arrival moves forward from one request to the next.
+
+        This is the weaker half of R1.9. The other half — that the stamp is taken
+        at handler entry rather than after the body is read — cannot be shown by
+        sequential requests, because they are correctly ordered whichever point
+        the stamp is taken at. ``test_recorder_falsification.py``'s slow-body
+        probe is what proves it, by making the two orders disagree.
+
+        Args:
+            recorder: The running recorder.
+        """
+        await send(recorder.host, recorder.port, probe("a1"), marker="a1")
+        await send(recorder.host, recorder.port, probe("a2"), marker="a2")
+
+        first, second = recorder.requests
+        assert first.arrival is not None and second.arrival is not None
+        assert second.arrival > first.arrival
+
+    async def test_a_request_that_never_completes_is_not_published(
+        self, recorder: RecordingUpstream
+    ) -> None:
+        """Assert a client that disconnects mid-body leaves no phantom capture.
+
+        The slot is reserved at handler entry so that a short request cannot
+        overtake a long one; if the body read then fails, that slot must not
+        reach :attr:`RecordingUpstream.requests`. §6.3.1 injects a client
+        disconnect at four points, so T-B4 and T-W9 meet this immediately — and
+        an unfilled slot would surface to them as a capture nobody sent, naming
+        the wrong problem entirely.
+
+        Args:
+            recorder: The running recorder.
+        """
+        # Announce a body, send one byte of it, then vanish.
+        truncated = (
+            b"POST /v1/chat/completions HTTP/1.1\r\nHost: h\r\n"
+            b"X-Probe-Marker: gone\r\nContent-Length: 50\r\n\r\nx"
+        )
+        sock = socket.create_connection((recorder.host, recorder.port))
+        try:
+            await asyncio.to_thread(sock.sendall, truncated)
+            await _until(lambda: bool(recorder.connections), what="the connection to be accepted")
+        finally:
+            sock.close()
+
+        await send(recorder.host, recorder.port, probe("real"), marker="real")
+
+        assert [c.path for c in recorder.requests] == ["/v1/chat/completions"]
+        assert all(c.method for c in recorder.requests), (
+            f"a slot for an incomplete request was published: {recorder.requests}"
+        )
+
+
+class TestTheConnectionLog:
+    """R1.10 — the evidence §5.2.1 needs and the request list cannot give."""
+
+    async def test_it_logs_a_connection_that_sends_no_request(
+        self, recorder: RecordingUpstream
+    ) -> None:
+        """Assert a connection carrying nothing is still recorded.
+
+        §5.2.1: *"An upstream connection with no matching tunnel port is a
+        bypass, and it is the only thing this assertion needs to catch."* Such a
+        connection is invisible in the request list by construction, so a
+        recorder without this log cannot support the containment claim at all.
+
+        Args:
+            recorder: The running recorder.
+        """
+        sock = socket.create_connection((recorder.host, recorder.port))
+        source_port = sock.getsockname()[1]
+        try:
+            await _until(lambda: bool(recorder.connections), what="the connection to be accepted")
+        finally:
+            sock.close()
+
+        assert recorder.requests == []
+        assert source_port in {c.peer_port for c in recorder.connections}
+        assert all(c.requests == 0 for c in recorder.connections)
+
+    async def test_one_keep_alive_connection_is_one_record_carrying_both_requests(
+        self, recorder: RecordingUpstream
+    ) -> None:
+        """Assert requests sharing a connection share its record.
+
+        This is why §4.3 C5's "count distinct TCP connections" cannot be a
+        de-duplication of peer ports, and why the log is keyed on the connection
+        rather than on the port.
+
+        Args:
+            recorder: The running recorder.
+        """
+        sock = socket.create_connection((recorder.host, recorder.port))
+        source_port = sock.getsockname()[1]
+        try:
+            for expected, marker in enumerate(("k1", "k2"), start=1):
+                sock.sendall(probe(marker))
+                await _until(
+                    lambda n=expected: len(recorder.requests) >= n,
+                    what=f"request {expected} on the keep-alive connection",
+                )
+        finally:
+            sock.close()
+
+        assert len(recorder.requests) == 2
+        assert {r.peer_port for r in recorder.requests} == {source_port}
+
+        carrying = [c for c in recorder.connections if c.peer_port == source_port]
+        assert len(carrying) == 1, f"expected one connection record, got {carrying}"
+        assert carrying[0].requests == 2
+
+    async def test_concurrent_connections_are_logged_separately(
+        self, recorder: RecordingUpstream
+    ) -> None:
+        """Assert two connections open at once each get their own record.
+
+        Args:
+            recorder: The running recorder.
+        """
+        socks = []
+        try:
+            for marker in ("c1", "c2"):
+                sock = socket.create_connection((recorder.host, recorder.port))
+                sock.sendall(probe(marker))
+                socks.append(sock)
+            await _until(lambda: len(recorder.requests) >= 2, what="both concurrent requests")
+            ports = {s.getsockname()[1] for s in socks}
+        finally:
+            for sock in socks:
+                sock.close()
+
+        assert ports <= {c.peer_port for c in recorder.connections}
+
+        # Each request is attributed to its own connection, not both to one.
+        # A recorder that looked the connection up by peer *port* would still
+        # pass the line above; this is what distinguishes it.
+        by_port = {c.peer_port: c.requests for c in recorder.connections}
+        assert [by_port[port] for port in ports] == [1, 1], (
+            f"each concurrent connection should carry one request; got {by_port}"
+        )
+
+
+class TestMinimalSuccessResponses:
+    """R2 — replies the bridge accepts in one attempt."""
+
+    @pytest.mark.parametrize(
+        "fmt", [WireFormat.ANTHROPIC_MESSAGES, WireFormat.CHAT_COMPLETIONS],
+        ids=lambda f: f.value,
+    )
+    def test_the_non_streaming_success_is_not_empty_by_the_bridges_own_judgement(
+        self, fmt: WireFormat
+    ) -> None:
+        """Assert the bridge would not treat the reply as an empty response.
+
+        An empty response costs 80 seconds of retry ladder
+        (``_EMPTY_RETRY_DELAYS`` + ``_EMPTY_FINAL_DELAYS``) and, on a balancing
+        profile, fails over — and failover *is* body-mutating (§4.3 C3), so the
+        harness would manufacture a delta no product code caused.
+
+        This is the one place this suite imports from ``src/kitty``, and
+        deliberately: the bridge's own judgement is the only authority on the
+        question. The independence rule protects the *oracle*, not a test whose
+        whole claim is "the real bridge accepts this".
+
+        Args:
+            fmt: The wire format under test.
+        """
+        from kitty.bridge.server import BridgeServer
+
+        assert BridgeServer._is_empty_cc_response(minimal_success_body(fmt)) is False
+
+    def test_the_emptiness_judgement_still_rejects_a_hollow_body(self) -> None:
+        """The negative control for the check above.
+
+        Without it, a judgement that had stopped discriminating would report
+        every reply as non-empty and the assertion would pass forever.
+        """
+        from kitty.bridge.server import BridgeServer
+
+        hollow = {"choices": [{"index": 0, "message": {"role": "assistant", "content": ""},
+                               "finish_reason": "stop"}]}
+        assert BridgeServer._is_empty_cc_response(hollow) is True
+
+    def test_the_chat_completions_stream_is_not_empty_by_the_translators_judgement(self) -> None:
+        """Assert the streaming reply survives the streaming emptiness oracle.
+
+        The non-streaming check above does not cover this: a streaming reply is
+        judged by ``translator.response_was_empty`` instead
+        (``server.py`` 2983/3831/4487).
+        """
+        from kitty.bridge.messages.translator import MessagesTranslator
+
+        translator = MessagesTranslator()
+        for chunk in _sse_payloads(minimal_success_stream(WireFormat.CHAT_COMPLETIONS)):
+            translator.translate_stream_chunk("chatcmpl-recorder", "recorder-model", chunk)
+
+        assert translator.response_was_empty is False
+
+    def test_the_streaming_judgement_still_rejects_a_contentless_stream(self) -> None:
+        """The negative control for the check above."""
+        from kitty.bridge.messages.translator import MessagesTranslator
+
+        translator = MessagesTranslator()
+        translator.translate_stream_chunk(
+            "chatcmpl-x", "m",
+            {"choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}]},
+        )
+        assert translator.response_was_empty is True
+
+    def test_the_anthropic_stream_is_a_sentence_in_the_sse_grammar(self) -> None:
+        """Assert the Anthropic stream is well-formed, because nothing else checks it.
+
+        Verified at ``server.py:3616``: a native Messages stream is forwarded to
+        the client byte-for-byte and never reaches a translator, so **no**
+        bridge-side emptiness judgement sees it. §6.2.2's grammar is the only
+        guard on this path, which is why it is asserted here rather than assumed.
+        """
+        events = [
+            payload["type"]
+            for payload in _sse_payloads(minimal_success_stream(WireFormat.ANTHROPIC_MESSAGES))
+        ]
+        assert events == [
+            "message_start", "content_block_start", "content_block_delta",
+            "content_block_stop", "message_delta", "message_stop",
+        ]
+
+        deltas = [
+            p for p in _sse_payloads(minimal_success_stream(WireFormat.ANTHROPIC_MESSAGES))
+            if p["type"] == "content_block_delta"
+        ]
+        assert deltas and deltas[0]["delta"]["text"], "the stream must carry actual text"
+
+    async def test_it_streams_when_the_request_asks_to_stream(
+        self, recorder: RecordingUpstream
+    ) -> None:
+        """Assert ``"stream": true`` is answered with SSE, not JSON.
+
+        A streaming request answered with a JSON body is not a success; it lands
+        in the same retry ladder an empty reply would.
+
+        Args:
+            recorder: The running recorder.
+        """
+        reply = await _exchange(recorder, probe("s", body=b'{"stream": true}'))
+        assert b"text/event-stream" in reply
+        assert b"data: " in reply
+
+    async def test_it_returns_json_when_the_request_does_not_stream(
+        self, recorder: RecordingUpstream
+    ) -> None:
+        """Assert a non-streaming request gets a JSON body.
+
+        Args:
+            recorder: The running recorder.
+        """
+        reply = await _exchange(recorder, probe("n", body=b'{"stream": false}'))
+        assert b"application/json" in reply
+
+
+class TestFormatDispatch:
+    """R2.2 — the reply's format follows the URL, as a real provider's does."""
+
+    @pytest.mark.parametrize(
+        ("path", "expected_marker"),
+        [
+            ("/v1/messages", b'"type": "message"'),
+            ("/api/anthropic/v1/messages", b'"type": "message"'),
+            ("/v1/chat/completions", b'"object": "chat.completion"'),
+            ("/openai/deployments/d1/chat/completions", b'"object": "chat.completion"'),
+            ("/endpoints/openapi/chat/completions", b'"object": "chat.completion"'),
+        ],
+    )
+    async def test_real_adapter_paths_select_the_right_format(
+        self, recorder: RecordingUpstream, path: str, expected_marker: bytes
+    ) -> None:
+        """Assert every real upstream path shape dispatches correctly.
+
+        These are the paths the shipped adapters actually post to. An exact
+        match on ``/chat/completions`` would have selected correctly for three
+        adapters and wrongly for the rest — Azure bakes the deployment into the
+        path, vertex prefixes ``/endpoints/openapi``, and zai_anthropic serves
+        Messages under ``/api/anthropic``.
+
+        Args:
+            recorder: The running recorder.
+            path: The upstream path.
+            expected_marker: A byte string only the right format's body carries.
+        """
+        reply = await _exchange(recorder, probe("d", path=path))
+        assert expected_marker in reply
+        recorder.assert_all_paths_matched()
+
+    async def test_an_unmatched_path_is_recorded_and_fails_at_teardown(
+        self, recorder: RecordingUpstream
+    ) -> None:
+        """Assert the fallback is loud rather than silent.
+
+        A wrong-format reply does not fail loudly on its own: the adapter parses
+        nothing out of it, the bridge judges the response empty, and the test
+        pays the retry ladder. So the fallback is recorded and turned into an
+        error at teardown.
+
+        Args:
+            recorder: The running recorder.
+        """
+        await _exchange(recorder, probe("u", path="/not/an/api"))
+
+        assert recorder.unmatched == ["/not/an/api"]
+        with pytest.raises(UnmatchedPathError, match="fallback format"):
+            recorder.assert_all_paths_matched()
+
+        # Opt out of the fixture's own teardown guard: this test *meant* to take
+        # the fallback, and the guard would otherwise fail it for succeeding.
+        recorder.unmatched.clear()
+
+    async def test_a_malformed_body_still_gets_a_success(
+        self, recorder: RecordingUpstream
+    ) -> None:
+        """Assert an unparseable body is answered, not rejected.
+
+        T-C6 contributes a malformed body to the corpus. A harness 5xx there
+        reads to the bridge as an upstream error and triggers failover, which
+        *is* body-mutating — the harness would fabricate the delta the oracle
+        exists to find.
+
+        Args:
+            recorder: The running recorder.
+        """
+        reply = await _exchange(recorder, probe("m", body=b"{not json at all"))
+        assert reply.startswith(b"HTTP/1.1 200"), reply[:40]
+
+    def test_it_refuses_a_default_format_it_does_not_serve(self) -> None:
+        """Assert construction fails for a format §7.2 assigns elsewhere.
+
+        Failing here beats replying in a format no adapter asked for. Bedrock
+        Converse, OpenAI Responses and Ollama ``/api/chat`` belong to T-B1–T-B3.
+        """
+        with pytest.raises(ValueError, match="primary recorder serves"):
+            RecordingUpstream(default_format=WireFormat.BEDROCK_CONVERSE)
+
+
+class TestTheResponderSeam:
+    """R2.4 — what T-B4 builds its failure library on."""
+
+    async def test_a_custom_responder_owns_status_and_headers(
+        self, recorder: RecordingUpstream
+    ) -> None:
+        """Assert the hook can produce an error status, not only a body.
+
+        §7.2 requires every recorder to replay "error statuses, Cloudflare
+        blocks, empty responses, context-too-large rejections". A hook that
+        could only supply a body could express none of them.
+
+        Args:
+            recorder: The running recorder.
+        """
+
+        async def blocked(captured: CapturedRequest, response: Reply) -> None:
+            """Reply as a Cloudflare block would.
+
+            Args:
+                captured: The recorded request.
+                response: The response to write.
+            """
+            response.content_length = 7
+            await response.begin(403, {"Server": "cloudflare"})
+            await response.write(b"blocked")
+            await response.write_eof()
+
+        recorder.responder = blocked
+        reply = await _exchange(recorder, probe("b"))
+
+        assert reply.startswith(b"HTTP/1.1 403")
+        assert b"cloudflare" in reply
+        # The request is still recorded: what the recorder replies has no
+        # bearing on what it observed.
+        assert len(recorder.requests) == 1
+
+    async def test_a_responder_can_abort_mid_stream(
+        self, recorder: RecordingUpstream
+    ) -> None:
+        """Assert a disconnect part-way through a stream is expressible.
+
+        §6.3.1 injects a failure at four points, one of which is *after content
+        has been emitted*. A hook returning a finished response could not
+        express it, and T-B4 would have to edit the recorder — which is the
+        thing this seam exists to prevent.
+
+        Args:
+            recorder: The running recorder.
+        """
+
+        async def truncate(captured: CapturedRequest, response: Reply) -> None:
+            """Write two events, then drop the connection.
+
+            Args:
+                captured: The recorded request.
+                response: The response to write.
+            """
+            await response.begin(200, {"Content-Type": "text/event-stream"})
+            for chunk in minimal_success_stream(WireFormat.CHAT_COMPLETIONS)[:2]:
+                await response.write(chunk)
+            await response.abort()
+
+        recorder.responder = truncate
+        reply = await _exchange(recorder, probe("t", body=b'{"stream": true}'))
+
+        assert b"data: " in reply
+        assert b"[DONE]" not in reply, "the stream must have been cut before its terminator"
+
+
+class TestTheRecorderStaysIndependentOfKitty:
+    """D6 — the rule `contract.py` enforces, extended to this module.
+
+    Asserting the property in prose only is what ``contract.py``'s own docstring
+    calls a defect: *"a rule that reads like a guarantee and guarantees
+    nothing"*.
+    """
+
+    def test_the_recorder_imports_nothing_from_kitty(self) -> None:
+        """Assert the recorder is not written in terms of the code under test.
+
+        A recorder that asked kitty how to read a request would inherit kitty's
+        bugs, and the fidelity claim would reduce to self-consistency.
+        """
+        source = Path(recorder_module.__file__).read_text(encoding="utf-8")
+        assert len(source) > 1000, "read no meaningful source; the guard would pass vacuously"
+
+        offending = [line.strip() for line in source.splitlines() if _KITTY_IMPORT.search(line)]
+        assert offending == [], f"recorder.py must not import kitty: {offending}"
+
+
+async def _until(predicate: Callable[[], bool], *, what: str) -> None:
+    """Yield to the event loop until ``predicate`` holds.
+
+    Waits on a **condition**, never on a fixed span: a `sleep()`-based wait is
+    the leading cause of flaky tests, and it is slow by construction because the
+    span has to be generous enough for the slowest machine.
+
+    Args:
+        predicate: The condition to wait for.
+        what: What is being waited for, for the failure message.
+
+    Raises:
+        AssertionError: When the condition has not held within the budget. This
+            is a real failure, not a slow machine: the work is local and
+            in-process.
+    """
+    for _ in range(_SETTLE_ATTEMPTS):
+        if predicate():
+            return
+        await asyncio.sleep(_SETTLE_STEP)
+    raise AssertionError(f"timed out waiting for {what}")
+
+
+async def _exchange(recorder: RecordingUpstream, raw: bytes) -> bytes:
+    """Send ``raw`` and return the reply bytes.
+
+    Stops at the end of the response rather than at end-of-connection. aiohttp
+    keeps a connection alive for ``keepalive_timeout`` (3630 seconds by
+    default), so reading to EOF would stall every one of these tests until the
+    socket timeout expired — minutes across the module, in the gating layer.
+
+    Args:
+        recorder: The running recorder.
+        raw: The request bytes.
+
+    Returns:
+        The reply: headers, and as much body as arrives with them.
+    """
+    return await asyncio.to_thread(_exchange_blocking, recorder.host, recorder.port, raw)
+
+
+def _exchange_blocking(host: str, port: int, raw: bytes) -> bytes:
+    """Do the blocking half of :func:`_exchange`.
+
+    Args:
+        host: The recorder's bind address.
+        port: The recorder's listening port.
+        raw: The request bytes.
+
+    Returns:
+        The reply bytes.
+    """
+    sock = socket.create_connection((host, port), timeout=_REPLY_TIMEOUT)
+    try:
+        sock.sendall(raw)
+        chunks: list[bytes] = []
+        while True:
+            try:
+                chunk = sock.recv(65536)
+            except (TimeoutError, OSError):
+                break
+            if not chunk:
+                break
+            chunks.append(chunk)
+            if _reply_is_complete(b"".join(chunks)):
+                break
+    finally:
+        sock.close()
+    return b"".join(chunks)
+
+
+def _reply_is_complete(reply: bytes) -> bool:
+    """Return whether a full response has arrived.
+
+    Args:
+        reply: What has been read so far.
+
+    Returns:
+        True once the headers are in and the body they describe is complete —
+        by ``Content-Length`` where one is given, by the terminating zero-length
+        chunk for a chunked body, and by the headers alone otherwise.
+    """
+    head, separator, body = reply.partition(b"\r\n\r\n")
+    if not separator:
+        return False
+
+    lowered = head.lower()
+    for line in lowered.split(b"\r\n")[1:]:
+        name, _, value = line.partition(b":")
+        if name.strip() == b"content-length":
+            return len(body) >= int(value.strip())
+
+    if b"transfer-encoding: chunked" in lowered:
+        return body.endswith(b"0\r\n\r\n")
+
+    # No length and no chunking: the body runs to end-of-connection, so the
+    # headers are all that can be waited for deterministically.
+    return True
+
+
+def _sse_payloads(chunks: tuple[bytes, ...]) -> list[dict]:
+    """Return the JSON payloads of an SSE stream's ``data:`` lines.
+
+    Args:
+        chunks: The stream's chunks.
+
+    Returns:
+        Each ``data:`` payload parsed, skipping the ``[DONE]`` sentinel.
+    """
+    payloads = []
+    for line in b"".join(chunks).decode().splitlines():
+        if not line.startswith("data: "):
+            continue
+        body = line[len("data: "):].strip()
+        if body and body != "[DONE]":
+            payloads.append(json.loads(body))
+    return payloads
+
+
+class TestTheFixtureGuardIsActuallyWired:
+    """A guard the fixture does not call is a guard that protects nothing.
+
+    :meth:`RecordingUpstream.assert_all_paths_matched` has its own behavioural
+    test above, but that proves only that the method works — not that anything
+    runs it. A review pass found the method implemented and never called, so
+    R2.2's "fails the fixture at teardown" was satisfied by two hand-written
+    call sites and by nothing structural.
+
+    Reading the fixture's source is the same technique
+    ``tests/harness/test_contract.py`` and ``tests/test_egress_coverage.py``
+    already use for guards whose *wiring* is the thing at risk.
+    """
+
+    def test_the_recorder_fixture_calls_the_unmatched_path_guard(self) -> None:
+        """Assert the fixture runs the fallback guard on teardown.
+
+        Without this, deleting one line from the fixture would silently return
+        the suite to the state the review found: every test free to be answered
+        in the wrong format, and the resulting empty-looking response paying the
+        80-second retry ladder rather than failing.
+        """
+        source = Path(__file__).read_text(encoding="utf-8")
+        fixture = source.split("async def recorder()", 1)[1].split("\nclass ", 1)[0]
+
+        assert "assert_all_paths_matched()" in fixture, (
+            "the recorder fixture must call assert_all_paths_matched() on teardown; "
+            "R2.2's loud fallback is otherwise enforced by nothing"
+        )
+
+    def test_this_guard_reads_the_fixture_and_not_the_whole_file(self) -> None:
+        """The positive control: the slice must actually isolate the fixture.
+
+        A split that silently returned the entire file would find the call
+        somewhere else and pass forever.
+        """
+        source = Path(__file__).read_text(encoding="utf-8")
+        fixture = source.split("async def recorder()", 1)[1].split("\nclass ", 1)[0]
+
+        assert len(fixture) < len(source) / 4, "the slice is not isolating the fixture"
+        assert "class TestCaptureFidelity" not in fixture

--- a/tests/harness/test_recorder_conformance.py
+++ b/tests/harness/test_recorder_conformance.py
@@ -1,0 +1,723 @@
+"""The conformance checks' own falsification suite.
+
+`.system_design/TEST_SUITE.md` §7.2 · plan task **T-W4** (KBR-27), rule §1.4.
+
+Plan §1.4 exists because four review rounds produced four harnesses that would
+have passed while proving nothing. The checks in :mod:`harness.recorder_conformance`
+are the thing every Epic B recorder is judged by, so they are themselves given
+deliberate defects here: each check is handed a :class:`~harness.contract.CapturedRequest`
+that is wrong in exactly the way that check exists to notice, and must reject it.
+
+These tests need no recorder and no socket. That is the point of the checks being
+pure functions over data — a decision entangled with a live server could not be
+given a falsification case at all, which is the reasoning ``tests/layers.py``
+records for the same choice.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from harness.contract import CapturedRequest
+from harness.recorder_conformance import (
+    CHECK_NAMES,
+    PER_EXCHANGE_CHECKS,
+    PER_SESSION_CHECKS,
+    Recording,
+    SentRequest,
+    _parse_sent,
+    check_arrival_increases,
+    check_body,
+    check_connection_logged,
+    check_header_casing,
+    check_header_duplicates,
+    check_header_order,
+    check_host,
+    check_method,
+    check_path,
+    check_peer_port,
+    check_query,
+    check_request_count,
+    check_request_order,
+    check_scheme,
+    correlate,
+)
+
+# A probe rich enough that every per-exchange check has something to lose:
+# mixed casing, a duplicate, an obs-text value, a percent-encoded path whose
+# escapes differ in case, and a query that is neither sorted nor decodable
+# without changing it.
+_RAW = (
+    b"POST /v1/mess%61ges/m1/a%2Fb%2fc?Beta=A%20B&key=k&beta=c HTTP/1.1\r\n"
+    b"Host: Upstream.Example:443\r\n"
+    b"X-Api-Key: secret\r\n"
+    b"anthropic-version: 2023-06-01\r\n"
+    b"ANTHROPIC-BETA: one\r\n"
+    b"anthropic-beta: two\r\n"
+    b"X-Weird: caf\xe9\r\n"
+    b"X-Probe-Marker: m1\r\n"
+    b"Content-Length: 7\r\n"
+    b"\r\n"
+    b'{"a":1}'
+)
+
+_SCHEME = "http"
+
+
+@pytest.fixture
+def sent() -> SentRequest:
+    """Return the reference request the conforming capture is built from.
+
+    Returns:
+        A :class:`SentRequest` parsed from :data:`_RAW`, as the driver would
+        produce it.
+    """
+    return _parse_sent(_RAW, source_port=54321, marker="m1")
+
+
+@pytest.fixture
+def captured(sent: SentRequest) -> CapturedRequest:
+    """Return a capture that is correct in every respect.
+
+    Every falsification case below mutates exactly one field of this, so a case
+    that fails proves the check noticed *that* field and not some other
+    difference.
+
+    Args:
+        sent: The reference request.
+
+    Returns:
+        A conforming :class:`CapturedRequest`.
+    """
+    return CapturedRequest(
+        method=sent.method,
+        scheme=_SCHEME,
+        host=sent.header("Host") or "",
+        path=sent.path,
+        query=sent.query,
+        headers=sent.headers,
+        body=sent.body,
+        arrival=100.0,
+        peer_port=sent.source_port,
+    )
+
+
+def test_the_check_list_is_the_fourteen_the_design_specifies() -> None:
+    """Guard the list itself, because every other assertion counts against it.
+
+    R4.2 asserts a defect trips its *named* check and no other. That sentence is
+    only meaningful against a written list, so a check silently dropped from the
+    tuples would weaken the whole falsification suite without failing anything.
+    """
+    assert len(CHECK_NAMES) == 14, f"expected 14 checks, found {len(CHECK_NAMES)}: {CHECK_NAMES}"
+    assert len(set(CHECK_NAMES)) == 14, f"duplicate check names: {CHECK_NAMES}"
+    assert len(PER_EXCHANGE_CHECKS) == 10
+    assert len(PER_SESSION_CHECKS) == 4
+
+
+class TestEveryPerExchangeCheckPassesAConformingCapture:
+    """The positive control for the ten per-exchange checks.
+
+    Without it, a check that had stopped comparing anything would read as a
+    clean bill of health forever — and every falsification case below would
+    still pass, because they only require a check to *fail*.
+    """
+
+    @pytest.mark.parametrize("check", PER_EXCHANGE_CHECKS, ids=lambda c: c.__name__)
+    def test_check_accepts_a_faithful_capture(
+        self, check, captured: CapturedRequest, sent: SentRequest
+    ) -> None:
+        """Assert a correct capture is not rejected.
+
+        Args:
+            check: One of the ten per-exchange checks.
+            captured: A conforming capture.
+            sent: The request that produced it.
+        """
+        check(captured, sent, scheme=_SCHEME)
+
+
+class TestEachPerExchangeCheckRejectsItsOwnDefect:
+    """Each check, handed the one defect it exists to notice."""
+
+    def test_method_check_rejects_a_changed_method(
+        self, captured: CapturedRequest, sent: SentRequest
+    ) -> None:
+        """Assert a rewritten method is caught.
+
+        Args:
+            captured: A conforming capture.
+            sent: The request that produced it.
+        """
+        with pytest.raises(AssertionError, match="method"):
+            check_method(replace(captured, method="GET"), sent, scheme=_SCHEME)
+
+    def test_scheme_check_rejects_a_scheme_the_recorder_does_not_serve(
+        self, captured: CapturedRequest, sent: SentRequest
+    ) -> None:
+        """Assert a capture claiming the wrong scheme is caught.
+
+        Args:
+            captured: A conforming capture.
+            sent: The request that produced it.
+        """
+        with pytest.raises(AssertionError, match="scheme"):
+            check_scheme(replace(captured, scheme="https"), sent, scheme=_SCHEME)
+
+    def test_host_check_rejects_a_lower_cased_authority(
+        self, captured: CapturedRequest, sent: SentRequest
+    ) -> None:
+        """Assert the authority's casing is defended.
+
+        ``request.url`` lower-cases the host, so this is the shape a recorder
+        built on it produces.
+
+        Args:
+            captured: A conforming capture.
+            sent: The request that produced it.
+        """
+        with pytest.raises(AssertionError, match="host"):
+            check_host(replace(captured, host="upstream.example:443"), sent, scheme=_SCHEME)
+
+    def test_host_check_rejects_an_invented_authority_when_none_was_sent(self) -> None:
+        """Assert a fabricated host is caught on a request that sent no ``Host``.
+
+        This is the defect aiohttp's ``request.host`` produces by itself: with no
+        ``Host`` header it returns ``socket.getfqdn()``, the machine's own name.
+        It is invisible on any probe that *does* send a ``Host``, which is why
+        the falsification matrix aims this check at the no-``Host`` probe.
+        """
+        raw = b"POST /m2/nohost HTTP/1.0\r\nX-Probe-Marker: m2\r\nContent-Length: 1\r\n\r\nx"
+        hostless = _parse_sent(raw, source_port=1, marker="m2")
+        fabricated = CapturedRequest(
+            method="POST", scheme=_SCHEME, host="build-runner-07", path="/m2/nohost",
+            query="", headers=hostless.headers, body=b"x", arrival=1.0, peer_port=1,
+        )
+        with pytest.raises(AssertionError, match="invented"):
+            check_host(fabricated, hostless, scheme=_SCHEME)
+
+    def test_path_check_rejects_a_percent_decoded_path(
+        self, captured: CapturedRequest, sent: SentRequest
+    ) -> None:
+        """Assert a decoded path is caught.
+
+        ``request.path`` decodes, so this is what a recorder built on it records.
+
+        Args:
+            captured: A conforming capture.
+            sent: The request that produced it.
+        """
+        with pytest.raises(AssertionError, match="path"):
+            check_path(replace(captured, path="/v1/messages/m1/a/b/c"), sent, scheme=_SCHEME)
+
+    def test_path_check_rejects_case_folded_escapes(
+        self, captured: CapturedRequest, sent: SentRequest
+    ) -> None:
+        """Assert re-quoting that normalises ``%2f`` to ``%2F`` is caught.
+
+        A decode check alone would not see this: the path is still encoded, and
+        still decodes to the same string.
+
+        Args:
+            captured: A conforming capture.
+            sent: The request that produced it.
+        """
+        folded = captured.path.replace("%2f", "%2F")
+        assert folded != captured.path, "the probe must contain a lower-case escape to fold"
+        with pytest.raises(AssertionError, match="path"):
+            check_path(replace(captured, path=folded), sent, scheme=_SCHEME)
+
+    def test_query_check_rejects_a_percent_decoded_query(
+        self, captured: CapturedRequest, sent: SentRequest
+    ) -> None:
+        """Assert a decoded query is caught.
+
+        ``request.query_string`` decodes, turning ``%20`` into a space.
+
+        Args:
+            captured: A conforming capture.
+            sent: The request that produced it.
+        """
+        with pytest.raises(AssertionError, match="query"):
+            check_query(replace(captured, query="Beta=A B&key=k&beta=c"), sent, scheme=_SCHEME)
+
+    def test_query_check_rejects_a_dropped_query(
+        self, captured: CapturedRequest, sent: SentRequest
+    ) -> None:
+        """Assert losing the query entirely is caught.
+
+        On Azure the query carries the API version and the path carries the
+        deployment, and P6 removes ``model`` from the body — so a lost query can
+        make two different routes look identical.
+
+        Args:
+            captured: A conforming capture.
+            sent: The request that produced it.
+        """
+        with pytest.raises(AssertionError, match="query"):
+            check_query(replace(captured, query=""), sent, scheme=_SCHEME)
+
+    def test_query_check_rejects_a_reordered_query(
+        self, captured: CapturedRequest, sent: SentRequest
+    ) -> None:
+        """Assert re-serialising the query in sorted order is caught.
+
+        Args:
+            captured: A conforming capture.
+            sent: The request that produced it.
+        """
+        with pytest.raises(AssertionError, match="query"):
+            check_query(replace(captured, query="Beta=A%20B&beta=c&key=k"), sent, scheme=_SCHEME)
+
+    def test_body_check_rejects_a_re_encoded_body(
+        self, captured: CapturedRequest, sent: SentRequest
+    ) -> None:
+        """Assert a body that has been through a text round-trip is caught.
+
+        Args:
+            captured: A conforming capture.
+            sent: The request that produced it.
+        """
+        with pytest.raises(AssertionError, match="body"):
+            check_body(replace(captured, body=b'{"a": 1}'), sent, scheme=_SCHEME)
+
+    def test_header_casing_check_rejects_lower_cased_names(
+        self, captured: CapturedRequest, sent: SentRequest
+    ) -> None:
+        """Assert normalised header casing is caught.
+
+        Args:
+            captured: A conforming capture.
+            sent: The request that produced it.
+        """
+        lowered = tuple((name.lower(), value) for name, value in captured.headers)
+        with pytest.raises(AssertionError, match="casing"):
+            check_header_casing(replace(captured, headers=lowered), sent, scheme=_SCHEME)
+
+    def test_header_order_check_rejects_sorted_headers(
+        self, captured: CapturedRequest, sent: SentRequest
+    ) -> None:
+        """Assert reordering is caught.
+
+        Args:
+            captured: A conforming capture.
+            sent: The request that produced it.
+        """
+        ordered = tuple(sorted(captured.headers))
+        assert [n for n, _ in ordered] != [n for n, _ in captured.headers], (
+            "the probe's headers must not already be sorted, or this proves nothing"
+        )
+        with pytest.raises(AssertionError, match="order"):
+            check_header_order(replace(captured, headers=ordered), sent, scheme=_SCHEME)
+
+    def test_header_duplicate_check_rejects_a_collapsed_repeat(
+        self, captured: CapturedRequest, sent: SentRequest
+    ) -> None:
+        """Assert dropping a repeated header is caught.
+
+        A mapping-shaped recorder loses exactly this: ``anthropic-beta`` is sent
+        twice and a dict keeps one.
+
+        Args:
+            captured: A conforming capture.
+            sent: The request that produced it.
+        """
+        seen: set[str] = set()
+        collapsed = []
+        for name, value in captured.headers:
+            if name.lower() in seen:
+                continue
+            seen.add(name.lower())
+            collapsed.append((name, value))
+        assert len(collapsed) < len(captured.headers), "the probe must contain a duplicate header"
+        with pytest.raises(AssertionError, match="header values per name"):
+            check_header_duplicates(replace(captured, headers=tuple(collapsed)), sent, scheme=_SCHEME)
+
+    def test_peer_port_check_rejects_the_recorders_own_listening_port(
+        self, captured: CapturedRequest, sent: SentRequest
+    ) -> None:
+        """Assert reporting the listening port instead of the peer's is caught.
+
+        §5.2.1 joins the proxy's tunnel log on this value, so the defect
+        produces a join that succeeds against the wrong connection rather than
+        one that fails.
+
+        Args:
+            captured: A conforming capture.
+            sent: The request that produced it.
+        """
+        with pytest.raises(AssertionError, match="peer_port"):
+            check_peer_port(replace(captured, peer_port=8080), sent, scheme=_SCHEME)
+
+
+class TestEachPerSessionCheckRejectsItsOwnDefect:
+    """The four whole-recording checks, each handed its own defect."""
+
+    @staticmethod
+    def _session(
+        markers: tuple[str, ...], arrivals: tuple[float, ...], ports: tuple[int, ...]
+    ) -> tuple[Recording, list[SentRequest]]:
+        """Build a recording and the sends that should have produced it.
+
+        Args:
+            markers: The markers, in recorded order.
+            arrivals: The arrival stamps, in recorded order.
+            ports: The peer ports, in recorded order.
+
+        Returns:
+            The recording, the sent requests (always in marker order ``m1,
+            m2, ...`` so a recording that differs is out of order), and the
+            ports the driver opened.
+        """
+        requests = [
+            CapturedRequest(
+                method="POST", scheme=_SCHEME, host="h", path=f"/{marker}/x", query="",
+                headers=(("Host", "h"), ("X-Probe-Marker", marker)), body=b"", arrival=arrival,
+                peer_port=port,
+            )
+            for marker, arrival, port in zip(markers, arrivals, ports, strict=True)
+        ]
+        sent = [
+            _parse_sent(
+                f"POST /{marker}/x HTTP/1.1\r\nHost: h\r\nX-Probe-Marker: {marker}\r\n\r\n".encode(),
+                source_port=port, marker=marker,
+            )
+            for marker, port in zip(sorted(markers), sorted(ports), strict=True)
+        ]
+        connections = [(i, port, 1) for i, port in enumerate(sorted(ports))]
+        return Recording(requests=requests, connections=connections), sent, sorted(ports)
+
+    def test_arrival_check_rejects_a_constant_clock(self) -> None:
+        """Assert a recorder stamping the same time on everything is caught.
+
+        This is the defect a ``>=`` comparison lets through, which is why the
+        requirement is *strictly* increasing.
+        """
+        recording, sent, opened = self._session(("m1", "m2"), (7.0, 7.0), (101, 102))
+        with pytest.raises(AssertionError, match="strictly increase"):
+            check_arrival_increases(recording, sent, opened)
+
+    def test_arrival_check_rejects_a_backwards_clock(self) -> None:
+        """Assert a timestamp taken after the response, out of order, is caught."""
+        recording, sent, opened = self._session(("m1", "m2"), (9.0, 8.0), (101, 102))
+        with pytest.raises(AssertionError, match="strictly increase"):
+            check_arrival_increases(recording, sent, opened)
+
+    def test_arrival_check_rejects_a_missing_timestamp(self) -> None:
+        """Assert a recorder that never populates ``arrival`` is caught.
+
+        ``CapturedRequest.arrival`` defaults to ``None``, so a recorder that
+        simply forgot the field would otherwise produce captures that look
+        structurally valid.
+        """
+        recording, sent, opened = self._session(("m1", "m2"), (1.0, 2.0), (101, 102))
+        recording.requests[0] = replace(recording.requests[0], arrival=None)
+        with pytest.raises(AssertionError, match="float"):
+            check_arrival_increases(recording, sent, opened)
+
+    def test_order_check_rejects_a_reordered_recording(self) -> None:
+        """Assert a recorder appending out of order is caught.
+
+        Phrased over identity, not over ``arrival`` — so this defect and the
+        clock defects above each fail exactly one check.
+        """
+        recording, sent, opened = self._session(("m2", "m1"), (1.0, 2.0), (102, 101))
+        with pytest.raises(AssertionError, match="request order"):
+            check_request_order(recording, sent, opened)
+
+    def test_order_check_passes_a_constant_clock(self) -> None:
+        """Assert the ordering check is *not* tripped by a clock defect.
+
+        The negative half of R4.2: a defect must fail its named check and no
+        other. If ordering were phrased over ``arrival``, a constant clock would
+        fail here too and the falsification matrix would be ambiguous.
+        """
+        recording, sent, opened = self._session(("m1", "m2"), (7.0, 7.0), (101, 102))
+        check_request_order(recording, sent, opened)
+
+    def test_count_check_rejects_a_dropped_request(self) -> None:
+        """Assert a recorder that silently loses a request is caught."""
+        recording, sent, opened = self._session(("m1", "m2"), (1.0, 2.0), (101, 102))
+        recording.requests.pop()
+        with pytest.raises(AssertionError, match="no capture for"):
+            check_request_count(recording, sent, opened)
+
+    def test_connection_check_rejects_a_missing_connection_record(self) -> None:
+        """Assert a recorder logging no connection for a request is caught."""
+        recording, sent, opened = self._session(("m1", "m2"), (1.0, 2.0), (101, 102))
+        recording.connections.pop()
+        with pytest.raises(AssertionError, match="opened but never logged"):
+            check_connection_logged(recording, sent, opened)
+
+    def test_connection_check_rejects_logging_only_connections_that_sent_a_request(self) -> None:
+        """Assert the silent-connection defect is caught.
+
+        §5.2.1's whole negative is an upstream connection with no matching
+        tunnel. A connection that carries no HTTP request is invisible in the
+        request list, so a recorder that logs only request-bearing connections
+        cannot support the containment claim — and would pass every other check
+        in this module.
+        """
+        recording, sent, opened = self._session(("m1",), (1.0,), (101,))
+
+        # A second connection was opened and sent nothing, and the recorder did
+        # not log it. It produces no `SentRequest` — which is exactly why the
+        # check takes the opened ports separately. Judged against `sent` alone
+        # it could only ever ask about connections that *did* send something,
+        # and that is the one thing a lazily-logging recorder gets right.
+        silent_port = 999
+        assert silent_port not in {p for _, p, _ in recording.connections}
+
+        with pytest.raises(AssertionError, match="opened but never logged"):
+            check_connection_logged(recording, sent, [*opened, silent_port])
+
+
+class TestCorrelationIsByMarkerNotPosition:
+    """The property that keeps one defect from tripping fourteen checks."""
+
+    def test_correlate_finds_a_capture_out_of_position(self) -> None:
+        """Assert a capture is found by its marker regardless of where it sits.
+
+        This is what lets the per-exchange checks pass against a recorder whose
+        only fault is ordering, so that :func:`check_request_order` is the single
+        check that fails.
+        """
+        recording = Recording(
+            requests=[
+                CapturedRequest(method="POST", scheme="http", host="h", path="/m2/x", query="",
+                                headers=(("X-Probe-Marker", "m2"),)),
+                CapturedRequest(method="POST", scheme="http", host="h", path="/m1/x", query="",
+                                headers=(("X-Probe-Marker", "m1"),)),
+            ]
+        )
+        first = _parse_sent(b"POST /m1/x HTTP/1.1\r\nHost: h\r\nX-Probe-Marker: m1\r\n\r\n", 1, "m1")
+        assert correlate(recording, first).path == "/m1/x"
+
+    def test_correlate_refuses_an_ambiguous_marker(self) -> None:
+        """Assert two captures carrying one marker is an error, not a silent pick.
+
+        Returning the first match would let a recorder that duplicated a request
+        pass every per-exchange check.
+        """
+        recording = Recording(
+            requests=[
+                CapturedRequest(method="POST", scheme="http", host="h", path="/m1/x", query="",
+                                headers=(("X-Probe-Marker", "m1"),)),
+                CapturedRequest(method="POST", scheme="http", host="h", path="/m1/x", query="",
+                                headers=(("X-Probe-Marker", "m1"),)),
+            ]
+        )
+        sent = _parse_sent(b"POST /m1/x HTTP/1.1\r\nHost: h\r\nX-Probe-Marker: m1\r\n\r\n", 1, "m1")
+        with pytest.raises(AssertionError, match="exactly one capture"):
+            correlate(recording, sent)
+
+
+class TestTheHeaderChecksAreOrthogonal:
+    """The three header checks must not overlap, or R4.2 is unreachable.
+
+    R4.2 requires each deliberate defect to be rejected by its **named** check
+    and by no other. The three header defects — lower-casing names, sorting
+    them, dropping a duplicate — all disturb the same field, so the checks are
+    defined to be blind to each other's territory: casing by containment, order
+    as a subsequence of lower-cased names, duplicates by per-name value lists.
+
+    Those definitions are easy to "tidy" back into equality comparisons by a
+    later reader who sees three checks doing nearly the same thing. These tests
+    are what makes that tidying fail.
+    """
+
+    @staticmethod
+    def _lower_cased(captured: CapturedRequest) -> CapturedRequest:
+        """Return the capture a name-lower-casing recorder would produce.
+
+        Args:
+            captured: A conforming capture.
+
+        Returns:
+            The same capture with every header name lower-cased.
+        """
+        return replace(captured, headers=tuple((n.lower(), v) for n, v in captured.headers))
+
+    @staticmethod
+    def _sorted(captured: CapturedRequest) -> CapturedRequest:
+        """Return the capture a header-sorting recorder would produce.
+
+        Args:
+            captured: A conforming capture.
+
+        Returns:
+            The same capture with its headers sorted.
+        """
+        return replace(captured, headers=tuple(sorted(captured.headers)))
+
+    @staticmethod
+    def _deduplicated(captured: CapturedRequest) -> CapturedRequest:
+        """Return the capture a mapping-shaped recorder would produce.
+
+        Args:
+            captured: A conforming capture.
+
+        Returns:
+            The same capture with repeated header names collapsed to the first.
+        """
+        seen: set[str] = set()
+        kept = []
+        for name, value in captured.headers:
+            if name.lower() in seen:
+                continue
+            seen.add(name.lower())
+            kept.append((name, value))
+        return replace(captured, headers=tuple(kept))
+
+    def test_lower_casing_fails_only_the_casing_check(
+        self, captured: CapturedRequest, sent: SentRequest
+    ) -> None:
+        """Assert a re-casing recorder is not also reported as reordering or dropping.
+
+        Args:
+            captured: A conforming capture.
+            sent: The request that produced it.
+        """
+        defective = self._lower_cased(captured)
+        with pytest.raises(AssertionError, match="casing"):
+            check_header_casing(defective, sent, scheme=_SCHEME)
+        check_header_order(defective, sent, scheme=_SCHEME)
+        check_header_duplicates(defective, sent, scheme=_SCHEME)
+
+    def test_sorting_fails_only_the_order_check(
+        self, captured: CapturedRequest, sent: SentRequest
+    ) -> None:
+        """Assert a sorting recorder is not also reported as re-casing or dropping.
+
+        Args:
+            captured: A conforming capture.
+            sent: The request that produced it.
+        """
+        defective = self._sorted(captured)
+        assert [n for n, _ in defective.headers] != [n for n, _ in captured.headers], (
+            "the probe's headers must not already be sorted, or this proves nothing"
+        )
+        with pytest.raises(AssertionError, match="order"):
+            check_header_order(defective, sent, scheme=_SCHEME)
+        check_header_casing(defective, sent, scheme=_SCHEME)
+        check_header_duplicates(defective, sent, scheme=_SCHEME)
+
+    def test_dropping_a_duplicate_fails_only_the_duplicate_check(
+        self, captured: CapturedRequest, sent: SentRequest
+    ) -> None:
+        """Assert a mapping-shaped recorder is not also reported as re-casing or reordering.
+
+        Args:
+            captured: A conforming capture.
+            sent: The request that produced it.
+        """
+        defective = self._deduplicated(captured)
+        assert len(defective.headers) < len(captured.headers), (
+            "the probe must contain a duplicate header, or this proves nothing"
+        )
+        with pytest.raises(AssertionError, match="header values per name"):
+            check_header_duplicates(defective, sent, scheme=_SCHEME)
+        check_header_casing(defective, sent, scheme=_SCHEME)
+        check_header_order(defective, sent, scheme=_SCHEME)
+
+
+class TestTheSessionChecksAreOrthogonal:
+    """Ordering, counting and timing must not overlap, for the same reason."""
+
+    @staticmethod
+    def _session(markers, arrivals, ports):
+        """Build a recording and the sends that should have produced it.
+
+        Args:
+            markers: The markers, in recorded order.
+            arrivals: The arrival stamps, in recorded order.
+            ports: The peer ports, in recorded order.
+
+        Returns:
+            The recording and the sent requests in marker order.
+        """
+        return TestEachPerSessionCheckRejectsItsOwnDefect._session(markers, arrivals, ports)
+
+    def test_a_reordering_recorder_still_passes_the_count_and_clock_checks(self) -> None:
+        """Assert an out-of-order recorder trips the ordering check alone."""
+        recording, sent, opened = self._session(("m2", "m1"), (2.0, 1.0), (102, 101))
+        with pytest.raises(AssertionError, match="request order"):
+            check_request_order(recording, sent, opened)
+        check_request_count(recording, sent, opened)
+        # Read in SENT order the arrivals are 1.0 then 2.0, which is correct.
+        # Walking the recorded list instead would report a clock defect here,
+        # and the falsification matrix could not tell the two apart.
+        check_arrival_increases(recording, sent, opened)
+
+    def test_a_dropping_recorder_trips_the_count_check_alone(self) -> None:
+        """Assert a recorder losing a request is not also reported as misordering.
+
+        This is the defect nothing else catches: §4.3 C6's "``/healthz`` never
+        causes an upstream request" rests on a recorder that cannot silently
+        lose one.
+        """
+        recording, sent, opened = self._session(("m1", "m2"), (1.0, 2.0), (101, 102))
+        recording.requests.pop()
+        with pytest.raises(AssertionError, match="no capture for"):
+            check_request_count(recording, sent, opened)
+        check_request_order(recording, sent, opened)
+        check_arrival_increases(recording, sent, opened)
+
+    def test_a_constant_clock_trips_the_clock_check_alone(self) -> None:
+        """Assert a broken clock is not also reported as misordering or dropping."""
+        recording, sent, opened = self._session(("m1", "m2"), (7.0, 7.0), (101, 102))
+        with pytest.raises(AssertionError, match="strictly increase"):
+            check_arrival_increases(recording, sent, opened)
+        check_request_order(recording, sent, opened)
+        check_request_count(recording, sent, opened)
+
+
+class TestTheAssertionsWithNoDefectOfTheirOwn:
+    """Coverage for check branches that no falsification recorder reaches.
+
+    A review pass mutation-tested every assertion in the conformance module and
+    found three that could be deleted with the suite still green. One was a
+    tautology and is gone. These are the other two: both guard real failure
+    modes that no *recorder* defect happens to produce, so they need a
+    hand-built recording instead — an assertion nothing exercises is
+    indistinguishable from one that cannot fail.
+    """
+
+    def test_count_check_rejects_a_capture_nobody_sent(self) -> None:
+        """Assert an invented capture is caught.
+
+        The mirror of a dropped request: a recorder that duplicates one, or
+        manufactures one from a health check, corrupts the evidence just as
+        badly. §4.3 C6 — "``/healthz`` never causes an upstream request" —
+        rests on this half.
+        """
+        recording, sent, opened = TestEachPerSessionCheckRejectsItsOwnDefect._session(
+            ("m1",), (1.0,), (101,)
+        )
+        recording.requests.append(
+            CapturedRequest(
+                method="POST", scheme=_SCHEME, host="h", path="/ghost/x", query="",
+                headers=(("X-Probe-Marker", "ghost"),), body=b"", arrival=2.0, peer_port=101,
+            )
+        )
+        with pytest.raises(AssertionError, match="captures nobody sent"):
+            check_request_count(recording, sent, opened)
+
+    def test_connection_check_rejects_a_miscounted_connection(self) -> None:
+        """Assert a connection log that miscounts its requests is caught.
+
+        This is the other half of R1.10: a capture must be attributable to the
+        connection that carried it. A log that records the connection but loses
+        track of what rode on it cannot support §4.3 C5's distinct-connection
+        count.
+        """
+        recording, sent, opened = TestEachPerSessionCheckRejectsItsOwnDefect._session(
+            ("m1", "m2"), (1.0, 2.0), (101, 102)
+        )
+        connection_id, peer_port, _ = recording.connections[0]
+        recording.connections[0] = (connection_id, peer_port, 0)
+
+        with pytest.raises(AssertionError, match="accounts for 1 requests, 2 were sent"):
+            check_connection_logged(recording, sent, opened)

--- a/tests/harness/test_recorder_falsification.py
+++ b/tests/harness/test_recorder_falsification.py
@@ -309,22 +309,29 @@ class TextRoundTripRecorder(RecordingUpstream):
 
 
 class ReorderingRecorder(RecordingUpstream):
-    """Files captures in a stable order of its own instead of arrival order.
+    """Publishes captures in a stable order of its own, not arrival order.
 
     Sorted by the probe marker, descending — not by path, which every request in
     an ordinary probe shares, and which would therefore make this "defect" a
     no-op that proved nothing.
+
+    **The defect is in the published view, not in the slots.** Sorting
+    ``_slots`` in place would move entries out from under the indices reserved
+    for requests still in flight, so a third concurrent request would overwrite
+    someone else's row — a second, accidental defect, and the falsification
+    matrix could no longer say which one a failure came from. A recorder
+    subclass is a template as much as a test; the shape it teaches has to be the
+    safe one.
     """
 
-    def store(self, index: int, captured: CapturedRequest) -> None:
-        """File the capture, then re-sort the slots by marker.
+    @property
+    def requests(self) -> list[CapturedRequest]:
+        """Return the captures sorted by marker instead of by arrival.
 
-        Args:
-            index: The slot reserved when the request arrived.
-            captured: The capture to file.
+        Returns:
+            The completed captures, in the wrong order.
         """
-        self._slots[index] = captured
-        self._slots.sort(key=lambda c: marker_of(c) or "", reverse=True)
+        return sorted(super().requests, key=lambda c: marker_of(c) or "", reverse=True)
 
 
 class DroppingRecorder(RecordingUpstream):
@@ -332,18 +339,38 @@ class DroppingRecorder(RecordingUpstream):
 
     Nothing but the coverage check catches this, and §4.3 C6's *"``/healthz``
     never causes an upstream request"* rests on a recorder that cannot lose one.
+
+    Like :class:`ReorderingRecorder`, the loss is in the published view. Popping
+    from ``_slots`` would shift every higher index down by one and corrupt the
+    rows of requests still in flight.
     """
 
-    def store(self, index: int, captured: CapturedRequest) -> None:
-        """File the capture, then discard every second one.
+    @property
+    def requests(self) -> list[CapturedRequest]:
+        """Return every other capture.
+
+        Returns:
+            The completed captures with the odd-numbered ones missing.
+        """
+        return [c for i, c in enumerate(super().requests) if i % 2 == 0]
+
+
+class MiscountingConnectionRecorder(RecordingUpstream):
+    """Logs every connection, but never records what rode on it.
+
+    The other half of R1.10, and the half the matrix was missing: a log that
+    lists the right connections but cannot attribute a capture to one of them
+    still cannot support §4.3 C5's distinct-connection count. It passes the
+    "every opened port is logged" half of :func:`check_connection_logged`
+    outright, so only the carried-count assertion rejects it.
+    """
+
+    def count_on_connection(self, connection_id: int) -> None:
+        """Do not attribute the request to its connection.
 
         Args:
-            index: The slot reserved when the request arrived.
-            captured: The capture to file.
+            connection_id: The connection's id, ignored.
         """
-        super().store(index, captured)
-        if index % 2 == 1:
-            self._slots.pop(index)
 
 
 class LazyConnectionServer(_ConnectionLoggingServer):
@@ -619,6 +646,18 @@ class TestSessionDefectsAreCaughtByExactlyTheirOwnCheck:
         failing = next(c for c in PER_SESSION_CHECKS if c.__name__ == "check_request_count")
         recording, sent, opened = await self._run_pair(DroppingRecorder)
         self._assert_only(failing, recording, sent, opened, "no capture for")
+
+    async def test_a_miscounting_connection_log_fails_only_the_connection_check(self) -> None:
+        """Assert a log that cannot attribute a capture to a connection is caught.
+
+        Distinct from the lazy log above: every opened port *is* recorded, so
+        the first half of the check passes and only the carried-count half
+        fires. Both halves need their own defect, or one of them is an assertion
+        nothing exercises.
+        """
+        failing = next(c for c in PER_SESSION_CHECKS if c.__name__ == "check_connection_logged")
+        recording, sent, opened = await self._run_pair(MiscountingConnectionRecorder)
+        self._assert_only(failing, recording, sent, opened, "accounts for 0 requests")
 
     async def test_a_frozen_clock_fails_only_the_arrival_check(self) -> None:
         """Assert a constant clock is attributable to the arrival check alone."""

--- a/tests/harness/test_recorder_falsification.py
+++ b/tests/harness/test_recorder_falsification.py
@@ -1,0 +1,762 @@
+"""Deliberately broken recorders the conformance suite must reject.
+
+`.system_design/TEST_SUITE.md` §7.2 · plan **§1.4** (KBR-27, T-W4).
+
+> *"The first working version of every harness ships with at least one
+> falsification case — a deliberate defect it must detect, running in the
+> suite."*
+
+The rule exists because four design-review rounds produced four harnesses that
+would have passed while proving nothing. A recording upstream is the harness the
+whole of I1 reads its evidence from, so a check of it that is wired to nothing
+would not be noticed by anything else.
+
+Each recorder below breaks **one** thing, and each is asserted twice:
+
+1. its named check rejects it, and
+2. **no other check fails on the same exchange.**
+
+The second half is what catches an over-broad check. Without it, a check that
+failed on everything would satisfy every case here and the matrix would be
+worthless — which is exactly the shape of defect §1.4 was written about.
+
+Each defect also names the **probe** that exposes it. A defect is only
+observable against an input that distinguishes it: a recorder reading
+``request.host`` is byte-for-byte correct on any request that carries a ``Host``
+header, and one that re-encodes the body through ``str`` is correct on any body
+that happens to be valid UTF-8.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+import time
+from collections.abc import Sequence
+from dataclasses import replace
+from typing import Any
+
+import pytest
+from aiohttp import web
+
+from harness.contract import CapturedRequest, WireFormat
+from harness.recorder import ConnectionRecord, RecordingUpstream, _ConnectionLoggingServer
+from harness.recorder_conformance import (
+    LATIN_PROBE,
+    MARKER_HEADER,
+    NO_HOST_PROBE,
+    PER_EXCHANGE_CHECKS,
+    PER_SESSION_CHECKS,
+    RICH_PROBE,
+    Recording,
+    SentRequest,
+    _parse_sent,
+    check_connection_logged,
+    correlate,
+    marker_of,
+    open_connection_only,
+    probe,
+    recording_of,
+    send,
+)
+
+# --------------------------------------------------------------------------
+# The defective recorders
+# --------------------------------------------------------------------------
+
+
+class LowerCasingRecorder(RecordingUpstream):
+    """Normalises header names, the way any mapping-backed capture would."""
+
+    def capture(
+        self, request: web.BaseRequest, body: bytes, arrival: float
+    ) -> CapturedRequest:
+        """Return the capture with every header name lower-cased.
+
+        Args:
+            request: The inbound aiohttp request.
+            body: The entity body, already read.
+            arrival: The timestamp taken at handler entry.
+
+        Returns:
+            The deliberately wrong capture.
+        """
+        captured = super().capture(request, body, arrival)
+        return _replace_headers(captured, [(n.lower(), v) for n, v in captured.headers])
+
+
+class SortingRecorder(RecordingUpstream):
+    """Emits headers in sorted order, losing the order they arrived in."""
+
+    def capture(
+        self, request: web.BaseRequest, body: bytes, arrival: float
+    ) -> CapturedRequest:
+        """Return the capture with its headers sorted.
+
+        Args:
+            request: The inbound aiohttp request.
+            body: The entity body, already read.
+            arrival: The timestamp taken at handler entry.
+
+        Returns:
+            The deliberately wrong capture.
+        """
+        captured = super().capture(request, body, arrival)
+        return _replace_headers(captured, sorted(captured.headers))
+
+
+class DeduplicatingRecorder(RecordingUpstream):
+    """Keeps one entry per header name, as a ``dict`` would."""
+
+    def capture(
+        self, request: web.BaseRequest, body: bytes, arrival: float
+    ) -> CapturedRequest:
+        """Return the capture with repeated header names collapsed.
+
+        Args:
+            request: The inbound aiohttp request.
+            body: The entity body, already read.
+            arrival: The timestamp taken at handler entry.
+
+        Returns:
+            The deliberately wrong capture.
+        """
+        captured = super().capture(request, body, arrival)
+        seen: set[str] = set()
+        kept = []
+        for name, value in captured.headers:
+            if name.lower() in seen:
+                continue
+            seen.add(name.lower())
+            kept.append((name, value))
+        return _replace_headers(captured, kept)
+
+
+class OwnPortRecorder(RecordingUpstream):
+    """Records its own listening port instead of the peer's.
+
+    The failure this produces downstream is not a broken join against §5.2.1's
+    tunnel log — it is a join that *succeeds*, against the wrong connection.
+    """
+
+    def capture(
+        self, request: web.BaseRequest, body: bytes, arrival: float
+    ) -> CapturedRequest:
+        """Return the capture with the recorder's own listening port.
+
+        Args:
+            request: The inbound aiohttp request.
+            body: The entity body, already read.
+            arrival: The timestamp taken at handler entry.
+
+        Returns:
+            The deliberately wrong capture.
+        """
+        return _replace(super().capture(request, body, arrival), peer_port=self.port)
+
+
+class DecodedQueryRecorder(RecordingUpstream):
+    """Uses ``request.query_string``, which is percent-decoded."""
+
+    def capture(
+        self, request: web.BaseRequest, body: bytes, arrival: float
+    ) -> CapturedRequest:
+        """Return the capture with a percent-decoded query.
+
+        Args:
+            request: The inbound aiohttp request.
+            body: The entity body, already read.
+            arrival: The timestamp taken at handler entry.
+
+        Returns:
+            The deliberately wrong capture.
+        """
+        return _replace(super().capture(request, body, arrival), query=request.query_string)
+
+
+class DroppedQueryRecorder(RecordingUpstream):
+    """Keeps no query at all.
+
+    On Azure the query carries the API version while the path carries the
+    deployment, and P6 removes ``model`` from the body — so a lost query can
+    make two different routes indistinguishable.
+    """
+
+    def capture(
+        self, request: web.BaseRequest, body: bytes, arrival: float
+    ) -> CapturedRequest:
+        """Return the capture with no query at all.
+
+        Args:
+            request: The inbound aiohttp request.
+            body: The entity body, already read.
+            arrival: The timestamp taken at handler entry.
+
+        Returns:
+            The deliberately wrong capture.
+        """
+        return _replace(super().capture(request, body, arrival), query="")
+
+
+class DecodedPathRecorder(RecordingUpstream):
+    """Uses ``request.path``, which is percent-decoded."""
+
+    def capture(
+        self, request: web.BaseRequest, body: bytes, arrival: float
+    ) -> CapturedRequest:
+        """Return the capture with a percent-decoded path.
+
+        Args:
+            request: The inbound aiohttp request.
+            body: The entity body, already read.
+            arrival: The timestamp taken at handler entry.
+
+        Returns:
+            The deliberately wrong capture.
+        """
+        return _replace(super().capture(request, body, arrival), path=request.path)
+
+
+class HostAttributeRecorder(RecordingUpstream):
+    """Uses ``request.host``, which invents a value when none was sent.
+
+    aiohttp returns ``socket.getfqdn()`` — the machine's own name — for a
+    request with no ``Host`` header. Only the no-``Host`` probe can see it.
+    """
+
+    def capture(
+        self, request: web.BaseRequest, body: bytes, arrival: float
+    ) -> CapturedRequest:
+        """Return the capture with aiohttp's own ``request.host``.
+
+        Args:
+            request: The inbound aiohttp request.
+            body: The entity body, already read.
+            arrival: The timestamp taken at handler entry.
+
+        Returns:
+            The deliberately wrong capture.
+        """
+        return _replace(super().capture(request, body, arrival), host=request.host)
+
+
+class FrozenClockRecorder(RecordingUpstream):
+    """Stamps the same arrival time on everything."""
+
+    def capture(
+        self, request: web.BaseRequest, body: bytes, arrival: float
+    ) -> CapturedRequest:
+        """Return the capture with a fixed arrival timestamp.
+
+        Args:
+            request: The inbound aiohttp request.
+            body: The entity body, already read.
+            arrival: The timestamp taken at handler entry.
+
+        Returns:
+            The deliberately wrong capture.
+        """
+        return _replace(super().capture(request, body, arrival), arrival=0.0)
+
+
+class LateClockRecorder(RecordingUpstream):
+    """Stamps arrival when the capture is built, not when the request arrived.
+
+    The difference only shows when a body takes time to arrive — which is the
+    normal case for the large transcripts §7.1's corpus is made of.
+    """
+
+    def capture(
+        self, request: web.BaseRequest, body: bytes, arrival: float
+    ) -> CapturedRequest:
+        """Return the capture with arrival stamped now, not at entry.
+
+        Args:
+            request: The inbound aiohttp request.
+            body: The entity body, already read.
+            arrival: The timestamp taken at handler entry.
+
+        Returns:
+            The deliberately wrong capture.
+        """
+        return _replace(super().capture(request, body, arrival), arrival=time.monotonic())
+
+
+class TextRoundTripRecorder(RecordingUpstream):
+    """Records ``request.text()`` re-encoded, losing the original bytes.
+
+    Invisible on valid UTF-8, which is why its probe declares ``charset=latin-1``
+    and sends high bytes: aiohttp then decodes latin-1 and the re-encode to
+    UTF-8 returns different bytes.
+    """
+
+    def capture(
+        self, request: web.BaseRequest, body: bytes, arrival: float
+    ) -> CapturedRequest:
+        """Return the capture with the body decoded and re-encoded.
+
+        Args:
+            request: The inbound aiohttp request.
+            body: The entity body, already read.
+            arrival: The timestamp taken at handler entry.
+
+        Returns:
+            The deliberately wrong capture.
+        """
+        captured = super().capture(request, body, arrival)
+        charset = request.charset or "utf-8"
+        return _replace(captured, body=body.decode(charset).encode("utf-8"))
+
+
+class ReorderingRecorder(RecordingUpstream):
+    """Files captures in a stable order of its own instead of arrival order.
+
+    Sorted by the probe marker, descending — not by path, which every request in
+    an ordinary probe shares, and which would therefore make this "defect" a
+    no-op that proved nothing.
+    """
+
+    def store(self, index: int, captured: CapturedRequest) -> None:
+        """File the capture, then re-sort the slots by marker.
+
+        Args:
+            index: The slot reserved when the request arrived.
+            captured: The capture to file.
+        """
+        self._slots[index] = captured
+        self._slots.sort(key=lambda c: marker_of(c) or "", reverse=True)
+
+
+class DroppingRecorder(RecordingUpstream):
+    """Silently loses every second request.
+
+    Nothing but the coverage check catches this, and §4.3 C6's *"``/healthz``
+    never causes an upstream request"* rests on a recorder that cannot lose one.
+    """
+
+    def store(self, index: int, captured: CapturedRequest) -> None:
+        """File the capture, then discard every second one.
+
+        Args:
+            index: The slot reserved when the request arrived.
+            captured: The capture to file.
+        """
+        super().store(index, captured)
+        if index % 2 == 1:
+            self._slots.pop(index)
+
+
+class LazyConnectionServer(_ConnectionLoggingServer):
+    """Registers the connection with aiohttp, but logs nothing at accept time."""
+
+    def connection_made(self, handler: Any, transport: Any) -> None:
+        """Accept the connection without recording it.
+
+        `web.Server.connection_made` is still called, so aiohttp keeps working:
+        the defect is the missing evidence, not a broken server.
+
+        Args:
+            handler: The ``RequestHandler`` for this connection.
+            transport: The connection's transport.
+        """
+        web.Server.connection_made(self, handler, transport)
+
+
+class LazyConnectionRecorder(RecordingUpstream):
+    """Logs a connection only when it produces a request.
+
+    This is R4.1's row 13, and it is the **plausible** version of the defect: a
+    recorder that logs connections from inside the request handler looks
+    completely correct for every request-bearing connection, and is wrong only
+    for the one shape §5.2.1 cares about — a connection that carries nothing.
+
+    An earlier version of this class logged *no* connections at all, which any
+    ordinary request would catch. That made the row untestable for its own
+    defect and is exactly the §1.4 trap.
+    """
+
+    _server_class = LazyConnectionServer
+
+    def capture(self, request, body, arrival):
+        """Log the connection now, on the way to recording the request.
+
+        Args:
+            request: The inbound aiohttp request.
+            body: The entity body, already read.
+            arrival: The timestamp taken at handler entry.
+
+        Returns:
+            The capture, unmodified.
+        """
+        peer = request.transport.get_extra_info("peername") if request.transport else None
+        self.connections.append(
+            ConnectionRecord(len(self.connections), peer[1] if peer else -1, 1)
+        )
+        return super().capture(request, body, arrival)
+
+
+def _replace(captured: CapturedRequest, **changes: object) -> CapturedRequest:
+    """Return a copy of ``captured`` with ``changes`` applied.
+
+    Args:
+        captured: The capture to copy.
+        **changes: Fields to override.
+
+    Returns:
+        The modified capture.
+    """
+    return replace(captured, **changes)  # type: ignore[arg-type]
+
+
+def _replace_headers(
+    captured: CapturedRequest, headers: Sequence[tuple[str, str]]
+) -> CapturedRequest:
+    """Return a copy of ``captured`` carrying ``headers``.
+
+    Args:
+        captured: The capture to copy.
+        headers: The replacement header pairs.
+
+    Returns:
+        The modified capture.
+    """
+    return _replace(captured, headers=tuple(headers))
+
+
+# --------------------------------------------------------------------------
+# Probes
+# --------------------------------------------------------------------------
+
+
+_LATIN_BODY = b'{"n":"caf\xe9"}'
+_LATIN = (
+    b"POST /v1/chat/completions HTTP/1.1\r\n"
+    b"Host: h\r\n"
+    b"X-Probe-Marker: latin\r\n"
+    b"Content-Type: application/json; charset=latin-1\r\n"
+    b"Content-Length: " + str(len(_LATIN_BODY)).encode() + b"\r\n"
+    b"\r\n" + _LATIN_BODY
+)
+
+
+async def _run_single(cls: type[RecordingUpstream], raw: bytes, marker: str):
+    """Drive one request at a recorder and return the capture and what was sent.
+
+    Args:
+        cls: The recorder class to instantiate.
+        raw: The probe request bytes.
+        marker: The probe's correlation marker.
+
+    Returns:
+        The recorder, the capture and the :class:`SentRequest`.
+    """
+    upstream = cls(default_format=WireFormat.CHAT_COMPLETIONS)
+    await upstream.start()
+    try:
+        sent = await send(upstream.host, upstream.port, raw, marker=marker)
+        captured = correlate(recording_of(upstream), sent)
+        return upstream, captured, sent
+    finally:
+        await upstream.stop()
+
+
+def _assert_only(
+    failing, captured: CapturedRequest, sent: SentRequest, scheme: str, expected: str
+) -> None:
+    """Assert ``failing`` rejects the capture and every other check accepts it.
+
+    Args:
+        failing: The check that must reject.
+        captured: The defective capture.
+        sent: The request that produced it.
+        scheme: The recorder's declared scheme.
+        expected: Text the rejection message must contain. Without it, a check
+            that blew up on some unrelated condition would satisfy R4.2's
+            "rejected by its named check" — failing, but not for its own reason.
+
+    Raises:
+        AssertionError: When the named check passes, rejects for the wrong
+            reason, or when any other check fails on the same exchange.
+    """
+    with pytest.raises(AssertionError, match=expected):
+        failing(captured, sent, scheme=scheme)
+
+    for check in PER_EXCHANGE_CHECKS:
+        if check is failing:
+            continue
+        try:
+            check(captured, sent, scheme=scheme)
+        except AssertionError as exc:  # pragma: no cover - only on a real defect
+            raise AssertionError(
+                f"{failing.__name__} was the named check, but {check.__name__} also "
+                f"failed on the same exchange: {exc}. A defect must be attributable "
+                "to one check, or the falsification matrix cannot say what it caught."
+            ) from exc
+
+
+class TestCaptureDefectsAreCaughtByExactlyTheirOwnCheck:
+    """R4.1 / R4.2 for the ten per-exchange checks."""
+
+    @pytest.mark.parametrize(
+        ("cls", "check_name", "raw", "marker", "expected"),
+        [
+            (LowerCasingRecorder, "check_header_casing", RICH_PROBE, "rich", "header casing"),
+            (SortingRecorder, "check_header_order", RICH_PROBE, "rich", "header order"),
+            (DeduplicatingRecorder, "check_header_duplicates", RICH_PROBE, "rich",
+             "header values per name"),
+            (OwnPortRecorder, "check_peer_port", RICH_PROBE, "rich", "peer_port"),
+            (DecodedQueryRecorder, "check_query", RICH_PROBE, "rich", "query"),
+            (DroppedQueryRecorder, "check_query", RICH_PROBE, "rich", "query"),
+            (DecodedPathRecorder, "check_path", RICH_PROBE, "rich", "path"),
+            (HostAttributeRecorder, "check_host", NO_HOST_PROBE, "nohost", "invented"),
+            (TextRoundTripRecorder, "check_body", LATIN_PROBE, "latin", "body"),
+        ],
+        ids=lambda v: v.__name__ if isinstance(v, type) else (v if isinstance(v, str) else ""),
+    )
+    async def test_defect_fails_its_named_check_and_no_other(
+        self, cls, check_name: str, raw: bytes, marker: str, expected: str
+    ) -> None:
+        """Assert one deliberate capture defect is attributable to one check.
+
+        Args:
+            cls: The defective recorder.
+            check_name: The check that must reject it.
+            raw: The probe that exposes the defect.
+            marker: The probe's marker.
+            expected: Text the rejection message must carry, so the check is
+                known to have failed for its own reason.
+        """
+        failing = next(c for c in PER_EXCHANGE_CHECKS if c.__name__ == check_name)
+        upstream, captured, sent = await _run_single(cls, raw, marker)
+        _assert_only(failing, captured, sent, upstream.scheme, expected)
+
+    async def test_the_host_defect_is_invisible_when_a_host_header_is_sent(self) -> None:
+        """Assert the no-``Host`` probe is load-bearing, not decoration.
+
+        ``request.host`` returns the ``Host`` header verbatim whenever one was
+        sent, so on any other probe this recorder is indistinguishable from a
+        correct one. Recording that here stops someone "simplifying" the
+        falsification matrix by reusing the rich probe for every case.
+        """
+        failing = next(c for c in PER_EXCHANGE_CHECKS if c.__name__ == "check_host")
+        upstream, captured, sent = await _run_single(HostAttributeRecorder, RICH_PROBE, "rich")
+        failing(captured, sent, scheme=upstream.scheme)
+
+    async def test_the_text_round_trip_defect_is_invisible_on_utf8(self) -> None:
+        """Assert the latin-1 probe is load-bearing.
+
+        A body that is already valid UTF-8 survives ``decode`` + ``encode``
+        unchanged, so on the ordinary probe this recorder looks correct.
+        """
+        failing = next(c for c in PER_EXCHANGE_CHECKS if c.__name__ == "check_body")
+        upstream, captured, sent = await _run_single(
+            TextRoundTripRecorder, probe("plain", body=b'{"a":1}'), "plain"
+        )
+        failing(captured, sent, scheme=upstream.scheme)
+
+
+class TestSessionDefectsAreCaughtByExactlyTheirOwnCheck:
+    """R4.1 / R4.2 for the four whole-recording checks."""
+
+    @staticmethod
+    async def _run_pair(cls: type[RecordingUpstream]):
+        """Drive two ordinary requests at a recorder.
+
+        Args:
+            cls: The recorder class to instantiate.
+
+        Returns:
+            The recording, the requests sent, and the ports opened.
+        """
+        upstream = cls(default_format=WireFormat.CHAT_COMPLETIONS)
+        await upstream.start()
+        try:
+            sent = [
+                await send(upstream.host, upstream.port, probe(marker), marker=marker)
+                for marker in ("aaa", "bbb")
+            ]
+            return recording_of(upstream), sent, [s.source_port for s in sent]
+        finally:
+            await upstream.stop()
+
+    @staticmethod
+    def _assert_only(failing, recording: Recording, sent, opened, expected: str) -> None:
+        """Assert only ``failing`` rejects this recording, and for its own reason.
+
+        Args:
+            failing: The check that must reject.
+            recording: The defective recording.
+            sent: The requests that produced it.
+            opened: The ports the driver opened.
+            expected: Text the rejection message must contain.
+
+        Raises:
+            AssertionError: When the named check passes, rejects for the wrong
+                reason, or when another check fails.
+        """
+        with pytest.raises(AssertionError, match=expected):
+            failing(recording, sent, opened)
+
+        for check in PER_SESSION_CHECKS:
+            if check is failing:
+                continue
+            try:
+                check(recording, sent, opened)
+            except AssertionError as exc:  # pragma: no cover - only on a real defect
+                raise AssertionError(
+                    f"{failing.__name__} was the named check, but {check.__name__} "
+                    f"also failed: {exc}"
+                ) from exc
+
+    async def test_a_reordering_recorder_fails_only_the_order_check(self) -> None:
+        """Assert misordering is attributable to the ordering check alone."""
+        failing = next(c for c in PER_SESSION_CHECKS if c.__name__ == "check_request_order")
+        recording, sent, opened = await self._run_pair(ReorderingRecorder)
+        self._assert_only(failing, recording, sent, opened, "request order")
+
+    async def test_a_dropping_recorder_fails_only_the_coverage_check(self) -> None:
+        """Assert a lost request is attributable to the coverage check alone."""
+        failing = next(c for c in PER_SESSION_CHECKS if c.__name__ == "check_request_count")
+        recording, sent, opened = await self._run_pair(DroppingRecorder)
+        self._assert_only(failing, recording, sent, opened, "no capture for")
+
+    async def test_a_frozen_clock_fails_only_the_arrival_check(self) -> None:
+        """Assert a constant clock is attributable to the arrival check alone."""
+        failing = next(c for c in PER_SESSION_CHECKS if c.__name__ == "check_arrival_increases")
+        recording, sent, opened = await self._run_pair(FrozenClockRecorder)
+        self._assert_only(failing, recording, sent, opened, "strictly increase")
+
+    async def test_a_late_clock_is_caught_when_a_body_arrives_slowly(self) -> None:
+        """Assert stamping arrival after the body read is caught.
+
+        The probe is what makes this observable: the first request's body is
+        delivered *after* the second request has completed, so a recorder that
+        stamps at capture time reverses the two. A recorder stamping at handler
+        entry — which is what the real one does — records them in the order they
+        arrived.
+        """
+        failing = next(c for c in PER_SESSION_CHECKS if c.__name__ == "check_arrival_increases")
+
+        upstream = LateClockRecorder(default_format=WireFormat.CHAT_COMPLETIONS)
+        await upstream.start()
+        try:
+            recording, sent, opened = await _drive_slow_body_pair(upstream)
+        finally:
+            await upstream.stop()
+
+        with pytest.raises(AssertionError, match="strictly increase"):
+            failing(recording, sent, opened)
+
+    async def test_the_same_probe_passes_against_the_real_recorder(self) -> None:
+        """The positive control for the slow-body probe.
+
+        Without it, a probe that had stopped producing overlapping requests
+        would make the case above pass for the wrong reason.
+        """
+        upstream = RecordingUpstream(default_format=WireFormat.CHAT_COMPLETIONS)
+        await upstream.start()
+        try:
+            recording, sent, opened = await _drive_slow_body_pair(upstream)
+        finally:
+            await upstream.stop()
+
+        for check in PER_SESSION_CHECKS:
+            check(recording, sent, opened)
+
+    async def test_a_lazily_logged_connection_log_fails_the_connection_check(self) -> None:
+        """Assert a log that only sees request-bearing connections is caught.
+
+        §5.2.1's bypass is a connection that carries **no** HTTP request. A
+        recorder that logs from inside the request handler is correct for every
+        other connection, so this is the only probe that distinguishes it — and
+        the reason :func:`check_connection_logged` is given the opened ports
+        rather than inferring them from what was sent.
+        """
+        upstream = LazyConnectionRecorder(default_format=WireFormat.CHAT_COMPLETIONS)
+        await upstream.start()
+        try:
+            silent_port = await open_connection_only(upstream.host, upstream.port)
+            sent = await send(upstream.host, upstream.port, probe("c"), marker="c")
+            recording = recording_of(upstream)
+        finally:
+            await upstream.stop()
+
+        opened = [silent_port, sent.source_port]
+        with pytest.raises(AssertionError, match="opened but never logged"):
+            check_connection_logged(recording, [sent], opened)
+
+    async def test_the_real_recorder_logs_the_same_silent_connection(self) -> None:
+        """The positive control for the probe above.
+
+        Without it, a probe that had stopped opening a silent connection would
+        make the case above pass for the wrong reason — and the defect it names
+        would go unexercised again.
+        """
+        upstream = RecordingUpstream(default_format=WireFormat.CHAT_COMPLETIONS)
+        await upstream.start()
+        try:
+            silent_port = await open_connection_only(upstream.host, upstream.port)
+            sent = await send(upstream.host, upstream.port, probe("c"), marker="c")
+            recording = recording_of(upstream)
+        finally:
+            await upstream.stop()
+
+        check_connection_logged(recording, [sent], [silent_port, sent.source_port])
+
+
+async def _drive_slow_body_pair(upstream: RecordingUpstream):
+    """Send two requests whose arrival order and completion order differ.
+
+    The first request's headers arrive first, but its body is withheld until the
+    second request has been served in full. A recorder stamping ``arrival`` at
+    handler entry therefore records them in one order, and one stamping at
+    capture time records them in the other.
+
+    Args:
+        upstream: The running recorder.
+
+    Returns:
+        The recording, the requests sent in the order they began, and the ports
+        opened.
+    """
+    body = b'{"slow":1}'
+    head = (
+        f"POST /v1/chat/completions HTTP/1.1\r\nHost: h\r\n"
+        f"{MARKER_HEADER}: slow\r\nContent-Length: {len(body)}\r\n\r\n"
+    ).encode()
+
+    slow_sock = socket.create_connection((upstream.host, upstream.port))
+    try:
+        slow_port = slow_sock.getsockname()[1]
+        await asyncio.to_thread(slow_sock.sendall, head)
+        # The handler is now blocked reading the body, so its arrival is stamped.
+        await _wait_until(
+            lambda: len(upstream.connections) >= 1, "the slow request to be accepted"
+        )
+
+        fast = await send(upstream.host, upstream.port, probe("fast"), marker="fast")
+
+        await asyncio.to_thread(slow_sock.sendall, body)
+        await _wait_until(lambda: len(upstream.requests) >= 2, "the slow request's body")
+    finally:
+        slow_sock.close()
+
+    slow = _parse_sent(head + body, slow_port, "slow")
+    return recording_of(upstream), [slow, fast], [slow_port, fast.source_port]
+
+
+async def _wait_until(predicate, what: str) -> None:
+    """Yield to the loop until ``predicate`` holds.
+
+    Args:
+        predicate: The condition to wait for.
+        what: What is being waited for, for the failure message.
+
+    Raises:
+        AssertionError: When the condition does not hold within the budget.
+    """
+    for _ in range(400):
+        if predicate():
+            return
+        await asyncio.sleep(0.005)
+    raise AssertionError(f"timed out waiting for {what}")


### PR DESCRIPTION
Plan task **T-W4** ([KBR-27](https://shelpuk.atlassian.net/browse/KBR-27)), design `TEST_SUITE.md` §7.2 and the new §7.2.1. Unblocked by KBR-25 (T-W2), merged in #52.

## Context for the Product Owner

Kitty Bridge sits between a coding agent and ~25 model providers, rewriting each request so the agent believes it is talking to its native vendor. The product promise is that the bridge is **invisible**: whatever the agent sends, the provider sees the same conversation.

Nobody can currently prove that, because nothing in the test suite records what actually left the building.

This PR builds the instrument. It is a fake provider that accepts the bridge's outbound calls and records them with forensic fidelity — exact header spelling and order, the exact URL, the exact bytes, and which TCP connection carried them. It ships no assertions about the product; later tickets do the judging. Three of them are blocked on this one, and all three inherit the contract it fixes, which is why it is worth getting exactly right rather than quickly.

**No production code is touched.** `git diff origin/main -- src/` is empty.

**One product observation, raised and deliberately not acted on.** When the bridge talks to an Anthropic-format provider and streams the reply, it forwards those bytes to the agent without inspecting them (`server.py:3616`). Every other provider format is checked for "the model replied with nothing" and retried. That path is not. A provider returning an empty-but-well-formed stream would reach the user as an empty answer with no retry. It may be intentional; it is recorded in §7.2.1 and flagged on the ticket for a decision.

## What is here

| File | Role |
|---|---|
| `tests/harness/recorder.py` | The recording upstream |
| `tests/harness/recorder_conformance.py` | 14 checks + the shared probe driver — the contract T-B1/T-B2/T-B3 must each pass |
| `tests/harness/test_recorder.py` | The recorder against real sockets |
| `tests/harness/test_recorder_conformance.py` | The checks' own falsification suite |
| `tests/harness/test_recorder_falsification.py` | 14 deliberately broken recorders |

229 tests, ~1.5 s. No `sleep`-based waiting anywhere; every wait polls a condition.

## Every capture decision is a way to look correct and lie

Each was settled by probe on the pinned stack, not by reading documentation:

| Field | Read from | Because the obvious choice |
|---|---|---|
| Headers | `raw_headers`, **latin-1** | `utf-8` refuses obs-text a real client may send |
| Path | `rel_url.raw_path` | `request.path` is percent-**decoded** — Azure's deployment id vanishes, and once P6 strips `model` that is the *only* difference between two requests |
| Query | `rel_url.raw_query_string` | `request.query_string` is percent-**decoded** |
| Authority | the `Host` header itself | `request.host` **fabricates** — with no `Host` it returns `socket.getfqdn()`, the CI machine's own name, and that fallback differs across the versions `pyproject.toml` allows. `request.url` lower-cases it |

Plus three construction facts, each of which fails as a bare client-side `ConnectionResetError` with no traceback if got wrong: `client_max_size=0` via a `request_factory` (**it is not a `Server` argument**), `auto_decompress=False`, and connection logging via `web.Server.connection_made`.

**`client_max_size` is the one with product consequences.** The 1 MiB default turns the corpus's over-budget transcripts into a harness 413 — which is M6's own trigger, so the harness would manufacture the conversation-rewriting it exists to detect and report it as a product defect. Set to `0`, which disables the check; not to a bigger number, because the comparison is `>=` and any ceiling is something a later corpus entry outgrows.

**The connection log is contract shape.** §5.2.1's whole negative is a connection carrying *no* request — invisible in any request list by construction. Keyed on the handler **object**: `id()` would reintroduce the port-reuse aliasing the log exists to eliminate, one level down, and `WeakKeyDictionary` is impossible because `RequestHandler` is not weak-referenceable. With TLS the seam fires after the handshake, so a failed negotiation is invisible — recorded for T-B2/T-E2 rather than left to be found as a green containment test.

## A correction to the plan

The plan justified the success responses as *"the retry paths … are themselves body-mutating"*. §4.3 C3 says the opposite: transport-blip and empty-response retries are "the two that repeat a request **unchanged**". The real costs are sharper — an empty reply is **80 seconds** of real sleep in a gating job (the defect commit `691e974` already fixed once), and on a balancing profile it fails over, which *is* mutating. Corrected in `TEST_SUITE_IMPLEMENTATION_PLAN.md`.

Emptiness is judged by the **upstream** format, not the inbound endpoint — including the Anthropic-streaming cell that reaches no judgement at all.

## Fourteen checks, fourteen defects, and attribution

A defect must be rejected by its **named** check with **no other check failing on the same exchange**. Under the obvious definitions that is unreachable: lower-casing header names disturbs order too, dropping a duplicate disturbs both. So the semantics are deliberately blind to each other's territory — casing by *containment*, order by *subsequence*, duplicates by *per-name values*, arrival read in *sent* order. **Two tests exist solely to fail if someone tidies those back into equality**, because they will look redundant.

Captures correlate to sends by a marker in a **header** — any other location is destroyed by one of the defects, and correlation would then fail with "no capture found" instead of the named check failing.

## Four defects of the §1.4 shape, caught while building this

Each found by mutating the thing under test, none by reading it:

1. **A check that could not fail for the defect it named.** `check_connection_logged`, judged against the requests *sent*, could only ask about connections that sent something — precisely what a lazily-logging recorder gets right. Its "deliberately broken" recorder logged *nothing*, which any request catches, and the unit test propped it up by fabricating a `SentRequest` for a connection that had sent nothing. Fixed: the check is told which ports were **opened**; the defect is now the plausible lazy log.
2. **A defect recorder that sorted by a field every probe shared** — a no-op whose test proved nothing.
3. **A probe driver that blocked the recorder's own event loop**, so the server never accepted and the empty recording looked like a broken recorder.
4. **A connection map keyed on `id(handler)`** — CPython reuses addresses.

(1) and (4) were caught in review; a guard specified but never called was too, and unwiring it was *still* undetectable afterwards, so a structural source guard now asserts the fixture calls it — the technique `test_contract.py` and `test_egress_coverage.py` already use here.

## Review trail

Three `system-design-reviewer` passes (8 blockers, 21 concerns) and one `code-reviewer` pass (2 blockers — both real, both above). Every finding and its disposition is in `.requirements/20260911T153302Z_recorder_primary_aiohttp/REQUIREMENTS.md` §9.

Sized **M** in the plan, corrected to **L**.

## Verification

`ruff` · `lint-imports` · `mypy src/kitty` · `pytest -m "l1 or l2"` → **3608 passed**.

⚠️ One failure, `test_bridge_management.py::TestBridgeReachable::test_connect_target_table[::ffff:0.0.0.0-127.0.0.1]`. **Pre-existing and unrelated** — verified by running it against a pristine `origin/main` worktree, where it fails identically. It is a pure-function assertion in `kitty.bridge.manage._connect_target`, and this branch changes no source. Environment-specific; CI is green on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016GTtJS1VSesqdAsp66n6fz


[KBR-27]: https://shelpuk.atlassian.net/browse/KBR-27?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ