### PR TITLE
State one client version, from one source (KBR-8)

### DIFF
--- a/.system_design/TEST_SUITE.md
+++ b/.system_design/TEST_SUITE.md
@@ -733,18 +733,30 @@ documentation only; each needed its own ticket. F3, F4 and F5 were live breaches
 defined above. **F5 has since been fixed under KBR-7**, together with the hook-level half of its
 guard; see its entry below and §6.2.3. The rest remain open.
 
-- **F1 — Agent identity is handled per-provider, not by policy.** *(KBR-8.)* Upstream headers are built from
+- **F1 — Agent identity is handled per-provider, not by policy.** *(KBR-8 — the self-contradiction
+  **fixed**; the policy gap remains.)* Upstream headers are built from
   scratch, so Claude Code's `user-agent`, `x-app`, `anthropic-beta` and `x-stainless-*` never
   reach the provider. Four adapters compensate ad hoc (P9a, P9c): `KimiCodeAdapter`, `BytePlusAdapter`
   and `MimoAdapter` hard-code `User-Agent: claude-code/1.0` — Kimi's carries a comment recording
   the string was on the provider's allowlist as of 2026-04-18 — and `OpenAISubscriptionAdapter`
   synthesises a Codex CLI identity. Everywhere else, including `zai_coding`, aiohttp's default
   goes instead.
-  **The subscription adapter contradicts itself in a single request:** its user-agent is
-  `codex_cli_rs/{kitty.__version__}` (currently `1.9.0`) while its `version` header is the
-  constant `0.128.0`. A client claiming to be Codex CLI 1.9.0 *and* 0.128.0 at once is a one-line
-  detection rule — and the user-agent tracks kitty's release train, so it changes with every
-  kitty release and with nothing else. Tracked as G3, KBR-8 and Q1.
+  **The subscription adapter contradicted itself in a single request — FIXED (KBR-8,
+  2026-09-11).** Its user-agent was `codex_cli_rs/{kitty.__version__}` while its `version` header
+  was the constant `0.128.0`. A client claiming to be Codex CLI 1.9.1 *and* 0.128.0 at once is a
+  one-line detection rule, and the user-agent tracked kitty's release train, changing with every
+  kitty release and with nothing else. **The finding's own text demonstrates it:** the defect was
+  filed reading `1.9.0` and measured reading `1.9.1`, moved by a kitty release and nothing else.
+  `_build_user_agent` now reads `_CODEX_CLI_VERSION`, the same constant the `version` header
+  carries, so the two agree by construction. The behavioural guard is
+  `tests/test_upstream_identity_consistency.py`, which sweeps every registered adapter through a
+  mirror of `BridgeServer._build_upstream_headers` — plus the subscription adapter's
+  `_build_codex_headers`, since it overrides no hook and would otherwise be invisible. It stands
+  in until T-G9 / KBR-78 lands the exact-set contract, exactly as
+  `tests/bridge/test_vendor_token_guard.py` stands in until T-G5.
+  **What KBR-8 did not close:** identity is still ad hoc per adapter — three hard-coded
+  `claude-code/1.0` strings, one synthesised Codex identity, and aiohttp's default everywhere else.
+  That is the policy half of G3, and it waits on Q1.
 - **F2 — The README's endpoint table does not match the router.** *(KBR-9.)* README documents
   `POST /v1/gemini/generateContent`; `_register_routes` registers
   `/v1beta/models/{model}:generateContent` and `:streamGenerateContent`, and the README omits
@@ -2033,7 +2045,7 @@ does not surface work that is done. `TEST_SUITE_IMPLEMENTATION_PLAN.md` §16 mir
 | **G21** | §8's skip rule is stated in prose and nothing checks it — KBR-138 | Found while closing KBR-132. The known breach is fixed, and every skip left in a *gating* layer is a platform or interpreter one — but that is an observation, not a mechanism, and the next resource-availability skip written into `l1`, `l2`, `l3` or `acceptance` re-creates the same silent-green defect | A check over the collected suite that fails on a resource-availability skip in a gating layer, with a planted skip as its falsification case (§1.4). It must be **layer-aware**: `tests/integration/test_agent_e2e.py` holds three legitimate resource skips (missing credentials, profile, agent binary) that are legal only because they sit in `agent_live`, so a flat grep would report them and be turned off. Two further questions: static sweep or runtime hook, and whether a permitted skip is recognised by condition shape or declared by marker | **3** |
 | **G1** | I1 is unstated and untested | No definition of "unchanged"; mutation sites discoverable only by reading 6,463 lines | Register (§3.2) + oracle (§3.3) | **1** |
 | **G2** | No-bypass unproven **for the bridge's serving path**; no negative assertion; start-path guard is file-granular | `test_egress_https_proxy.py` proves the transports and drives `egress_cmd._probe` | Sealed-network harness (§5.2) per transport (§5.5) + AST start-path guard | **1** |
-| **G3** | I2 partially breached (F1) — KBR-8 | Identity ad hoc per adapter; the subscription adapter reports two different versions in one request | Header contract + parity baseline, then a policy and a code fix | **2** |
+| **G3** | I2 partially breached (F1) — KBR-8 · **fix landed, gap open** | Identity is still ad hoc per adapter. The subscription adapter no longer reports two different versions in one request: **KBR-8 fixed that on 2026-09-11**, and `tests/test_upstream_identity_consistency.py` guards both halves of §4.3 C1's F1 assertions across every registered adapter | Remaining: the exact-set header contract (T-G9 / **KBR-78**) and the parity baseline (T-C7, T-I12), then a policy — Q1 | **2** |
 | **G4** | L1 strength unmeasured | Line coverage only | `mutmut` ≥ 85% **per target group** on the §6.1 scope | **2** |
 | **G8** | No corpus of real agent traffic | Synthetic fixtures encode our assumptions | Golden corpus (§7.1) | **2** |
 | **G10** | Custom-transport containment untested | Proven at transport level, never through the bridge; ambient `HTTP_PROXY`/`NO_PROXY` untested; the OAuth leg untested | §5.5 + §6.2.4 | **2** |

--- a/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
+++ b/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
@@ -327,7 +327,7 @@ one case it existed for. T-E1 now ships the report; T-E9 only checks it is compl
 | **T-G6** | OpenAPI 3.1 + schemathesis | | T-W8 | Five POST routes plus `/healthz`, `/stats`, `/v1/models`, **targeting bridge mode**; plus a per-protocol registration-matrix guard | §6.2.1 | L |
 | **T-G7** | SSE grammar state machine | | T-B4, T-W8 | Every stream, including error streams and mid-stream failover, is a sentence in the grammar | §6.2.2 | M |
 | **T-G8** | aiohttp proxy contract | | T-W5 | Session-level proxy across `>=3.11,<3.14`; a per-request `proxy=None` cannot escape it | §6.2.4 | S |
