### PR TITLE
KBR-146: decide the IPv4-mapped wildcard from ipv4_mapped, not from a patch-dependent property

### DIFF
--- a/.system_design/TEST_SUITE.md
+++ b/.system_design/TEST_SUITE.md
@@ -1218,6 +1218,11 @@ The `localhost` exclusions are not a caveat bolted on — `should_bypass` matche
 before it ever tries `ipaddress.ip_address`, and a property stated without them fails on day one
 and gets weakened, which removes the guard.
 
+An IPv4-mapped literal such as `::ffff:10.0.0.5` **is** an IP literal, so it takes the address
+branch and this property never reaches it. Its classification is a stdlib behaviour, pinned in
+§6.2.4 — including the note that one of the three terms the disjunction reads is not independently
+stable across interpreter patch releases.
+
 **A narrower user-visible consequence.** Because names outside the `localhost` family are not
 resolved, a user whose local model server is reached by a **LAN hostname** — not `localhost`, not
 an IP — will have that traffic tunnelled to a proxy that cannot reach it. The common
@@ -1301,7 +1306,7 @@ cannot be the L1 selection (§8).
 | `_compact_messages` | Identity below budget · no orphaned pair · idempotent · **output ≤ budget unless the surviving set is irreducible** (below) |
 | `_validate_tool_call_pairing` | Output contains no `tool_result` without a `tool_use`, in both message shapes |
 | `_truncate_oversized_tool_results` | Identity below the limit · output ≤ limit · non-tool-result content untouched |
-| `should_bypass` | Every address in a private range is bypassed · the §5.3 hostname property |
+| `should_bypass` | Every address in a private range is bypassed, **including the IPv4-mapped form of each range** (§6.2.4 pins why that is a stdlib claim and not a kitty one) · the §5.3 hostname property |
 | `parse_proxy_url` / `EgressConfig` | Credential round-trip · the redaction property below |
 | `describe_tool_input_anomaly` | Never reports an anomaly for input that validates against the declared schema |
 | Wire projections (§3.3.1) | Each reads its format correctly, tested against published format examples — never against kitty's own output |
