### PR TITLE
Release 1.9.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kitty-bridge"
-version = "1.9.1"
+version = "1.9.2"
 description = "Kitty Bridge — launch coding agents through a local API bridge"
 readme = "README.md"
 license = "MIT"

--- a/src/kitty/__init__.py
+++ b/src/kitty/__init__.py
@@ -4,5 +4,5 @@ import logging
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
-__version__ = "1.9.1"
+__version__ = "1.9.2"
 __all__ = ["__version__"]


### PR DESCRIPTION
Bumps `pyproject.toml` and `src/kitty/__init__.py` to **1.9.2**. Two lines; no other change.

## Context for the Product Owner

**A patch, not a minor.** Two things changed for users since 1.9.1, and both are repairs to behaviour that was wrong rather than anything new. Nothing breaks: a working profile keeps working, and no configuration needs touching.

### 1. Kitty no longer puts its own name into your request — #49 ([KBR-5](https://shelpuk.atlassian.net/browse/KBR-5))

Kitty Bridge sells one promise above all others: the provider on the other end cannot tell it is there. Your agent's traffic should look like your agent's traffic.

There was a hole in that. When a conversation grew too large for the model's window and Kitty could not shrink it enough, it **threw the conversation away and replaced it with a message reading `[Kitty Bridge: …]`** — sending the product's own name upstream, in the request body, attributed to the user. A provider logging request bodies could have spotted an intermediary from that string alone, and the agent would have received an answer to a message nobody wrote.

Now the request fails properly: Kitty returns a normal `400` in whatever protocol the agent speaks, and the turn stops. A user who hits the window ceiling sees a real error — documented in the README — instead of a silently rewritten conversation.

### 2. Pasting your provider's endpoint URL no longer breaks the profile — #58 ([KBR-134](https://shelpuk.atlassian.net/browse/KBR-134))

Kitty builds each request as *your base URL* + *the endpoint*. So if you pasted the full endpoint — which is exactly what every provider's own documentation shows you — Kitty appended the endpoint a second time, produced a doubled path, and the provider returned a 404. An easy mistake to make and a confusing one to debug.

Kitty now removes one redundant copy of the endpoint, and **only** when doing so cannot change where the request actually lands. A URL it cannot parse is left alone rather than turned into a crash at launch. Profiles that were already correct behave exactly as before.

### Everything else ships no product code

The bulk of the work since 1.9.1 is test infrastructure for the fidelity and containment guarantees: layer markers and CI job selection (#51), the projection input contract (#52), the Permitted-Mutation Register as data (#57), the aiohttp recorder (#60), the assertion-exemption registry (#59), plus review tooling and design documents. None of it is in the shipped package's behaviour.

## Release mechanics

Merging this does **not** publish. The `v1.9.2` tag does, and `publish.yml` gates the upload on the same full suite a pull request must pass — a tag whose tests fail never reaches PyPI, where a version number can never be reused.

Verified before opening: `tests/test_pypi_packaging.py` passes with the bump (26 tests), and no stale `1.9.1` string remains anywhere in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HdkFBQQRUhxJaL2Sj1Ep4t


[KBR-5]: https://shelpuk.atlassian.net/browse/KBR-5?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KBR-134]: https://shelpuk.atlassian.net/browse/KBR-134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