-| **T-G9** | **Header contract** | defect | T-W7 | Exact header set per adapter — names, absences, casing, value shape. No `User-Agent` or version header derived from `kitty.__version__`; where both are sent they agree. **This catches KBR-8** | §4.3 C1 | M |
+| **T-G9** | **Header contract** | defect | T-W7 | Exact header set per adapter — names, absences, casing, value shape. No `User-Agent` or version header derived from `kitty.__version__`; where both are sent they agree. **KBR-8 fixed the defect and landed those two assertions behaviourally** in `tests/test_upstream_identity_consistency.py`, so T-G9's remaining scope is the exact set — names, absences, casing, value shape — and it inherits that file's positive controls | §4.3 C1 | M |
 | **T-G10** | curl_cffi proxy contract | | T-W5 | `proxies=` honoured; precedence over ambient `HTTP_PROXY`/`NO_PROXY` | §6.2.4 | S |
 | **T-G11** | botocore proxy contract + **declare `botocore`** | | T-W5 | `Config(proxies=)` precedence over the environment; and the dependency is declared, since a containment guarantee currently rests on an undeclared transitive | §6.2.4 | S |
 | **T-G12** | `keyring` backend contract | | — | Backend resolution on each supported platform | §6.2.4 | S |
@@ -520,7 +520,7 @@ merge.** So:
 | ~~KBR-5~~ | ~~G14~~ | T-G5, TR-4 | **DONE 2026-09-07** — atomic fix + tests, red at base revision. TR-4's exemption withdrawn |
 | KBR-6 | G15 | T-G3 | Atomic fix + test now |
 | KBR-7 · **CLOSED** | G16 | T-G4 | Route taken: atomic fix + hook-level guard landed together, red evidence in the PR. T-G4 still owns the wire boundary. (Status convention: `TEST_SUITE.md` §9.2.) |
-| KBR-8 | G3 | T-G9, TR-1c | Atomic fix + test now |
+| KBR-8 · **CLOSED** | G3 | T-G9, TR-1c | Route taken: atomic fix + behavioural guard landed together, red evidence in the PR (2026-09-11). T-G9 still owns the exact-set contract and TR-1c the acceptance scenario; G3's policy half waits on Q1. (Status convention: `TEST_SUITE.md` §9.2.) |
 | KBR-9 | G6 | T-G1 | Atomic fix + test now |
 | KBR-132 · **CLOSED** | G21 | — | Route taken: atomic fix + regression test, red at base, evidence in the PR. The broader guard is **KBR-138**, which has no plan-task ID because it was filed after this plan was written; G21 is its design gap. (Status convention: `TEST_SUITE.md` §9.2.) |
 

--- a/src/kitty/providers/openai_subscription.py
+++ b/src/kitty/providers/openai_subscription.py
@@ -95,7 +95,10 @@ def _codex_backoff(attempt: int) -> float:
     return float((millis * jitter) / 1000.0)
 
 
-# Codex CLI version sent in the version header.
+# Codex CLI version.  The single source for BOTH version fields this adapter
+# sends -- the `version` header and the user-agent's product version -- because a
+# client stating two different versions in one request is an intermediary and
+# nothing else (KBR-8).
 # The checked-in reference workspace has 0.0.0 (dev placeholder), but
 # the real released Codex CLI version is used in production builds.
 _CODEX_CLI_VERSION = "0.128.0"
@@ -281,13 +284,23 @@ class OpenAISubscriptionAdapter(OpenAIAdapter):
 
         Matches ``get_codex_user_agent()`` in
         ``codex-rs/login/src/auth/default_client.rs``.
-        """
-        from kitty import __version__
 
+        Returns:
+            The impersonated Codex CLI user-agent, versioned from
+            :data:`_CODEX_CLI_VERSION` -- the same constant
+            :meth:`_build_codex_headers` puts in the ``version`` header.
+
+        The version is deliberately **not** ``kitty.__version__`` (KBR-8).
+        Reading it from there made a single request claim to be two different
+        Codex CLI versions at once -- something no genuine client does, and so a
+        one-line detection rule for bridge traffic -- and tied the header to
+        kitty's release train, changing it on every kitty release and nothing
+        else.  See ``.system_design/TEST_SUITE.md`` finding F1 and 4.3 C1.
+        """
         os_type = platform.system()
         os_version = platform.release()
         arch = platform.machine()
-        return f"codex_cli_rs/{__version__} ({os_type} {os_version}; {arch})"
+        return f"codex_cli_rs/{_CODEX_CLI_VERSION} ({os_type} {os_version}; {arch})"
 
     def _build_codex_headers(self, access_token: str, id_token: str) -> dict[str, str]:
         """Build headers matching the Codex CLI (reqwest + rustls).

--- a/src/kitty/providers/openai_subscription.py
+++ b/src/kitty/providers/openai_subscription.py
@@ -95,12 +95,15 @@ def _codex_backoff(attempt: int) -> float:
     return float((millis * jitter) / 1000.0)
 
 
-# Codex CLI version.  The single source for BOTH version fields this adapter
-# sends -- the `version` header and the user-agent's product version -- because a
-# client stating two different versions in one request is an intermediary and
-# nothing else (KBR-8).
-# The checked-in reference workspace has 0.0.0 (dev placeholder), but
-# the real released Codex CLI version is used in production builds.
+# The impersonated Codex CLI version, and the single source for BOTH version
+# fields this adapter sends -- the `version` header and the user-agent's product
+# version -- because a client stating two different versions in one request is an
+# intermediary and nothing else (KBR-8).
+#
+# The value is the real released Codex CLI version, not kitty's.  (Codex's own
+# checked-in reference workspace carries 0.0.0, a dev placeholder; its release
+# builds carry the real one, which is what this impersonates.)  Nothing rewrites
+# this at build time -- it is edited here when the impersonated version moves.
 _CODEX_CLI_VERSION = "0.128.0"
 
 # curl_cffi TLS impersonation target — matches the browser-like TLS fingerprint

--- a/tests/providers/test_openai_subscription.py
+++ b/tests/providers/test_openai_subscription.py
@@ -576,8 +576,10 @@ class TestCodexHeaders:
         """
         headers = adapter._build_codex_headers("tok", _make_id_token())
 
-        user_agent_version = headers["User-Agent"].split("/", 1)[1].split(" ", 1)[0]
-        assert user_agent_version == headers["version"]
+        # Asserted as a prefix rather than by parsing the product out of the
+        # user-agent: a second parser here would be a second shape to keep in
+        # step with the one in `tests/test_upstream_identity_consistency.py`.
+        assert headers["User-Agent"].startswith(f"codex_cli_rs/{headers['version']} (")
 
 
 # ── curl_cffi error mapping ──────────────────────────────────────────────

--- a/tests/providers/test_openai_subscription.py
+++ b/tests/providers/test_openai_subscription.py
@@ -552,6 +552,33 @@ class TestCodexHeaders:
 
         assert headers["version"] == _CODEX_CLI_VERSION
 
