### PR TITLE
Accept a string `input` on /v1/responses, on both upstream paths (KBR-144)

### DIFF
--- a/.system_design/TEST_SUITE.md
+++ b/.system_design/TEST_SUITE.md
@@ -164,6 +164,7 @@ downstream error, so it mutates nothing — leaving **thirteen live** bridge-lev
 | M12 | Substitute fallback assistant text | `_EMPTY_ASSISTANT_FALLBACK_TEXT` in `bridge/messages/translator.py` **and** `bridge/responses/translator.py` | Upstream returned an empty response | **Response-side**, not part of the eleven request-path rows. |
 | ~~M13~~ | **Withdrawn — no longer a mutation.** Was: discard the conversation and substitute a `[Kitty Bridge: …]` user message. | `_compact_messages` / `_apply_compaction` post-condition | No non-system message survives | **Closed by KBR-5.** The post-condition now raises `CompactionFailedError` and the handler returns a protocol-native 400 downstream; nothing is substituted, so there is no mutation left to register. The row is kept struck through rather than deleted so a reader of finding F3 can still find it. **The trigger recorded here was wrong** — see F3. |
 | M14 | **Replace the destination entirely** — scheme, host and path are built from the profile by `build_base_url()` + `get_upstream_path()` | `BridgeServer._build_upstream_url` | Always | The agent addressed a loopback bridge; the request has to reach the real provider. Listed because **the destination is a mutation surface the body cannot show**: on Azure an identical body sent to the wrong deployment path is a different request entirely (§3.3.5). |
+| M15 | Rewrite a string `input` into the single-item list form | `normalize_responses_request` (`bridge/responses/translator.py`), called from `_handle_responses` before the body forks | Always, on the Responses protocol — a body already in the array form meets this row with a no-op rather than avoiding it, which is why it is unconditional | OpenAI's `CreateResponse` defines the two forms as the **same request**: `input` is `oneOf` a string (*"a text input to the model, equivalent to a text input with the `user` role"*) or an array, and everything downstream reads the array. Listed rather than omitted because the rewrite is real bytes at the `curl_cffi` boundary of §3.2.3, where `_original_body` **is** this body; the projection cannot express the difference, so the row takes §3.3.1a's escape for P16's reason. **KBR-144.** |
 
 #### 3.2.2 Provider-level
 
@@ -225,7 +226,7 @@ partial today — see gap G22.
 **Conditional rows are the point.** Every row whose trigger is a condition must be provably
 *inert* when that condition is absent — the sharpest form of "unless absolutely necessary", and
 what §3.3.2 assertion 2 tests, with the trigger complements §3.3.4 requires. M1, M2, M10, M14, P1,
-P6, P9a, P9b, P9c, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20 and P21 are unconditional
+P6, P9a, P9b, P9c, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, P21 and M15 are unconditional
 by design and are exempt from that assertion.
 
 **M14, P20 and P21 were missing from that list until KBR-26**, while their own trigger cells read
@@ -2214,7 +2215,7 @@ T-K6's business, together with the job that runs them; doing it earlier would re
 every gate. T-H1 must take that reclassification into account before it measures a mutation
 baseline, because it selects on `l1`.
 
-**Three modules have been added to that set since, and they are named here so T-K6 inherits a
+**Four modules have been added to that set since, and they are named here so T-K6 inherits a
 list rather than a search** — the count is what T-K6 and T-H1 plan against.
 
 - **KBR-132:** `tests/bridge/test_tls_certs.py` spawns a real `openssl` in one of its five cases.
@@ -2225,6 +2226,10 @@ list rather than a search** — the count is what T-K6 and T-H1 plan against.
   `tests/harness/test_recorder_conformance.py` is genuinely `l1` — its checks are pure functions
   over data and it opens nothing. The two socket-binding modules together run in **~1 second**,
   measured, which is the number the fast-gate budget should carry until T-K6 moves them.
+- **KBR-144:** `tests/bridge/test_responses_string_input.py` starts a real `BridgeServer` on an
+  ephemeral port in three of its classes, following the existing convention of
+  `tests/bridge/test_crash_resilience.py` rather than inventing a second one. The whole module
+  runs in **~0.6 seconds**, measured, of which the socket-binding cases are ~0.1.
 
 **The load gate has to be wired, not merely declared.** The table above marks Load as gating a
 release, but `publish.yml` currently depends only on the reusable `tests.yml`. Putting the load

--- a/.system_design/TEST_SUITE.md
+++ b/.system_design/TEST_SUITE.md
@@ -563,7 +563,8 @@ the path.
 **`not projectable` is a legal value for the register's field column, and it requires a reason.**
 P16 uses it — the `input_text`/`output_text` tag is redundant with the turn's role, so carrying it
 would put one vendor's spelling into a wire-independent form — as do the whole-body protocol
-translations M2, M9, P11 and P12, and **P1** for the reason below. An empty cell would leave those
+translations M2, M9, P11 and P12, **P1** for the reason below, and **M15**, whose two spellings of
+a Responses `input` are one request (KBR-144). An empty cell would leave those
 rows silently unfalsifiable; an explicit value with a reason does not.
 
 ⚠️ **`residual` is never a legal register anchor.** P1 strips kitty's internal keys, which no

--- a/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
+++ b/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
@@ -239,7 +239,7 @@ must not be collapsed.
 |---|---|---|---|---|
 | **T-A1** | Anthropic Messages reader | T-W2 | §3.3.1 | M |
 | **T-A2** | Chat Completions reader | T-W2 | §3.3.1 | M |
