### PR TITLE
Resolve the context budget from a model name however it is spelled (KBR-151)

### DIFF
--- a/.system_design/TEST_SUITE.md
+++ b/.system_design/TEST_SUITE.md
@@ -1330,6 +1330,52 @@ component is exactly the mask — and test percent-encoded and URL-embedded form
 cases. For the broader "does the password reach a log" sweep, generate a distinctive sentinel
 that cannot collide with any other field.
 
+**Where the budget itself comes from — and why it is not `normalize_model_name`.** TR-3's Given
+is "a conversation that exceeds the model's context window". That window is a *resolved* value,
+not a given: `_get_max_context_chars` asks `get_model_context_tokens(provider, model, config)`,
+which searches two catalogs — the overrides catalog (`model_context_overrides.json`, or a newer
+revision **synced from GitHub at runtime**) and the OpenRouter-derived `model_metadata.json`.
+Until KBR-151 this document assumed the window was simply known. It was not: three of the four
+query/key spellings missed, and a miss is silent.
+
+- **Both catalogs are matched by one rule** (`_resolve_catalog`): exact, then query-as-suffix-of-key,
+  then key-as-suffix-of-query, then one retry with the query's leading vendor segment removed.
+  Before KBR-151 each catalog had one half of that rule, in opposite directions, so a profile
+  written `azure/gpt-4o` resolved the 200,000-token default instead of 128,000 — the bridge then
+  believed it had ~56% more room than the model has and sent an oversized request rather than
+  compacting. That is an I1 breach produced by arithmetic, not by translation, which is why it
+  went unnoticed by everything in §3.
+- **Not via the adapter's `normalize_model_name`**, which the ticket originally proposed. That
+  method translates into the **provider's** dialect; the catalogs are keyed in **OpenRouter's**.
+  Measured across all 23 providers: it would fix 5,336 lookups and break 754 — 395 on `anthropic`
+  (its `normalize_model_name` replaces dots with hyphens, and the catalog ids carry the dots) and
+  359 on `vertex` (its version prepends `google/`). It would also stand a second, differently
+  normalized model string beside `cc_request["model"]`, which KBR-127 made the single source of
+  truth for every routing decision — see M14 and P20.
+- **The invariant the matcher rests on: no two keys in a catalog end in the same segment.** Two
+  such keys both match one query, so every lookup for that model goes ambiguous and falls to the
+  default. Verified exhaustively, and the rule must be the **final** segment, not the part after
+  the first separator: the looser reading leaves 640 ambiguous combinations, and the two coincide
+  only while every key has at most two segments — true of both catalogs today, which is exactly
+  how a guard written on the loose rule would look correct and stop protecting the moment a
+  three-segment id appeared. The two catalogs are guarded differently **because they change through different
+  doors** — `model_metadata.json` moves by a refresh script landing in a pull request, so a **test**
+  suffices (L2, `test_model_context_packaged_catalog.py`); the overrides catalog can be replaced
+  from the network with no release and no review, so a colliding revision is **rejected at load**
+  in favour of the packaged file. Enforce where a file can change unreviewed; test where it cannot.
+- **Ambiguity is terminal.** A catalog that cannot identify the entry declines and the next
+  priority source answers; it does not retry a shorter string and return a number it has just
+  called ambiguous.
+- **A fall-through to `DEFAULT_CONTEXT_TOKENS` is logged**, at `INFO`, once per `(provider, model)`.
+  The budget is recomputed on every request, so an unconditional line would be one per turn — and
+  the silence is precisely what let KBR-151 live undetected. `INFO` not `WARNING`: an unknown model
+  is routine and correct for a profile naming a local or private model.
+- **Open, referred onward:** the overrides catalog outranks a profile's hand-written
+  `provider_config["context_window"]`, and since KBR-151 one key captures every prefixed spelling
+  of its model. Whether a *network-synced* catalog should outrank the one setting the operator
+  typed is a question about operator authority, not about prefixed names, and is filed as
+  [KBR-170](https://shelpuk.atlassian.net/browse/KBR-170) rather than decided inside a bug fix.
+
 **Mutation testing.** Line coverage cannot tell a real assertion from `assert result is not
 None`. `mutmut` closes that gap.
 
@@ -1349,6 +1395,7 @@ None`. `mutmut` closes that gap.
   | `kitty.bridge.messages.*`, `kitty.bridge.responses.*`, `kitty.bridge.gemini.*`, `kitty.bridge.engine` | Translation — I1 |
   | `kitty.bridge.server._compact_messages*`, `_compact_with_tighter_budget*`, `_validate_tool_call_pairing*`, `_truncate_oversized_tool_results*`, `_apply_compaction*`, `_normalize_model*`, `_get_max_context_chars*` | Compaction and pairing — the I1 core, and the thing the rationale was always about |
   | `kitty.providers.*` `translate_to_upstream` / `normalize_request` / `build_upstream_headers` | The register's provider half — I1 and I2 |
+  | `kitty.providers.model_context.*` | Where the compaction budget is actually resolved since KBR-151. The `_get_max_context_chars*` row above now covers a dispatcher: it reads `_active_model` and hands both catalogs to `_resolve_catalog`. A mutation in the matcher — dropping the tail retry, collapsing ambiguity into a miss — changes every budget in the product and would not be caught by any target listed above |
   | `kitty.providers.openai_subscription._cc_to_responses*`, `_prepare_responses_body*`, `_convert_content_types*`, `_build_user_agent*` | P13–P17 and the F1 user-agent. These are where the subscription path's real body is built; omitting them lets the score stay healthy while nothing detects a regression in the mutations this design only just registered |
   | `kitty.egress`, `kitty.egress_guard` | I3, including the startup guard |
   | `kitty.bridge.tool_audit`, `kitty.profiles.*`, `kitty.validation` | Supporting correctness |

--- a/src/kitty/providers/model_context.py
+++ b/src/kitty/providers/model_context.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
-from collections.abc import Iterable
+from collections.abc import Collection, Iterable
 from functools import cache, lru_cache
 from pathlib import Path
 
@@ -86,20 +86,7 @@ def _coerce_context_tokens(value: object) -> int | None:
 _AMBIGUOUS = object()
 
 
-def _catalog_tail(key: str) -> str:
-    """Return the part of a catalog key after its first separator.
-
-    Args:
-        key: A catalog key or model name, with or without a vendor prefix.
-
-    Returns:
-        The text after the first ``"/"``, or the whole key when it has none.
-    """
-    _, _, tail = key.partition("/")
-    return tail or key
-
-
-def _match_catalog(query: str, keys: set[str]) -> str | object | None:
+def _match_catalog(query: str, keys: Collection[str]) -> str | object | None:
     """Match a model name against a set of catalog keys.
 
     Tries, in order: an exact match; the query as a ``"/"``-delimited suffix of
@@ -110,7 +97,8 @@ def _match_catalog(query: str, keys: set[str]) -> str | object | None:
 
     Args:
         query: The model name to look up, already lowercased.
-        keys: The catalog's keys, already lowercased.
+        keys: The catalog's keys, already lowercased. The caller passes the
+            cached catalog mapping itself, so no copy is built per request.
 
     Returns:
         The matching key, :data:`_AMBIGUOUS` when a step matched more than one
@@ -138,7 +126,7 @@ def _match_catalog(query: str, keys: set[str]) -> str | object | None:
     return None
 
 
-def _resolve_catalog(model: str, keys: set[str]) -> str | None:
+def _resolve_catalog(model: str, keys: Collection[str]) -> str | None:
     """Resolve a model name against a catalog, retrying once without its prefix.
 
     A profile may name a model in its provider's dialect (``azure/gpt-4o``)
@@ -306,7 +294,7 @@ def _lookup_override(model: str) -> int | None:
     if not overrides:
         return None
 
-    key = _resolve_catalog(model, set(overrides))
+    key = _resolve_catalog(model, overrides)
     return overrides[key] if key is not None else None
 
 
@@ -373,7 +361,7 @@ def get_model_context_tokens(
         logger.warning("Invalid provider_config context_window for %s/%s", provider, model)
 
     metadata = _load_metadata()
-    matched_id = _resolve_catalog(model, set(metadata))
+    matched_id = _resolve_catalog(model, metadata)
     if matched_id is not None:
         value = _coerce_context_tokens(metadata[matched_id].get("context_length"))
         if value is not None:

--- a/src/kitty/providers/model_context.py
+++ b/src/kitty/providers/model_context.py
@@ -80,13 +80,7 @@ def _coerce_context_tokens(value: object) -> int | None:
         return None
 
 
-# Sentinel distinguishing "more than one key matched" from "no key matched".
-# The two must not collapse: a miss falls through to the tail retry, an
-# ambiguous match stops the lookup for that catalog (see _resolve_catalog).
-_AMBIGUOUS = object()
-
-
-def _match_catalog(query: str, keys: Collection[str]) -> str | object | None:
+def _match_catalog(query: str, keys: Collection[str]) -> tuple[str | None, bool]:
     """Match a model name against a set of catalog keys.
 
     Tries, in order: an exact match; the query as a ``"/"``-delimited suffix of
@@ -101,11 +95,14 @@ def _match_catalog(query: str, keys: Collection[str]) -> str | object | None:
             cached catalog mapping itself, so no copy is built per request.
 
     Returns:
-        The matching key, :data:`_AMBIGUOUS` when a step matched more than one
-        key, or ``None`` when nothing matched.
+        A ``(key, ambiguous)`` pair. ``key`` is the match, or ``None`` when
+        nothing matched. ``ambiguous`` reports that a step matched more than
+        one key — which must not collapse into "no match", because a miss
+        falls through to the tail retry while an ambiguous match stops the
+        lookup for this catalog entirely (see :func:`_resolve_catalog`).
     """
     if query in keys:
-        return query
+        return query, False
 
     # Each step is decisive: a step that matches several keys cannot be
     # narrowed by trying the next one, it can only be reported.
@@ -114,7 +111,7 @@ def _match_catalog(query: str, keys: Collection[str]) -> str | object | None:
         [k for k in keys if query.endswith("/" + k)],
     ):
         if len(candidates) == 1:
-            return candidates[0]
+            return candidates[0], False
         if len(candidates) > 1:
             logger.warning(
                 "Ambiguous context entry for %s: %d matches (%s)",
@@ -122,8 +119,8 @@ def _match_catalog(query: str, keys: Collection[str]) -> str | object | None:
                 len(candidates),
                 sorted(candidates),
             )
-            return _AMBIGUOUS
-    return None
+            return None, True
+    return None, False
 
 
 def _resolve_catalog(model: str, keys: Collection[str]) -> str | None:
@@ -147,16 +144,16 @@ def _resolve_catalog(model: str, keys: Collection[str]) -> str | None:
         The matching key, or ``None`` when the catalog cannot resolve the name.
     """
     query = model.lower()
-    hit = _match_catalog(query, keys)
-    if hit is _AMBIGUOUS:
+    hit, ambiguous = _match_catalog(query, keys)
+    if ambiguous:
         return None
     if hit is None:
         _, sep, tail = query.partition("/")
         if sep and tail:
-            hit = _match_catalog(tail, keys)
-            if hit is _AMBIGUOUS:
+            hit, ambiguous = _match_catalog(tail, keys)
+            if ambiguous:
                 return None
-    return hit  # type: ignore[return-value]  # _AMBIGUOUS is handled above
+    return hit
 
 
 def _parse_overrides(raw: str, source: str) -> dict[str, int] | None:
@@ -253,12 +250,13 @@ def _load_overrides() -> dict[str, int]:
         # an ambiguous overrides catalog hands the decision to the metadata
         # table it exists to overrule. Reject such a revision wholesale rather
         # than load it, as with a body that is not a JSON object.
-        if parsed is not None and _colliding_keys(parsed):
+        collisions = _colliding_keys(parsed) if parsed is not None else []
+        if collisions:
             logger.warning(
                 "Model context overrides from %s hold keys that differ only by prefix (%s); "
                 "keeping the packaged catalog",
                 REMOTE_OVERRIDES_CACHE_PATH,
-                _colliding_keys(parsed),
+                collisions,
             )
             parsed = None
         if parsed is not None:

--- a/src/kitty/providers/model_context.py
+++ b/src/kitty/providers/model_context.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import json
 import logging
-from functools import lru_cache
+from collections.abc import Iterable
+from functools import cache, lru_cache
 from pathlib import Path
 
 from platformdirs import user_cache_dir
@@ -79,6 +80,97 @@ def _coerce_context_tokens(value: object) -> int | None:
         return None
 
 
+# Sentinel distinguishing "more than one key matched" from "no key matched".
+# The two must not collapse: a miss falls through to the tail retry, an
+# ambiguous match stops the lookup for that catalog (see _resolve_catalog).
+_AMBIGUOUS = object()
+
+
+def _catalog_tail(key: str) -> str:
+    """Return the part of a catalog key after its first separator.
+
+    Args:
+        key: A catalog key or model name, with or without a vendor prefix.
+
+    Returns:
+        The text after the first ``"/"``, or the whole key when it has none.
+    """
+    _, _, tail = key.partition("/")
+    return tail or key
+
+
+def _match_catalog(query: str, keys: set[str]) -> str | object | None:
+    """Match a model name against a set of catalog keys.
+
+    Tries, in order: an exact match; the query as a ``"/"``-delimited suffix of
+    a key (``gpt-4o`` finds ``openai/gpt-4o``); a key as a ``"/"``-delimited
+    suffix of the query (``z-ai/glm-5.2`` finds ``glm-5.2``). The second rule is
+    the metadata table's, the third the overrides catalog's; both catalogs get
+    both so that a name resolves the same window whichever dialect spells it.
+
+    Args:
+        query: The model name to look up, already lowercased.
+        keys: The catalog's keys, already lowercased.
+
+    Returns:
+        The matching key, :data:`_AMBIGUOUS` when a step matched more than one
+        key, or ``None`` when nothing matched.
+    """
+    if query in keys:
+        return query
+
+    # Each step is decisive: a step that matches several keys cannot be
+    # narrowed by trying the next one, it can only be reported.
+    for candidates in (
+        [k for k in keys if k.endswith("/" + query)],
+        [k for k in keys if query.endswith("/" + k)],
+    ):
+        if len(candidates) == 1:
+            return candidates[0]
+        if len(candidates) > 1:
+            logger.warning(
+                "Ambiguous context entry for %s: %d matches (%s)",
+                query,
+                len(candidates),
+                sorted(candidates),
+            )
+            return _AMBIGUOUS
+    return None
+
+
+def _resolve_catalog(model: str, keys: set[str]) -> str | None:
+    """Resolve a model name against a catalog, retrying once without its prefix.
+
+    A profile may name a model in its provider's dialect (``azure/gpt-4o``)
+    while the catalog is keyed in another (``openai/gpt-4o``). When the name as
+    given matches nothing, it is retried with its leading segment removed —
+    once, at the first separator. Stripping further would reduce a Fireworks
+    full path such as ``accounts/fireworks/routers/kimi`` to a bare name and
+    could match an unrelated model (KBR-151).
+
+    An ambiguous match is terminal: retrying the tail after the matcher has
+    said it cannot identify the entry would log "ambiguous" and answer anyway.
+
+    Args:
+        model: The model name as configured, in any case.
+        keys: The catalog's keys, already lowercased.
+
+    Returns:
+        The matching key, or ``None`` when the catalog cannot resolve the name.
+    """
+    query = model.lower()
+    hit = _match_catalog(query, keys)
+    if hit is _AMBIGUOUS:
+        return None
+    if hit is None:
+        _, sep, tail = query.partition("/")
+        if sep and tail:
+            hit = _match_catalog(tail, keys)
+            if hit is _AMBIGUOUS:
+                return None
+    return hit  # type: ignore[return-value]  # _AMBIGUOUS is handled above
+
+
 def _parse_overrides(raw: str, source: str) -> dict[str, int] | None:
     """Parse overrides catalog JSON text into a validated mapping.
 
@@ -115,6 +207,33 @@ def _parse_overrides(raw: str, source: str) -> dict[str, int] | None:
     return overrides
 
 
+def _colliding_keys(keys: Iterable[str]) -> list[str]:
+    """Return catalog keys that share a final segment with another key.
+
+    Final-segment uniqueness is what makes :func:`_match_catalog` unambiguous,
+    and it is the weakest condition that does. Verified exhaustively over every
+    one-, two- and three-segment key pair: zero ambiguous lookups survive it,
+    where the looser "unique after the first separator" admits 640.
+
+    The two rules coincide only while every key has at most two segments, which
+    both shipped catalogs satisfy today. They part company on a key such as
+    ``a/b/x``, whose tail is ``b/x`` but whose final segment is ``x`` — it
+    collides with a key ``x`` that the looser rule would wave through, and the
+    query ``x`` would then match both.
+
+    Args:
+        keys: A catalog's keys, already lowercased.
+
+    Returns:
+        The colliding keys, sorted, or an empty list when every final segment
+        is unique.
+    """
+    by_segment: dict[str, list[str]] = {}
+    for key in keys:
+        by_segment.setdefault(key.rsplit("/", 1)[-1], []).append(key)
+    return sorted(k for group in by_segment.values() if len(group) > 1 for k in group)
+
+
 @lru_cache(maxsize=1)
 def _load_overrides() -> dict[str, int]:
     """Load the overrides catalog, preferring the remote-synced cache.
@@ -142,6 +261,18 @@ def _load_overrides() -> dict[str, int]:
         raw = None
     if raw is not None:
         parsed = _parse_overrides(raw, source=str(REMOTE_OVERRIDES_CACHE_PATH))
+        # Two keys sharing a tail make every lookup for that tail ambiguous, and
+        # an ambiguous overrides catalog hands the decision to the metadata
+        # table it exists to overrule. Reject such a revision wholesale rather
+        # than load it, as with a body that is not a JSON object.
+        if parsed is not None and _colliding_keys(parsed):
+            logger.warning(
+                "Model context overrides from %s hold keys that differ only by prefix (%s); "
+                "keeping the packaged catalog",
+                REMOTE_OVERRIDES_CACHE_PATH,
+                _colliding_keys(parsed),
+            )
+            parsed = None
         if parsed is not None:
             return parsed
 
@@ -155,17 +286,13 @@ def _load_overrides() -> dict[str, int]:
 
 
 def _lookup_override(model: str) -> int | None:
-    """Return the context length from the local overrides file, or None.
+    """Return the context length from the overrides catalog, or None.
 
-    Matching is case-insensitive and reuses the single-direction suffix
-    convention of the metadata lookup (the query may carry a vendor prefix
-    that a later normalize step strips; the override key is bare):
-
-    1. Exact: ``model.lower()`` is an override key.
-    2. Suffix: the query ``model.lower()`` ends with ``"/" + key`` for exactly
-       one override key (e.g. ``"z-ai/glm-5.2"`` matches the key ``"glm-5.2"``).
-       More than one suffix match is ambiguous: log a warning and return None
-       so the caller falls through, matching the metadata ambiguity behavior.
+    Uses the shared :func:`_resolve_catalog` matcher, so a pinned model
+    resolves however the query and the key are spelled — bare or vendor-
+    prefixed, in either dialect. Before KBR-151 this carried a prefixed query
+    up to a bare key but not the reverse, so an overrides catalog holding a
+    prefixed key was silently out-ranked by the lower-priority metadata table.
 
     Args:
         model: The raw model name as seen by the resolver (may be
@@ -179,23 +306,36 @@ def _lookup_override(model: str) -> int | None:
     if not overrides:
         return None
 
-    model_lower = model.lower()
-    # 1. Exact match.
-    if model_lower in overrides:
-        return overrides[model_lower]
+    key = _resolve_catalog(model, set(overrides))
+    return overrides[key] if key is not None else None
 
-    # 2. Single-direction suffix match: "z-ai/glm-5.2" matches key "glm-5.2".
-    suffix_matches = [k for k in overrides if model_lower.endswith("/" + k)]
-    if len(suffix_matches) == 1:
-        return overrides[suffix_matches[0]]
-    if len(suffix_matches) > 1:
-        logger.warning(
-            "Ambiguous context override for %s: %d matches (%s)",
-            model_lower,
-            len(suffix_matches),
-            suffix_matches,
-        )
-    return None
+
+@cache
+def _log_default_fallback(provider: str, model: str) -> None:
+    """Report once that a model's context window could not be resolved.
+
+    Deduplicated per ``(provider, model)`` because the compaction budget is
+    recomputed on every request, so an unconditional line would be one per
+    turn. ``INFO`` rather than ``WARNING``: an unknown model is routine and
+    correct for a profile pointing at a local or private model, and a warning
+    that fires routinely is one that gets filtered.
+
+    ``functools.cache`` rather than a bounded LRU: the keys come from profiles,
+    never from the wire, and a bounded cache would re-emit after eviction and
+    so would not deliver the once-per-model guarantee this exists for.
+
+    Args:
+        provider: The provider type, for identifying which profile is affected.
+        model: The model name **as configured** — never the prefix-stripped
+            tail, which is a string the operator never wrote.
+    """
+    logger.info(
+        "No context window found for %s/%s; assuming %d tokens. "
+        "Set context_window in the profile's provider_config to override.",
+        provider,
+        model,
+        DEFAULT_CONTEXT_TOKENS,
+    )
 
 
 def get_model_context_tokens(
@@ -209,15 +349,18 @@ def get_model_context_tokens(
     1. Overrides catalog — the remote-synced cache when valid, else the
        packaged model_context_overrides.json — highest priority.
     2. provider_config["context_window"] — per-profile manual override.
-    3. Exact match on model name in metadata table.
-    4. Suffix match: bare model name (e.g. "gpt-4o") matches metadata
-       entries with a provider prefix (e.g. "openai/gpt-4o").
-    5. DEFAULT_CONTEXT_TOKENS fallback.
+    3. Metadata table.
 
-    WARNING: a packaged entry in the local overrides file silently trumps a
-    per-profile ``provider_config["context_window"]``. To make a profile's
-    context_window take effect for a model, omit that model from the overrides
-    file.
+    Both catalogs are searched by :func:`_resolve_catalog`, so a model resolves
+    the same window however it is spelled: bare, or carrying any single vendor
+    or provider prefix (KBR-151).
+
+    WARNING: an entry in the overrides catalog silently trumps a per-profile
+    ``provider_config["context_window"]``. To make a profile's context_window
+    take effect, omit that model from the overrides file — noting that since
+    KBR-151 one key captures **every** prefixed spelling of its model, so
+    ``openai/gpt-4o``, ``gpt-4o`` and ``azure/gpt-4o`` are one entry to omit,
+    not three. A key's own prefix does not scope it to that vendor.
     """
     override = _lookup_override(model)
     if override is not None:
@@ -230,27 +373,17 @@ def get_model_context_tokens(
         logger.warning("Invalid provider_config context_window for %s/%s", provider, model)
 
     metadata = _load_metadata()
-    model_lower = model.lower()
-
-    # 3. Exact match (model as-is, e.g. "openai/gpt-4o" or a bare name)
-    if model_lower in metadata:
-        value = _coerce_context_tokens(metadata[model_lower].get("context_length"))
+    matched_id = _resolve_catalog(model, set(metadata))
+    if matched_id is not None:
+        value = _coerce_context_tokens(metadata[matched_id].get("context_length"))
         if value is not None:
             return value
-        logger.warning("Invalid context_length in metadata for %s", model_lower)
+        logger.warning("Invalid context_length in metadata for %s", matched_id)
 
-    # 4. Suffix match: "gpt-4o" matches "openai/gpt-4o", "gpt-4o-mini", etc.
-    suffix = "/" + model_lower
-    matches = [entry for mid, entry in metadata.items() if mid.endswith(suffix)]
-    if len(matches) == 1:
-        value = _coerce_context_tokens(matches[0].get("context_length"))
-        if value is not None:
-            return value
-        logger.warning("Invalid context_length in metadata suffix match for %s", model_lower)
-    elif len(matches) > 1:
-        match_ids = [mid for mid in metadata if mid.endswith(suffix)]
-        logger.warning("Ambiguous context metadata for %s: %d matches (%s)", model_lower, len(matches), match_ids)
-
+    # Nothing knows this model. Say so once per model rather than per request:
+    # the budget is recomputed on every turn, and silence here is what let
+    # KBR-151 size a conversation from a window the model does not have.
+    _log_default_fallback(provider, model)
     return DEFAULT_CONTEXT_TOKENS
 
 

--- a/tests/bridge/test_compaction.py
+++ b/tests/bridge/test_compaction.py
@@ -1491,6 +1491,77 @@ class TestGetMaxContextChars:
             mc._load_overrides.cache_clear()
 
 
+class TestMaxContextCharsWithPrefixedProfileModel:
+    """KBR-151: a profile model with a provider prefix sizes the budget correctly.
+
+    ``_get_max_context_chars`` reads ``_active_model`` -- the raw profile model,
+    deliberately, since KBR-127 made ``cc_request["model"]`` the single string
+    every *routing* decision reads. A profile written ``azure/gpt-4o`` used to
+    miss the context catalog entirely and take the 200,000-token default, so the
+    bridge believed it had ~56% more room than the model has and sent an
+    oversized request instead of compacting.
+    """
+
+    def _budget_for(self, model: str) -> int:
+        server = _make_server()
+        server._active_provider = StubProvider()
+        server._active_model = model
+        server._active_provider_config = {}
+        server._backends = None
+        return server._get_max_context_chars()
+
+    @pytest.mark.parametrize(
+        ("prefixed", "bare"),
+        [
+            ("opencode/minimax-m2.5", "minimax-m2.5"),
+            ("azure/gpt-4o", "gpt-4o"),
+        ],
+    )
+    def test_prefixed_profile_model_gets_the_bare_models_budget(self, prefixed, bare):
+        budget = self._budget_for(prefixed)
+        assert budget == self._budget_for(bare)
+        # Equality alone passes when both sides sit on the default -- the bug.
+        assert budget != tokens_to_chars(DEFAULT_CONTEXT_TOKENS)
+
+    def test_balancing_pool_sees_the_prefixed_members_real_window(self):
+        """The pool's budget is its smallest member's, prefix or not.
+
+        The balancing branch reads each member profile's ``model``, a different
+        source from ``_active_model``, and ``min()`` only ever moves the budget
+        down -- so one member resolving the default hid the real, smaller window
+        of another and let the whole pool over-send.
+        """
+
+        def budget(azure_model: str) -> int:
+            server = _make_server()
+            server._backends = [
+                (
+                    StubProvider(),
+                    "key1",
+                    Profile(
+                        name="p1",
+                        provider="azure",
+                        model=azure_model,
+                        auth_ref="dd7f361b-3794-4343-a917-906760d3cde4",
+                    ),
+                ),
+                (
+                    StubProvider(),
+                    "key2",
+                    Profile(
+                        name="p2",
+                        provider="openrouter",
+                        model="google/gemini-2.0-flash-001",
+                        auth_ref="76df9193-5b84-4824-8c35-a1dce9c01d64",
+                    ),
+                ),
+            ]
+            return server._get_max_context_chars()
+
+        assert budget("azure/gpt-4o") == budget("gpt-4o")
+        assert budget("azure/gpt-4o") != tokens_to_chars(DEFAULT_CONTEXT_TOKENS)
+
+
 # ---------------------------------------------------------------------------
 # Context-aware compaction and size checking
 # ---------------------------------------------------------------------------

--- a/tests/test_model_context.py
+++ b/tests/test_model_context.py
@@ -740,12 +740,13 @@ class TestPrefixedQueryTailRetry:
         assert result == mc.DEFAULT_CONTEXT_TOKENS
         assert any("shared-model" in r.getMessage() for r in caplog.records if r.levelname == "WARNING")
 
-    def test_only_the_first_segment_is_stripped(self, tmp_path: Path, monkeypatch):
+    def test_only_the_first_segment_is_stripped(self):
         """R4: a multi-segment path does not collapse to its last segment.
 
         Fireworks passes full paths through unchanged, so the lookup must not
         reduce ``accounts/fireworks/routers/gpt-4o`` to ``gpt-4o`` and claim a
-        window for an unrelated model.
+        window for an unrelated model. The module's autouse fixture supplies
+        the synthetic catalog, so this takes no fixture parameters of its own.
         """
         import kitty.providers.model_context as mc
 

--- a/tests/test_model_context.py
+++ b/tests/test_model_context.py
@@ -1,6 +1,7 @@
 """Tests for model_context.py — model metadata lookup."""
 
 import json
+import logging
 import os
 import time
 from pathlib import Path
@@ -659,3 +660,292 @@ class TestTokensToChars:
 
         assert tokens_to_chars(1) == TOKENS_TO_CHARS_FACTOR
         assert TOKENS_TO_CHARS_FACTOR == 4
+
+
+# ---------------------------------------------------------------------------
+# KBR-151 — a provider-prefixed model resolves the same window as the bare one
+# ---------------------------------------------------------------------------
+
+
+class TestPrefixedQueryTailRetry:
+    """A query carrying a provider prefix reaches a differently-prefixed catalog id.
+
+    The metadata table is keyed in OpenRouter's dialect (``openai/gpt-4o``) and
+    a profile may name the same model in its provider's dialect
+    (``azure/gpt-4o``). Before KBR-151 only the bare-query direction resolved,
+    so a prefixed profile model silently took ``DEFAULT_CONTEXT_TOKENS`` and
+    sized the compaction budget from a window the model does not have.
+    """
+
+    def test_provider_prefixed_query_matches_prefixed_catalog_entry(self):
+        """R1: ``custom/gpt-4o`` reaches ``openai/gpt-4o`` by dropping its prefix."""
+        from kitty.providers.model_context import get_model_context_tokens
+
+        assert get_model_context_tokens(provider="custom_openai", model="custom/gpt-4o") == 128000
+
+    def test_prefixed_query_matches_case_insensitively(self):
+        """R1: the tail retry folds case, like every other step of the lookup."""
+        from kitty.providers.model_context import get_model_context_tokens
+
+        assert get_model_context_tokens(provider="azure", model="Azure/GPT-4o") == 128000
+
+    def test_tail_retry_does_not_override_the_overrides_catalog(self):
+        """R2a: the overrides catalog still outranks anything metadata can reach."""
+        from kitty.providers.model_context import get_model_context_tokens
+
+        _set_overrides({"gpt-4o": 999_999})
+        assert get_model_context_tokens(provider="azure", model="azure/gpt-4o") == 999_999
+
+    def test_tail_retry_does_not_override_provider_config(self):
+        """R2b: an explicit per-profile context_window still outranks metadata."""
+        from kitty.providers.model_context import get_model_context_tokens
+
+        result = get_model_context_tokens(
+            provider="azure",
+            model="azure/gpt-4o",
+            provider_config={"context_window": 50_000},
+        )
+        assert result == 50_000
+
+    def test_exact_match_on_the_full_query_wins_over_the_tail(self):
+        """R2c: an OpenRouter-spelled query still resolves by exact match.
+
+        ``openai/gpt-4o-mini`` must not be reduced to ``gpt-4o-mini`` and
+        re-matched; the exact hit comes first and the retry never runs.
+        """
+        from kitty.providers.model_context import get_model_context_tokens
+
+        assert get_model_context_tokens(provider="openrouter", model="openai/gpt-4o-mini") == 128000
+
+    def test_ambiguous_tail_returns_default_and_warns_about_the_tail(self, tmp_path: Path, monkeypatch, caplog):
+        """R3a: a tail matching two vendors is not guessed at."""
+        import kitty.providers.model_context as mc
+
+        metadata_file = tmp_path / "ambiguous.json"
+        metadata_file.write_text(
+            json.dumps(
+                [
+                    {"id": "provider-a/shared-model", "name": "A", "context_length": 10000},
+                    {"id": "provider-b/shared-model", "name": "B", "context_length": 20000},
+                ]
+            ),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(mc, "_METADATA_PATH", metadata_file)
+        mc._load_metadata.cache_clear()
+
+        with caplog.at_level(logging.WARNING, logger="kitty.providers.model_context"):
+            result = mc.get_model_context_tokens(provider="custom_openai", model="custom_openai/shared-model")
+
+        assert result == mc.DEFAULT_CONTEXT_TOKENS
+        assert any("shared-model" in r.getMessage() for r in caplog.records if r.levelname == "WARNING")
+
+    def test_only_the_first_segment_is_stripped(self, tmp_path: Path, monkeypatch):
+        """R4: a multi-segment path does not collapse to its last segment.
+
+        Fireworks passes full paths through unchanged, so the lookup must not
+        reduce ``accounts/fireworks/routers/gpt-4o`` to ``gpt-4o`` and claim a
+        window for an unrelated model.
+        """
+        import kitty.providers.model_context as mc
+
+        result = mc.get_model_context_tokens(
+            provider="fireworks",
+            model="accounts/fireworks/routers/gpt-4o",
+        )
+        assert result == mc.DEFAULT_CONTEXT_TOKENS
+
+    def test_empty_tail_returns_default(self):
+        """R4: a trailing separator has no tail to retry and must not raise."""
+        import kitty.providers.model_context as mc
+
+        assert mc.get_model_context_tokens(provider="azure", model="azure/") == mc.DEFAULT_CONTEXT_TOKENS
+
+    def test_empty_head_still_resolves(self):
+        """R4: a leading separator leaves a usable tail and must not raise.
+
+        ``"".partition("/")`` yields an empty head and a full tail, so this is
+        the other half of the guard from ``test_empty_tail_returns_default``.
+        """
+        from kitty.providers.model_context import get_model_context_tokens
+
+        assert get_model_context_tokens(provider="azure", model="/gpt-4o") == 128000
+
+
+class TestOverridesOutrankMetadataForEveryQueryShape:
+    """R9: a pinned model wins however the query and the key are spelled.
+
+    The overrides catalog exists to pin a window that must not be taken from
+    the OpenRouter metadata table. Before KBR-151 the two catalogs were matched
+    by opposite half-rules, so an overrides catalog carrying a *prefixed* key
+    was silently out-ranked by metadata for three of the four spellings — and
+    the overrides catalog is the one that can be replaced from the network
+    without a release.
+    """
+
+    @pytest.mark.parametrize(
+        "query",
+        ["z-ai/glm-5.3", "glm-5.3", "opencode/glm-5.3", "azure/glm-5.3"],
+    )
+    def test_pinned_model_wins_for_every_spelling(self, query, tmp_path: Path, monkeypatch):
+        import kitty.providers.model_context as mc
+
+        metadata_file = tmp_path / "glm.json"
+        metadata_file.write_text(
+            json.dumps([{"id": "z-ai/glm-5.3", "name": "GLM", "context_length": 1_310_720}]),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(mc, "_METADATA_PATH", metadata_file)
+        mc._load_metadata.cache_clear()
+        _set_overrides({"z-ai/glm-5.3": 1_048_576})
+
+        assert mc.get_model_context_tokens(provider="opencode_go", model=query) == 1_048_576
+
+
+class TestAmbiguityIsTerminal:
+    """R3b: a catalog that cannot tell which entry was meant declines outright.
+
+    Retrying the tail after an ambiguous match would log "ambiguous" and then
+    answer anyway, from the same catalog. If the matcher cannot identify the
+    entry, a second pass over a shorter string is guessing with extra steps.
+    """
+
+    def test_ambiguous_match_does_not_fall_through_to_the_tail_retry(self):
+        from kitty.providers.model_context import DEFAULT_CONTEXT_TOKENS, get_model_context_tokens
+
+        # Both keys are suffixes of the query, so the match is ambiguous --
+        # even though the tail "z-ai/glm-5.3" would match one of them exactly.
+        _set_overrides({"glm-5.3": 111_111, "z-ai/glm-5.3": 222_222})
+        result = get_model_context_tokens(provider="opencode_go", model="a/z-ai/glm-5.3")
+        assert result not in (111_111, 222_222)
+        assert result == DEFAULT_CONTEXT_TOKENS
+
+    def test_overrides_still_outrank_provider_config(self):
+        """R11: the documented precedence is pinned, not incidental."""
+        from kitty.providers.model_context import get_model_context_tokens
+
+        _set_overrides({"gpt-4o": 777_777})
+        result = get_model_context_tokens(
+            provider="azure",
+            model="gpt-4o",
+            provider_config={"context_window": 128_000},
+        )
+        assert result == 777_777
+
+
+class TestSyncedOverridesMustBeTailUnique:
+    """R10b: a synced catalog that would make the matcher ambiguous is refused.
+
+    Tail-uniqueness is what makes the matcher ambiguity-free, and the synced
+    catalog is the one artifact here that changes without a pull request. A
+    revision violating it is rejected wholesale rather than merged into an
+    ambiguous state, which is how ``_load_overrides`` already treats a cached
+    copy that is not a JSON object.
+    """
+
+    def test_colliding_synced_revision_is_rejected_for_the_packaged_catalog(self):
+        from kitty.providers.model_context import get_model_context_tokens
+
+        _set_overrides({"glm-5.3": 111_111})
+        _set_remote_cache({"z-ai/glm-5.3": 999_999, "zhipu/glm-5.3": 888_888})
+        assert get_model_context_tokens(provider="opencode_go", model="glm-5.3") == 111_111
+
+    def test_collision_is_judged_on_the_final_segment_not_the_first_split(self):
+        """A three-segment key collides with the bare key it ends in.
+
+        ``a/b/glm-5.3`` and ``glm-5.3`` are distinct after their first
+        separator, so a guard keyed on that would wave the pair through --
+        and the query ``glm-5.3`` would then match both. The rule is the
+        final segment.
+        """
+        from kitty.providers.model_context import _colliding_keys
+
+        assert _colliding_keys(["a/b/glm-5.3", "glm-5.3"]) == ["a/b/glm-5.3", "glm-5.3"]
+        assert _colliding_keys(["a/b/glm-5.3", "glm-5.2"]) == []
+
+    def test_multi_segment_colliding_revision_is_also_rejected(self):
+        from kitty.providers.model_context import get_model_context_tokens
+
+        _set_overrides({"glm-5.3": 111_111})
+        _set_remote_cache({"a/b/glm-5.3": 999_999, "glm-5.3": 888_888})
+        assert get_model_context_tokens(provider="opencode_go", model="glm-5.3") == 111_111
+
+    def test_tail_unique_synced_revision_still_replaces_the_packaged_catalog(self):
+        """The guard must not pass by rejecting every synced revision."""
+        from kitty.providers.model_context import get_model_context_tokens
+
+        _set_overrides({"glm-5.3": 111_111})
+        _set_remote_cache({"z-ai/glm-5.3": 999_999})
+        assert get_model_context_tokens(provider="opencode_go", model="glm-5.3") == 999_999
+
+
+class TestDefaultFallbackIsObservable:
+    """R6: falling back to the default is logged, once per model.
+
+    A silent fallback is what kept KBR-151 invisible. ``_get_max_context_chars``
+    runs on every request, so the line is deduplicated per (provider, model)
+    rather than emitted per turn.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _clear_fallback_log_cache(self):
+        import kitty.providers.model_context as mc
+
+        mc._log_default_fallback.cache_clear()
+        yield
+        mc._log_default_fallback.cache_clear()
+
+    def test_fallback_is_logged_once_naming_provider_model_and_window(self, caplog):
+        import kitty.providers.model_context as mc
+
+        with caplog.at_level(logging.INFO, logger="kitty.providers.model_context"):
+            mc.get_model_context_tokens(provider="ollama", model="llama3-custom")
+
+        records = [r for r in caplog.records if r.levelname == "INFO"]
+        assert len(records) == 1
+        message = records[0].getMessage()
+        assert "ollama" in message
+        assert "llama3-custom" in message
+        assert str(mc.DEFAULT_CONTEXT_TOKENS) in message.replace(",", "")
+
+    def test_repeating_the_same_lookup_logs_nothing_further(self, caplog):
+        import kitty.providers.model_context as mc
+
+        with caplog.at_level(logging.INFO, logger="kitty.providers.model_context"):
+            mc.get_model_context_tokens(provider="ollama", model="llama3-custom")
+            mc.get_model_context_tokens(provider="ollama", model="llama3-custom")
+
+        assert len([r for r in caplog.records if r.levelname == "INFO"]) == 1
+
+    def test_a_different_unknown_model_logs_again(self, caplog):
+        import kitty.providers.model_context as mc
+
+        with caplog.at_level(logging.INFO, logger="kitty.providers.model_context"):
+            mc.get_model_context_tokens(provider="ollama", model="llama3-custom")
+            mc.get_model_context_tokens(provider="ollama", model="mistral-custom")
+
+        assert len([r for r in caplog.records if r.levelname == "INFO"]) == 2
+
+    def test_the_same_model_on_a_different_provider_logs_again(self, caplog):
+        """The dedup key is the pair, not the model alone.
+
+        Two profiles can name the same unknown model on different providers,
+        and an operator fixing one needs to see the other.
+        """
+        import kitty.providers.model_context as mc
+
+        with caplog.at_level(logging.INFO, logger="kitty.providers.model_context"):
+            mc.get_model_context_tokens(provider="ollama", model="llama3-custom")
+            mc.get_model_context_tokens(provider="custom_openai", model="llama3-custom")
+
+        assert len([r for r in caplog.records if r.levelname == "INFO"]) == 2
+
+    def test_the_logged_model_is_the_one_the_operator_configured(self, caplog):
+        """The line names the query, never the tail the retry derived from it."""
+        import kitty.providers.model_context as mc
+
+        with caplog.at_level(logging.INFO, logger="kitty.providers.model_context"):
+            mc.get_model_context_tokens(provider="azure", model="azure/unknown-deployment")
+
+        message = caplog.records[0].getMessage()
+        assert "azure/unknown-deployment" in message

--- a/tests/test_model_context.py
+++ b/tests/test_model_context.py
@@ -764,7 +764,7 @@ class TestPrefixedQueryTailRetry:
     def test_empty_head_still_resolves(self):
         """R4: a leading separator leaves a usable tail and must not raise.
 
-        ``"".partition("/")`` yields an empty head and a full tail, so this is
+        ``"/gpt-4o".partition("/")`` yields an empty head and a full tail, so this is
         the other half of the guard from ``test_empty_tail_returns_default``.
         """
         from kitty.providers.model_context import get_model_context_tokens

--- a/tests/test_model_context_packaged_catalog.py
+++ b/tests/test_model_context_packaged_catalog.py
@@ -137,3 +137,129 @@ class TestPackagedCatalogPriority:
 
         result = get_model_context_tokens("openai", "totally-unknown-model-xyz", None)
         assert result == DEFAULT_CONTEXT_TOKENS
+
+
+def _metadata_window(catalog_id: str) -> int:
+    """Return the packaged metadata table's context length for an exact id.
+
+    Expectations are read from the catalog rather than hardcoded: the table is
+    regenerated from OpenRouter, so a pinned literal would turn a routine
+    refresh into a failure that reads as "the KBR-151 fix broke".
+
+    Args:
+        catalog_id: An exact, lowercase id in ``model_metadata.json``.
+
+    Returns:
+        The context length in tokens.
+    """
+    import json
+
+    from kitty.providers.model_context import _METADATA_PATH
+
+    models = json.loads(_METADATA_PATH.read_text(encoding="utf-8"))
+    return next(m["context_length"] for m in models if m["id"].lower() == catalog_id)
+
+
+class TestProviderPrefixedProfileModels:
+    """KBR-151: a profile model carrying a provider prefix resolves normally.
+
+    ``OpenCodeGoAdapter`` and ``AzureOpenAIAdapter`` both define
+    ``normalize_model_name`` precisely because users write their models that
+    way, and OpenCode Go's own documentation names its models with the prefix.
+    Before the fix these fell through to ``DEFAULT_CONTEXT_TOKENS``: on Azure
+    that is 200,000 assumed against 128,000 real, so the bridge does not
+    compact when it should and the upstream rejects the oversized request.
+    """
+
+    @pytest.mark.parametrize(
+        ("provider", "prefixed", "bare"),
+        [
+            ("opencode_go", "opencode/minimax-m2.5", "minimax-m2.5"),
+            ("opencode_go", "opencode/glm-5", "glm-5"),
+            ("azure", "azure/gpt-4o", "gpt-4o"),
+            ("azure", "Azure/GPT-4o", "gpt-4o"),
+        ],
+    )
+    def test_prefixed_and_bare_resolve_alike(self, provider, prefixed, bare):
+        from kitty.providers.model_context import DEFAULT_CONTEXT_TOKENS, get_model_context_tokens
+
+        resolved = get_model_context_tokens(provider, prefixed, None)
+        assert resolved == get_model_context_tokens(provider, bare, None)
+        # Equality alone would pass with both sides sitting on the default,
+        # which is the bug. The point is that a real window was found.
+        assert resolved != DEFAULT_CONTEXT_TOKENS
+
+    def test_balancing_minimum_sees_the_real_azure_window(self):
+        """The pool's budget is its smallest member's, prefix or not.
+
+        ``get_balancing_min_context_tokens`` takes a ``min()``, so a member
+        that silently resolved the 200,000 default hid the Azure member's real
+        128,000 and let the whole pool over-send.
+        """
+        from kitty.providers.model_context import get_balancing_min_context_tokens
+
+        backends = [
+            ("azure", "azure/gpt-4o", None),
+            ("opencode_go", "opencode/minimax-m2.5", None),
+        ]
+        assert get_balancing_min_context_tokens(backends) == _metadata_window("openai/gpt-4o")
+
+
+class TestNormalizeModelNameIsNotTheRightTransform:
+    """KBR-151 rejected routing this lookup through ``normalize_model_name``.
+
+    That method translates a model name into the **provider's** dialect; the
+    catalogs are keyed in OpenRouter's. Measured over all 23 providers, doing
+    so would have fixed 5,336 lookups and broken 754 — 395 on ``anthropic``,
+    whose ``normalize_model_name`` replaces dots with hyphens, and 359 on
+    ``vertex``, whose version prepends ``google/``.
+
+    These two tests pin the windows that change would have destroyed, so it
+    cannot be reintroduced silently.
+    """
+
+    def test_dotted_anthropic_model_keeps_its_window(self):
+        """``claude-sonnet-4-5`` is absent from the catalog; the dotted id is not."""
+        from kitty.providers.model_context import DEFAULT_CONTEXT_TOKENS, get_model_context_tokens
+
+        resolved = get_model_context_tokens("anthropic", "claude-sonnet-4.5", None)
+        assert resolved == _metadata_window("anthropic/claude-sonnet-4.5")
+        assert resolved != DEFAULT_CONTEXT_TOKENS
+
+    def test_bare_vertex_model_keeps_its_window(self):
+        """Prepending ``google/`` would miss the exact id and the suffix rule."""
+        from kitty.providers.model_context import DEFAULT_CONTEXT_TOKENS, get_model_context_tokens
+
+        resolved = get_model_context_tokens("vertex", "gemini-2.5-pro", None)
+        assert resolved == _metadata_window("google/gemini-2.5-pro")
+        assert resolved != DEFAULT_CONTEXT_TOKENS
+
+
+class TestCatalogTailsAreUnique:
+    """Tail-uniqueness is what makes the KBR-151 matcher unambiguous.
+
+    Two keys sharing a final segment both match one query, so every lookup for
+    that name would go ambiguous and fall to the default. The metadata table is
+    regenerated from OpenRouter, so a collision would arrive through a data
+    refresh with nothing else red.
+    """
+
+    def test_no_two_metadata_ids_share_a_final_segment(self):
+        import json
+
+        from kitty.providers.model_context import _METADATA_PATH, _colliding_keys
+
+        models = json.loads(_METADATA_PATH.read_text(encoding="utf-8"))
+        ids = [m["id"].lower() for m in models if isinstance(m, dict) and "id" in m]
+        assert _colliding_keys(ids) == [], (
+            "two catalog ids share a final segment; every lookup for that model name "
+            "will now resolve DEFAULT_CONTEXT_TOKENS"
+        )
+
+    def test_no_two_override_keys_share_a_final_segment(self):
+        import json
+
+        from kitty.providers.model_context import _OVERRIDES_PATH, _colliding_keys
+
+        keys = [k.lower() for k in json.loads(_OVERRIDES_PATH.read_text(encoding="utf-8"))]
+        assert _colliding_keys(keys) == []


### PR DESCRIPTION
Fixes [KBR-151](https://shelpuk.atlassian.net/browse/KBR-151).

## Context for the Product Owner

Kitty keeps a conversation inside the model's context window by compacting it — dropping older turns when the conversation grows past what the model can hold. To do that it has to know how large that window is, which it looks up by model name.

**The bug:** if a user writes their model with a provider prefix — `azure/gpt-4o` rather than `gpt-4o` — the lookup missed and kitty fell back to a generic 200,000-token assumption. On Azure the real figure is 128,000. Kitty believed it had **56% more room than it had**, so it did not compact when it should have, sent an oversized request, and the provider rejected it. That shows up to the user as a failed or degraded turn on exactly the long conversations compaction exists to rescue.

The other direction is milder but still costly: `opencode/minimax-m2.5` resolved 200,000 against a real 204,800, so kitty compacted earlier than needed and discarded conversation the model could have held.

Prefixed model names are not exotic. Two adapters exist specifically because users write them that way, and OpenCode Go's own documentation names its models with the prefix.

**After this change:** a model resolves the same window however it is written. Measured across every model in the catalog and all 23 providers — **9,130 lookups fixed, none broken**.

**One thing this does not change, deliberately.** A related question surfaced — a catalog synced from the network can silently overrule a context limit the user set by hand — and it is filed as [KBR-170](https://shelpuk.atlassian.net/browse/KBR-170) rather than answered here. It is a question about whose setting wins, not about model names, and it deserves a decision rather than a side effect. Today's behaviour is pinned by a test so it cannot drift while that decision is pending.

## What was wrong, technically

The window comes from two catalogs: the overrides file (packaged, or a revision synced from GitHub at runtime) and the OpenRouter-derived `model_metadata.json`. Each was searched by a **different half-rule, running in the opposite direction**. Between them they covered two of the four ways a query and a key can be spelled:

| Query | Key | Overrides | Metadata |
|---|---|---|---|
| bare | bare | ✅ exact | — |
| prefixed | bare | ✅ suffix | — |
| bare | prefixed | ❌ **miss** | ✅ suffix |
| prefixed, *different* prefix | prefixed | ❌ miss | ❌ **miss** |

Row 4 is the reported bug. Row 3 was a second, unreported one: an overrides catalog carrying a prefixed key was silently out-ranked by the very metadata table it exists to overrule.

## The fix

Both catalogs now share **one matcher**: exact → query-as-suffix-of-key → key-as-suffix-of-query → one retry with the leading vendor segment removed. Each catalog keeps the reach it had and gains the other's.

Measured over 10,637 spellings of every catalog entry across all 23 providers: **unchanged 1,507 · fixed 9,130 · broken 0 · changed 0.**

### Not via `normalize_model_name`, which the ticket proposed

That method translates a model name into the **provider's** dialect; the catalogs are keyed in **OpenRouter's**. Measured, routing the lookup through it would fix 5,336 lookups and **break 754**:

| Provider | fixed | broken |
|---|---:|---:|
| anthropic | 202 | **395** — its `normalize_model_name` replaces dots with hyphens, while the catalog ids carry the dots |
| vertex | 0 | **359** — its version *prepends* `google/`, which then misses both rules |

`anthropic` + `claude-sonnet-4.5` resolves 1,000,000 today and would have resolved 200,000 — an 80% under-estimate, five times the harm this ticket reports, in the opposite direction. Two tests pin those values so the rejected approach cannot be reintroduced silently.

There is also a structural reason: `_get_max_context_chars` reads the raw profile model, and normalizing there would stand a second, differently-normalized model string beside `cc_request["model"]`, which KBR-127 made the single source of truth for routing. **`server.py` and `cli/launcher.py` are untouched.**

### The invariant underneath

The matcher is unambiguous only while **no two keys in a catalog end in the same segment**. Verified exhaustively. The looser "unique after the first separator" reading leaves **640** ambiguous combinations, and coincides with the correct rule only while every key has at most two segments — true of both catalogs today, which is how a guard written the loose way would look correct and quietly stop protecting the moment a three-segment id appeared.

The two catalogs are guarded differently **because they change through different doors**: `model_metadata.json` moves by pull request, so a test suffices; the overrides catalog can be replaced from the network with no release and no review, so a colliding revision is **rejected at load**.

Ambiguity is also now terminal — a catalog that cannot identify the entry declines rather than retrying a shorter string and returning a number it has just called ambiguous.

### Observability

A fall-through to the default is logged at `INFO`, once per `(provider, model)`. The budget is recomputed on every request, so an unconditional line would be one per turn — and that silence is what kept this defect invisible.

## Testing

| Layer | File | Covers |
|---|---|---|
| L1 | `tests/test_model_context.py` | the matcher, against synthetic catalogs: prefix retry, case folding, precedence, ambiguity terminality, multi-segment collisions, the synced-revision guard, the fallback log |
| L2 | `tests/test_model_context_packaged_catalog.py` | the real shipped catalog: the ticket's six rows, the balancing minimum, the two anti-regression pins, final-segment uniqueness |
| L1 | `tests/bridge/test_compaction.py` | `_get_max_context_chars` on **both** branches — single backend and balancing pool |

Every new test was watched failing against the unfixed module before being made to pass. L2 expectations are read from the catalog rather than hardcoded, so a routine OpenRouter refresh does not read as "this fix broke".

Local gate: `ruff`, `lint-imports`, `mypy` clean; `pytest -m "l1 or l2"` **4,237 passed, 2 skipped**.

## Review history

The spec went through two `system-design-reviewer` passes before any code was written. The first found that the original fix widened a precedence hole; the second found the repair still reachable through ambiguity, and that one of my figures was wrong. Both are fixed here. A third pass by `code-reviewer` was cut short by a rate limit, but its two partial probes were chased down and both were real — the final-segment rule above is one of them, and a missing test for per-provider log deduplication was the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JkxLUaQYgWJq9qVeGZSz7x


[KBR-151]: https://shelpuk.atlassian.net/browse/KBR-151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KBR-170]: https://shelpuk.atlassian.net/browse/KBR-170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