+    def test_user_agent_version_is_the_codex_version(
+        self, adapter: OpenAISubscriptionAdapter
+    ) -> None:
+        """The user-agent reports the impersonated Codex CLI version (KBR-8).
+
+        Both version fields come from ``_CODEX_CLI_VERSION``, so the assertion
+        is against that constant rather than a literal: pinning the literal here
+        would make bumping the impersonated version fail a test that has no
+        opinion about which version it should be.
+        """
+        from kitty.providers.openai_subscription import _CODEX_CLI_VERSION
+
+        assert adapter._build_user_agent().startswith(f"codex_cli_rs/{_CODEX_CLI_VERSION} (")
+
+    def test_user_agent_and_version_header_agree(
+        self, adapter: OpenAISubscriptionAdapter
+    ) -> None:
+        """One request states one client version (KBR-8).
+
+        A client claiming to be Codex CLI 1.9.1 in its user-agent and 0.128.0 in
+        its ``version`` header identifies itself as an intermediary outright.
+        """
+        headers = adapter._build_codex_headers("tok", _make_id_token())
+
+        user_agent_version = headers["User-Agent"].split("/", 1)[1].split(" ", 1)[0]
+        assert user_agent_version == headers["version"]
+
 
 # ── curl_cffi error mapping ──────────────────────────────────────────────
 

--- a/tests/test_layer_selection.py
+++ b/tests/test_layer_selection.py
@@ -400,6 +400,7 @@ class TestTheWholeSuiteIsCoherent:
             "tests/test_internal_key_completeness.py",
             "tests/test_egress_coverage.py",
             "tests/test_wire_shape_honesty.py",
+            "tests/test_upstream_identity_consistency.py",
             "tests/test_github_actions.py",
             "tests/test_layer_markers.py",
             "tests/test_layer_selection.py",