-| **T-A3** | OpenAI Responses reader | T-W2 | §3.3.1 | M |
+| **T-A3** | OpenAI Responses reader — **must read a string `input` and the single-item array form into the identical `Request`** (register row M15 takes §3.3.1a's escape on exactly that equivalence; if the reader ever tells them apart, M15 needs a projectable anchor) | T-W2 | §3.3.1 · §3.3.1a | M |
 | **T-A4** | Gemini reader — **consumes the URL as well as the body** | T-W2 | §3.3.5 | M |
 | **T-A5** | Bedrock Converse reader | T-W2 | §3.3.1 | M |
 | **T-A6** | Ollama `/api/chat` reader | T-W2 | §3.3.1 | S |

--- a/src/kitty/bridge/responses/translator.py
+++ b/src/kitty/bridge/responses/translator.py
@@ -32,7 +32,7 @@ from kitty.bridge.responses.events import (
     format_response_in_progress_event,
 )
 
-__all__ = ["ResponsesTranslator"]
+__all__ = ["InvalidResponsesRequest", "ResponsesTranslator", "normalize_responses_request"]
 
 # MiniMax interleaved thinking tags: <اخل>...</اخل>
 _THINKING_TAG_RE = re.compile(r"<\u0627\u062e\u0644>.*?</\u0627\u062e\u0644>", re.DOTALL)
@@ -67,6 +67,78 @@ def _empty_assistant_fallback_text(context: dict | None = None) -> str:
 def _strip_thinking_tags(text: str) -> str:
     """Strip MiniMax-style interleaved thinking tags from content."""
     return _THINKING_TAG_RE.sub("", text).strip()
+
+
+class InvalidResponsesRequest(ValueError):
+    """Raised when a Responses request carries a shape the dialect does not permit.
+
+    Carried out of :func:`normalize_responses_request` so
+    :meth:`kitty.bridge.server.BridgeServer._handle_responses` can answer with the
+    endpoint's 400 envelope.  Without a distinct type the handler's catch-all
+    renders every one of these as a 500, which
+    ``.system_design/TEST_SUITE.md`` §6.2.1 forbids: the bridge must never
+    return a server error for a client's malformed body.
+    """
+
+
+def normalize_responses_request(body: dict) -> dict:
+    """Return a Responses request with ``input`` in its array form
+
+    OpenAI's ``CreateResponse`` schema defines ``input`` as ``oneOf`` a string
+    -- *"a text input to the model, equivalent to a text input with the*
+    ``user`` *role"* -- or an array of input items.  Everything downstream reads
+    the array, so the string is converted here, once, and the two forms become
+    one request.
+
+    **Call this before the inbound body forks.** ``.system_design/TEST_SUITE.md``
+    §3.2.3 records that two upstream bodies are built from one Responses
+    request: the Chat Completions body, from :meth:`ResponsesTranslator.translate_request`,
+    and -- on ``openai_subscription`` -- a Responses body built inside the
+    transport from the *raw* inbound dict.  Normalising only in the translator
+    leaves the second path iterating the string character by character and
+    shipping the user's text as a list of its own letters (KBR-144).
+
+    The rewrite is **register row M15** (§3.2.1).  It takes §3.3.1a's
+    ``not projectable`` escape, because both forms project to the same
+    wire-independent conversation -- one user turn carrying the text -- which is
+    the reasoning §3.3.1a applies to row P16.  The row exists rather than being
+    omitted because the rewrite is real bytes on the ``curl_cffi`` boundary, and
+    it binds the future OpenAI-Responses reader to read the two forms alike.
+
+    Args:
+        body: The decoded inbound request body.
+
+    Returns:
+        A body whose ``input``, if present, is a list of input-item objects.
+        The argument is never modified; an already-normalised body is returned
+        unchanged, so calling this twice is safe.
+
+    Raises:
+        InvalidResponsesRequest: The body is not a JSON object, or ``input`` is
+            neither a string nor an array of objects.
+    """
+    # A field can only be read off an object; valid JSON is a weaker claim.
+    if not isinstance(body, dict):
+        raise InvalidResponsesRequest(f"Request body must be a JSON object, got {type(body).__name__}")
+
+    if "input" not in body:
+        return body
+
+    value = body["input"]
+    # The spec's own equivalence, applied verbatim.
+    if isinstance(value, str):
+        item = {"type": "message", "role": "user", "content": [{"type": "input_text", "text": value}]}
+        return {**body, "input": [item]}
+
+    if not isinstance(value, list):
+        raise InvalidResponsesRequest(f"'input' must be a string or an array, got {type(value).__name__}")
+
+    # Reported by index, because a client sending a long transcript needs to know which item.
+    for index, element in enumerate(value):
+        if not isinstance(element, dict):
+            raise InvalidResponsesRequest(f"'input[{index}]' must be an object, got {type(element).__name__}")
+
+    return body
 
 
 class ResponsesTranslator:
@@ -124,6 +196,9 @@ class ResponsesTranslator:
 
     def translate_request(self, responses_request: dict) -> dict:
         """Convert a Responses API request to a Chat Completions request."""
+        # Idempotent, and the live caller has normalised already -- this is here so
+        # the translator is correct for any caller, not only the handler.
+        responses_request = normalize_responses_request(responses_request)
         messages = []
 
         # System instructions -> system message
@@ -155,7 +230,9 @@ class ResponsesTranslator:
         messages = self._merge_consecutive_system_messages(messages)
 
         result: dict = {
-            "model": responses_request["model"],
+            # `CreateResponse` declares no required fields, and register row M1
+            # replaces this with the profile's model anyway.
+            "model": responses_request.get("model", ""),
             "messages": messages,
             "stream": responses_request.get("stream", False),
         }

--- a/src/kitty/bridge/server.py
+++ b/src/kitty/bridge/server.py
@@ -41,7 +41,11 @@ from kitty.bridge.messages.translator import MessagesTranslator
 from kitty.bridge.responses.events import (
     format_error_event as responses_format_error,
 )
-from kitty.bridge.responses.translator import ResponsesTranslator
+from kitty.bridge.responses.translator import (
+    InvalidResponsesRequest,
+    ResponsesTranslator,
+    normalize_responses_request,
+)
 from kitty.bridge.tool_audit import AUDIT_MARKER, ToolUseAuditor, collect_tool_schemas, report_tool_use
 from kitty.cloudflare import is_cloudflare_block
 from kitty.egress import EgressConfig, should_bypass
@@ -2542,6 +2546,22 @@ class BridgeServer:
         logger.debug("═══ RESPONSES API REQUEST ═══")
         logger.debug("Request headers: %s", dict(request.headers))
         logger.debug("Request body: %s", json.dumps(body, indent=2, ensure_ascii=False))
+
+        # Before the body forks: `_original_body` below hands this same dict to a
+        # custom transport, which builds its own upstream body from it (KBR-144).
+        # In its own `try`, ahead of the catch-all below, which would render a
+        # malformed body as a 500 -- and below the JSON-parse block, whose
+        # `except Exception` would relabel it "Invalid JSON body".
+        try:
+            body = normalize_responses_request(body)
+        except InvalidResponsesRequest as exc:
+            logger.warning("Malformed Responses API request body: %s", exc)
+            # `reason` for the same purpose `_compaction_failed_response` gives it:
+            # this endpoint already returns two byte-identical 400 envelopes, and
+            # without a marker neither a test nor an operator can tell them apart.
+            return self._error_response(
+                {"error": {"code": "invalid_request", "message": str(exc), "reason": "invalid_input"}}
+            )
 
         try:
             translator = ResponsesTranslator()

--- a/src/kitty/bridge/server.py
+++ b/src/kitty/bridge/server.py
@@ -2582,19 +2582,13 @@ class BridgeServer:
         logger.debug("Request headers: %s", dict(request.headers))
         logger.debug("Request body: %s", json.dumps(body, indent=2, ensure_ascii=False))
 
-        # Before the body forks: `_original_body` below hands this same dict to a
-        # custom transport, which builds its own upstream body from it (KBR-144).
-        # In its own `try`, ahead of the catch-all below, which would render a
-        # malformed body as a 500 -- and below the JSON-parse block, whose
-        # `except Exception` would relabel it "Invalid JSON body".
+        # Before the body forks: `_original_body` below hands this dict to a custom transport (KBR-144).
+        # Sited between the two `try`s on purpose -- above, it reads as bad JSON; below, as a 500.
         try:
             body = normalize_responses_request(body)
         except InvalidResponsesRequest as exc:
             logger.warning("Malformed Responses API request body: %s", exc)
-            # `reason` for the same purpose `_compaction_failed_response` gives it:
-            # three other rejections on this endpoint answer in this same envelope,
-            # and without a marker neither a test nor an operator reading a log can
-            # say which one fired.
+            # `reason` marks which of this endpoint's four same-shaped 400s fired.
             return self._error_response(
                 {"error": {"code": "invalid_request", "message": str(exc), "reason": "invalid_input"}}
             )

--- a/tests/bridge/test_responses_string_input.py
+++ b/tests/bridge/test_responses_string_input.py
@@ -24,6 +24,7 @@ list" passes on the defect.
 
 from __future__ import annotations
 
+import copy
 import json
 
 import aiohttp
@@ -250,11 +251,16 @@ class TestTheNormaliser:
         """``input`` is optional; its absence is not a shape error."""
         assert normalize_responses_request({"model": _MODEL}) == {"model": _MODEL}
 
-    def test_the_caller_s_body_is_not_mutated(self) -> None:
-        """The handler logs the body it received; normalising in place would relabel that log."""
-        original = _string_body()
-        normalize_responses_request(original)
-        assert original["input"] == _TEXT
+    @pytest.mark.parametrize("body", [_string_body(), _array_body()], ids=["string", "array"])
+    def test_the_caller_s_body_is_not_mutated(self, body: dict) -> None:
+        """The handler logs the body it received; normalising in place would relabel that log.
+
+        Both branches, so the claim stays true of the normaliser rather than of
+        the one branch that rewrites anything today.
+        """
+        before = copy.deepcopy(body)
+        normalize_responses_request(body)
+        assert body == before
 
     def test_an_empty_string_is_a_string_like_any_other(self) -> None:
         """``""`` is in the ``oneOf`` string branch, so it gets no special case.
@@ -374,8 +380,12 @@ class TestTheUpstreamBodyOnTheDefaultTransport:
                         payload=_CC_REPLY,
                         callback=_record,
                     )
-                status, _ = await _post(port, body)
+                status, payload = await _post(port, body)
             assert status == 200, f"expected the request to be served, got {status}"
+            # R1 claims a *stream*, not merely a 200: `_post` hands back raw text
+            # when the reply is not JSON, which is what an SSE reply looks like.
+            if stream:
+                assert "data:" in payload, f"expected an SSE reply, got {payload!r}"
             assert len(captured) == 1, f"expected exactly one upstream attempt, got {len(captured)}"
             return captured[0]
         finally:
@@ -517,6 +527,7 @@ class TestTheInputFamilyNeverReturnsAServerError:
         finally:
             await server.stop_async()
         assert status == 200
+        assert len(captured) == 1, f"expected exactly one upstream attempt, got {len(captured)}"
         assert captured[0]["model"] == (profile_model or "")
 
 

--- a/tests/bridge/test_responses_string_input.py
+++ b/tests/bridge/test_responses_string_input.py
@@ -1,0 +1,559 @@
+"""A string ``input`` on ``/v1/responses`` is the same request as the array form.
+
+``.system_design/TEST_SUITE.md`` §1 (I1 Message Fidelity) · §3.2.3 (serialization
+paths) · §6.2.1 (``not_a_server_error``) · Jira **KBR-144**.
+
+OpenAI's ``CreateResponse`` schema defines ``input`` as ``oneOf`` a **string**
+(*"a text input to the model, equivalent to a text input with the ``user``
+role"*) or an array of input items.  Kitty accepted only the array: the string
+was iterated character by character and the endpoint answered 500.
+
+Two upstream bodies are built from one inbound Responses request (§3.2.3), and
+each gets its own equality here, because the defect landed differently on each:
+
+* the **default transport** built a Chat Completions body from the translator,
+  and never got that far — it raised;
+* the **Responses-origin custom transport** (``openai_subscription``) built its
+  body from the *raw* inbound body and did **not** raise.  It shipped
+  ``input: ["h", "i"]``.  A well-formed, non-empty, silently wrong request.
+
+That second case is why the assertions below are equalities between the two
+forms rather than status checks.  A test that asserted "200, and ``input`` is a
+list" passes on the defect.
+"""
+
+from __future__ import annotations
+
+import json
+
+import aiohttp
+import pytest
+from aioresponses import aioresponses
+
+from kitty.bridge.responses.translator import (
+    InvalidResponsesRequest,
+    ResponsesTranslator,
+    normalize_responses_request,
+)
+from kitty.bridge.server import BridgeServer
+from kitty.providers.base import ProviderAdapter
+
+# ── Fixtures of shape, not of value ──────────────────────────────────────────
+
+_TEXT = "hi"
+_MODEL = "test-model"
+
+
+def _array_input(text: str = _TEXT) -> list[dict]:
+    """Return the array spelling of a single user text input.
+
+    Args:
+        text: The user's text.
+
+    Returns:
+        The single-item ``input`` list the string form is equivalent to.
+    """
+    return [{"type": "message", "role": "user", "content": [{"type": "input_text", "text": text}]}]
+
+
+def _string_body(**extra: object) -> dict:
+    """Return a Responses request whose ``input`` is a bare string.
+
+    Args:
+        **extra: Additional top-level fields, e.g. ``stream``.
+
+    Returns:
+        The request body.
+    """
+    return {"model": _MODEL, "input": _TEXT, **extra}
+
+
+def _array_body(**extra: object) -> dict:
+    """Return the equivalent Responses request whose ``input`` is an array.
+
+    Args:
+        **extra: Additional top-level fields, e.g. ``stream``.
+
+    Returns:
+        The request body.
+    """
+    return {"model": _MODEL, "input": _array_input(), **extra}
+
+
+class _StubProvider(ProviderAdapter):
+    """A default-transport provider that names an upstream we can intercept."""
+
+    @property
+    def provider_type(self) -> str:
+        """Return the adapter's registry key.
+
+        Returns:
+            A name no real provider uses.
+        """
+        return "stub"
+
+    @property
+    def default_base_url(self) -> str:
+        """Return the upstream base URL.
+
+        Returns:
+            A URL ``aioresponses`` intercepts; nothing leaves the process.
+        """
+        return "https://upstream.invalid/v1"
+
+    def build_request(self, model: str, messages: list[dict], **kwargs: object) -> dict:
+        """Build a Chat Completions request.
+
+        Args:
+            model: The model name.
+            messages: The Chat Completions messages.
+            **kwargs: Remaining request parameters.
+
+        Returns:
+            The request body.
+        """
+        return {"model": model, "messages": messages, "stream": kwargs.get("stream", False)}
+
+    def parse_response(self, response_data: dict) -> dict:
+        """Return the upstream response unchanged.
+
+        Args:
+            response_data: The upstream body.
+
+        Returns:
+            The same body.
+        """
+        return response_data
+
+    def map_error(self, status_code: int, body: dict) -> Exception:
+        """Map an upstream error onto an exception.
+
+        Args:
+            status_code: The upstream HTTP status.
+            body: The upstream error body.
+
+        Returns:
+            The exception to raise.
+        """
+        return Exception(f"upstream {status_code}: {body}")
+
+
+class _RecordingCustomTransport(_StubProvider):
+    """A custom-transport provider that records the body it is handed.
+
+    §3.2.3: on this path the shipped bytes are built *inside* the transport from
+    ``cc_request["_original_body"]``, so that is the only honest capture point.
+    """
+
+    def __init__(self) -> None:
+        """Initialise the capture slot."""
+        self.original_bodies: list[dict] = []
+
+    @property
+    def use_custom_transport(self) -> bool:
+        """Declare that this adapter owns its own HTTP.
+
+        Returns:
+            Always ``True``.
+        """
+        return True
+
+    async def make_request(self, cc_request: dict) -> dict:
+        """Record the Responses body and answer with a minimal success.
+
+        Args:
+            cc_request: The bridge's request, carrying ``_original_body``.
+
+        Returns:
+            A minimal Chat Completions response.
+        """
+        self.original_bodies.append(cc_request["_original_body"])
+        return {
+            "id": "chatcmpl-1",
+            "model": _MODEL,
+            "choices": [{"index": 0, "message": {"role": "assistant", "content": "ok"}, "finish_reason": "stop"}],
+        }
+
+    async def stream_request(self, cc_request: dict, write) -> None:  # noqa: ANN001
+        """Record the Responses body and write one complete SSE reply.
+
+        Args:
+            cc_request: The bridge's request, carrying ``_original_body``.
+            write: The bridge's byte sink for the downstream stream.
+        """
+        self.original_bodies.append(cc_request["_original_body"])
+        await write(b'data: {"type": "response.completed"}\n\n')
+
+
+def _bridge(provider: ProviderAdapter | None = None, *, model: str | None = _MODEL) -> BridgeServer:
+    """Build a bridge-mode server, which is the only mode registering all routes.
+
+    Args:
+        provider: The active provider; a default-transport stub when omitted.
+        model: The profile's model, or ``None`` for a profile that sets none —
+            the branch of ``_normalize_model`` that leaves the client's value.
+
+    Returns:
+        An unstarted :class:`~kitty.bridge.server.BridgeServer`.
+    """
+    return BridgeServer(None, provider or _StubProvider(), "test-key", model=model)  # type: ignore[arg-type]
+
+
+async def _post(port: int, body: object) -> tuple[int, object]:
+    """POST a body to ``/v1/responses`` and read the reply.
+
+    Args:
+        port: The bridge's ephemeral port.
+        body: The JSON body to send.
+
+    Returns:
+        The status code and the decoded reply, JSON where the reply is JSON and
+        the raw text otherwise — a streamed reply is SSE, not JSON.
+    """
+    async with aiohttp.ClientSession() as session, session.post(
+        f"http://127.0.0.1:{port}/v1/responses",
+        data=json.dumps(body),
+        headers={"content-type": "application/json"},
+    ) as resp:
+        raw = await resp.text()
+        try:
+            return resp.status, json.loads(raw)
+        except json.JSONDecodeError:
+            return resp.status, raw
+
+
+_CC_REPLY = {
+    "id": "chatcmpl-1",
+    "model": _MODEL,
+    "choices": [{"index": 0, "message": {"role": "assistant", "content": "ok"}, "finish_reason": "stop"}],
+}
+
+_CC_CHUNK = {"id": "chatcmpl-1", "choices": [{"index": 0, "delta": {"content": "ok"}, "finish_reason": "stop"}]}
+_CC_STREAM = b"data: " + json.dumps(_CC_CHUNK).encode() + b"\n\ndata: [DONE]\n\n"
+
+
+# ── R1, R5, R6 — the normaliser itself ───────────────────────────────────────
+
+
+class TestTheNormaliser:
+    """The pure function, asserted without a server or an event loop."""
+
+    def test_a_string_input_becomes_one_user_text_message(self) -> None:
+        """The spec's equivalence, spelled out rather than implied by an equality."""
+        assert normalize_responses_request(_string_body())["input"] == _array_input()
+
+    def test_an_array_input_is_returned_unchanged(self) -> None:
+        """The normaliser must not start rewriting well-formed input."""
+        assert normalize_responses_request(_array_body()) == _array_body()
+
+    def test_a_body_with_no_input_is_returned_unchanged(self) -> None:
+        """``input`` is optional; its absence is not a shape error."""
+        assert normalize_responses_request({"model": _MODEL}) == {"model": _MODEL}
+
+    def test_the_caller_s_body_is_not_mutated(self) -> None:
+        """The handler logs the body it received; normalising in place would relabel that log."""
+        original = _string_body()
+        normalize_responses_request(original)
+        assert original["input"] == _TEXT
+
+    def test_an_empty_string_is_a_string_like_any_other(self) -> None:
+        """``""`` is in the ``oneOf`` string branch, so it gets no special case.
+
+        This changes behaviour that was previously accidental: on the
+        subscription path ``_prepare_responses_body``'s ``if
+        original_body.get("input")`` is falsy for ``""``, so the field was
+        dropped from the upstream body entirely.  A turn whose text is empty and
+        no turn at all are different requests; the client asked for the first.
+        """
+        assert normalize_responses_request({"model": _MODEL, "input": ""})["input"] == _array_input("")
+
+    def test_an_empty_array_is_left_alone(self) -> None:
+        """The array branch's degenerate case is already in the target form."""
+        assert normalize_responses_request({"model": _MODEL, "input": []})["input"] == []
+
+    @pytest.mark.parametrize(
+        "body",
+        [_string_body(), _array_body(), {"model": _MODEL}, {"model": _MODEL, "input": ""}, {"input": []}],
+    )
+    def test_normalisation_is_idempotent(self, body: dict) -> None:
+        """Called at the handler and again in the translator, so this is load-bearing."""
+        once = normalize_responses_request(body)
+        assert normalize_responses_request(once) == once
+
+    @pytest.mark.parametrize("bad", [123, None, {"role": "user"}, True])
+    def test_an_input_that_is_neither_string_nor_array_is_refused(self, bad: object) -> None:
+        """``InputParam`` is ``oneOf`` string or array, and is not nullable."""
+        with pytest.raises(InvalidResponsesRequest, match="input"):
+            normalize_responses_request({"model": _MODEL, "input": bad})
+
+    @pytest.mark.parametrize("bad", [[1], ["text"], [None], [_array_input()[0], 2]])
+    def test_an_array_item_that_is_not_an_object_is_refused(self, bad: list) -> None:
+        """Every member of the array form is an ``InputItem`` object."""
+        with pytest.raises(InvalidResponsesRequest, match=r"input\[\d\]"):
+            normalize_responses_request({"model": _MODEL, "input": bad})
+
+    @pytest.mark.parametrize("bad", [["a", "list"], "a string", 5, None])
+    def test_a_body_that_is_not_a_json_object_is_refused(self, bad: object) -> None:
+        """Valid JSON is not the same claim as a valid request."""
+        with pytest.raises(InvalidResponsesRequest, match="object"):
+            normalize_responses_request(bad)  # type: ignore[arg-type]
+
+    def test_the_message_names_the_field_and_carries_no_exception_text(self) -> None:
+        """A 400 exists to tell the client what to change."""
+        with pytest.raises(InvalidResponsesRequest) as excinfo:
+            normalize_responses_request({"model": _MODEL, "input": 123})
+        message = str(excinfo.value)
+        assert "input" in message
+        assert "int" in message or "number" in message
+        assert "Traceback" not in message
+
+
+# ── R2, R4, R6 — the translator ──────────────────────────────────────────────
+
+
+class TestTheTwoFormsAreOneRequest:
+    """The equivalence, proven at the lowest layer that can prove it."""
+
+    def test_both_forms_translate_to_the_same_chat_completions_body(self) -> None:
+        """One equality, so the two forms cannot be edited apart."""
+        assert ResponsesTranslator().translate_request(_string_body()) == ResponsesTranslator().translate_request(
+            _array_body()
+        )
+
+    def test_the_string_form_reaches_the_upstream_as_the_user_s_text(self) -> None:
+        """Pins the value, so the equality above cannot be satisfied by two wrong bodies."""
+        assert ResponsesTranslator().translate_request(_string_body())["messages"] == [
+            {"role": "user", "content": _TEXT}
+        ]
+
+    def test_a_body_without_a_model_is_translated_rather_than_refused(self) -> None:
+        """``CreateResponse`` declares no required fields, and register row M1 overrides ``model`` anyway."""
+        assert ResponsesTranslator().translate_request({"input": _TEXT})["messages"] == [
+            {"role": "user", "content": _TEXT}
+        ]
+
+
+# ── R2 — the default transport, end to end ───────────────────────────────────
+
+
+class TestTheUpstreamBodyOnTheDefaultTransport:
+    """What the twenty default-transport adapters actually send."""
+
+    async def _upstream_body_for(self, body: dict, *, stream: bool) -> dict:
+        """Drive one request through a real bridge and return the captured upstream body.
+
+        Args:
+            body: The inbound Responses request.
+            stream: Whether to exercise the streaming handler.
+
+        Returns:
+            The Chat Completions body the bridge POSTed upstream.
+        """
+        captured: list[dict] = []
+        server = _bridge()
+        port = await server.start_async()
+        try:
+            # `passthrough` keeps the client's own POST to the bridge off the mock.
+            with aioresponses(passthrough=["http://127.0.0.1"]) as mocked:
+
+                def _record(url: object, **kwargs: object) -> None:
+                    captured.append(kwargs["json"])  # type: ignore[arg-type]
+
+                if stream:
+                    mocked.post(
+                        "https://upstream.invalid/v1/chat/completions",
+                        status=200,
+                        body=_CC_STREAM,
+                        headers={"Content-Type": "text/event-stream"},
+                        callback=_record,
+                    )
+                else:
+                    mocked.post(
+                        "https://upstream.invalid/v1/chat/completions",
+                        status=200,
+                        payload=_CC_REPLY,
+                        callback=_record,
+                    )
+                status, _ = await _post(port, body)
+            assert status == 200, f"expected the request to be served, got {status}"
+            assert len(captured) == 1, f"expected exactly one upstream attempt, got {len(captured)}"
+            return captured[0]
+        finally:
+            await server.stop_async()
+
+    @pytest.mark.parametrize("stream", [False, True], ids=["non_streaming", "streaming"])
+    async def test_both_forms_send_the_same_upstream_body(self, stream: bool) -> None:
+        """R2 — the string form must be indistinguishable upstream."""
+        from_string = await self._upstream_body_for(_string_body(stream=stream), stream=stream)
+        from_array = await self._upstream_body_for(_array_body(stream=stream), stream=stream)
+        assert from_string == from_array
+
+
+# ── R3 — the Responses-origin custom transport ───────────────────────────────
+
+
+class TestTheUpstreamBodyOnTheCustomTransport:
+    """The path that did not raise, and shipped the defect (§3.2.3, row ``curl_cffi``)."""
+
+    async def _original_body_for(self, body: dict, *, stream: bool) -> dict:
+        """Drive one request and return the Responses body handed to the transport.
+
+        Args:
+            body: The inbound Responses request.
+            stream: Whether to exercise the streaming handler.
+
+        Returns:
+            ``cc_request["_original_body"]`` as the transport received it.
+        """
+        provider = _RecordingCustomTransport()
+        server = _bridge(provider)
+        port = await server.start_async()
+        try:
+            status, _ = await _post(port, body)
+            assert status == 200, f"expected the request to be served, got {status}"
+            assert len(provider.original_bodies) == 1
+            return provider.original_bodies[0]
+        finally:
+            await server.stop_async()
+
+    @pytest.mark.parametrize("stream", [False, True], ids=["non_streaming", "streaming"])
+    async def test_both_forms_hand_the_transport_the_same_body(self, stream: bool) -> None:
+        """R3 — the equality that closes the silent-corruption defect."""
+        from_string = await self._original_body_for(_string_body(stream=stream), stream=stream)
+        from_array = await self._original_body_for(_array_body(stream=stream), stream=stream)
+        assert from_string == from_array
+
+    @pytest.mark.parametrize("stream", [False, True], ids=["non_streaming", "streaming"])
+    async def test_the_user_s_text_is_not_shredded_into_characters(self, stream: bool) -> None:
+        """The falsification control.
+
+        The defect produced ``input: ["h", "i"]`` — a list, non-empty, and a
+        200.  An assertion that checked only the status or only the type passes
+        on it, so the shredded body is named explicitly.
+        """
+        captured = await self._original_body_for(_string_body(stream=stream), stream=stream)
+        assert captured["input"] != list(_TEXT)
+        assert captured["input"] == _array_input()
+
+    async def test_the_body_that_ships_is_the_same_for_both_forms(self) -> None:
+        """Composed through the real builder, so the claim is about the shipped bytes.
+
+        §3.2.3 puts this path's serialization boundary inside the transport:
+        ``_prepare_responses_body`` is what turns ``_original_body`` into the
+        request ``openai_subscription`` sends.
+        """
+        from kitty.providers.openai_subscription import OpenAISubscriptionAdapter
+
+        from_string = await self._original_body_for(_string_body(), stream=False)
+        from_array = await self._original_body_for(_array_body(), stream=False)
+        assert OpenAISubscriptionAdapter._prepare_responses_body(
+            from_string
+        ) == OpenAISubscriptionAdapter._prepare_responses_body(from_array)
+
+
+# ── R5 — the endpoint answers 400, never 500 ─────────────────────────────────
+
+
+class TestTheInputFamilyNeverReturnsAServerError:
+    """§6.2.1's ``not_a_server_error``, for the shapes this change claims.
+
+    Scoped deliberately: ``tools``, a ``reasoning`` item's ``summary`` and a
+    ``function_call_output`` without ``call_id`` still reach the catch-all.
+    Those are filed separately and belong to §6.2.1's ``schemathesis`` job,
+    which fuzzes the published schema instead of guessing which shapes a human
+    will try.
+    """
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            {"model": _MODEL, "input": 123},
+            {"model": _MODEL, "input": [1, 2]},
+            {"model": _MODEL, "input": None},
+            ["not", "an", "object"],
+            "not an object either",
+        ],
+    )
+    async def test_a_malformed_body_is_a_client_error(self, body: object) -> None:
+        """A 400 in the endpoint's existing envelope, not a 500."""
+        server = _bridge()
+        port = await server.start_async()
+        try:
+            status, payload = await _post(port, body)
+        finally:
+            await server.stop_async()
+        assert status == 400, f"expected 400 for {body!r}, got {status}: {payload!r}"
+        error = payload["error"]  # type: ignore[index]
+        assert error["code"] == "invalid_request"
+        # Without the marker this is byte-identical to the "Invalid JSON body" 400
+        # one branch above, so the assertion would pass on a normaliser that never
+        # ran. `_compaction_failed_response` documents the same reasoning.
+        assert error["reason"] == "invalid_input", f"answered by a different 400: {error!r}"
+        assert "input" in error["message"] or "object" in error["message"]
+        assert "internal error" not in error["message"].lower()
+
+    @pytest.mark.parametrize("profile_model", [_MODEL, None], ids=["profile_sets_a_model", "profile_sets_none"])
+    async def test_a_body_without_a_model_is_served(self, profile_model: str | None) -> None:
+        """R4 — ``model`` is optional in ``CreateResponse``; refusing it would be kitty's error.
+
+        Both branches of ``_normalize_model`` are exercised.  What the second one
+        sends is stated rather than asserted away: with no profile model and none
+        from the client there is nothing to fill in, so ``model: ""`` goes
+        upstream and the provider answers in its own dialect.  That is a 400 from
+        the provider, not a 500 from kitty, which is the claim §6.2.1 makes.
+        """
+        captured: list[dict] = []
+        server = _bridge(model=profile_model)
+        port = await server.start_async()
+        try:
+            with aioresponses(passthrough=["http://127.0.0.1"]) as mocked:
+                mocked.post(
+                    "https://upstream.invalid/v1/chat/completions",
+                    status=200,
+                    payload=_CC_REPLY,
+                    callback=lambda url, **kwargs: captured.append(kwargs["json"]),
+                )
+                status, _ = await _post(port, {"input": _TEXT})
+        finally:
+            await server.stop_async()
+        assert status == 200
+        assert captured[0]["model"] == (profile_model or "")
+
+
+# ── R6 — the obligation on the future wire reader ────────────────────────────
+
+
+class TestNoSerializationBoundarySeesAStringInput:
+    """Normalisation happens before the body forks, so no §3.2.3 boundary sees a string.
+
+    Register row **M15** (``.system_design/TEST_SUITE.md`` §3.2.1) records this
+    rewrite and takes §3.3.1a's ``not projectable`` escape, on the argument that
+    the two spellings are one request.  That argument holds only while the
+    rewrite lands *before* the body forks — otherwise one §3.2.3 boundary would
+    ship a string and the other an array, and M15 would be describing two
+    different upstream bodies.
+
+    This is the narrow, decidable half of that claim, and all it is.  The other
+    half — that the future OpenAI-Responses reader (plan task **T-A3**) projects
+    both forms into the identical ``Request`` — cannot be tested before the
+    reader exists, and is **not** tested here: it is carried by M15's
+    ``not_projectable_reason``, which the L2 register guards keep alive, and by
+    the T-A3 row of the implementation plan.
+    """
+
+    async def test_the_custom_transport_boundary_never_sees_a_string(self) -> None:
+        """The ``curl_cffi`` row of §3.2.3."""
+        provider = _RecordingCustomTransport()
+        server = _bridge(provider)
+        port = await server.start_async()
+        try:
+            await _post(port, _string_body())
+        finally:
+            await server.stop_async()
+        assert isinstance(provider.original_bodies[0]["input"], list)
+
+    def test_the_default_transport_boundary_never_sees_a_string(self) -> None:
+        """The ``Bridge aiohttp`` row: a CC body has ``messages``, and no ``input`` at all."""
+        translated = ResponsesTranslator().translate_request(_string_body())
+        assert "input" not in translated
+        assert isinstance(translated["messages"], list)

