### PR TITLE
Encode kitty's output as UTF-8 whatever the locale says (KBR-10)

### DIFF
--- a/.github/review/scripts/select_rules.py
+++ b/.github/review/scripts/select_rules.py
@@ -93,6 +93,15 @@ RULE_SPECS: tuple[RuleSpec, ...] = (
             f"{PKG}/bridge/**/*.py",
             f"{PKG}/bridge_runner.py",
             f"{PKG}/cloudflare.py",
+            # `io_encoding.py` sets the process's stdout and stderr encoding and
+            # is called by `bridge_runner.main`. It appears here AND under `cli`
+            # -- deliberately, because its two callers are the two entry points
+            # and a change to it changes what both of them emit. It is not in
+            # `core`: that rule's membership test is "imported by every layer",
+            # and this is imported by exactly two modules, so putting it there
+            # would fan out to providers, launchers and credentials rules that
+            # have nothing to say about it.
+            f"{PKG}/io_encoding.py",
         ),
     ),
     # The provider adapters: upstream request build, auth, headers, error mapping,
@@ -162,6 +171,11 @@ RULE_SPECS: tuple[RuleSpec, ...] = (
         patterns=(
             f"{PKG}/cli/**/*.py",
             f"{PKG}/tui/**/*.py",
+            # The other half of the pair described under `bridge`: this is what
+            # `cli.main.main` calls before it writes anything, so `cli.md`'s
+            # "errors to stderr, results to stdout" section is the rule a change
+            # here has to be read against.
+            f"{PKG}/io_encoding.py",
         ),
     ),
     RuleSpec(

--- a/.system_design/TEST_SUITE.md
+++ b/.system_design/TEST_SUITE.md
@@ -1973,6 +1973,13 @@ its five cases. Named here rather than left for T-K6 to rediscover, since the co
 and T-H1 plan against. KBR-132 deliberately did **not** move it — the rule above applies to a test
 fixing a skip defect exactly as it applies to any other.
 
+KBR-10 added the largest one: `tests/cli/test_stream_encoding.py` spawns **35 child interpreters**
+per run, ×4 Python versions. It has no choice — the behaviour it proves is that kitty survives a
+hostile *interpreter start-up encoding*, and `PYTHONIOENCODING` is read before any in-process test
+exists, so a real child is the only oracle. Each spawn is short (the whole file runs in ~14s), but
+T-H1 should note that mutation testing over `l1` will re-pay that cost per mutant, and may want to
+deselect this file from the mutation baseline rather than from the gate.
+
 **The load gate has to be wired, not merely declared.** The table above marks Load as gating a
 release, but `publish.yml` currently depends only on the reusable `tests.yml`. Putting the load
 run in "its own workflow" would leave publication free to proceed while load fails — or while it

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -198,3 +198,24 @@ name = "Launchers must not import CLI module"
 type = "forbidden"
 source_modules = ["kitty.launchers"]
 forbidden_modules = ["kitty.cli"]
+
+# kitty.io_encoding is imported by BOTH entry points -- kitty.cli.main and
+# kitty.bridge_runner -- so it has to sit below every layer. That is the whole
+# reason it is its own module rather than a function in cli/main.py: a
+# bridge_runner -> kitty.cli import would invert the direction the contract
+# above enforces, and would NOT be caught, because kitty.bridge_runner is a
+# sibling top-level module rather than a descendant of kitty.bridge. This
+# contract pins the property the module docstring claims.
+[[tool.importlinter.contracts]]
+name = "The stream-encoding leaf must import nothing from kitty"
+type = "forbidden"
+source_modules = ["kitty.io_encoding"]
+forbidden_modules = [
+    "kitty.cli",
+    "kitty.bridge",
+    "kitty.launchers",
+    "kitty.tui",
+    "kitty.profiles",
+    "kitty.credentials",
+    "kitty.providers",
+]

--- a/src/kitty/bridge_runner.py
+++ b/src/kitty/bridge_runner.py
@@ -19,6 +19,16 @@ from kitty.io_encoding import harden_output_streams
 
 
 def main() -> None:
+    """Run the bridge server in the foreground until it is signalled to stop.
+
+    Invoked as ``python -m kitty.bridge_runner`` by
+    :func:`kitty.bridge.manage.start_bridge`, which owns the daemonisation. This
+    is the second of kitty's two process entry points, so anything that
+    configures the *process* rather than the server belongs here as well as in
+    :func:`kitty.cli.main.main`.
+
+    Reads its configuration from the command line; see ``--help``.
+    """
     # `kitty bridge start` spawns this process with stdout and stderr as pipes,
     # so the locale-codepage path is not an edge case here -- it is the only
     # path. The parent reads this stderr back and decodes it as UTF-8

--- a/src/kitty/bridge_runner.py
+++ b/src/kitty/bridge_runner.py
@@ -15,9 +15,16 @@ import sys
 from pathlib import Path
 
 from kitty.bridge.server import BridgeServer
+from kitty.io_encoding import harden_output_streams
 
 
 def main() -> None:
+    # `kitty bridge start` spawns this process with stdout and stderr as pipes,
+    # so the locale-codepage path is not an edge case here -- it is the only
+    # path. The parent reads this stderr back and decodes it as UTF-8
+    # (`bridge/manage.py`), which is correct only because of this call.
+    harden_output_streams()
+
     parser = argparse.ArgumentParser(prog="kitty.bridge_runner")
     parser.add_argument("--host", default=None)
     parser.add_argument("--port", type=int, default=None)

--- a/src/kitty/cli/main.py
+++ b/src/kitty/cli/main.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from kitty import __version__
+from kitty.io_encoding import harden_output_streams
 
 __all__ = ["main", "map_child_exit_code"]
 
@@ -131,6 +132,10 @@ def _build_parser():
 
 def main() -> None:
     """Main entry point for the kitty CLI."""
+    # Before the first write of any kind: on Windows a piped stdout encodes
+    # with the locale codepage and dies on the banner's em dash (KBR-10).
+    harden_output_streams()
+
     from kitty.tui.display import print_banner
 
     print_banner(__version__)

--- a/src/kitty/io_encoding.py
+++ b/src/kitty/io_encoding.py
@@ -1,0 +1,63 @@
+"""Process-level output-stream encoding, applied at every kitty entry point.
+
+Kitty has two entry points — the ``kitty`` console script
+(:func:`kitty.cli.main.main`) and the background bridge process
+(:func:`kitty.bridge_runner.main`). Both must harden their streams before they
+write anything, so the setting lives here rather than in either of them:
+``kitty.bridge_runner`` importing ``kitty.cli`` would invert the dependency
+direction that ``pyproject.toml``'s import contracts enforce everywhere else,
+and would pull the whole CLI into every systemd, launchd and NSSM bridge
+service. This module imports nothing but :mod:`sys` and :mod:`contextlib`, so
+any layer may depend on it.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import sys
+
+__all__ = ["harden_output_streams"]
+
+
+def harden_output_streams() -> None:
+    """Encode ``stdout`` and ``stderr`` as UTF-8 regardless of the machine's locale.
+
+    On Windows, Python encodes a **non-console** ``stdout`` with the locale
+    codepage — ``cp1252``, ``cp437``, ``cp932`` — and ships it with
+    ``errors='strict'``. Piping, redirecting to a file, or being captured by a
+    parent process is enough to select that path, so any character the codepage
+    cannot represent killed the process with :exc:`UnicodeEncodeError`. That
+    made ``kitty doctor > diagnostics.txt`` — the command the README tells a
+    user to run when something is wrong — the invocation that crashed (KBR-10).
+
+    The text at risk is not only kitty's own status glyphs: a Russian, Japanese
+    or Chinese Windows install has a non-ASCII ``C:\\Users\\<name>``, and kitty
+    prints paths.
+
+    ``errors`` is passed explicitly and never left to default.
+    :meth:`io.TextIOWrapper.reconfigure` silently resets it to ``'strict'``
+    whenever ``encoding`` is given, which would *downgrade* ``stderr`` — Python
+    ships that stream as ``'backslashreplace'`` — and UTF-8 with ``'strict'``
+    still raises on a lone surrogate, the form :func:`os.fsdecode` produces from
+    an undecodable filename. Only an explicit non-strict handler makes "kitty
+    cannot die encoding its own output" true.
+
+    A stream that cannot be reconfigured is left exactly as it was: under
+    ``pythonw.exe`` ``sys.stdout`` is ``None``, a test may have substituted an
+    :class:`io.StringIO`, and a closed or detached stream raises. Hardening
+    output must never itself become the thing that fails.
+    """
+    for name in ("stdout", "stderr"):
+        # getattr twice rather than a hasattr check: `sys.stdout` is `None`
+        # under pythonw.exe, and a substituted stream may be any file-like
+        # object, including one with no reconfigure at all. One expression
+        # covers both.
+        stream = getattr(sys, name, None)
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is None:
+            continue
+
+        # A closed or detached stream raises ValueError. That is a stream we
+        # cannot help, not a reason to abort the command the user asked for.
+        with contextlib.suppress(ValueError):
+            reconfigure(encoding="utf-8", errors="backslashreplace")

--- a/tests/cli/test_stream_encoding.py
+++ b/tests/cli/test_stream_encoding.py
@@ -1,0 +1,583 @@
+"""Tests for output-stream encoding hardening at the kitty entry points.
+
+KBR-10: on Windows, Python encodes ``stdout`` with the machine's *locale*
+codepage whenever the stream is not a console — a pipe, a redirect to a file, a
+parent process capturing output. Any character that codepage cannot represent
+killed the process with :exc:`UnicodeEncodeError`, so ``kitty doctor >
+diagnostics.txt`` — the command the README tells a user to run when something is
+wrong — was the invocation that crashed.
+
+The module has two halves. :class:`TestHardenOutputStreams` drives
+:func:`kitty.io_encoding.harden_output_streams` against real
+:class:`io.TextIOWrapper` objects and proves what it does to them. The
+subprocess tests spawn a real child, because the claim is about the *interpreter
+start-up encoding* and no in-process test can create one: ``PYTHONIOENCODING``
+is read before the test exists.
+
+**Layer.** ``l1`` by path default, and it stays there even though it spawns
+processes: ``TEST_SUITE.md`` §8.2 forbids moving a test to ``l3`` before the
+Subsystem job exists, and ``l3`` is selected by no job today. §8.2 lists this
+file among the ``l1`` modules that spawn processes, for T-K6 and T-H1.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# Locale codepages a Windows machine really uses, none of which is a superset of
+# the other: cp1252 holds the em dash but not the status glyphs, cp437 holds
+# neither, and ascii is the floor. Testing only cp1252 would miss that
+# `kitty --version` crashes, because cp1252 happens to contain the one character
+# the banner needs.
+HOSTILE_ENCODINGS = ("cp1252", "cp437", "ascii")
+
+# Every command a non-interactive caller can reach. `--version` and `--help` are
+# here because the ticket wrongly listed them as safe: argparse emits ASCII, but
+# the banner printed before it does not.
+COMMANDS = (
+    ("--version",),
+    ("--help",),
+    ("doctor",),
+    ("egress", "show"),
+    ("profile",),
+    ("setup",),
+)
+
+# A directory name outside cp1252. This is the realistic Windows shape, not a
+# contrivance: on a Russian, Japanese or Chinese install `C:\Users\<name>` is
+# non-ASCII by default and `%LOCALAPPDATA%` derives from it.
+NON_ASCII_DIRECTORY = "дом"
+
+# Substrings that mean the child died rather than reported. Both are needed:
+# `kitty egress show` exits 1 with and without the bug, so an exit-code
+# assertion alone passes against the defect — the ticket names this trap
+# explicitly.
+_CRASH_MARKERS = ("UnicodeEncodeError", "Traceback (most recent call last)")
+
+
+def _isolated_environment(home: Path, encoding: str) -> dict[str, str]:
+    """Build a scrubbed environment for a child kitty process.
+
+    The child must not read or write the developer's real ``~/.config/kitty``
+    — ``rules/python-tests.md`` makes that a critical finding — and its exit
+    code must reflect the code path rather than whichever profiles the runner
+    happens to have.
+
+    Args:
+        home: Directory to use as the child's home. Created if absent.
+        encoding: Value for ``PYTHONIOENCODING``, which fixes the child's
+            start-up stream encoding and so simulates a Windows locale on a
+            Linux runner.
+
+    Returns:
+        A complete environment mapping, with nothing inherited but the few
+        variables an interpreter needs to start.
+    """
+    home.mkdir(parents=True, exist_ok=True)
+
+    # Built from empty with an allowlist, never scrubbed from os.environ: a
+    # denylist would have to enumerate every KITTY_* variable `main()` reads,
+    # and would silently admit the next one somebody adds.
+    environment = {
+        "PYTHONIOENCODING": encoding,
+        # POSIX reads HOME; Windows `ntpath.expanduser` never does -- it reads
+        # USERPROFILE, then HOMEDRIVE + HOMEPATH. Without all of them `Path.home()`
+        # raises, and a dozen kitty modules call it, so the child would die of a
+        # missing home and be reported as an encoding crash.
+        "HOME": str(home),
+        "USERPROFILE": str(home),
+        "HOMEDRIVE": "",
+        "HOMEPATH": str(home),
+        "XDG_CONFIG_HOME": str(home / ".config"),
+        # Read by platformdirs on Windows, not by kitty directly.
+        "LOCALAPPDATA": str(home / "AppData" / "Local"),
+        "PATH": "",
+    }
+
+    # Windows cannot start an interpreter without this; everything else is
+    # deliberately dropped.
+    for inherited in ("SYSTEMROOT", "SystemRoot"):
+        if inherited in os.environ:
+            environment[inherited] = os.environ[inherited]
+
+    return environment
+
+
+def _run_child(argv: list[str], *, home: Path, encoding: str) -> subprocess.CompletedProcess[bytes]:
+    """Run a child interpreter with a fixed stream encoding and capture raw bytes.
+
+    Args:
+        argv: Arguments after the interpreter, e.g. ``["-m", "kitty", "doctor"]``.
+        home: Directory to isolate the child into.
+        encoding: Value for ``PYTHONIOENCODING``.
+
+    Returns:
+        The completed process, with ``stdout`` and ``stderr`` as :class:`bytes`.
+
+    Raises:
+        subprocess.TimeoutExpired: If the child has not exited within 60
+            seconds, so a hang is reported here rather than as an undiagnosed
+            30-minute CI timeout.
+
+    🔴 Bytes, never ``text=True``. A ``cp1252`` child writes the em dash as the
+    single byte ``0x97``; decoding that as UTF-8 — which ``text=True`` does on a
+    UTF-8 runner — raises :exc:`UnicodeDecodeError` *in this process*. The
+    harness would then go red in its own plumbing at the base revision, and the
+    "fails before the fix" evidence would be a decode bug in disguise.
+    """
+    return subprocess.run(  # noqa: S603
+        [sys.executable, *argv],
+        env=_isolated_environment(home, encoding),
+        stdin=subprocess.DEVNULL,
+        capture_output=True,
+        timeout=60,
+        check=False,
+    )
+
+
+def _run_kitty(command: tuple[str, ...], *, home: Path, encoding: str) -> subprocess.CompletedProcess[bytes]:
+    """Run one kitty command in an isolated child.
+
+    Args:
+        command: The command words, e.g. ``("egress", "show")``.
+        home: Directory to isolate the child into.
+        encoding: Value for ``PYTHONIOENCODING``.
+
+    Returns:
+        The completed process, with output as :class:`bytes`.
+    """
+    return _run_child(["-m", "kitty", *command], home=home, encoding=encoding)
+
+
+def _crashed(completed: subprocess.CompletedProcess[bytes]) -> bool:
+    """Report whether a child died of an unhandled exception.
+
+    Args:
+        completed: A finished child process.
+
+    Returns:
+        True when the child's stderr carries a traceback or an encoding error.
+
+    ``errors="replace"`` because the bytes under test are, by construction, not
+    valid UTF-8 — decoding them strictly would raise here instead of answering
+    the question.
+    """
+    stderr = completed.stderr.decode("utf-8", errors="replace")
+
+    return any(marker in stderr for marker in _CRASH_MARKERS)
+
+
+@pytest.fixture(scope="module")
+def utf8_baseline(tmp_path_factory: pytest.TempPathFactory) -> dict[tuple[str, ...], int]:
+    """Record each command's exit code under a UTF-8 start-up encoding.
+
+    Args:
+        tmp_path_factory: Module-scoped temporary directory factory.
+
+    Returns:
+        Exit code per command, measured once and reused by every encoding.
+
+    This is the oracle for "the command's own exit code". Hard-coding the
+    numbers instead would encode today's behaviour into the test and break on
+    any unrelated change to what ``kitty doctor`` returns. The baseline is
+    asserted crash-free before it is trusted: a baseline that itself died would
+    otherwise let the comparison pass by matching one crash against another.
+    """
+    baseline: dict[tuple[str, ...], int] = {}
+
+    for command in COMMANDS:
+        # A fresh home per command, because every cell this is the oracle for
+        # gets one. Sharing would compare a virgin run against one that had
+        # already left lock files behind.
+        home = tmp_path_factory.mktemp("utf8-baseline-home")
+        completed = _run_kitty(command, home=home, encoding="utf-8")
+        assert not _crashed(completed), (
+            f"the UTF-8 baseline for {command} crashed, so it cannot serve as the "
+            f"oracle for the hostile-codepage runs:\n"
+            f"{completed.stderr.decode('utf-8', errors='replace')}"
+        )
+        baseline[command] = completed.returncode
+
+    return baseline
+
+
+@pytest.fixture(scope="module")
+def non_ascii_home_baseline(tmp_path_factory: pytest.TempPathFactory) -> int:
+    """Record ``kitty cleanup``'s exit code when its home path is not ASCII.
+
+    Args:
+        tmp_path_factory: Module-scoped temporary directory factory.
+
+    Returns:
+        The exit code under a UTF-8 start-up encoding.
+    """
+    home = tmp_path_factory.mktemp("non-ascii-baseline") / NON_ASCII_DIRECTORY
+    completed = _run_kitty(("cleanup",), home=home, encoding="utf-8")
+
+    assert not _crashed(completed), (
+        "the UTF-8 baseline for `kitty cleanup` under a non-ASCII home crashed:\n"
+        f"{completed.stderr.decode('utf-8', errors='replace')}"
+    )
+
+    return completed.returncode
+
+
+def _harden() -> None:
+    """Call the entry point's stream hardening.
+
+    The import is here rather than at module scope so that a missing
+    ``harden_output_streams`` fails only the unit tests. A module-level import
+    would fail *collection*, taking the subprocess regression tests down with
+    it — and the §16 "red at the base revision" evidence would then show an
+    ``ImportError`` where it has to show the defect itself.
+    """
+    from kitty.io_encoding import harden_output_streams
+
+    harden_output_streams()
+
+
+def _locale_stream(encoding: str = "cp1252") -> io.TextIOWrapper:
+    """Build a strict, locale-encoded text stream over an in-memory buffer.
+
+    Args:
+        encoding: The codepage to start the stream in.
+
+    Returns:
+        A stream shaped like the ``sys.stdout`` a Windows machine hands a piped
+        process: a real :class:`io.TextIOWrapper`, not a double, so the tests
+        assert on what ``reconfigure`` actually does rather than on a recorded
+        call.
+    """
+    return io.TextIOWrapper(io.BytesIO(), encoding=encoding, errors="strict")
+
+
+class TestHardenOutputStreams:
+    """Unit tests for :func:`kitty.io_encoding.harden_output_streams`.
+
+    Every test replaces **both** streams. Leaving ``sys.stderr`` alone would let
+    the call reconfigure pytest's own capture object as a side effect, which is
+    harmless but would make one test's behaviour depend on another's.
+
+    The three cases that break ``sys.stdout`` also assert that ``sys.stderr``
+    *was* hardened. Without that second assertion, turning the loop's
+    ``continue`` into a ``break`` — or wrapping the whole loop in one ``try`` —
+    would silently leave stderr on the locale codepage and every test here would
+    still pass. That matters: ``print_error`` and ``print_warning`` write to
+    stderr, and the bridge child's stderr is the stream ``bridge/manage.py``
+    reads back.
+    """
+
+    def test_it_switches_a_locale_encoded_stream_to_utf8(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A cp1252 stream ends up UTF-8, and the bytes it writes prove it."""
+        stream = _locale_stream()
+        monkeypatch.setattr(sys, "stdout", stream)
+        monkeypatch.setattr(sys, "stderr", _locale_stream())
+
+        _harden()
+        stream.write("✓ — ℹ")
+        stream.flush()
+
+        assert (stream.encoding, stream.errors) == ("utf-8", "backslashreplace")
+        assert stream.buffer.getvalue() == "✓ — ℹ".encode()
+
+    def test_it_hardens_stderr_as_well_as_stdout(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Both streams are reconfigured, not just the one the ticket named."""
+        err = _locale_stream("cp437")
+        monkeypatch.setattr(sys, "stdout", _locale_stream("cp437"))
+        monkeypatch.setattr(sys, "stderr", err)
+
+        _harden()
+
+        assert (err.encoding, err.errors) == ("utf-8", "backslashreplace")
+
+    def test_a_lone_surrogate_no_longer_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """UTF-8 alone is not enough: ``errors`` has to be non-strict too.
+
+        A lone surrogate is what :func:`os.fsdecode` produces from an
+        undecodable filename, and UTF-8 cannot represent it. Reconfiguring the
+        encoding without the error handler would leave this raising, and
+        reconfiguring with ``encoding`` alone silently resets ``errors`` to
+        ``strict``.
+        """
+        stream = _locale_stream()
+        monkeypatch.setattr(sys, "stdout", stream)
+        monkeypatch.setattr(sys, "stderr", _locale_stream())
+
+        _harden()
+        stream.write("name-\udcff")
+        stream.flush()
+
+        assert stream.buffer.getvalue() == rb"name-\udcff"
+
+    def test_a_stream_that_cannot_be_reconfigured_is_left_alone(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``io.StringIO`` has no ``reconfigure``, and must not become a crash."""
+        stream = io.StringIO()
+        err = _locale_stream()
+        monkeypatch.setattr(sys, "stdout", stream)
+        monkeypatch.setattr(sys, "stderr", err)
+
+        _harden()
+
+        assert sys.stdout is stream
+        assert (err.encoding, err.errors) == ("utf-8", "backslashreplace")
+
+    def test_a_stream_whose_reconfigure_raises_is_left_alone(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A closed stream raises :exc:`ValueError`; hardening must survive it.
+
+        Reachable in production: ``kitty >&-`` closes stdout before the process
+        starts. Verified that both a closed and a detached stream raise
+        ``ValueError`` here rather than something broader.
+        """
+        stream = _locale_stream()
+        stream.close()
+        err = _locale_stream()
+        monkeypatch.setattr(sys, "stdout", stream)
+        monkeypatch.setattr(sys, "stderr", err)
+
+        _harden()
+
+        assert sys.stdout is stream
+        assert (err.encoding, err.errors) == ("utf-8", "backslashreplace")
+
+    def test_a_missing_stream_is_left_alone(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Under ``pythonw.exe`` there is no stdout at all, and it is ``None``."""
+        err = _locale_stream()
+        monkeypatch.setattr(sys, "stdout", None)
+        monkeypatch.setattr(sys, "stderr", err)
+
+        _harden()
+
+        assert sys.stdout is None
+        assert (err.encoding, err.errors) == ("utf-8", "backslashreplace")
+
+
+@pytest.mark.parametrize("encoding", HOSTILE_ENCODINGS)
+@pytest.mark.parametrize("command", COMMANDS, ids=lambda c: "-".join(c).lstrip("-"))
+def test_a_command_is_unaffected_by_a_hostile_codepage(
+    command: tuple[str, ...],
+    encoding: str,
+    tmp_path: Path,
+    utf8_baseline: dict[tuple[str, ...], int],
+) -> None:
+    """Every kitty command survives a locale codepage it cannot encode into.
+
+    Both assertions carry one logical claim — this invocation behaves as it does
+    under UTF-8 — so they belong in one test. The exit-code half alone would
+    pass against the defect for ``egress show``, which exits 1 either way; the
+    traceback half is what discriminates.
+
+    Args:
+        command: The kitty command words under test.
+        encoding: The start-up encoding forced on the child.
+        tmp_path: Per-test isolated home.
+        utf8_baseline: Exit code per command under UTF-8.
+
+    This sweep is **breadth, not depth**. On Linux ``doctor``, ``profile`` and
+    ``setup`` exit at the TTY check having printed only the banner, and
+    ``--help`` dies on the banner before argparse's help path is reached, so all
+    six commands exercise the same two string literals. The depth — text kitty
+    does not control — is
+    :func:`test_a_non_ascii_home_path_survives_a_hostile_codepage`.
+    """
+    completed = _run_kitty(command, home=tmp_path / "home", encoding=encoding)
+
+    assert not _crashed(completed), (
+        f"`kitty {' '.join(command)}` died under {encoding}:\n"
+        f"{completed.stderr.decode('utf-8', errors='replace')}"
+    )
+    assert completed.returncode == utf8_baseline[command], (
+        f"`kitty {' '.join(command)}` returned {completed.returncode} under {encoding} "
+        f"but {utf8_baseline[command]} under utf-8; the codepage changed the outcome."
+    )
+
+
+@pytest.mark.parametrize("encoding", HOSTILE_ENCODINGS)
+def test_a_non_ascii_home_path_survives_a_hostile_codepage(
+    encoding: str,
+    tmp_path: Path,
+    non_ascii_home_baseline: int,
+) -> None:
+    """Text kitty does not control also survives — the discriminating case.
+
+    ``kitty cleanup`` prints the settings path it inspected, so a home directory
+    named ``дом`` puts a string kitty never chose onto **stdout**. This is what
+    separates the fix that was built from the one that was rejected: a patch
+    that only swapped the five decorative glyphs for ASCII would turn every cell
+    of the breadth sweep green and still crash here, at the path.
+
+    Args:
+        encoding: The start-up encoding forced on the child.
+        tmp_path: Per-test isolated home root.
+        non_ascii_home_baseline: The same command's exit code under UTF-8.
+
+    The stdout assertion is the positive half: without it the test would pass
+    against a kitty that had stopped printing the path altogether.
+    """
+    completed = _run_kitty(("cleanup",), home=tmp_path / NON_ASCII_DIRECTORY, encoding=encoding)
+
+    assert not _crashed(completed), (
+        f"`kitty cleanup` died under {encoding} with a non-ASCII home path:\n"
+        f"{completed.stderr.decode('utf-8', errors='replace')}"
+    )
+    assert completed.returncode == non_ascii_home_baseline
+    assert NON_ASCII_DIRECTORY in completed.stdout.decode("utf-8", errors="replace"), (
+        "the path kitty inspected did not reach stdout, so this test would have "
+        "passed without proving anything about encoding it."
+    )
+
+
+@pytest.mark.parametrize("encoding", HOSTILE_ENCODINGS)
+def test_the_harness_detects_an_unhardened_child(encoding: str, tmp_path: Path) -> None:
+    """Falsification: the harness must fail when handed a known defect.
+
+    ``TEST_SUITE_IMPLEMENTATION_PLAN.md`` §1.4 — a harness never shown to fail
+    is indistinguishable from one that cannot. The deliberate defect is real
+    product code (:func:`kitty.tui.display.print_info`) called without the entry
+    point that hardens the streams, which is exactly the state ``kitty egress
+    show`` was in before this change.
+
+    ``print_info`` rather than :func:`~kitty.tui.display.print_banner`: the
+    banner's em dash **is** in cp1252 (0x97), so it does not crash there — which
+    is precisely why the ticket wrongly recorded ``kitty --version`` as safe.
+    ``ℹ`` (U+2139) is in none of the three, and is the character the reported
+    ``egress show`` traceback names.
+
+    Parametrised over all three encodings so the case cannot later be narrowed
+    to one that no longer bites.
+
+    Routed through :func:`_run_child`, not around it, so the whole runner is
+    under test: an environment builder that silently stopped passing
+    ``PYTHONIOENCODING`` would leave the tests above permanently green, and
+    turns this one red.
+
+    Args:
+        encoding: The start-up encoding forced on the child.
+        tmp_path: Per-test isolated home.
+    """
+    completed = _run_child(
+        ["-c", "from kitty.tui.display import print_info; print_info('x')"],
+        home=tmp_path / "home",
+        encoding=encoding,
+    )
+
+    assert _crashed(completed), (
+        f"an unhardened child printing an unencodable glyph under {encoding} did "
+        "not register as a crash, so the harness cannot detect the defect it "
+        "exists to catch."
+    )
+
+
+@pytest.mark.parametrize("encoding", HOSTILE_ENCODINGS)
+def test_the_real_process_streams_end_up_utf8(encoding: str, tmp_path: Path) -> None:
+    """The hardening reaches the genuine ``sys.stdout``, not just a test double.
+
+    The unit tests substitute a stream; the subprocess matrix only observes the
+    *absence* of a crash, which ``errors="replace"`` or ``"ignore"`` would also
+    produce while silently discarding the handler the design chose. This case
+    reads the two attributes back out of a real interpreter and pins both.
+
+    Args:
+        encoding: The start-up encoding forced on the child.
+        tmp_path: Per-test isolated home.
+    """
+    completed = _run_child(
+        [
+            "-c",
+            "from kitty.io_encoding import harden_output_streams; harden_output_streams(); "
+            "import sys; print(sys.stdout.encoding, sys.stdout.errors, "
+            "sys.stderr.encoding, sys.stderr.errors)",
+        ],
+        home=tmp_path / "home",
+        encoding=encoding,
+    )
+
+    assert completed.stdout.decode().split() == [
+        "utf-8",
+        "backslashreplace",
+        "utf-8",
+        "backslashreplace",
+    ]
+
+
+def test_the_glyphs_still_reach_stdout_on_a_utf8_stream(tmp_path: Path) -> None:
+    """Kitty's own non-ASCII output survives — the fix did not degrade it.
+
+    Every other test here proves the *absence* of a crash, which an
+    implementation that stripped the em dash and ``ℹ`` from ``display.py`` would
+    also achieve. That is the ASCII-glyph fix §5 D1 rejects, arriving by the
+    back door, and without this assertion the suite could not see it.
+
+    Args:
+        tmp_path: Per-test isolated home.
+    """
+    completed = _run_kitty(("--version",), home=tmp_path / "home", encoding="utf-8")
+
+    assert "—" in completed.stdout.decode("utf-8")
+
+
+class _Sentinel(Exception):
+    """Raised by a stub to stop an entry point at the moment under test."""
+
+
+class TestEntryPointsHardenFirst:
+    """Both entry points must harden before they write or parse anything.
+
+    Without these, a ``harden_output_streams()`` call dropped from
+    ``bridge_runner.main`` — or moved below the first write in either — is green
+    across every other test in this module, because the subprocess matrix only
+    ever spawns ``python -m kitty``. Follows the recorder-plus-sentinel pattern
+    of ``tests/test_entry_point_refresh.py``: the sentinel guarantees the
+    assertion runs at the exact moment the next step would have happened.
+    """
+
+    def test_the_cli_hardens_before_printing_the_banner(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``kitty.cli.main`` hardens, then prints the banner — in that order."""
+        import kitty.cli.main as cli_main
+        import kitty.tui.display as display
+
+        order: list[str] = []
+
+        def fake_banner(_version: str) -> None:
+            order.append("write")
+            raise _Sentinel
+
+        monkeypatch.setattr(cli_main, "harden_output_streams", lambda: order.append("harden"))
+        monkeypatch.setattr(display, "print_banner", fake_banner)
+
+        with pytest.raises(_Sentinel):
+            cli_main.main()
+
+        assert order == ["harden", "write"]
+
+    def test_the_bridge_runner_hardens_before_parsing_arguments(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``kitty.bridge_runner`` hardens before argparse can write usage text.
+
+        The bridge child's streams are pipes by construction, and argparse
+        prints to them on a bad flag, so the ordering matters here for the same
+        reason it does in the CLI.
+        """
+        import argparse
+
+        import kitty.bridge_runner as bridge_runner
+
+        order: list[str] = []
+
+        def fake_parse_args(_self: argparse.ArgumentParser, *_args: object, **_kwargs: object) -> None:
+            order.append("parse")
+            raise _Sentinel
+
+        monkeypatch.setattr(bridge_runner, "harden_output_streams", lambda: order.append("harden"))
+        monkeypatch.setattr(argparse.ArgumentParser, "parse_args", fake_parse_args)
+
+        with pytest.raises(_Sentinel):
+            bridge_runner.main()
+
+        assert order == ["harden", "parse"]

--- a/tests/cli/test_stream_encoding.py
+++ b/tests/cli/test_stream_encoding.py
@@ -22,6 +22,7 @@ file among the ``l1`` modules that spawn processes, for T-K6 and T-H1.
 
 from __future__ import annotations
 
+import inspect
 import io
 import os
 import subprocess
@@ -29,6 +30,8 @@ import sys
 from pathlib import Path
 
 import pytest
+
+from kitty.tui.display import print_info
 
 # Locale codepages a Windows machine really uses, none of which is a superset of
 # the other: cp1252 holds the em dash but not the status glyphs, cp437 holds
@@ -59,6 +62,13 @@ NON_ASCII_DIRECTORY = "дом"
 # assertion alone passes against the defect — the ticket names this trap
 # explicitly.
 _CRASH_MARKERS = ("UnicodeEncodeError", "Traceback (most recent call last)")
+
+# The character `print_info` emits, and the reason the falsification case below
+# is a defect at all. Named here so the test can check its own premise: if the
+# product ever swapped this glyph for one a codepage *can* encode, the
+# falsification assertion would go red saying the harness is broken, when what
+# actually changed is the bait. See `test_the_harness_detects_an_unhardened_child`.
+FALSIFICATION_GLYPH = "\u2139"
 
 
 def _isolated_environment(home: Path, encoding: str) -> dict[str, str]:
@@ -460,6 +470,17 @@ def test_the_harness_detects_an_unhardened_child(encoding: str, tmp_path: Path) 
         encoding: The start-up encoding forced on the child.
         tmp_path: Per-test isolated home.
     """
+    # Check the premise before trusting the conclusion: this case only tests the
+    # harness while `print_info` still emits a character `encoding` cannot hold.
+    source = inspect.getsource(print_info)
+    assert FALSIFICATION_GLYPH in source, (
+        f"`print_info` no longer emits {FALSIFICATION_GLYPH!r}, so driving it is "
+        "no longer a deliberate defect. The harness is not broken — this test's "
+        "bait is. Pick a character no codepage in HOSTILE_ENCODINGS can encode."
+    )
+    with pytest.raises(UnicodeEncodeError):
+        FALSIFICATION_GLYPH.encode(encoding)
+
     completed = _run_child(
         ["-c", "from kitty.tui.display import print_info; print_info('x')"],
         home=tmp_path / "home",


### PR DESCRIPTION
Fixes [KBR-10](https://shelpuk.atlassian.net/browse/KBR-10).

## Context for the Product Owner

**Who was broken.** Any Windows user whose machine is not set to a UTF-8 locale — which is most of them outside an English install — could not send us their diagnostics. `kitty doctor > diagnostics.txt`, the exact command our README tells them to run when something goes wrong, died with a Python traceback and left them an empty file. The failure reads as *"kitty is broken"*, not *"your console cannot draw a tick mark"*, so it costs us trust at the worst possible moment: when the user is already stuck and trying to get help.

Interactive use was always fine. The crash only happened when output went to a **pipe or a file** — which is also every scripted install, every containerised install, and every CI job.

**What we found beyond the ticket.**

1. **`kitty --version` was affected too.** The ticket recorded it as safe. It only looked safe because the reporter's codepage happens to contain the one exotic character in our startup banner. On a Japanese, Cyrillic or Greek install it crashes — and `--version` is what an installer script calls first to check kitty is working.
2. **The users hit hardest were the ones we would least want to lose.** If a Windows account name is not in English — `C:\Users\Кирилл` — then kitty crashed printing a path it had just read off that user's own machine. A fix limited to our own tick and cross marks, which is the obvious reading of the ticket, would have left this broken. There is now a test whose only job is to stop us taking that cheaper route later.
3. **The background bridge service had the same bug.** Its output is piped by definition, so it was never not affected. Fixed in the same change.

**What users will notice.** Nothing, if their machine already worked. Everyone else gets commands that complete, and diagnostics files that can be read and sent to us.

**One follow-up filed:** [KBR-154](https://shelpuk.atlassian.net/browse/KBR-154) — if the bridge fails to start *and* the user's locale is not UTF-8, the message explaining why can still be lost. Rarer (it needs an already-broken install), different code path, its own ticket.

---

## What changed

`kitty` now sets its own output streams to UTF-8 at start-up, instead of accepting whatever the machine's locale imposes. This is exactly what the ticket's documented workaround (`PYTHONIOENCODING=utf-8`) does — applied by the product rather than asked of the user.

| File | Change |
|---|---|
| `src/kitty/io_encoding.py` | **New.** `harden_output_streams()` — the whole fix, 8 lines of logic. |
| `src/kitty/cli/main.py` | Import + call, first statement of `main()`. |
| `src/kitty/bridge_runner.py` | Import + call, first statement of `main()`. |
| `pyproject.toml` | A fourth import-linter contract pinning the new module as a dependency-free leaf. |
| `tests/cli/test_stream_encoding.py` | **New.** 36 tests. |
| `.system_design/TEST_SUITE.md` | Records the new file's cost against §8.2's count, for T-K6 and T-H1. |

### Three decisions worth reading

**Why UTF-8 rather than ASCII fallbacks for the glyphs.** Substituting `v`/`x`/`i` for `✓`/`✗`/`ℹ` only fixes characters we enumerate. Paths, and upstream provider error bodies, pass through the same console and can carry anything — so the crash survives, and the glyph register becomes a thing to maintain. Measured, with a Cyrillic home directory:

```
HOME=…/дом  PYTHONIOENCODING=cp1252  kitty cleanup
→ exit 1, UnicodeEncodeError … can't encode characters in position 40-42
```

Position 40–42 is inside the **path**. `test_a_non_ascii_home_path_survives_a_hostile_codepage` is the test that holds this line.

**Why `errors="backslashreplace"` is passed explicitly.** Two measured facts, either of which makes the naive one-liner wrong:

- `reconfigure(encoding=...)` **silently resets `errors` to `'strict'`** — so `reconfigure(encoding="utf-8")` alone would *downgrade* stderr, which Python ships as `backslashreplace`. A regression introduced by the fix for a crash.
- UTF-8 with `'strict'` still raises on a lone surrogate — what `os.fsdecode` returns for an undecodable filename. "Switch it to UTF-8" is not the same as "it can no longer crash".

**Why a new module rather than a function in `cli/main.py`.** `kitty.bridge_runner` needs it too, and it is a top-level module rather than part of the `kitty.bridge` package — so a `bridge_runner` → `kitty.cli` import would invert our layering **and pass `lint-imports` silently**. The new leaf imports only `sys` and `contextlib`, and the added contract enforces that rather than leaving it as a docstring claim.

## Evidence

Per `TEST_SUITE_IMPLEMENTATION_PLAN.md` §16, one atomic PR with the regression tests shown red at the base revision.

**At `e796c1f` (fix reverted, tests kept): 27 failed, 8 passed.**

```
6  unit          — the function does not exist yet
13 breadth       — the real crash (cp437 ×6, ascii ×6, egress show @ cp1252)
3  depth         — the real crash, in the path rather than a glyph
3  stream state  — encoding/errors never became utf-8/backslashreplace
2  ordering      — neither entry point calls it

8 passed         — the 5 cp1252 cells that never crashed, plus the 3
                   falsification cells, which test an unhardened child and
                   are supposed to pass either way
```

**With the fix: 36 passed.** Full local gate: `ruff` clean, `lint-imports` 4 contracts kept / 0 broken, `mypy` clean on 88 files, and `pytest -m "l1 or l2"` green.

The end-to-end user story, before → after:

```
$ HOME=…/Кирилл PYTHONIOENCODING=cp1252 kitty cleanup > diagnostics.txt
before: exit 1, traceback on stderr, diagnostics.txt empty
after:  exit 0, stderr empty, diagnostics.txt is UTF-8 with the path intact
```

## On the tests

The ticket warns that `kitty egress show` exits 1 with **and** without the bug, so an exit-code assertion alone passes against the defect. The suite handles that by asserting the absence of a traceback *and* comparing each exit code against the same command's exit code under UTF-8 — with that baseline itself asserted crash-free first, so one crash cannot be matched against another.

Per §1.4, the harness ships with a falsification case: three cells drive the whole runner at unhardened product code and require it to report a crash, so a runner that quietly stopped passing `PYTHONIOENCODING` to the child turns red instead of green. `print_info` and not `print_banner` — the banner's em dash *is* in cp1252, so that child would not have crashed. Two review rounds and a hand-check caught that one.

The 35 subprocess spawns are not incidental: the behaviour under test is the **interpreter's start-up encoding**, which is fixed before any in-process test exists. A real child is the only oracle.

Reviewed by `system-design-reviewer` (two rounds, five blockers) and `code-reviewer` (two rounds, verdict APPROVE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VMeBsTCWi33JzGFU8RLB1k


[KBR-10]: https://shelpuk.atlassian.net/browse/KBR-10?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KBR-154]: https://shelpuk.atlassian.net/browse/KBR-154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