--- a/tests/test_upstream_identity_consistency.py
+++ b/tests/test_upstream_identity_consistency.py
@@ -1,0 +1,597 @@
+"""Regression guard: one impersonated client version, from one source.
+
+KBR-8.  :class:`~kitty.providers.openai_subscription.OpenAISubscriptionAdapter`
+impersonates the Codex CLI and stated its version **twice, from two different
+sources, in the same request**: ``User-Agent`` was built as
+``codex_cli_rs/{kitty.__version__}`` while the ``version`` header carried the
+module constant ``_CODEX_CLI_VERSION``.  Measured on the base revision, one
+request claimed to be ``codex_cli_rs/1.9.1`` and ``version: 0.128.0`` at once.
+
+That is two defects, and this module asserts against both — the two further C1
+assertions ``TEST_SUITE.md`` §4.3 draws out of finding F1:
+
+* **A self-contradiction.**  No genuine Codex CLI disagrees with itself, so a
+  provider comparing the two fields has a one-line rule that identifies bridge
+  traffic with no false positives.  A breach of I2 — and unlike the rest of F1
+  it is not *missing* information but *contradictory* information, which only an
+  intermediary can produce.
+* **A version oracle.**  A user-agent derived from ``kitty.__version__`` changes
+  when kitty ships and at no other time.  KBR-8 was filed when it read
+  ``1.9.0``; it read ``1.9.1`` by the time the fix was written, so the ticket's
+  own text was falsified by a kitty release.
+
+**Where this asserts.**  Over the headers each adapter actually puts on the
+wire, enumerated by :func:`wire_routes`.  Two decisions make that real rather
+than nominal:
+
+1. :func:`dispatch_headers` **mirrors** ``BridgeServer._build_upstream_headers``
+   (``server.py:6612-6615``) instead of calling ``build_upstream_headers``
+   directly, so an adapter that routes headers by model — ``opencode_go`` today
+   — is swept on the builder the server would actually call.  Calling the base
+   hook directly would inspect a dict that never ships.
+2. ``openai_subscription`` is swept on ``_build_codex_headers`` as well.  It does
+   not override ``build_upstream_headers`` at all, so **the KBR-8 defect is
+   invisible without that entry**: its custom transport builds wire headers at
+   ``openai_subscription.py:551`` and ``:723`` and hands them to curl_cffi.
+
+Both are §6.2.3's "the hook is not the wire", which already caught this repo out
+in KBR-7; here it is the difference between a guard and a decoration.
+
+**Coverage of the three custom-transport adapters,** stated explicitly because
+two of the three are the cases where a sweep can look busy and see nothing:
+
+* ``ollama_cloud`` — its transport calls the hook (``ollama_cloud.py:374`` and
+  ``:403``), so for it the hook genuinely is the wire.  Covered.
+* ``openai_subscription`` — covered via ``_build_codex_headers``, as above.
+* ``bedrock`` — **not covered.**  It builds no headers of its own; boto3 signs
+  the request and botocore sets its own ``User-Agent``.  The dict the inherited
+  hook returns never ships.  Residual recorded against T-G9 / KBR-78.
+
+**Why behavioural rather than a source scan.**  The checks patch
+``kitty.__version__`` and read the headers that come out, instead of grepping
+``src/`` for ``__version__``.  A source scan asserts what the code *says*; the
+sentinel asserts what an adapter *emits*, and so catches a derivation written in
+a form no pattern anticipated.  Adapters are constructed **inside**
+:meth:`Route.headers`, under the patch, for the same reason: an adapter that
+bound the version in ``__init__`` would escape a sweep that built it first.
+
+**What this does not cover**, so the next reader does not over-trust it:
+
+* The sentinel finds a version *copied* into a header, not one *transformed*
+  into it.  ``__version__.split(".")[0]``, or a hash of it, is still a kitty
+  version oracle and still passes.  No behavioural sentinel can close that; it
+  is named here rather than left to be discovered.
+* Adapters branch on their inputs, and only the branches :func:`wire_routes`
+  names are swept — both of ``opencode_go``'s model routes and both of
+  ``azure``'s credential shapes, one branch of anything added later.
+* The token-exchange leg at ``auth/openai_oauth.py:310-312`` sends only
+  ``Authorization`` — the same impersonated client making a request under a
+  different identity.  That is Q1's territory, not KBR-8's.
+* The exact-set header contract — names, absences, casing, value shape per
+  adapter — is **T-G9 / KBR-78**, not this file.  This is the defect-scoped
+  guard ``TEST_SUITE_IMPLEMENTATION_PLAN.md`` §16 asks for on the KBR-8 row's
+  "atomic fix + test now" route, and T-G9 subsumes it the way T-G5 subsumes
+  KBR-5's ``tests/bridge/test_vendor_token_guard.py``.
+
+The identity *policy* — what each adapter should claim to be — is Q1, and is
+untouched here: this file only requires that whatever an adapter claims, it
+claims it once and does not read it from kitty's release train.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from typing import NamedTuple
+
+import pytest
+
+from kitty.providers.base import ProviderAdapter
+from kitty.providers.openai import OpenAIAdapter
+from kitty.providers.openai_subscription import _CODEX_CLI_VERSION, OpenAISubscriptionAdapter
+from kitty.providers.registry import _registry, get_provider
+
+pytestmark = pytest.mark.l2
+
+#: Stand-in for ``kitty.__version__`` during the sweep.  Deliberately not a
+#: plausible version string: it must be impossible to confuse with a real value
+#: an adapter might legitimately hard-code.
+_SENTINEL = "0.0.0-kitty-version-sentinel"
+
+#: Credentials for the builders.  Values are irrelevant — no request is made —
+#: but they must be non-empty, since an adapter may branch on a missing key.
+_API_KEY = "test-key"
+_ACCESS_TOKEN = "test-access-token"
+
+#: ``AzureOpenAIAdapter.build_upstream_headers`` returns a different header set
+#: for a Microsoft Entra bearer token than for an API key, so both are swept.
+_ENTRA_KEY = "Bearer test-entra-token"
+
+#: ``_extract_account_id`` parses this as a JWT inside a bare ``except``, so an
+#: empty string yields no ``ChatGPT-Account-Id`` header rather than raising.
+_EMPTY_ID_TOKEN = ""
+
+#: The model every route is swept on unless the adapter routes by model.
+_DEFAULT_MODEL = "claude-sonnet-4-5"
+
+#: ``OpenCodeGoAdapter`` picks its wire shape — and so its header set — from the
+#: model name, so one model per route.  See ``opencode._MESSAGES_MODELS``.
+_OPENCODE_MODELS = ("claude-sonnet-4-5", "minimax-m2.5")
+
+#: A user-agent's leading ``<token>/<version>`` product, as RFC 9110 §5.5.3
+#: defines it.  Only the first product is read: Codex CLI's trailing
+#: ``(<os> <release>; <arch>)`` comment carries version-like numbers that are the
+#: operating system's, not the client's.
+_USER_AGENT_PRODUCT = re.compile(r"^(?P<token>[^/\s]+)/(?P<version>[^\s]+)")
+
+
+def header_value(headers: Mapping[str, str], name: str) -> str | None:
+    """Look a header up without regard to the casing it was written in.
+
+    Args:
+        headers: The header set an adapter produced.
+        name: The header name to find, in any casing.
+
+    Returns:
+        The matching header's value, or ``None`` when the set has no such
+        header.  The first match wins; adapters build these from dict literals,
+        so a duplicate name cannot occur.
+
+    HTTP header names are case-insensitive (RFC 9110 §5.1), and this codebase
+    exercises that freely — ``OpenAISubscriptionAdapter`` sends ``User-Agent``
+    beside a lowercase ``version``, and ``ZaiAnthropicAdapter`` a capitalised
+    ``Authorization`` beside lowercase ``content-type``.  A case-sensitive lookup
+    would let this guard pass by simply failing to find the pair it compares.
+    """
+    lowered = name.lower()
+
+    return next((value for key, value in headers.items() if key.lower() == lowered), None)
+
+
+def kitty_version_leaks(headers: Mapping[str, str], sentinel: str) -> list[str]:
+    """Return every header that carries kitty's version.
+
+    Args:
+        headers: The header set an adapter produced while ``kitty.__version__``
+            was patched to ``sentinel``.
+        sentinel: The stand-in value that was patched in.
+
+    Returns:
+        One ``"name: value"`` line per offending header, sorted; empty when no
+        header is derived from kitty's version.
+
+    Names are scanned as well as values.  A header *named* for the bridge's
+    version would be as good a fingerprint as one valued by it, and costs one
+    ``or`` to rule out.
+    """
+    return sorted(
+        f"{name}: {value}"
+        for name, value in headers.items()
+        if sentinel in name or sentinel in value
+    )
+
+
+def version_disagreement(headers: Mapping[str, str]) -> tuple[str, str] | None:
+    """Return the two client versions a header set states, when they differ.
+
+    Args:
+        headers: The header set an adapter produced.
+
+    Returns:
+        ``(user-agent version, version header)`` when the set states both and
+        they disagree; ``None`` when they agree, or when the set does not state
+        both and so cannot contradict itself.
+
+    The ``version`` header is matched by its **exact** name, not by any header
+    whose name contains "version".  ``anthropic-version: 2023-06-01`` — which
+    ``AnthropicAdapter``, ``ZaiAnthropicAdapter`` and ``OpenCodeGoAdapter``'s
+    Messages route all send — declares the *API* version, not the client's, and
+    comparing it against a user-agent would manufacture a failure out of two
+    fields that were never claiming the same thing.
+    """
+    user_agent = header_value(headers, "user-agent")
+    declared = header_value(headers, "version")
+
+    # Neither header alone can contradict anything: this returns None for every
+    # adapter that sends one, the other, or neither.
+    if user_agent is None or declared is None:
+        return None
+
+    product = _USER_AGENT_PRODUCT.match(user_agent)
+    if product is None:
+        return None
+
+    found = product.group("version")
+
+    return None if found == declared else (found, declared)
+
+
+def dispatch_headers(provider: ProviderAdapter, api_key: str, model: str) -> dict[str, str]:
+    """Build a provider's headers the way the bridge itself builds them.
+
+    Args:
+        provider: The adapter to ask.
+        api_key: The resolved upstream credential.
+        model: The active model, which model-routing adapters select on.
+
+    Returns:
+        The header set the bridge would send for this provider and model.
+
+    This mirrors ``BridgeServer._build_upstream_headers``
+    (``server.py:6612-6615``) deliberately, rather than calling
+    ``build_upstream_headers`` directly.  The server prefers an adapter's
+    per-model builder when it has one, so a sweep that skipped that branch would
+    inspect, for ``opencode_go``, a dict the server never sends.  The duplication
+    is the point: ``TestTheSweepCatchesWhatItClaimsTo`` plants an adapter that
+    leaks only through the per-model builder, so dropping this branch fails.
+    """
+    # `hasattr`, matching the server: the hook is optional and defined on only
+    # one adapter, so there is no base-class method to override.
+    if hasattr(provider, "build_upstream_headers_for_model"):
+        return provider.build_upstream_headers_for_model(api_key, model)  # type: ignore[attr-defined]  # optional provider hook, as in server.py
+
+    return provider.build_upstream_headers(api_key)
+
+
+class Route(NamedTuple):
+    """One header-producing path through an adapter.
+
+    Attributes:
+        label: Human-readable identifier, used as the parametrised test id.
+        provider_type: Registry key of the adapter to construct.
+        api_key: Credential to build with — the shape some adapters branch on.
+        model: Active model, which model-routing adapters select on.
+        codex_transport: When true, build through
+            ``OpenAISubscriptionAdapter._build_codex_headers`` instead of the
+            bridge's header dispatch, because that adapter's custom transport
+            bypasses the dispatch entirely.
+    """
+
+    label: str
+    provider_type: str
+    api_key: str = _API_KEY
+    model: str = _DEFAULT_MODEL
+    codex_transport: bool = False
+
+    def headers(self) -> dict[str, str]:
+        """Construct the adapter and return the headers this route produces.
+
+        Returns:
+            The header set as the bridge would send it for this route.
+
+        The adapter is constructed **here**, not when the route is enumerated,
+        so that it is built while ``kitty.__version__`` is patched.  An adapter
+        that read the version in ``__init__`` would otherwise bind the real
+        value before the sentinel landed, and the sweep would see nothing.
+        """
+        provider = get_provider(self.provider_type, {})
+
+        if self.codex_transport:
+            return provider._build_codex_headers(_ACCESS_TOKEN, _EMPTY_ID_TOKEN)  # type: ignore[attr-defined]  # subscription-only custom transport
+
+        return dispatch_headers(provider, self.api_key, self.model)
+
+
+def wire_routes() -> list[Route]:
+    """Enumerate every header-producing route that reaches an upstream provider.
+
+    Returns:
+        One :class:`Route` per adapter, plus the extra routes named below.
+
+    Every registry entry contributes its default route.  Three adapters
+    contribute more, and each addition exists because the default route would
+    otherwise miss something real:
+
+    * ``openai_subscription`` — its wire headers come from
+      ``_build_codex_headers``, which the header dispatch never reaches, so
+      **the KBR-8 defect is invisible without this route**;
+    * ``opencode_go`` — routes by model, so one model on each of its two routes;
+    * ``azure`` — returns ``Authorization`` for a Microsoft Entra bearer token
+      and ``api-key`` for an API key, so both credential shapes are swept.
+    """
+    routes = [
+        Route(label=f"{provider_type}", provider_type=provider_type)
+        for provider_type in sorted(_registry)
+    ]
+
+    routes.append(
+        Route(
+            label="openai_subscription[_build_codex_headers]",
+            provider_type="openai_subscription",
+            codex_transport=True,
+        )
+    )
+    routes.extend(
+        Route(label=f"opencode_go[{model}]", provider_type="opencode_go", model=model)
+        for model in _OPENCODE_MODELS
+    )
+    routes.append(Route(label="azure[entra]", provider_type="azure", api_key=_ENTRA_KEY))
+
+    return routes
+
+
+_WIRE_ROUTES = wire_routes()
+_ROUTE_IDS = [route.label for route in _WIRE_ROUTES]
+
+
+class _RegressedSubscriptionAdapter(OpenAISubscriptionAdapter):
+    """The KBR-8 defect, restored, so the checks can be shown to catch it.
+
+    ``_build_user_agent`` here is the implementation this change removed: the
+    version comes from ``kitty.__version__`` while the inherited
+    ``_build_codex_headers`` still sends ``_CODEX_CLI_VERSION`` in the ``version``
+    header, so one object exhibits both defects at once.
+
+    The positive control is the *historical* defect rather than an invented one,
+    so it cannot drift away from what the guard claims to prevent — the same
+    choice T-G5 makes with M13's synthetic string.
+    """
+
+    @staticmethod
+    def _build_user_agent() -> str:
+        """Build the pre-fix user-agent, derived from kitty's own version.
+
+        Returns:
+            A Codex CLI user-agent whose version is ``kitty.__version__``.
+
+        The import is inside the function on purpose.  Read at module scope it
+        would bind before ``monkeypatch`` lands and the control would go green
+        against a defect it never reproduced.
+        """
+        from kitty import __version__
+
+        return f"codex_cli_rs/{__version__} (Linux 6.0.0; x86_64)"
+
+
+class _PlantedVersionOracle(OpenAIAdapter):
+    """A registered adapter carrying both defects, for falsifying the sweep.
+
+    Exhibits a user-agent derived from ``kitty.__version__`` *and* a ``version``
+    header that disagrees with it, through the ordinary
+    :meth:`build_upstream_headers` hook.
+
+    Subclasses a concrete adapter rather than :class:`ProviderAdapter` itself,
+    which leaves ``build_request``, ``parse_response`` and ``map_error``
+    abstract — three stubs unrelated to headers would be noise here.
+    """
+
+    @property
+    def provider_type(self) -> str:
+        """Return the registry key this planted adapter answers to.
+
+        Returns:
+            The planted provider type.
+        """
+        return "_planted_oracle"
+
+    def build_upstream_headers(self, api_key: str) -> dict[str, str]:
+        """Build headers exhibiting both KBR-8 defects.
+
+        Args:
+            api_key: Resolved upstream credential, echoed into ``Authorization``.
+
+        Returns:
+            A header set whose user-agent is versioned from kitty's own version
+            and disagrees with the ``version`` header beside it.
+        """
+        from kitty import __version__
+
+        return {
+            "Authorization": f"Bearer {api_key}",
+            "User-Agent": f"planted_cli/{__version__}",
+            "version": _CODEX_CLI_VERSION,
+        }
+
+
+class _PlantedPerModelOracle(_PlantedVersionOracle):
+    """The same defects, reachable only through the per-model header builder.
+
+    The plain hook is clean, so this adapter is caught **only** if the sweep
+    follows the bridge's own dispatch into
+    :meth:`build_upstream_headers_for_model`.  It is the falsification case for
+    :func:`dispatch_headers`: delete that branch and the controls below fail.
+    """
+
+    @property
+    def provider_type(self) -> str:
+        """Return the registry key this planted adapter answers to.
+
+        Returns:
+            The planted provider type.
+        """
+        return "_planted_per_model"
+
+    def build_upstream_headers(self, api_key: str) -> dict[str, str]:
+        """Build a clean header set, so only the per-model route offends.
+
+        Args:
+            api_key: Resolved upstream credential.
+
+        Returns:
+            A header set with no user-agent and no version.
+        """
+        return {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
+
+    def build_upstream_headers_for_model(self, api_key: str, model: str) -> dict[str, str]:
+        """Build headers exhibiting both KBR-8 defects, per model.
+
+        Args:
+            api_key: Resolved upstream credential.
+            model: Active model, ignored — every model offends.
+
+        Returns:
+            A header set whose user-agent is versioned from kitty's own version
+            and disagrees with the ``version`` header beside it.
+        """
+        return _PlantedVersionOracle.build_upstream_headers(self, api_key)
+
+
+class TestNoHeaderIsDerivedFromKittyVersion:
+    """R2: no adapter reads kitty's release train into an upstream header."""
+
+    @pytest.mark.parametrize("route", _WIRE_ROUTES, ids=_ROUTE_IDS)
+    def test_route_emits_no_kitty_version(
+        self, route: Route, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No header an adapter emits carries kitty's version."""
+        monkeypatch.setattr("kitty.__version__", _SENTINEL)
+
+        leaks = kitty_version_leaks(route.headers(), _SENTINEL)
+
+        assert not leaks, (
+            f"{route.label} derives an upstream header from kitty.__version__, "
+            f"which makes the header change with every kitty release and with "
+            f"nothing else — a version oracle for the bridge (KBR-8, "
+            f"TEST_SUITE.md §4.3 C1). Offending headers: {leaks}"
+        )
+
+
+class TestClientVersionIsStatedOnce:
+    """R3: an adapter stating its version twice states the same version twice."""
+
+    @pytest.mark.parametrize("route", _WIRE_ROUTES, ids=_ROUTE_IDS)
+    def test_route_does_not_contradict_itself(self, route: Route) -> None:
+        """A user-agent version and a ``version`` header agree, where both exist."""
+        disagreement = version_disagreement(route.headers())
+
+        assert disagreement is None, (
+            f"{route.label} sends two different client versions in one request: "
+            f"User-Agent says {disagreement[0]!r} and the version header says "  # type: ignore[index]
+            f"{disagreement[1]!r}. No genuine client disagrees with itself, so "  # type: ignore[index]
+            f"this is a one-line detection rule for bridge traffic (KBR-8, "
+            f"TEST_SUITE.md §4.3 C1)."
+        )
+
+    def test_the_agreement_check_is_not_vacuous(self) -> None:
+        """Some swept route actually states both versions.
+
+        Exactly one does today — ``openai_subscription``'s Codex transport — so
+        the sweep above is a true statement about an empty set everywhere else.
+        Without this assertion, renaming the ``version`` header or changing the
+        user-agent's shape would empty the population the check inspects, and
+        every assertion in this class would stay green while stating nothing.
+        """
+        pair_bearing = [
+            route.label
+            for route in _WIRE_ROUTES
+            if header_value(route.headers(), "user-agent") is not None
+            and header_value(route.headers(), "version") is not None
+        ]
+
+        assert "openai_subscription[_build_codex_headers]" in pair_bearing, (
+            "No swept route states both a user-agent version and a version "
+            f"header, so the agreement check compares nothing. Found: {pair_bearing}"
+        )
+
+
+class TestTheChecksCatchTheDefectTheyDescribe:
+    """§1.4 harness rule, part one: the checks fail on the real defect."""
+
+    def test_version_oracle_is_detected(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The sentinel check flags a user-agent derived from kitty's version."""
+        monkeypatch.setattr("kitty.__version__", _SENTINEL)
+        regressed = _RegressedSubscriptionAdapter()
+
+        leaks = kitty_version_leaks(
+            regressed._build_codex_headers(_ACCESS_TOKEN, _EMPTY_ID_TOKEN), _SENTINEL
+        )
+
+        assert leaks == [f"User-Agent: codex_cli_rs/{_SENTINEL} (Linux 6.0.0; x86_64)"]
+
+    def test_self_contradiction_is_detected(self) -> None:
+        """The agreement check flags the two versions the pre-fix adapter sent."""
+        from kitty import __version__
+
+        regressed = _RegressedSubscriptionAdapter()
+
+        disagreement = version_disagreement(
+            regressed._build_codex_headers(_ACCESS_TOKEN, _EMPTY_ID_TOKEN)
+        )
+
+        assert disagreement == (__version__, _CODEX_CLI_VERSION)
+
+    def test_an_agreeing_header_set_is_not_flagged(self) -> None:
+        """The agreement check does not fire when the two versions match.
+
+        Without this, a ``version_disagreement`` that returned ``None``
+        unconditionally would satisfy every other assertion in this file.
+        """
+        assert version_disagreement({"User-Agent": "codex_cli_rs/1.2.3", "version": "1.2.3"}) is None
+        assert version_disagreement({"User-Agent": "codex_cli_rs/1.2.3", "version": "9.9.9"}) == (
+            "1.2.3",
+            "9.9.9",
+        )
+
+    def test_an_api_version_header_is_not_read_as_a_client_version(self) -> None:
+        """``anthropic-version`` is the API's version and must not be compared."""
+        headers = {"User-Agent": "claude-code/1.0", "anthropic-version": "2023-06-01"}
+
+        assert version_disagreement(headers) is None
+
+
+class TestTheSweepCatchesWhatItClaimsTo:
+    """§1.4 harness rule, part two: the *enumeration* is falsified, not just the checks.
+
+    A guard whose check function is proven and whose enumeration is not is the
+    failure §1.4 names — proof that a function was called, where the enforcement
+    was the branch after it.  Each test here plants a defective adapter in the
+    registry and asserts the sweep itself surfaces it.
+    """
+
+    def test_a_planted_adapter_is_swept(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A registered adapter with both defects is found by the sweep."""
+        monkeypatch.setitem(_registry, "_planted_oracle", _PlantedVersionOracle)
+        monkeypatch.setattr("kitty.__version__", _SENTINEL)
+
+        planted = [route for route in wire_routes() if route.provider_type == "_planted_oracle"]
+
+        assert planted, "the sweep did not enumerate a newly registered adapter"
+        for route in planted:
+            headers = route.headers()
+            assert kitty_version_leaks(headers, _SENTINEL)
+            assert version_disagreement(headers) == (_SENTINEL, _CODEX_CLI_VERSION)
+
+    def test_a_planted_per_model_adapter_is_swept(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An adapter that offends only via its per-model builder is still found.
+
+        This is what pins :func:`dispatch_headers` to the server's own dispatch.
+        Sweeping ``build_upstream_headers`` directly would read this adapter's
+        clean hook and report it innocent.
+        """
+        monkeypatch.setitem(_registry, "_planted_per_model", _PlantedPerModelOracle)
+        monkeypatch.setattr("kitty.__version__", _SENTINEL)
+
+        planted = [route for route in wire_routes() if route.provider_type == "_planted_per_model"]
+
+        assert planted, "the sweep did not enumerate a newly registered adapter"
+        for route in planted:
+            headers = route.headers()
+            assert kitty_version_leaks(headers, _SENTINEL)
+            assert version_disagreement(headers) == (_SENTINEL, _CODEX_CLI_VERSION)
+
+
+class TestTheSweepLooksAtEverything:
+    """A sweep that enumerates nothing passes forever; assert what it reaches."""
+
+    def test_every_registered_adapter_is_covered(self) -> None:
+        """The sweep reaches every registry entry, not merely some."""
+        swept = {route.provider_type for route in _WIRE_ROUTES}
+
+        assert swept == set(_registry)
+
+    def test_the_subscription_wire_builder_is_covered(self) -> None:
+        """The one route that makes this guard real is in the enumeration.
+
+        ``openai_subscription`` does not override ``build_upstream_headers``, so
+        without this route the sweep is blind to KBR-8 and passes unfixed.
+        """
+        assert "openai_subscription[_build_codex_headers]" in _ROUTE_IDS
+
+    def test_both_model_routes_of_the_routing_adapter_are_covered(self) -> None:
+        """``opencode_go`` picks its header set by model, so both routes are swept."""
+        for model in _OPENCODE_MODELS:
+            assert f"opencode_go[{model}]" in _ROUTE_IDS
+
+    def test_both_azure_credential_shapes_are_covered(self) -> None:
+        """``azure`` returns a different header set per credential shape."""
+        assert "azure[entra]" in _ROUTE_IDS

--- a/tests/test_upstream_identity_consistency.py
+++ b/tests/test_upstream_identity_consistency.py
@@ -32,7 +32,7 @@ than nominal:
 2. ``openai_subscription`` is swept on ``_build_codex_headers`` as well.  It does
    not override ``build_upstream_headers`` at all, so **the KBR-8 defect is
    invisible without that entry**: its custom transport builds wire headers at
-   ``openai_subscription.py:551`` and ``:723`` and hands them to curl_cffi.
+   ``openai_subscription.py:564`` and ``:736`` and hands them to curl_cffi.
 
 Both are §6.2.3's "the hook is not the wire", which already caught this repo out
 in KBR-7; here it is the difference between a guard and a decoration.
@@ -46,6 +46,12 @@ two of the three are the cases where a sweep can look busy and see nothing:
 * ``bedrock`` — **not covered.**  It builds no headers of its own; boto3 signs
   the request and botocore sets its own ``User-Agent``.  The dict the inherited
   hook returns never ships.  Residual recorded against T-G9 / KBR-78.
+
+That these three are the *only* custom-transport adapters is not re-asserted
+here: ``tests/test_wire_shape_honesty.py`` pins the set mechanically, on the
+``use_custom_transport`` property that makes this sweep blind in the first
+place.  A fourth adapter forces a decision there, and this list is then stale by
+the same test.
 
 **Why behavioural rather than a source scan.**  The checks patch
 ``kitty.__version__`` and read the headers that come out, instead of grepping
@@ -134,8 +140,9 @@ def header_value(headers: Mapping[str, str], name: str) -> str | None:
 
     Returns:
         The matching header's value, or ``None`` when the set has no such
-        header.  The first match wins; adapters build these from dict literals,
-        so a duplicate name cannot occur.
+        header.  The first match wins, which is arbitrary only if a set carries
+        the same name in two casings (``Version`` beside ``version`` are distinct
+        dict keys); no adapter does, and T-G9 owns the exact set.
 
     HTTP header names are case-insensitive (RFC 9110 §5.1), and this codebase
     exercises that freely — ``OpenAISubscriptionAdapter`` sends ``User-Agent``
@@ -317,10 +324,12 @@ _ROUTE_IDS = [route.label for route in _WIRE_ROUTES]
 class _RegressedSubscriptionAdapter(OpenAISubscriptionAdapter):
     """The KBR-8 defect, restored, so the checks can be shown to catch it.
 
-    ``_build_user_agent`` here is the implementation this change removed: the
+    ``_build_user_agent`` here reproduces the *defect* this change removed: the
     version comes from ``kitty.__version__`` while the inherited
     ``_build_codex_headers`` still sends ``_CODEX_CLI_VERSION`` in the ``version``
-    header, so one object exhibits both defects at once.
+    header, so one object exhibits both defects at once.  The OS suffix is frozen
+    rather than read from :mod:`platform`, so the control can assert the emitted
+    header by equality instead of by pattern.
 
     The positive control is the *historical* defect rather than an invented one,
     so it cannot drift away from what the guard claims to prevent — the same
@@ -435,8 +444,13 @@ class TestNoHeaderIsDerivedFromKittyVersion:
     ) -> None:
         """No header an adapter emits carries kitty's version."""
         monkeypatch.setattr("kitty.__version__", _SENTINEL)
+        headers = route.headers()
 
-        leaks = kitty_version_leaks(route.headers(), _SENTINEL)
+        # An adapter returning {} would satisfy every assertion below by having
+        # emitted nothing at all.
+        assert headers, f"{route.label} produced no headers"
+
+        leaks = kitty_version_leaks(headers, _SENTINEL)
 
         assert not leaks, (
             f"{route.label} derives an upstream header from kitty.__version__, "
@@ -471,12 +485,14 @@ class TestClientVersionIsStatedOnce:
         user-agent's shape would empty the population the check inspects, and
         every assertion in this class would stay green while stating nothing.
         """
-        pair_bearing = [
-            route.label
-            for route in _WIRE_ROUTES
-            if header_value(route.headers(), "user-agent") is not None
-            and header_value(route.headers(), "version") is not None
-        ]
+        pair_bearing = []
+        for route in _WIRE_ROUTES:
+            headers = route.headers()
+            if (
+                header_value(headers, "user-agent") is not None
+                and header_value(headers, "version") is not None
+            ):
+                pair_bearing.append(route.label)
 
         assert "openai_subscription[_build_codex_headers]" in pair_bearing, (
             "No swept route states both a user-agent version and a version "
@@ -510,11 +526,13 @@ class TestTheChecksCatchTheDefectTheyDescribe:
 
         assert disagreement == (__version__, _CODEX_CLI_VERSION)
 
-    def test_an_agreeing_header_set_is_not_flagged(self) -> None:
-        """The agreement check does not fire when the two versions match.
+    def test_the_check_distinguishes_agreeing_from_disagreeing_pairs(self) -> None:
+        """The agreement check fires on a mismatch and stays silent on a match.
 
-        Without this, a ``version_disagreement`` that returned ``None``
-        unconditionally would satisfy every other assertion in this file.
+        Both directions in one test because they are one logical fact.  Without
+        the agreeing half, a ``version_disagreement`` that returned ``None``
+        unconditionally would satisfy every other assertion in this file;
+        without the disagreeing half, one that always reported a conflict would.
         """
         assert version_disagreement({"User-Agent": "codex_cli_rs/1.2.3", "version": "1.2.3"}) is None
         assert version_disagreement({"User-Agent": "codex_cli_rs/1.2.3", "version": "9.9.9"}) == (
@@ -588,10 +606,49 @@ class TestTheSweepLooksAtEverything:
         assert "openai_subscription[_build_codex_headers]" in _ROUTE_IDS
 
     def test_both_model_routes_of_the_routing_adapter_are_covered(self) -> None:
-        """``opencode_go`` picks its header set by model, so both routes are swept."""
+        """``opencode_go``'s swept models select *different* header sets.
+
+        Asserting the labels alone would be self-referential — this file builds
+        both the labels and the list it looks them up in, so the assertion holds
+        even if both models land on the same route and one branch goes unswept.
+        Comparing the emitted sets is what makes the claim about the adapter.
+        ``_MESSAGES_MODELS`` is slated to change under KBR-126, so this is a live
+        risk rather than a theoretical one.
+        """
+        by_model = {
+            model: Route(label=model, provider_type="opencode_go", model=model).headers()
+            for model in _OPENCODE_MODELS
+        }
+
         for model in _OPENCODE_MODELS:
             assert f"opencode_go[{model}]" in _ROUTE_IDS
 
+        # Compared by header *name*, not by value: the routes are built with the
+        # same credential, so a value comparison would pass on two identical
+        # branches only by accident, and fail to notice the day they collapse.
+        distinct = {tuple(sorted(headers)) for headers in by_model.values()}
+        assert len(distinct) == len(_OPENCODE_MODELS), (
+            f"the swept models no longer select different header sets, so one "
+            f"of opencode_go's routes is unswept: {by_model}"
+        )
+
     def test_both_azure_credential_shapes_are_covered(self) -> None:
-        """``azure`` returns a different header set per credential shape."""
+        """``azure`` returns a *different* header set per credential shape.
+
+        Same reasoning as above: ``_ENTRA_KEY`` must actually satisfy
+        ``AzureOpenAIAdapter.is_entra_token``, or the sweep covers the ``api-key``
+        branch twice and the label assertion never notices.
+        """
         assert "azure[entra]" in _ROUTE_IDS
+
+        api_key_headers = Route(label="k", provider_type="azure", api_key=_API_KEY).headers()
+        entra_headers = Route(label="e", provider_type="azure", api_key=_ENTRA_KEY).headers()
+
+        # By header *name*. The two routes carry different credentials, so their
+        # values differ even when both take the same branch -- comparing values
+        # would report success for a sweep that covered `api-key` twice.
+        assert sorted(api_key_headers) != sorted(entra_headers), (
+            f"both azure routes produced the same header names, so "
+            f"_ENTRA_KEY no longer reaches the Entra branch and one credential "
+            f"shape is unswept: {sorted(api_key_headers)}"
+        )


### PR DESCRIPTION
## Context for the Product Owner

Kitty Bridge lets someone use a coding-agent subscription through the bridge. That only keeps working while the upstream provider cannot tell the bridge is in the path — a provider that can identify bridge traffic can throttle it, block it, or close the account, and the user finds out mid-session.

The OpenAI subscription path impersonates the Codex CLI. It was announcing its version **twice, with two different answers, in the same request**: the `User-Agent` said one version, the `version` header said another. No genuine Codex CLI disagrees with itself, so a provider comparing those two fields had a one-line rule that identified bridge traffic with **no false positives** — the sharpest detection signal in the codebase.

It was also worse than a static fingerprint. The `User-Agent` number was *Kitty's own release version*, so it changed whenever Kitty shipped and at no other time — a version oracle for the bridge itself. The clearest evidence is the ticket: KBR-8 was filed when the header read `1.9.0`, and it measured `1.9.1` when this fix was written. A Kitty release had already moved it.

**After this change** both fields come from one constant, so they agree by construction rather than by coincidence, and neither is tied to Kitty's release train.

**What this does not change:** it does not decide *what identity* the bridge should present — that is the open product question Q1, and this fix is compatible with every option on the table. Identity is still handled ad hoc per adapter; that half of gap G3 stays open.

---

## What changed

**The fix** — `src/kitty/providers/openai_subscription.py`

`_build_user_agent` read `kitty.__version__`; it now reads `_CODEX_CLI_VERSION`, the same constant `_build_codex_headers` puts in the `version` header.

```
before   User-Agent: codex_cli_rs/1.9.1 (Linux 6.8.0-138-generic; x86_64)
         version:    0.128.0

after    User-Agent: codex_cli_rs/0.128.0 (Linux 6.8.0-138-generic; x86_64)
         version:    0.128.0
```

Three lines of behaviour; the rest of that diff records why, so the next reader cannot mistake the single source for an accident.

**The guard** — `tests/test_upstream_identity_consistency.py` (new, L2)

Asserts the two C1 assertions `TEST_SUITE.md` §4.3 draws out of finding F1, across **every** registered adapter:

1. no adapter derives an upstream header from `kitty.__version__`;
2. where an adapter sends both a user-agent version and a `version` header, the two agree.

Four design decisions are what make it a guard rather than a decoration:

- **It mirrors the bridge's own dispatch.** Headers are built through a copy of `BridgeServer._build_upstream_headers` rather than by calling `build_upstream_headers` directly, so a model-routing adapter is swept on the builder the server would actually call.
- **It sweeps `_build_codex_headers` too.** `openai_subscription` overrides no header hook — its wire headers are built inside its custom transport. **A sweep over `build_upstream_headers` alone passes on the unfixed revision.** This is §6.2.3's "the hook is not the wire," which already caught this repo out in KBR-7.
- **It is behavioural, not a source scan.** `kitty.__version__` is patched to a sentinel and the emitted headers are read, so a derivation written in a form no pattern anticipated is still caught. Adapters are constructed *inside* the patched context, so one binding the version in `__init__` cannot escape.
- **The enumeration is falsified, not just the checks.** Per the §1.4 harness rule, defective adapters are planted in the registry and the sweep must surface them — including one that offends *only* through a per-model builder, which fails if the dispatch mirror is removed.

Coverage is asserted as an exact set (`swept == set(_registry)`), plus both `opencode_go` model routes and both `azure` credential shapes. `bedrock` is recorded as **not covered** — botocore owns its headers — rather than quietly counted.

**Two L1 tests** at the defect site, and **one line** registering the new file in `test_layer_selection.py`'s pinned `l2` list.

**Design records** — `TEST_SUITE.md` finding F1 and gap G3, and the plan's §16 row, updated the way KBR-5 and KBR-7 recorded theirs: the self-contradiction is fixed, the policy half of G3 remains open, and T-G9 / KBR-78 still owns the exact-set contract.

---

## Regression evidence (plan §16)

§16 requires evidence that the regression test fails on the unfixed revision. With `src/kitty/providers/openai_subscription.py` reverted to base `e796c1f` and the tests from this branch:

```
FAILED tests/test_upstream_identity_consistency.py::TestNoHeaderIsDerivedFromKittyVersion::test_route_emits_no_kitty_version[openai_subscription[_build_codex_headers]]
FAILED tests/test_upstream_identity_consistency.py::TestClientVersionIsStatedOnce::test_route_does_not_contradict_itself[openai_subscription[_build_codex_headers]]
FAILED tests/providers/test_openai_subscription.py::TestCodexHeaders::test_user_agent_version_is_the_codex_version
FAILED tests/providers/test_openai_subscription.py::TestCodexHeaders::test_user_agent_and_version_header_agree
4 failed, 200 passed
```

The failure names the defect directly:

```
openai_subscription[_build_codex_headers] sends two different client versions in one
request: User-Agent says '1.9.1' and the version header says '0.128.0'.
```

Every positive control and coverage assertion passes on the unfixed revision — they are testing the checks, not the defect. With the fix applied, **204 pass**.

---

## Verification

- `ruff check .` — clean
- `lint-imports` — 3 contracts kept, 0 broken
- `mypy src/kitty` — no issues in 87 source files
- `pytest -m "l1 or l2" --strict-markers --require-category=l1 --require-category=l2` — the gating suite

Reviewed by the `system-design-reviewer` (four blocking findings, all applied: the dispatch mirror, the exact-set coverage assertion, the non-vacuous-population assertion, and falsifying the enumeration itself) and the `code-reviewer`.

Closes KBR-8.

---

## Review findings applied

**`system-design-reviewer`** (on the spec, before implementation) returned four blocking findings, all applied:

1. the sweep must mirror `BridgeServer._build_upstream_headers` rather than call `build_upstream_headers`, or `opencode_go`'s per-model route is never swept;
2. coverage must be an exact set against `_registry`, not "non-empty";
3. the *pair-bearing* population — the routes the agreement check actually inspects — must be asserted non-empty, or renaming the `version` header makes it vacuous and permanently green;
4. the enumeration itself must be falsified, not only the check functions.

**`code-reviewer`** (on the implementation) returned REQUEST CHANGES on one finding, applied in the second commit: two coverage assertions looked up a label this file builds in a list this file builds, and passed with both branch pairs collapsed. They now compare the header sets the routes emit — **by header name, not value**, since the two azure routes carry different credentials and so differ in their values even when both take the same branch. Re-verified against all three mutations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JkxLUaQYgWJq9qVeGZSz7x