--- a/tests/harness/register.py
+++ b/tests/harness/register.py
@@ -417,6 +417,28 @@ _BRIDGE_ROWS: tuple[MutationRow, ...] = (
         conditional=False,
         design_ref="§3.2.1 · §3.3.5",
     ),
+    MutationRow(
+        id="M15",
+        site=("kitty/bridge/responses/translator.py:normalize_responses_request",),
+        # Unconditional for M1's reason, not M2's. The trigger reads like a
+        # condition on the request, but a body already in the array form meets this
+        # row with a no-op rather than avoiding it, so there is no complement state
+        # for §3.3.2 assertion 2 to arrange.
+        trigger=_ALWAYS,
+        paths=(c.NOT_PROJECTABLE,),
+        conditional=False,
+        design_ref="§3.2.1 · §3.3.1a",
+        not_projectable_reason=(
+            "OpenAI's `CreateResponse` declares a string `input` and the single-item array form to be "
+            "one request, so the two project to one `Conversation` -- a single user turn carrying the "
+            "text -- and a projection that told them apart would be reading a vendor's spelling into a "
+            "wire-independent form. That is P16's reasoning. The rewrite is nonetheless real bytes at "
+            "the curl_cffi boundary of section 3.2.3, where `_original_body` is this body, which is why "
+            "it is a row and not an omission. **This binds the OpenAI-Responses reader, T-A3:** it must "
+            "read a string `input` and the single-item array form into the identical `Request`. If it "
+            "ever does not, this escape is void and M15 needs a projectable anchor."
+        ),
+    ),
 )
 
 # --------------------------------------------------------------------------