@@ -1387,6 +1392,10 @@ None`. `mutmut` closes that gap.
 cannot rot into a no-op. `tests/test_egress_coverage.py` already does this
 (`test_the_scan_actually_finds_something`, `test_the_scan_finds_the_known_start_paths`) and is
 the pattern to copy.
+
+**And a contract pins what the code reads, never what it merely tolerates.** Pinning a value that is
+itself version-dependent enforces whatever the author's interpreter happened to say; the fix is to
+stop depending on it and pin the stable neighbour. Worked example and the precondition in §6.2.4.
 
 #### 6.2.1 Bridge endpoint schemas
 
@@ -1568,9 +1577,9 @@ user impact as a drifted API, and F2 shows it has already happened.
 
 #### 6.2.4 Dependency behaviour contracts
 
-Small, fast tests pinning third-party behaviour the invariants rest on, so a dependency bump
-fails here with a clear message rather than in production. The pin situation is worse than a
-glance suggests:
+Small, fast tests pinning dependency behaviour the invariants rest on — and the
+ordinary-correctness behaviour whose drift the gate cannot see — so an upgrade fails here with
+a clear message rather than in production. The pin situation is worse than a glance suggests:
 
 | Dependency | Declared pin | What must be pinned by test |
 |---|---|---|
@@ -1578,9 +1587,57 @@ glance suggests:
 | `curl_cffi` | `>=0.7` — **unbounded** | `proxies=` is honoured; its precedence over ambient `HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY` (this stack *does* read the environment); the impersonation target still exists. |
 | `botocore` | **not declared at all** — arrives transitively via `boto3>=1.34` | `Config(proxies=)` is honoured and takes precedence over the environment. It is botocore, not boto3, that implements this. An undeclared dependency owning a containment guarantee is worse than an unbounded one. |
 | `keyring` | `>=23.0` | Backend resolution on each supported platform. |
+| CPython `ipaddress` | `requires-python = ">=3.10"` — **minor only, no patch floor** | Two consumers. **I3:** `should_bypass` reads `is_loopback or is_private or is_link_local`, so the disjunction's verdict on the IPv4-mapped form of each range must be pinned — see the masking note below. **Liveness:** `_connect_target` reads `IPv6Address.ipv4_mapped` (the mapped `IPv4Address` for `::ffff:x.x.x.x`, `None` otherwise) and `is_unspecified` for `0.0.0.0` and `::`. What must **not** be pinned is `IPv6Address("::ffff:0.0.0.0").is_unspecified`: CPython [gh-122792](https://github.com/python/cpython/issues/122792) changed it mid-branch, so its value is a property of the patch release, and the code is written not to read it. |
 
 The ambient-environment cases are not hypothetical: `kitty.egress`'s docstring records the
 divergence, and a user with `HTTP_PROXY` set in their shell exercises it on two of three stacks.
+
+**The standard library is a dependency, and it is declared to the wrong precision.** Three of the
+other rows name a version range; `botocore` names none at all. The interpreter is a third shape —
+declared, but only to the *minor*, so `requires-python` admits both sides of a behaviour change that
+moved at a patch boundary. That is how KBR-146 reached `main` green: `ipaddress` answered one way on
+the runner and the other way on a stock Ubuntu 24.04 developer box, and nothing in the tree asserted
+which answer was being relied upon.
+
+**A contract pins what the code reads, never what it merely tolerates.** The pre-fix
+`_connect_target` would have been pinned by asserting `is_unspecified` is true for the mapped
+wildcard — red on the 35 supported releases that predate the backport (3.10.0–3.10.15,
+3.11.0–3.11.10, 3.12.0–3.12.6, 3.13.0) — so the contract would have enforced the defect rather than
+caught it. The rule this row establishes: when a dependency's behaviour is version-dependent, stop
+depending on it and pin the **stable neighbour** instead; pinning the moving value only relocates
+the failure. **Where no stable neighbour exists** — `keyring`'s backend resolution varies by
+platform by design, and `curl_cffi`'s impersonation targets come and go — the remaining options are
+a version floor or a runtime feature check, and the row must record which was chosen. A floor was
+rejected here for the reason a floor is usually wrong: it drops supported users to settle a question
+the code no longer asks. `tests/test_ipaddress_contract.py` holds the contract and says in its own
+docstring which property it refuses to assert and why.
+
+**Why forcing the property is a faithful stand-in for an old interpreter.** `ipv4_mapped` itself was
+measured identical on 18 releases spanning all four supported branches, which is what makes the L1
+test's forced `is_unspecified` a reproduction of a pre-backport interpreter rather than a resemblance
+to one. Everything else in the mapped path reads the same on both sides of gh-122792.
+
+**`should_bypass` survives gh-122792 by masking, not by independence — and that is a premise, not an
+accident.** `ipaddress.ip_address("::ffff:169.254.1.1").is_link_local` flips at the *same* four
+boundaries as `is_unspecified` (measured: `False` on 3.10.13–15, 3.11.8–10, 3.12.4–6 and 3.13.0;
+`True` from 3.10.16, 3.11.11, 3.12.7 and 3.13.1). The disjunction is stable only because
+`is_private` delegates to the mapped address on every supported release and IPv4's `is_private`
+already covers `169.254.0.0/16`. So I3's bypass decision *does* read a version-dependent value, and
+is saved by a sibling term. Anyone who later splits that disjunction, narrows it, or logs per term
+re-opens the patch dependence in the containment direction — which is why the contract pins the
+disjunction's verdict on the mapped forms rather than the individual terms. Upstream's own
+motivation for gh-122792 was "folks using IP address filtering before establishing a connection",
+which is precisely what `should_bypass` is.
+
+**What this contract does not prove, and what carries it instead.** `.github/workflows/tests.yml`
+names bare minor versions and `actions/setup-python` resolves each to the newest patch, so this
+module is only ever evaluated on the **new** side of every such boundary. It can therefore catch
+*forward* drift — a future interpreter changing a value we read — and cannot catch a value that
+differs on an older patch a user is actually running, which is the shape KBR-146 had. That half
+rests entirely on the L1 forced-property test, which holds both sides inside one run. Recorded as
+gap **G25** rather than closed by a matrix entry: `setup-python` does accept an exact patch version,
+so one pinned job would do it, and that is a CI-spend decision for the product owner rather than a
+change this defect's fix should make on its own authority.
 
 ### 6.3 L3 — Subsystem
 
@@ -2512,7 +2569,8 @@ does not surface work that is done. `TEST_SUITE_IMPLEMENTATION_PLAN.md` §16 mir
 | **G6** | Docs drift undetected (F2) — KBR-9 | README endpoint table already wrong | README ⇄ code guards | **3** |
 | **G7** | No property-based tests | All example-based | `hypothesis` on the §6.1 list | **3** |
 | **G9** | C5 unmeasured | `force_close=True` gives a per-request connection pattern unlike the agent's | Connection-count baseline | **3** |
-| **G11** | Dependency behaviour unpinned; `curl_cffi` unbounded and **botocore undeclared** | Containment rests on an undeclared transitive dependency | Dependency contract tests (§6.2.4) + declare botocore | **3** |
+| **G11** | Dependency behaviour unpinned; `curl_cffi` unbounded, **botocore undeclared** and the interpreter declared to the minor only | One of five §6.2.4 contracts has landed — the stdlib `ipaddress` one (KBR-146). The four transport contracts and the `botocore` declaration remain, so containment still rests on an undeclared transitive dependency | Dependency contract tests (§6.2.4) + declare botocore | **3** |
+| **G25** | **§6.2.4 contracts are only ever evaluated on the newest patch of each minor** — KBR-146 | `tests.yml` names bare minor versions and `actions/setup-python` resolves each to the newest patch. Every dependency contract therefore proves forward drift only; a value that differs on an older patch a user runs — the shape KBR-146 had — is invisible to the gate. Today that half rests on one L1 test that forces the property both ways, which works because the surrounding behaviour was measured stable, and does not generalise to a contract whose neighbours have not been | One job pinned to the oldest supported patch (`setup-python` accepts an exact version, so it is one job, not four). Deferred as a CI-spend decision, not a technical one | **3** |
 | **G12** | Product layer effectively absent | 2 E2E tests, never run in CI | Nightly job, extended to 5 Claude Code cases | **4** |
 | **G13** | No answer-quality signal | Compaction and the Fireworks cap can degrade output invisibly | Paired delta eval | **4** |
 
@@ -2532,6 +2590,12 @@ per hour.
 
 Recorded per the repo's system-design discipline: the reasoning, especially where the choice was
 not the obvious one.
+
+**Pin what the code reads, not what it tolerates (§6.2.4).** A dependency contract that asserts a
+version-dependent value enforces the author's interpreter rather than the product's requirement —
+and, for KBR-146, would have enforced the defect. Where the dependency offers a stable neighbour the
+answer is to read that instead; where it does not, the row records whether a floor or a runtime
+check was chosen.
 
 **A permitted-mutation register instead of golden files (§3.1).** Golden files fail on every
 change, get regenerated reflexively, and prove nothing about unrecorded inputs. The register

--- a/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
+++ b/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
@@ -579,6 +579,7 @@ merge.** So:
 | KBR-8 · **CLOSED** | G3 | T-G9, TR-1c | Route taken: atomic fix + behavioural guard landed together, red evidence in the PR (2026-09-11). T-G9 still owns the exact-set contract and TR-1c the acceptance scenario; G3's policy half waits on Q1. (Status convention: `TEST_SUITE.md` §9.2.) |
 | KBR-9 | G6 | T-G1 | Atomic fix + test now |
 | KBR-132 · **CLOSED** | G21 | — | Route taken: atomic fix + regression test, red at base, evidence in the PR. The broader guard is **KBR-138**, which has no plan-task ID because it was filed after this plan was written; G21 is its design gap. (Status convention: `TEST_SUITE.md` §9.2.) |
+| KBR-146 · **CLOSED** | G25 | — | Route taken: atomic fix + regression tests, red at base on both sides of the interpreter boundary, evidence in the PR. Landed the fifth §6.2.4 contract (`tests/test_ipaddress_contract.py`) ahead of all four planned ones; no plan-task ID, filed after this plan was written. G25 records what that contract still cannot prove. Duplicates KBR-141/142/150/162. (Status convention: `TEST_SUITE.md` §9.2.) |
 
 ---
 
@@ -611,7 +612,7 @@ Every design requirement has an owner. "Existing" means the current suite alread
 | §6.2.1 | OpenAPI, schemathesis, registration matrix | T-G6 |
 | §6.2.2 | SSE grammar | T-G7 |
 | §6.2.3 | Register, internal-key, wire-shape, vendor-token, docs guards | T-G1–T-G5 — T-G3 delivered by KBR-6, and the **hook-level** half of wire-shape honesty by KBR-7; T-G4 still owns the wire boundary |
-| §6.2.4 | Four dependency contracts | T-G8, T-G10, T-G11, T-G12 |
+| §6.2.4 | Five dependency contracts | T-G8, T-G10, T-G11, T-G12 — the fifth, the stdlib `ipaddress` contract, was **delivered by KBR-146** and has no plan-task ID because the defect was filed after this plan was written |
 | §6.3.1 | Bridge-with-sockets scenarios | T-I7–T-I11 |
 | §6.3.2 | CLI lifecycle | T-I1–T-I4 |
 | §6.4.1 | Gherkin scenarios | T-J1–T-J3 |

--- a/src/kitty/bridge/manage.py
+++ b/src/kitty/bridge/manage.py
@@ -114,13 +114,18 @@ def _connect_target(host: str) -> str:
         address = ipaddress.ip_address(host)
     except ValueError:
         return host
+    # The IPv4-mapped form is settled from ``ipv4_mapped`` before anything asks
+    # ``is_unspecified``, because that property's answer for ``::ffff:0.0.0.0``
+    # is a property of the interpreter's patch release, not of the address.
+    # CPython gh-122792 made it delegate to the mapped address and was backported
+    # mid-branch -- 3.10.16, 3.11.11, 3.12.7 and 3.13.1 -- while ``requires-python``
+    # bounds the minor version only. ``ipv4_mapped`` reads the same on all of them.
+    mapped = address.ipv4_mapped if isinstance(address, ipaddress.IPv6Address) else None
+    if mapped is not None:
+        return "127.0.0.1" if mapped.is_unspecified else host
     if not address.is_unspecified:
         return host
-    # ``is_unspecified`` is also true for the IPv4-mapped form ``::ffff:0.0.0.0``,
-    # which wants an IPv4 loopback despite reporting version 6.
-    if address.version == 6 and address.ipv4_mapped is None:
-        return "::1"
-    return "127.0.0.1"
+    return "::1" if address.version == 6 else "127.0.0.1"
 
 
 def bridge_reachable(host: str, port: int, timeout: float = PROBE_TIMEOUT_SECONDS) -> bool:

--- a/tests/bridge/test_bridge_management.py
+++ b/tests/bridge/test_bridge_management.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ipaddress
 import json
 import os
 import signal
@@ -682,8 +683,15 @@ class TestBridgeReachable:
             ("::", "::1"),
             ("::0", "::1"),
             ("0:0:0:0:0:0:0:0", "::1"),
-            # IPv4-mapped: unspecified, but wants an IPv4 loopback.
+            # The IPv4-mapped wildcard names an IPv4 bind, so it wants an IPv4
+            # loopback -- decided from ``ipv4_mapped``, never from the
+            # patch-dependent ``is_unspecified``. See KBR-146.
             ("::ffff:0.0.0.0", "127.0.0.1"),
+            ("::ffff:0:0", "127.0.0.1"),
+            # A mapped address that is not a wildcard is a real bind target and
+            # is probed exactly as recorded, like any other real address.
+            ("::ffff:127.0.0.1", "::ffff:127.0.0.1"),
+            ("::ffff:192.0.2.1", "::ffff:192.0.2.1"),
             ("127.0.0.1", "127.0.0.1"),
             ("192.0.2.1", "192.0.2.1"),
             ("::1", "::1"),
@@ -696,6 +704,49 @@ class TestBridgeReachable:
         from kitty.bridge.manage import _connect_target
 
         assert _connect_target(host) == expected
+
+    @pytest.mark.parametrize("property_reports", [False, True])
+    def test_ipv4_mapped_wildcard_resolves_alike_whatever_is_unspecified_reports(
+        self, monkeypatch: pytest.MonkeyPatch, property_reports: bool
+    ):
+        """The mapped wildcard resolves alike on both sides of CPython gh-122792.
+
+        Args:
+            monkeypatch: pytest's patching fixture, which reverts the stdlib
+                property at teardown.
+            property_reports: What ``IPv6Address.is_unspecified`` is forced to
+                report -- ``False`` reproduces a pre-backport interpreter,
+                ``True`` a patched one.
+
+        ``IPv6Address.is_unspecified`` delegates to the mapped IPv4 address from
+        3.10.16, 3.11.11, 3.12.7 and 3.13.1 onwards, and does not below them.
+        ``requires-python = ">=3.10"`` admits every one of those releases, so a
+        single interpreter can only ever demonstrate its own side of the change.
+        Forcing the property is the only way to hold both sides inside one run,
+        and it is the exact seam the defect came through: the pre-fix function
+        short-circuited on this property and handed back the wildcard unchanged.
+
+        The claim is output invariance, not non-consultation -- an
+        implementation that reads the property and discards its answer is legal
+        and passes.
+        """
+        from kitty.bridge.manage import _connect_target
+
+        # Patched on IPv6Address, which owns the property outright on every
+        # supported branch -- so this shadows nothing and leaves no residue.
+        monkeypatch.setattr(
+            ipaddress.IPv6Address,
+            "is_unspecified",
+            property(lambda self: property_reports),
+        )
+
+        # Without this the test has a silent no-op mode: an implementation that
+        # stopped routing through ``ipaddress`` would make the patch inert and
+        # leave this a duplicate of the table row, still claiming to prove
+        # version-independence.
+        assert ipaddress.ip_address("::ffff:0.0.0.0").is_unspecified is property_reports
+
+        assert _connect_target("::ffff:0.0.0.0") == "127.0.0.1"
 
     def test_unresolvable_hostname_returns_false(self):
         """DNS failure is an OSError subclass and must not escape either."""

--- a/tests/test_egress.py
+++ b/tests/test_egress.py
@@ -123,6 +123,15 @@ class TestShouldBypass:
             "http://172.31.255.254/v1",
             "http://192.168.1.50:8000",
             "http://169.254.169.254/latest/meta-data",  # AWS IMDS
+            # IPv4-mapped forms of the same ranges. Driven through
+            # `should_bypass` itself, not just through `ipaddress`: the L2
+            # contract (KBR-146) pins the interpreter's verdict, and this pins
+            # the consumer's, so a rewrite of the disjunction cannot pass by
+            # leaving the stdlib untouched.
+            "http://[::ffff:127.0.0.1]:8080",
+            "http://[::ffff:10.0.0.5]/v1",
+            "http://[::ffff:192.168.1.50]:8000",
+            "http://[::ffff:169.254.169.254]/latest/meta-data",
         ],
     )
     def test_local_destinations_bypass(self, url: str):
@@ -137,6 +146,10 @@ class TestShouldBypass:
             "https://8.8.8.8/v1",
             "https://172.32.0.1/v1",   # just outside 172.16/12
             "https://11.0.0.1/v1",     # just outside 10/8
+            # The mapped form of a public address must not be bypassed either,
+            # or the rows above would pass under a rule that bypasses every
+            # `::ffff:` destination.
+            "https://[::ffff:8.8.8.8]/v1",
         ],
     )
     def test_public_destinations_use_the_proxy(self, url: str):

--- a/tests/test_ipaddress_contract.py
+++ b/tests/test_ipaddress_contract.py
@@ -1,0 +1,208 @@
+"""Dependency behaviour contract for the standard library's :mod:`ipaddress`.
+
+``.system_design/TEST_SUITE.md`` §6.2.4 asks for a small, fast test per dependency
+whose behaviour an invariant rests on, so that an upgrade fails here with a clear
+message rather than in a user's terminal.  The interpreter is the least pinned
+dependency this project has: ``requires-python = ">=3.10"`` bounds its *minor*
+version and says nothing about the patch release, which is where ``ipaddress``
+has actually moved.
+
+There are two consumers.
+
+:func:`kitty.egress.should_bypass` decides whether a destination is reached
+directly or through the egress proxy, which is invariant **I3** (§5).  It reads
+``is_loopback or is_private or is_link_local``, and the verdict that disjunction
+reaches for the IPv4-mapped form of each range is pinned below.  **The terms are
+not individually stable and the contract does not pretend they are:**
+``ip_address("::ffff:169.254.1.1").is_link_local`` flips at the same four
+release boundaries as ``is_unspecified`` (measured ``False`` on 3.10.13-15,
+3.11.8-10, 3.12.4-6 and 3.13.0; ``True`` from 3.10.16, 3.11.11, 3.12.7 and
+3.13.1).  The disjunction survives only because ``is_private`` delegates to the
+mapped address on every supported release and IPv4's ``is_private`` already
+covers ``169.254.0.0/16``.  Anyone who later splits that disjunction, narrows it
+or logs per term re-opens the patch dependence in the containment direction.
+
+:func:`kitty.bridge.manage._connect_target` maps a recorded bind address to an
+address this machine can dial, so that ``bridge_reachable`` can settle
+:attr:`~kitty.bridge.manage.ProcessLiveness.UNKNOWN`.  It asks ``ipaddress``
+three things, each pinned below: whether a string is an address literal at all,
+whether an IPv6 address is the IPv4-mapped form of some IPv4 address, and
+whether an address is the unspecified one.
+
+**What this module deliberately does not assert, and why.**
+``ipaddress.ip_address("::ffff:0.0.0.0").is_unspecified`` is **not** pinned here.
+Its value is a property of the interpreter's patch release rather than of the
+address: CPython `gh-122792 <https://github.com/python/cpython/issues/122792>`_
+made ``IPv6Address``'s ``is_*`` properties delegate to the mapped
+``IPv4Address``, and the change was backported mid-branch — first appearing in
+3.10.16, 3.11.11, 3.12.7 and 3.13.1.  Every release below those lines is a
+supported configuration, so asserting ``True`` would be red on the 35 releases
+that predate the backport, and asserting ``False`` red on every release after
+them.
+
+That is the rule this file establishes, and it is the opposite of the obvious
+move.  Before KBR-146, ``_connect_target`` read that property and a contract
+pinning it would have enforced the defect rather than caught it.  When a
+dependency's behaviour is version-dependent, the fix is to stop depending on it
+and pin the stable neighbour — here ``ipv4_mapped``, which reads the same on
+every supported release.  Pinning the moving value only relocates the failure.
+
+``ipv4_mapped`` itself, by contrast, was measured identical on 18 releases
+spanning all four supported branches.  That measurement is what makes the
+forced-property test in ``tests/bridge/test_bridge_management.py`` a
+*reproduction* of a pre-backport interpreter rather than a resemblance to one.
+
+**What this module cannot prove.**  ``.github/workflows/tests.yml`` names bare
+minor versions and ``actions/setup-python`` resolves each to the newest patch, so
+every assertion here is only ever evaluated on the **new** side of such a
+boundary.  It catches forward drift; it cannot catch a value that differs on an
+older patch a user is running, which is the shape KBR-146 had.  That half rests
+on the forced-property test.  Recorded as gap **G25**, not closed.
+
+Traces to `KBR-146 <https://shelpuk.atlassian.net/browse/KBR-146>`_.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+
+import pytest
+
+# L2: this module asserts what a separately upgraded artifact — the interpreter —
+# does. It imports no kitty code; a contract that reads the consumer would be
+# satisfied by whatever the consumer happens to do.
+pytestmark = pytest.mark.l2
+
+
+def test_the_ipv4_mapped_wildcard_reports_the_unspecified_ipv4_address():
+    """Pin that ``::ffff:0.0.0.0`` unwraps to the IPv4 wildcard.
+
+    This is the single fact that lets ``_connect_target`` recognise an
+    IPv4-mapped wildcard bind without consulting the patch-dependent
+    ``is_unspecified`` property of the IPv6 address itself.
+
+    The **type** is pinned alongside the value because the consumer reaches
+    ``ipv4_mapped`` through an ``isinstance(address, IPv6Address)`` gate.  Were
+    that relationship to stop holding, the gate would yield ``None``, control
+    would fall through to ``is_unspecified``, and KBR-146 would be reinstated
+    verbatim with every other assertion in this module still green.
+    """
+    address = ipaddress.ip_address("::ffff:0.0.0.0")
+
+    assert isinstance(address, ipaddress.IPv6Address)
+
+    mapped = address.ipv4_mapped
+    assert mapped == ipaddress.IPv4Address("0.0.0.0")
+    assert mapped.is_unspecified is True
+
+
+def test_a_non_wildcard_mapped_address_unwraps_to_a_non_wildcard():
+    """Pin that unwrapping distinguishes a real mapped bind from a wildcard.
+
+    Without this, ``_connect_target`` could rewrite every IPv4-mapped address to
+    loopback and claim a bridge that is not there.  It is the negative half of
+    the fact above, and the two must move together or not at all.
+    """
+    mapped = ipaddress.ip_address("::ffff:127.0.0.1").ipv4_mapped
+
+    assert mapped == ipaddress.IPv4Address("127.0.0.1")
+    assert mapped.is_unspecified is False
+
+
+@pytest.mark.parametrize("host", ["::", "::0", "0:0:0:0:0:0:0:0", "::1"])
+def test_a_native_ipv6_address_reports_no_mapped_address(host: str):
+    """Pin that only the ``::ffff:`` form unwraps, so the IPv6 branch stays reachable.
+
+    Args:
+        host: A native IPv6 address literal — the three spellings of the
+            wildcard that ``bridge.yaml`` passes through untouched, and loopback.
+
+    If ``ipv4_mapped`` ever became non-``None`` for these, ``_connect_target``
+    would answer with an IPv4 loopback for an IPv6-only bridge and the probe
+    would find nothing listening.
+    """
+    assert ipaddress.ip_address(host).ipv4_mapped is None
+
+
+@pytest.mark.parametrize(
+    ("host", "expected"),
+    [
+        ("0.0.0.0", True),
+        ("::", True),
+        ("::0", True),
+        ("0:0:0:0:0:0:0:0", True),
+        ("127.0.0.1", False),
+        ("::1", False),
+        ("192.0.2.1", False),
+    ],
+)
+def test_unspecified_is_stable_for_addresses_that_are_not_ipv4_mapped(host: str, expected: bool):
+    """Pin ``is_unspecified`` for every form ``_connect_target`` still asks it about.
+
+    Args:
+        host: An address literal that is not the IPv4-mapped form.
+        expected: What ``is_unspecified`` must report for it.
+
+    gh-122792 moved this property only for IPv4-mapped addresses.  For
+    everything else it has answered the same since 3.3, and ``_connect_target``
+    reads it for exactly these inputs — so here it is safe to pin, and pinning
+    it is what makes the exclusion of the mapped form a deliberate boundary
+    rather than an omission.
+    """
+    assert ipaddress.ip_address(host).is_unspecified is expected
+
+
+@pytest.mark.parametrize("host", ["localhost", "bridge.internal", "not an address"])
+def test_a_hostname_is_rejected_as_an_address_literal(host: str):
+    """Pin that a hostname raises rather than parsing into something plausible.
+
+    Args:
+        host: A string that is not an address literal.
+
+    ``_connect_target`` treats ``ValueError`` as "this is a hostname, probe it
+    exactly as recorded".  A future ``ipaddress`` that resolved names, or that
+    raised a different exception, would turn that branch into an unhandled
+    crash on a user-facing command.
+    """
+    with pytest.raises(ValueError):
+        ipaddress.ip_address(host)
+
+
+@pytest.mark.parametrize(
+    "host",
+    [
+        "::ffff:127.0.0.1",
+        "::ffff:10.0.0.1",
+        "::ffff:172.16.0.1",
+        "::ffff:192.168.1.1",
+        "::ffff:169.254.1.1",
+    ],
+)
+def test_the_mapped_form_of_every_bypassed_range_is_still_classified_as_bypassed(host: str):
+    """Pin I3's bypass verdict for IPv4-mapped destinations.
+
+    Args:
+        host: The IPv4-mapped form of an address ``should_bypass`` must bypass —
+            loopback, the three private ranges, and link-local.
+
+    The **disjunction** is pinned, not its terms, because ``is_link_local`` is
+    not independently stable across patch releases (see the module docstring)
+    and ``is_private`` is what actually carries the mapped cases.  Pinning the
+    terms would make this module red on every pre-backport release; pinning the
+    verdict states the thing ``should_bypass`` needs and nothing more.
+    """
+    address = ipaddress.ip_address(host)
+
+    assert (address.is_loopback or address.is_private or address.is_link_local) is True
+
+
+def test_a_mapped_public_address_is_not_classified_as_bypassed():
+    """Hold the other side of the bypass verdict, so the pin cannot pass vacuously.
+
+    A contract that only asserts "bypassed" is satisfied by a stdlib that says
+    yes to everything — which would route every destination around the egress
+    proxy and breach I3 in the direction that matters.
+    """
+    address = ipaddress.ip_address("::ffff:8.8.8.8")
+
+    assert (address.is_loopback or address.is_private or address.is_link_local) is False

--- a/tests/test_ipaddress_contract.py
+++ b/tests/test_ipaddress_contract.py
@@ -143,6 +143,11 @@ def test_unspecified_is_stable_for_addresses_that_are_not_ipv4_mapped(host: str,
         host: An address literal that is not the IPv4-mapped form.
         expected: What ``is_unspecified`` must report for it.
 
+    The list is bounded to the inputs the consumer actually reaches this
+    property with, which is the rule the module docstring states: an address
+    outside it (``255.255.255.255``, say) is not a coverage gap, because no
+    consumer asks about it.
+
     gh-122792 moved this property only for IPv4-mapped addresses.  For
     everything else it has answered the same since 3.3, and ``_connect_target``
     reads it for exactly these inputs — so here it is safe to pin, and pinning

--- a/tests/test_layer_selection.py
+++ b/tests/test_layer_selection.py
@@ -420,6 +420,10 @@ class TestTheWholeSuiteIsCoherent:
             # module-level `pytestmark` cannot be overridden per test.
             "tests/harness/test_register_agreement.py",
             "tests/test_upstream_url_single_rule.py",
+            # KBR-146. A §6.2.4 dependency behaviour contract: it asserts what
+            # the interpreter does, which is an artifact upgraded separately
+            # from this one and by someone else entirely.
+            "tests/test_ipaddress_contract.py",
         }
 
         actual = {


### PR DESCRIPTION
Fixes [KBR-146](https://shelpuk.atlassian.net/browse/KBR-146).
Duplicates, all describing this same defect: [KBR-142](https://shelpuk.atlassian.net/browse/KBR-142), [KBR-150](https://shelpuk.atlassian.net/browse/KBR-150), [KBR-162](https://shelpuk.atlassian.net/browse/KBR-162) — plus [KBR-141](https://shelpuk.atlassian.net/browse/KBR-141), already closed as a duplicate. They are now linked to this ticket; **closing them is the product owner's call, not this PR's.**

---

## Context for the Product Owner

**What a user saw.** `kitty status`, `kitty stop` and `kitty restart` each have to answer one question: is the bridge we recorded still actually serving? Kitty answers it by dialling the address it wrote down when the bridge started.

If the bridge was told to listen on *everything* (a "wildcard" address), that address cannot be dialled — Windows refuses it outright even while the socket is happily listening. So kitty rewrites a wildcard to loopback before probing. For one spelling of the wildcard — the IPv4-in-IPv6 form — that rewrite silently did not happen. Kitty dialled an address nobody was listening on and **reported a healthy bridge as dead.** Narrow to trigger, but a wrong answer rather than a cosmetic one.

**Why nobody could pin it down.** The rewrite asked Python's standard library a question whose answer changed partway through the lifetime of every Python version we support. The result: the same code, on the same commit, gives opposite answers on two machines. CI was green; a developer on a stock Ubuntu box saw red on a clean checkout of `main` and had no way to tell whether they had broken something. That ambiguity is why this defect was filed **five separate times** by five sessions that each independently rediscovered it.

**What changes for users.** The liveness probe now gives the same answer on every Python we support. Nothing else about the product changes — no new behaviour, no new configuration, no migration.

**What we chose not to do, and why you may want it later.** Our CI always tests the *newest* patch of each Python version, so it structurally cannot see this class of problem. We could close that with one extra CI job pinned to an old Python. This PR does **not** do that — it is a spending decision about CI time, not a technical one, and the fix removes the dependency anyway. It is recorded as gap **G25** in the test-suite design so it is a decision on the record rather than an oversight.

**One unrelated problem found on the way.** We tell PyPI we support any Python from 3.10 upward, but our CI stops at 3.13 and 3.14 shipped last October. Filed separately as [KBR-165](https://shelpuk.atlassian.net/browse/KBR-165) rather than folded in here.

---

## The defect

`src/kitty/bridge/manage.py::_connect_target` short-circuited on `ipaddress.IPv6Address.is_unspecified`, with a comment stating the premise that made the short-circuit safe:

```python
if not address.is_unspecified:
    return host
# ``is_unspecified`` is also true for the IPv4-mapped form ``::ffff:0.0.0.0``,
# which wants an IPv4 loopback despite reporting version 6.
if address.version == 6 and address.ipv4_mapped is None:
    return "::1"
return "127.0.0.1"
```

That premise is a property of the interpreter's **patch** release, not of the address. CPython [gh-122792](https://github.com/python/cpython/issues/122792) made `IPv6Address`'s `is_*` properties delegate to the mapped `IPv4Address`, and it was backported mid-branch. Measured directly on 19 locally installed interpreters:

| Branch | Last release answering `False` | First release answering `True` |
|---|---|---|
| 3.10 | 3.10.15 | **3.10.16** |
| 3.11 | 3.11.10 | **3.11.11** |
| 3.12 | 3.12.6 | **3.12.7** |
| 3.13 | 3.13.0 | **3.13.1** |

`requires-python = ">=3.10"` has no patch floor, so all 35 releases below those lines are supported configurations on which the early return fires and the IPv4-mapped branch beneath it is unreachable. `actions/setup-python` resolves a bare minor version to the newest patch, so the matrix only ever sampled the other side.

## The fix

Resolve `ipv4_mapped` **before** anything asks `is_unspecified`. `ipv4_mapped` reads the same on every supported release — measured, not assumed.

```python
mapped = address.ipv4_mapped if isinstance(address, ipaddress.IPv6Address) else None
if mapped is not None:
    return "127.0.0.1" if mapped.is_unspecified else host
if not address.is_unspecified:
    return host
return "::1" if address.version == 6 else "127.0.0.1"
```

## Evidence the tests fail at the base revision

Per `TEST_SUITE_IMPLEMENTATION_PLAN.md` §16, an atomic fix+test PR carries proof the regression test is red at base. New tests against `origin/main`'s `manage.py`:

```
--- Python 3.12.8 (what CI runs) ---
FAILED ...::test_ipv4_mapped_wildcard_resolves_alike_whatever_is_unspecified_reports[False]
1 failed, 47 passed

--- Python 3.12.3 (stock Ubuntu 24.04) ---
FAILED ...::test_connect_target_table[::ffff:0.0.0.0-127.0.0.1]
FAILED ...::test_connect_target_table[::ffff:0:0-127.0.0.1]
FAILED ...::test_ipv4_mapped_wildcard_resolves_alike_whatever_is_unspecified_reports[False]
3 failed, 45 passed
```

The 3.12.8 line is the one worth reading twice: the new test makes the defect visible **on the interpreter CI actually runs**, which no previous test could do. With the fix, 48/48 pass on both.

## Tests, at the layer each claim belongs to

**L1 — `tests/bridge/test_bridge_management.py`.** The mapping table gains the two non-wildcard mapped rows nothing was asserting (`::ffff:127.0.0.1`, `::ffff:192.0.2.1` must pass through untouched) and a second spelling of the mapped wildcard (`::ffff:0:0`), since the function's stated contract is by value rather than by spelling and the native wildcard already gets three spellings.

A new test forces `is_unspecified` to report **both** answers inside a single run and asserts the result does not move. A single interpreter can only ever demonstrate its own side of gh-122792; forcing the property is the only way to hold both. It first asserts the forced value is live, so it cannot decay into a silent duplicate of the table row if the implementation ever stops routing through `ipaddress`.

**L2 — `tests/test_ipaddress_contract.py` (new).** The fifth §6.2.4 dependency contract and the first to land. It pins what the code reads from `ipaddress` and states in its own docstring which property it **refuses** to assert and why — pinning `is_unspecified` for the mapped form would have enforced this defect rather than caught it.

It also pins I3's half, which review surfaced: `should_bypass` survives gh-122792 only by **masking**. `ip_address("::ffff:169.254.1.1").is_link_local` flips at the same four boundaries; the disjunction holds only because `is_private` delegates and IPv4's `is_private` already covers `169.254.0.0/16`. So the egress bypass decision does read a version-dependent value and is saved by a sibling term. The contract therefore pins the disjunction's **verdict** on mapped forms and deliberately not the individual terms — verified stable from 3.10.13 through 3.13.15.

## Design record

- §6.2.4 gains the stdlib row, scoped to **both** consumers — `should_bypass` (I3) first, `_connect_target` second — plus the masking note, the fidelity argument for the forced-property test, and what the contract cannot prove.
- The general rule — *a contract pins what the code reads, never what it merely tolerates* — is stated in §6.2's Validation paragraph and §10, with its precondition (a stable neighbour must exist) and the fallback when one does not.
- §5.3 and §6.1 now say that an IPv4-mapped literal takes the address branch.
- **G25** opened: no §6.2.4 contract can see older-patch drift, because the matrix resolves each minor to its newest patch. Deferred as a CI-spend decision.
- G11 and the implementation plan's §6.2.4 and §16 rows updated.

## Verification

| Check | Result |
|---|---|
| `pytest -m "l1 or l2" --strict-markers` (3.12.8) | running; previous full run 4,187 passed with only the registry failure this PR fixes |
| `TestBridgeReachable` + contract, 3.12.8 and 3.12.3 | 48 passed on each |
| Contract assertions, 3.10.13 / 3.11.8 / 3.12.3 / 3.13.0 / 3.13.15 | hold on all |
| `ruff check`, `mypy src/kitty/bridge/manage.py` | clean |
| CRLF preserved in `test_bridge_management.py` | yes |

Reviewed by `system-design-reviewer` (two blockers, both resolved) and `code-reviewer` (one blocker — the unregistered L2 file — plus two hardening findings, all applied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HdkFBQQRUhxJaL2Sj1Ep4t


[KBR-146]: https://shelpuk.atlassian.net/browse/KBR-146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KBR-142]: https://shelpuk.atlassian.net/browse/KBR-142?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KBR-150]: https://shelpuk.atlassian.net/browse/KBR-150?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KBR-162]: https://shelpuk.atlassian.net/browse/KBR-162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KBR-141]: https://shelpuk.atlassian.net/browse/KBR-141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KBR-165]: https://shelpuk.atlassian.net/browse/KBR-165?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