--- a/tests/harness/test_register.py
+++ b/tests/harness/test_register.py
@@ -65,11 +65,11 @@ _SHAPES: tuple[tuple[str, str], ...] = (
 
 
 class TestTheRowsThemselves:
-    """§3.2 publishes 41 live rows; the data must be those rows and no others."""
+    """§3.2 publishes 42 live rows; the data must be those rows and no others."""
 
     def test_the_register_holds_every_live_row(self) -> None:
-        """14 bridge-level rows less the withdrawn M13, plus 28 provider-level."""
-        assert len(r.REGISTER) == 41
+        """15 bridge-level rows less the withdrawn M13, plus 28 provider-level."""
+        assert len(r.REGISTER) == 42
 
     def test_the_register_is_a_tuple_and_not_a_list(self) -> None:
         """`mypy` does not run over `tests/`, so the annotation is not enforcement.
@@ -319,14 +319,16 @@ class TestThePathsEachRowTouches:
         assert not c.path_matches(p15.paths[0], "conversation.tools[get_weather].description")
 
     def test_the_escape_is_used_only_where_the_design_expects_it(self) -> None:
-        """§3.3.1a names the whole-body translations and P16; P1 was added with a reason.
+        """§3.3.1a names the whole-body translations and P16; P1 and M15 were added with a reason.
 
         Pinned so that widening the escape is a deliberate edit here, not a
-        quiet way to make a hard row go away.
+        quiet way to make a hard row go away.  M15 (KBR-144) is the seventh: the
+        two spellings of a Responses ``input`` are one request, so the rewrite is
+        invisible to a wire-independent projection for P16's reason.
         """
         escaped = {row.id for row in r.REGISTER if not row.is_projectable}
 
-        assert escaped == {"M2", "M9", "P1", "P11", "P12", "P16"}
+        assert escaped == {"M2", "M9", "M15", "P1", "P11", "P12", "P16"}
 
 
 class TestTheModuleStandsAlone:

--- a/tests/harness/test_register_agreement.py
+++ b/tests/harness/test_register_agreement.py
@@ -86,14 +86,14 @@ class TestTheParserReadsTheDesignDocument:
 
     def test_the_parser_reads_both_tables(self, markdown: str) -> None:
         """A parser that read only §3.2.1 would still look healthy on the M rows."""
-        assert len([i for i in r.parse_register_markdown(markdown).live_ids if i.startswith("M")]) == 13
+        assert len([i for i in r.parse_register_markdown(markdown).live_ids if i.startswith("M")]) == 14
         assert len([i for i in r.parse_register_markdown(markdown).live_ids if i.startswith("P")]) == 28
 
     def test_the_parser_reads_the_unconditional_list(self, markdown: str) -> None:
         """§3.2.2's closing paragraph is the only place the exemption is written down."""
         parsed = r.parse_register_markdown(markdown)
 
-        assert len(parsed.unconditional_ids) == 21
+        assert len(parsed.unconditional_ids) == 22
         assert {"M14", "P20", "P21"} <= set(parsed.unconditional_ids)
 
     def test_a_document_with_no_register_tables_is_an_error_not_an_empty_result(self) -> None:
@@ -130,7 +130,7 @@ class TestTheParserReadsTheDesignDocument:
         """
         defective = markdown.replace(
             "| M14 |",
-            "| **M15** | A new mutation | `X.y` | Always | because |\n| M14 |",
+            "| **M16** | A new mutation | `X.y` | Always | because |\n| M14 |",
             1,
         )
 
@@ -146,13 +146,13 @@ class TestTheParserReadsTheDesignDocument:
         """
         defective = markdown.replace(
             "| M14 |",
-            "| M15 | A new mutation | `X.y` | Always | because |\n| M14 |",
+            "| M16 | A new mutation | `X.y` | Always | because |\n| M14 |",
             1,
         )
 
         problems = r.register_disagreements(r.REGISTER, defective)
 
-        assert any("M15" in problem for problem in problems), problems
+        assert any("M16" in problem for problem in problems), problems
 
     def test_an_id_published_twice_is_refused(self, markdown: str) -> None:
         """An id is the register's addressing scheme, so a repeat makes it ambiguous.


### PR DESCRIPTION
Closes [KBR-144](https://shelpuk.atlassian.net/browse/KBR-144).

## Context for the Product Owner

Kitty Bridge sits on the wire between a coding agent and an LLM provider. `/v1/responses` is the endpoint Codex-family clients speak.

OpenAI's own API specification says the user's prompt may be sent **either** as a plain string **or** as a structured array — and documents the two as *exactly equivalent*. The plain string is what every quick-start example and most one-line SDK calls produce. Kitty accepted only the array.

Two things were wrong, and the second is the more serious:

1. **On 20 of 21 providers, the plain string returned HTTP 500.** A correctly-written client was refused on its first request, with an error that tells it nothing about what to change and looks to an operator like a fault in kitty.

2. **On the ChatGPT-subscription provider, there was no error at all.** The bridge took the prompt `"hi"`, shredded it into `["h", "i"]`, and forwarded that to the provider as the customer's words. The request succeeded. Nothing in the logs said anything had happened. Measured before fixing:

   ```
   _prepare_responses_body({"model": "m", "input": "hi"})
   → {"model": "m", "stream": True, "store": False, "input": ["h", "i"]}
   ```

   `TEST_SUITE.md` §1 classes a breach of message fidelity as a **product failure**, not a bug. This was one, and it was invisible.

After this change a client may use either form, on every provider, streaming or not, and the provider receives an identical request either way.

**What is deliberately *not* fixed here** is on the ticket and on your desk: KBR-144's third acceptance criterion asks that *no* request body ever return a 500. This closes the `input` family, a non-object body, and a missing `model`. Three further shapes still crash the endpoint; closing those by hand means guessing which malformed shapes a human will try, and risks rejecting bodies real clients legitimately send. The design assigns that to an automated schema-fuzzing job. Filed as **KBR-159** rather than left implied.

## What changed

The string is normalised into the array form **once, before the inbound body forks**.

That placement is the whole design, and the ticket's suggested fix location is not sufficient. `TEST_SUITE.md` §3.2.3 records that one Responses request produces **two** upstream bodies: the Chat Completions body built by the translator, and — on `openai_subscription` — a Responses body built inside the transport from the *raw* inbound dict. Normalising only inside `translate_request`, as the ticket sketches, fixes the 500 and leaves defect 2 shipping.

| Path | Adapters | Upstream body built by |
|---|---|---|
| Bridge aiohttp | the 20 default-transport adapters | `ResponsesTranslator.translate_request` |
| curl_cffi | `openai_subscription` | `_prepare_responses_body(cc_request["_original_body"])` |

**Both call sites are load-bearing, and that was measured rather than argued.** Removing the handler's call with the translator's in place fails 11 tests, including every 400 and the corruption control; removing the translator's with the handler's in place fails 4, with exactly the `AttributeError` the ticket reports.

A malformed body now returns **400** in the endpoint's existing envelope, carrying `reason: "invalid_input"`. The marker is not decoration: three other rejections on this endpoint answer in the same envelope, and without it the malformed-body test passes on an implementation where the normaliser never ran — verified, it did.

A missing `model` no longer raises. `CreateResponse` declares no required fields, and register row M1 replaces the value anyway.

## Register row M15, and a correction I made against myself

My first specification argued this needed **no** entry in the Permitted-Mutation Register, because the two forms project to the same wire-independent conversation. Every clause of that is true; the conclusion does not follow. `TEST_SUITE.md` §3.3.1a provides for exactly this case and its provision is a **row** that takes the `not projectable` escape *with a stated reason* — as P16, M2, M9, P11, P12 and P1 all do. The rewrite is real bytes at the `curl_cffi` boundary, where `_original_body` **is** this body.

§3.2.5 says no guard proves the register complete, so the omission would have shipped green. That is why the reasoning now lives in the row itself, where `test_register.py` keeps it alive, and why it binds the future T-A3 wire reader.

## Verification

- **43 new tests.** The equalities compare two *captured* upstream bodies from two server runs, not a body against a literal, so the two forms cannot be edited apart.
- **Falsification control** names the shredded body explicitly: an assertion checking only "200, and `input` is a list" passes on defect 2.
- The `code-reviewer` verified coverage **by mutation**: eleven mutations of the implementation and five of the register data, every one caught, and it reproduced the two call-site removal counts of 11 and 4 exactly.
- Two `system-design-reviewer` passes; the first reversed the register decision above, the second caught four stale row counts I had left in the prose.
- `ruff`, `mypy`, `import-linter` clean.

**One pre-existing failure in the full suite, not from this change:** `test_connect_target_table[::ffff:0.0.0.0-127.0.0.1]`. Reproduced on a pristine `origin/main` worktree with `kitty` imported from that worktree's own `src`. Root-caused to CPython [gh-122792](https://github.com/python/cpython/issues/122792) and filed as **KBR-162** — the CI matrix is structurally blind to it.

## Filed, not folded in

Each reproduced before filing, none in scope here:

- **KBR-159** — three more body shapes that still return 500.
- **KBR-160** — the profile's model is discarded on the subscription path; the *client's* model ships. Register row M1 claims "always", and it is false there. Choosing the model is the product, so this one wants a PO decision: it may be deliberate.
- **KBR-162** — `_connect_target` rests on a CPython patch-level behaviour; a supported-but-older Python reports a running bridge as unreachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016GTtJS1VSesqdAsp66n6fz


[KBR-144]: https://shelpuk.atlassian.net/browse/KBR-144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