### PR TITLE
KBR-145: stop reporting a spent provider balance as a broken workflow

### DIFF
--- a/.github/review/README.md
+++ b/.github/review/README.md
@@ -205,7 +205,7 @@ step 2 above.
 ## Changing the review system
 
 `.github/workflows/ci.yml` runs `tests/test_review_scripts.py` on every pull
-request — 620 tests over the selector, the classifier, the notices, the redactor,
+request — 642 tests over the selector, the classifier, the notices, the redactor,
 the schema and the workflow's own wiring, plus the workflow parser, the
 runner-ceiling table and the `ci-required` aggregation. Run them locally the same
 way:

--- a/.github/review/scripts/interpret_claude_result.py
+++ b/.github/review/scripts/interpret_claude_result.py
@@ -185,13 +185,47 @@ CREDENTIAL_PATTERNS = (
 # same way, so re-running is pure waste. Both failures seen on the first live
 # run land here -- the apostrophes that truncated --json-schema, and the
 # unresolvable $schema reference.
+#
+# ⚠️ **This set is checked BEFORE `QUOTA_PATTERNS`, and that is still deliberate:
+# a rejected schema can coexist with other noise in the record.** `\b400\b` stays
+# here for a measured reason rather than a tidy one -- the context-management
+# refusal is a 400 whose body says "No quota was consumed for this request", so
+# demoting it below quota reports a genuine workflow fault as a spent balance.
+# `_write_diagnostic` already encodes that precedence, with its
+# CONTEXT_MANAGEMENT_REFUSAL branch above its quota branch.
+#
+# 🔴 **KBR-145 moved `invalid[_ ]request` OUT of this set**, to
+# `FATAL_UNLESS_PROVIDER_NAMED_PATTERNS` below. DeepSeek reports a spent balance
+# as a 402 carrying OpenAI's generic `"code":"invalid_request_error"`, so this
+# entry matched first and an operator was sent to debug a correct workflow --
+# observed live on PR #54, run 34622141943. It is the only entry that named a
+# generic error CODE rather than a specific failure, which is why it is the only
+# one that moved.
 FATAL_PATTERNS = (
     r"is not valid json",
     r"is not a valid json schema",
-    r"invalid[_ ]request",
     r"\b400\b",
     r"unterminated string",
 )
+
+# Fatal ONLY when no provider-named cause was found first. Consulted after
+# `QUOTA_PATTERNS` and `CREDENTIAL_PATTERNS`, and before `EXHAUSTED_PATTERNS`.
+#
+# ⚠️ **Named for the fact, not for a principle, because no clean principle
+# survives measurement.** "Generic loses to everything more specific" reads well
+# and is wrong: `EXHAUSTED_PATTERNS` contains the bare words `\btimeout\b` and
+# `\bcapacity\b`, which a model can write in its own prose, and `_outcome_text`
+# includes `result`. Yielding to those would let a $1.79 billed rejection be
+# called `exhausted` -- and `retry_verdict` then spends the $1.79 again.
+#
+# ⚠️ **The accepted exposure, stated so it cannot read as an oversight.** This
+# tier DOES yield to `quota`, `\bbilling\b`, `\b401\b` and `\b403\b`, all of
+# which are unanchored and can appear in prose. KBR-145 took that trade
+# knowingly: it fixes the two misclassifications anyone has observed -- the live
+# 402 and a 401 reported with this same generic code, which `map_error` fixtures
+# show OpenAI and Fireworks both do -- at the cost of four prose shapes nobody
+# has observed. Anchoring those four patterns is KBR-166.
+FATAL_UNLESS_PROVIDER_NAMED_PATTERNS = (r"invalid[_ ]request",)
 
 # upstream. Anchored on the beta's own dated slug, or on the refusal's distinctive
 # phrasing, and NOT on the bare words "context management".
@@ -665,7 +699,14 @@ def classify(
     haystack = (execution_text if scoped is None else scoped).lower()
 
     # Fatal first: a rejected schema can coexist with other noise in the record,
-    # and spending the remaining providers on it is pure waste.
+    # and spending the remaining providers on it is pure waste. That reasoning is
+    # unchanged for everything still in this set.
+    #
+    # 🔴 KBR-145 removed ONE entry from it. `invalid[_ ]request` named a generic
+    # error code rather than a specific failure, and DeepSeek uses that code for a
+    # spent balance, so "fatal first" reported a billing state as a broken
+    # workflow. It now lives in `FATAL_UNLESS_PROVIDER_NAMED_PATTERNS`, consulted
+    # below once quota and credentials have had their turn.
     hit = _first_match(FATAL_PATTERNS, haystack)
     if hit:
         return "fatal", f"workflow-level failure: {hit!r}"
@@ -677,6 +718,15 @@ def classify(
     hit = _first_match(CREDENTIAL_PATTERNS, haystack)
     if hit:
         return "exhausted", f"provider rejected the credentials or model: {hit!r}"
+
+    # 🔴 KBR-145. A generic error CODE is fatal only once the two sets that name a
+    # provider-side cause have had their turn. Both of those bill nothing, so the
+    # retry this verdict unlocks costs runner minutes rather than model spend --
+    # which is why the tier stops here and does not also yield to the transient set
+    # below, whose weakest members are ordinary English words.
+    hit = _first_match(FATAL_UNLESS_PROVIDER_NAMED_PATTERNS, haystack)
+    if hit:
+        return "fatal", f"workflow-level failure: {hit!r}"
 
     hit = _first_match(EXHAUSTED_PATTERNS, haystack)
     if hit:
@@ -1235,11 +1285,18 @@ def _write_diagnostic(
         # the failure an operator hits most often printed no guidance at all.
         reset = re.search(r"limit will reset at ([^\]\"]+)", evidence, re.I)
         lines += [
+            # 🔴 KBR-145: named OpenRouter until this ticket, and by then the
+            # profile had pointed at DeepSeek since 2026-07-28. The sentence was
+            # tolerable while this branch was reached rarely; fixing the
+            # classifier makes it the text an operator reads on the MOST common
+            # failure, so a wrong provider name here is a wrong instruction at
+            # the worst moment. Neutral wording cannot rot the same way: the
+            # profile is what selects a provider, and this module cannot see it.
             "The provider could not serve the request because its quota or "
-            "balance is spent. OpenRouter, the gateway the current kitty "
-            "profile points at, bills from a prepaid credit "
-            "balance and has no overage billing, so calls fail until it is "
-            "topped up." + (f" Resets at {reset.group(1).strip()}." if reset else ""),
+            "balance is spent. The gateway the active kitty profile points at "
+            "bills from a prepaid balance with no overage, so calls fail until "
+            "it is topped up."
+            + (f" Resets at {reset.group(1).strip()}." if reset else ""),
             "",
             "Nothing is wrong with this pull request, but the review did not "
             "run, so this check fails. Top up the balance and re-run.",

--- a/.github/review/scripts/interpret_claude_result.py
+++ b/.github/review/scripts/interpret_claude_result.py
@@ -510,7 +510,15 @@ def _extract_structured_output(raw_output: str, execution_text: str) -> dict | N
 #: patterns are searched. Reviewing a change under `.github/review/scripts/` therefore fed this
 #: module's own source into its own matcher: `interpret_claude_result.py` contains the literals
 #: ``\b400\b``, ``quota``, ``insufficient balance`` and ``billing``, and one read of it matches
-#: **nine** of :data:`QUOTA_PATTERNS` and three of :data:`FATAL_PATTERNS`.
+#: **most of** :data:`QUOTA_PATTERNS` and **every** fatal pattern in the file.
+#:
+#: ⚠️ **Stated as a shape rather than as figures, because the figures rotted.** This line
+#: quoted "nine of QUOTA_PATTERNS and three of FATAL_PATTERNS"; re-derived by running the
+#: match, the first was already wrong (ten of eleven) and the second was broken by KBR-145
+#: itself — splitting the fatal set and documenting the split introduced the literal
+#: ``invalid_request_error`` into this file, so that pattern began self-matching where its
+#: own bare regex text never had. The argument never rested on the counts, only on this
+#: module matching a great many of its own patterns, and nothing checked the numbers.
 #:
 #: Measured on PR #237: a genuine transient ``server_error`` — whose correct verdict is
 #: ``exhausted`` and whose correct advice is "re-run" — was reported as ``fatal``, *"re-running
@@ -720,10 +728,16 @@ def classify(
         return "exhausted", f"provider rejected the credentials or model: {hit!r}"
 
     # 🔴 KBR-145. A generic error CODE is fatal only once the two sets that name a
-    # provider-side cause have had their turn. Both of those bill nothing, so the
-    # retry this verdict unlocks costs runner minutes rather than model spend --
-    # which is why the tier stops here and does not also yield to the transient set
-    # below, whose weakest members are ordinary English words.
+    # provider-side cause have had their turn: DeepSeek reports a spent balance with
+    # OpenAI's generic code, so checking it first called a billing state a broken
+    # workflow. Reaching this branch returns `fatal`, which retries NOTHING -- the
+    # retry is what the two sets above unlock by matching instead.
+    #
+    # The tier stops HERE and does not also yield to the transient set below, whose
+    # weakest members (`\btimeout\b`, `\bcapacity\b`) a model can write in its own
+    # prose: that would call a $1.79 billed rejection `exhausted` and spend it again.
+    # The symmetric exposure from quota's own weak members is real and is stated
+    # beside the tuple rather than denied here.
     hit = _first_match(FATAL_UNLESS_PROVIDER_NAMED_PATTERNS, haystack)
     if hit:
         return "fatal", f"workflow-level failure: {hit!r}"

--- a/.github/review/tests/test_review_scripts.py
+++ b/.github/review/tests/test_review_scripts.py
@@ -550,7 +550,52 @@ CODING_PLAN_WEEKLY_QUOTA = (
 # It differs in the way that matters: it carries no reset time, because a
 # topped-up balance has no schedule. Anything that lifts a reset time into a
 # message must therefore stay optional.
-DEEPSEEK_NO_BALANCE = 'API Error: 402 {"error":{"message":"Insufficient Balance"}}'
+#
+# 🔴 **VERBATIM from run 34622141943 (PR #54), and the abridgement it replaces is
+# what KBR-145 was filed about.** This fixture used to be the first line below,
+# `DEEPSEEK_NO_BALANCE_ABRIDGED` -- real, but SHORTENED, and the part removed was
+# the part that changes the answer. DeepSeek reports a purely financial condition
+# with OpenAI's generic `"code":"invalid_request_error"`, which `FATAL_PATTERNS`
+# matched before `QUOTA_PATTERNS` was ever consulted, so a spent balance was
+# reported as a broken workflow. Confirmed against DeepSeek's own error-code
+# documentation and an independent third-party report of the same body.
+#
+# The module header requires every provider error string to be "copied verbatim
+# from a real workflow run, not invented". An ABRIDGED real string satisfies that
+# rule to the letter and defeats its purpose; that is the whole lesson here.
+DEEPSEEK_NO_BALANCE = (
+    'API Error: 402 {"error":{"message":"Insufficient Balance",'
+    '"type":"unknown_error","param":null,"code":"invalid_request_error"}}'
+)
+
+#: The abridged form, kept as a NAMED CONTROL rather than deleted.
+#:
+#: Its only job is to prove the two forms classify the same way. Deleting it would
+#: lose the evidence that they once did not, and a future edit could quietly
+#: re-abridge the fixture above with nothing to notice.
+DEEPSEEK_NO_BALANCE_ABRIDGED = (
+    'API Error: 402 {"error":{"message":"Insufficient Balance"}}'
+)
+
+#: The one refusal this configuration is documented to be able to hit, lifted to a
+#: module constant by KBR-145 so that `classify` and `_write_diagnostic` are judged
+#: against the SAME string. Two copies could drift, and the drift would hide exactly
+#: the regression the demotion risks.
+#:
+#: 🔴 **It carries a billing word on purpose** -- "No quota was consumed" matches
+#: `QUOTA_PATTERNS`' bare `quota`. That is what makes `\b400\b` staying in tier 1
+#: load-bearing rather than incidental: demote it below quota and this genuine
+#: workflow fault is reported as a spent balance.
+CONTEXT_MANAGEMENT_400_REFUSAL = (
+    "API Error: 400 No endpoints available that support Anthropic's "
+    "context management features (context-management-2025-06-27). "
+    "Context management requires a supported provider (Anthropic). "
+    "No quota was consumed for this request."
+)
+
+#: OpenRouter's wording for the same condition, lifted out of the two tests that
+#: inlined it so :data:`QUOTA_FIXTURES` can cover `insufficient credits`.
+OPENROUTER_NO_CREDITS = 'API Error: 402 {"error":{"message":"Insufficient credits"}}'
 # Observed: apostrophes in the schema truncated the shell argument.
 SCHEMA_UNTERMINATED = (
     "Error: --json-schema is not valid JSON: JSON Parse error: Unterminated string"
@@ -1888,8 +1933,15 @@ class TestClassify(unittest.TestCase):
         any file the reviewer opened landed in the haystack. Reviewing a change under
         `.github/review/scripts/` fed this module's own source into its own matcher: it
         contains the literals ``\\b400\\b``, ``quota``, ``insufficient balance`` and
-        ``billing``, and one read of it matches nine `QUOTA_PATTERNS` and three
-        `FATAL_PATTERNS`.
+        ``billing``, and one read of it matches most of `QUOTA_PATTERNS` and most of the
+        fatal vocabulary.
+
+        ⚠️ **Counted as a shape, not as a figure.** This sentence quoted "nine
+        `QUOTA_PATTERNS` and three `FATAL_PATTERNS`" until KBR-145 split the fatal set
+        in two and moved an entry between them, at which point the second number was
+        wrong and nothing checked it. The argument never depended on the exact counts --
+        it depends on this file matching a great many of its own patterns -- so the
+        durable form states that and the assertion below measures the rest.
 
         The consequence was not a vague mislabel. A transient `server_error` — whose correct
         verdict is `exhausted` and whose correct advice is "re-run" — was reported as `fatal`,
@@ -1998,9 +2050,16 @@ class TestClassify(unittest.TestCase):
         string values would classify a real provider failure as "no recognisable error" —
         scoping the haystack must not become ignoring it.
 
-        ⚠️ The error `type` here is deliberately not `invalid_request_error`: that string
-        matches `FATAL_PATTERNS`, which is checked first, so such a fixture would pass for
-        the wrong reason and prove nothing about reading nested values.
+        ⚠️ The error `type` here is deliberately not one that an EARLIER tier matches,
+        so the verdict below can only have come from reading the nested value. Any tier
+        consulted before quota would decide this record without the nested read ever
+        mattering, and the test would pass proving nothing.
+
+        🔴 **That constraint used to name `invalid_request_error` specifically**, because
+        it sat in `FATAL_PATTERNS` and was checked first. KBR-145 moved it to
+        `FATAL_UNLESS_PROVIDER_NAMED_PATTERNS`, which is consulted AFTER quota, so the
+        old sentence now describes a precedence the module no longer has. The rule it was
+        an instance of is the durable form and is what stands above.
         """
 
         record = json.dumps(
@@ -2023,7 +2082,13 @@ class TestClassify(unittest.TestCase):
         """Scoping too tightly would classify every failure as 'no recognisable error'."""
 
         record = json.dumps(
-            [{"type": "result", "result": DEEPSEEK_NO_BALANCE, "is_error": True}]
+            [
+                {
+                    "type": "result",
+                    "result": DEEPSEEK_NO_BALANCE_ABRIDGED,
+                    "is_error": True,
+                }
+            ]
         )
         status, reason = interpret.classify(record)
         self.assertEqual(status, "exhausted")
@@ -2198,12 +2263,7 @@ class TestClassify(unittest.TestCase):
         load-bearing rather than incidental.
         """
 
-        refusal = (
-            "API Error: 400 No endpoints available that support Anthropic's "
-            "context management features (context-management-2025-06-27). "
-            "Context management requires a supported provider (Anthropic). "
-            "No quota was consumed for this request."
-        )
+        refusal = CONTEXT_MANAGEMENT_400_REFUSAL
         with tempfile.TemporaryDirectory() as tmp:
             path = Path(tmp) / "diagnostic.txt"
             interpret._write_diagnostic(
@@ -15987,6 +16047,601 @@ class NoDocumentAttributesTheCatalogueRefreshToTheGateTests(unittest.TestCase):
         self.assertNotIn("update-metadata:", gate)
         self.assertNotIn("cron:", gate)
 
+
+# ---------------------------------------------------------------------------
+# KBR-145 -- a spent balance is not a workflow fault
+# ---------------------------------------------------------------------------
+
+#: Every record whose correct verdict is reached through `QUOTA_PATTERNS`.
+#:
+#: Named as a set so the classifier/diagnostic agreement below is asserted over all
+#: of them at once, and so :meth:`QuotaVocabularyTests.test_every_quota_pattern_is_exercised`
+#: can hold the set accountable to the patterns rather than the other way round.
+QUOTA_FIXTURES = (
+    ("CODING_PLAN_5H_QUOTA", CODING_PLAN_5H_QUOTA),
+    ("CODING_PLAN_WEEKLY_QUOTA", CODING_PLAN_WEEKLY_QUOTA),
+    ("DEEPSEEK_NO_BALANCE", DEEPSEEK_NO_BALANCE),
+    ("DEEPSEEK_NO_BALANCE_ABRIDGED", DEEPSEEK_NO_BALANCE_ABRIDGED),
+    ("OPENROUTER_NO_CREDITS", OPENROUTER_NO_CREDITS),
+)
+
+#: Quota patterns that no fixture above matches, each with the reason it is exempt.
+#:
+#: 🔴 **This tuple may only ever get SHORTER, and the length is frozen below to make
+#: that visible.** Fabricating a payload for any of these would violate the rule that
+#: every provider error string is copied verbatim from a real run -- and for the two
+#: KBR-166 entries it would cement in a test the very patterns that ticket exists to
+#: delete. The frozen length is a REVIEW TRIGGER, not an enforcement: a future author
+#: can still edit the number, but not without editing a line that says not to.
+QUOTA_PATTERNS_WITHOUT_FIXTURES = {
+    # Inherited-unobservable. May legitimately never earn a fixture.
+    r"\b1113\b": "inherited numeric code; no record on this endpoint carries it",
+    r"exceeded your current": "inherited wording; never observed in this repository",
+    # Unanchored-harmful. KBR-166's subject; these must disappear, not gain fixtures.
+    r"quota": "unanchored word -- KBR-166 anchors or deletes it",
+    r"\bbilling\b": "unanchored word -- KBR-166 anchors or deletes it",
+}
+
+#: A billed `invalid_request` whose prose matches ONLY `EXHAUSTED_PATTERNS`.
+#:
+#: ⚠️ **SYNTHETIC, and the verbatim-fixture rule is suspended for it deliberately.**
+#: No such record has been observed. It is admissible because it tests an ORDERING
+#: between two pattern tiers rather than a provider's wording -- it invents no
+#: provider vocabulary, only a prose word the model itself could write. It is the
+#: only row separating the chosen tier position from placing the tier last, and
+#: :meth:`TierPositionTests.test_the_generic_tier_is_consulted_before_transients`
+#: asserts its four discriminating properties before trusting its verdict.
+BILLED_INVALID_REQUEST_WITH_TRANSIENT_PROSE = json.dumps(
+    [
+        {
+            "type": "result",
+            "subtype": "error",
+            "error": {
+                "type": "invalid_request_error",
+                "message": "the request was rejected after a tool timeout",
+            },
+        }
+    ]
+)
+
+#: A rejected key reported with the CLI's generic error code.
+#:
+#: Observed vocabulary, not invented: `OpenAIAdapter.map_error` and
+#: `FireworksAdapter.map_error` are both fixtured against exactly this shape in
+#: `tests/test_provider_openai.py` and `tests/test_provider_fireworks.py`, and
+#: `map_error` maps a PROVIDER's response. So an OpenAI-compatible endpoint reports a
+#: dead key with the same generic code DeepSeek uses for a spent balance.
+CREDENTIAL_401_WITH_GENERIC_CODE = (
+    'API Error: 401 {"error":{"message":"invalid api key",'
+    '"type":"invalid_request_error"}}'
+)
+
+
+class QuotaVocabularyTests(unittest.TestCase):
+    """KBR-145. The quota fixtures must be accountable to the quota patterns.
+
+    A fixture list that nothing holds to account drifts silently: a pattern added to
+    `QUOTA_PATTERNS` with no fixture behind it is a classification nobody tests, and
+    the defect this ticket fixes was exactly an untested classification.
+    """
+
+    def test_every_quota_pattern_is_exercised_or_declared_exempt(self):
+        """Every quota pattern is covered by a fixture, or exempt with a reason.
+
+        🔴 **The bare form of this -- "every pattern has a fixture" -- is RED on
+        `main`**, and measuring it before writing it is what caught that. Four
+        patterns have no fixture, and fabricating payloads for them would invent
+        provider vocabulary this file forbids. So they are declared instead.
+        """
+
+        for pattern in interpret.QUOTA_PATTERNS:
+            with self.subTest(pattern=pattern):
+                covered = [
+                    name
+                    for name, text in QUOTA_FIXTURES
+                    if re.search(pattern, text.lower())
+                ]
+                self.assertTrue(
+                    covered or pattern in QUOTA_PATTERNS_WITHOUT_FIXTURES,
+                    f"{pattern!r} is matched by no fixture and is not declared "
+                    "exempt -- add a verbatim fixture, or declare it with a reason",
+                )
+
+    def test_no_exemption_is_stale(self):
+        """An exempt pattern that a fixture now matches must lose its exemption.
+
+        This is the half that makes the tuple shrink rather than merely permit
+        growth: as KBR-166 anchors `quota` and `\\bbilling\\b`, or as a real payload
+        arrives for an inherited code, the exemption goes red and must be removed.
+        """
+
+        for pattern in QUOTA_PATTERNS_WITHOUT_FIXTURES:
+            with self.subTest(pattern=pattern):
+                matching = [
+                    name
+                    for name, text in QUOTA_FIXTURES
+                    if re.search(pattern, text.lower())
+                ]
+                self.assertEqual(
+                    matching,
+                    [],
+                    f"{pattern!r} is declared exempt but {matching} now matches it "
+                    "-- delete the exemption",
+                )
+
+    def test_no_exemption_names_a_retired_pattern(self):
+        """Deleting a quota pattern must not leave a phantom exemption behind."""
+
+        for pattern in QUOTA_PATTERNS_WITHOUT_FIXTURES:
+            with self.subTest(pattern=pattern):
+                self.assertIn(
+                    pattern,
+                    interpret.QUOTA_PATTERNS,
+                    f"{pattern!r} is declared exempt but is no longer a quota "
+                    "pattern -- delete the exemption",
+                )
+
+    def test_the_exemption_list_only_ever_shrinks(self):
+        """Freeze the count so growing it is a deliberate, reviewed act.
+
+        ⚠️ Honestly a **review trigger, not an enforcement**. A future author can
+        edit this number; the point is that they cannot do it without editing a line
+        whose message tells them the number may only go down, and why.
+        """
+
+        self.assertLessEqual(
+            len(QUOTA_PATTERNS_WITHOUT_FIXTURES),
+            4,
+            "this list may only shrink -- KBR-166 removes `quota` and `\\bbilling\\b`; "
+            "a NEW quota pattern needs a verbatim fixture, not an exemption",
+        )
+
+def _quota_diagnostic(execution_text, status, reason):
+    """Render a diagnostic for one attempt and report whether it advises a top-up.
+
+    Args:
+        execution_text: The execution record to classify and embed.
+        status: The verdict to write into the diagnostic header.
+        reason: The reason line to write beneath it.
+
+    Returns:
+        True when the rendered diagnostic carries the top-up paragraph.
+    """
+
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "diagnostic.txt"
+        interpret._write_diagnostic(
+            str(path),
+            tier="kitty-bridge",
+            status=status,
+            reason=reason,
+            retryable=False,
+            record_present=True,
+            execution_text=execution_text,
+        )
+        return "Top up the balance" in path.read_text(encoding="utf-8")
+
+
+class SpentBalanceIsNotAWorkflowFaultTests(unittest.TestCase):
+    """KBR-145. A spent provider balance must not be reported as a broken workflow.
+
+    Observed live on PR #54, run ``34622141943``: DeepSeek reports a spent prepaid
+    balance as HTTP 402 whose body carries OpenAI's generic
+    ``"code":"invalid_request_error"``. That matched ``FATAL_PATTERNS``, which
+    :func:`interpret_claude_result.classify` consulted before ``QUOTA_PATTERNS``, so
+    the operator was sent to debug a workflow that was correct.
+    """
+
+    def test_the_observed_payload_is_a_spent_balance(self):
+        """The live payload from run 34622141943 classifies as exhausted.
+
+        Asserted on the literal ``insufficient balance`` rather than on the word
+        "balance", which the fixture itself contains and which would therefore be
+        satisfied whether the quota branch fired or not.
+        """
+
+        status, reason = interpret.classify(DEEPSEEK_NO_BALANCE)
+
+        self.assertEqual(status, "exhausted")
+        self.assertIn("insufficient balance", reason.lower())
+
+    def test_the_abridged_and_verbatim_payloads_agree(self):
+        """🔴 The control this ticket turns on: the two forms must not diverge.
+
+        They differ by one JSON field, and before KBR-145 that field flipped the
+        verdict -- the abridged form was ``exhausted`` while the real one was
+        ``fatal``. Naming both forms explicitly is what stops a future edit
+        collapsing them back into one.
+        """
+
+        abridged = interpret.classify(DEEPSEEK_NO_BALANCE_ABRIDGED)
+        verbatim = interpret.classify(DEEPSEEK_NO_BALANCE)
+
+        self.assertEqual(abridged[0], "exhausted", "the abridged form")
+        self.assertEqual(verbatim[0], "exhausted", "the verbatim form")
+        self.assertEqual(abridged, verbatim, "abridging the fixture changed the verdict")
+
+    def test_the_fixture_is_the_unabridged_payload(self):
+        """Guard the fixture itself, because abridging it is the defect.
+
+        Without this, a future edit could shorten the payload back to the form that
+        hid the bug and every behavioural test above would still pass.
+        """
+
+        self.assertIn('"code":"invalid_request_error"', DEEPSEEK_NO_BALANCE)
+        self.assertNotIn(
+            '"code":"invalid_request_error"',
+            DEEPSEEK_NO_BALANCE_ABRIDGED,
+            "the control must stay abridged or it controls nothing",
+        )
+
+    def test_a_rejected_key_reported_generically_is_not_a_workflow_fault(self):
+        """A 401 carrying the generic code is the same defect one tier over.
+
+        Observed vocabulary: `map_error` maps a PROVIDER's response, and both
+        `tests/test_provider_openai.py` and `tests/test_provider_fireworks.py`
+        fixture a 401 whose ``type`` is ``invalid_request_error``.
+        """
+
+        status, reason = interpret.classify(CREDENTIAL_401_WITH_GENERIC_CODE)
+
+        self.assertEqual(status, "exhausted")
+        self.assertIn("credential", reason.lower())
+
+
+class TierPositionTests(unittest.TestCase):
+    """KBR-145. Where the demoted pattern sits, proven by behaviour not by source order.
+
+    ``invalid[_ ]request`` moves out of ``FATAL_PATTERNS`` into
+    ``FATAL_UNLESS_PROVIDER_NAMED_PATTERNS``, consulted **after** quota and
+    credentials and **before** transients. Every assertion below is a verdict rather
+    than a reading of the tuple, because a tuple can be rewritten to satisfy a
+    membership check while restoring the defect.
+    """
+
+    def test_the_demoted_pattern_no_longer_decides_a_spent_balance(self):
+        """Membership, asserted through the matcher rather than through `in`.
+
+        🔴 `assertNotIn(r"invalid[_ ]request", FATAL_PATTERNS)` would be satisfied by
+        rewriting the entry as ``r"invalid[_ ]request(_error)?"`` inside
+        ``FATAL_PATTERNS`` -- restoring the bug while the test stayed green.
+        """
+
+        haystack = DEEPSEEK_NO_BALANCE.lower()
+
+        self.assertIsNone(
+            interpret._first_match(interpret.FATAL_PATTERNS, haystack),
+            "no tier-1 pattern may match a spent balance",
+        )
+        self.assertIsNotNone(
+            interpret._first_match(
+                interpret.FATAL_UNLESS_PROVIDER_NAMED_PATTERNS, haystack
+            ),
+            "the demoted tier must still recognise the generic code",
+        )
+
+    def test_the_generic_tier_is_consulted_after_quota_and_credentials(self):
+        """A quota or credential signal outranks the generic code.
+
+        These are the two rows that move the tier past `CREDENTIAL_PATTERNS`; both
+        carry `invalid_request` AND a more specific signal, and both bill nothing, so
+        a retry costs runner minutes rather than model spend.
+        """
+
+        for label, record, expected in (
+            ("spent balance", DEEPSEEK_NO_BALANCE, "insufficient balance"),
+            ("rejected key", CREDENTIAL_401_WITH_GENERIC_CODE, "401"),
+        ):
+            with self.subTest(record=label):
+                status, reason = interpret.classify(record)
+                self.assertEqual(status, "exhausted", label)
+                self.assertIn(expected, reason.lower(), label)
+
+    def test_the_generic_tier_is_consulted_before_transients(self):
+        """A transient WORD in a billed failure's prose must not make it retryable.
+
+        🔴 **The fixture's discriminating properties are asserted before its verdict
+        is trusted.** It is synthetic, and a synthetic discriminator can stop
+        discriminating silently: change its prose from "timeout" to "quota" and the
+        decision moves to `QUOTA_PATTERNS`, at which point the row returns
+        `exhausted` under every candidate position and pins nothing -- while still
+        passing. The four checks below are what make that go red instead.
+
+        The cost this pins is real money. `retry_verdict`'s exhausted branch retries
+        a non-timed-out attempt, and the record this shape is drawn from billed
+        $1.79 across 24 turns.
+        """
+
+        scoped = interpret._outcome_text(BILLED_INVALID_REQUEST_WITH_TRANSIENT_PROSE)
+        haystack = scoped.lower()
+
+        # The fixture discriminates only while exactly one tier claims it.
+        self.assertIsNone(interpret._first_match(interpret.FATAL_PATTERNS, haystack))
+        self.assertIsNone(interpret._first_match(interpret.QUOTA_PATTERNS, haystack))
+        self.assertIsNone(
+            interpret._first_match(interpret.CREDENTIAL_PATTERNS, haystack)
+        )
+        self.assertIsNotNone(
+            interpret._first_match(interpret.EXHAUSTED_PATTERNS, haystack),
+            "the fixture has stopped exercising the transient tier",
+        )
+
+        status, _ = interpret.classify(BILLED_INVALID_REQUEST_WITH_TRANSIENT_PROSE)
+        self.assertEqual(
+            status, "fatal", "a transient word must not outrank the generic code"
+        )
+
+    def test_a_schema_rejection_still_wins_over_everything(self):
+        """Tier 1 keeps its precedence, which is the reason it is checked first."""
+
+        for label, record in (
+            ("unterminated", SCHEMA_UNTERMINATED),
+            ("bad $schema ref", SCHEMA_BAD_REF),
+            ("context-management refusal", CONTEXT_MANAGEMENT_400_REFUSAL),
+        ):
+            with self.subTest(record=label):
+                self.assertEqual(interpret.classify(record)[0], "fatal", label)
+
+    def test_a_billed_generic_rejection_is_still_fatal(self):
+        """The demotion must not reach a record with no provider signal at all.
+
+        `BILLED_INVALID_REQUEST` billed $1.79 across 24 turns and names nothing an
+        operator could top up, so calling it `exhausted` would both mislabel it and
+        spend that again.
+        """
+
+        self.assertEqual(interpret.classify(BILLED_INVALID_REQUEST)[0], "fatal")
+
+
+class VerdictAndAdviceAgreeTests(unittest.TestCase):
+    """KBR-145. The status line and the advice beneath it must not contradict.
+
+    This is the invariant whose breach IS the reported defect. On `main` the live
+    402 rendered as::
+
+        status: fatal
+        retryable: false (another attempt could not help)
+        reason: workflow-level failure: 'invalid_request'
+
+        The provider could not serve the request because its quota or balance is
+        spent... Top up the balance and re-run.
+
+    -- because `_write_diagnostic`'s quota branch reads the EVIDENCE while `classify`
+    read pattern ORDER. The operator was handed two contradictory instructions and
+    the authoritative-looking one was wrong.
+    """
+
+    def test_a_quota_verdict_and_a_top_up_paragraph_imply_each_other(self):
+        """For an ordinary quota failure, the verdict and the advice agree.
+
+        Scoped to the guards the code actually imposes: a record-present attempt with
+        no findings payload, whose evidence matches neither tier 1 nor the
+        context-management refusal. The two exclusions below are what those guards
+        are for.
+        """
+
+        for name, record in QUOTA_FIXTURES:
+            with self.subTest(fixture=name):
+                status, reason = interpret.classify(record)
+                self.assertEqual(status, "exhausted", name)
+                self.assertTrue(
+                    reason.startswith("provider quota exhausted"),
+                    f"{name}: resolved by {reason!r}, not by the quota tier",
+                )
+                self.assertTrue(
+                    _quota_diagnostic(record, status, reason),
+                    f"{name}: verdict says quota, advice does not",
+                )
+
+    def test_a_tier_one_record_carrying_a_billing_word_is_a_named_exclusion(self):
+        """🔴 Excluded, and correctly so -- both halves of it are true.
+
+        A 400 whose message mentions a billing account is a genuine workflow fault
+        AND genuinely worth showing a billing paragraph for. The invariant above does
+        not reach it, and the fix is NOT to reorder `_write_diagnostic`: the
+        context-management branch forbids that in the other direction.
+        """
+
+        record = (
+            'API Error: 400 {"error":{"message":"the billing account is not '
+            'permitted to use this model"}}'
+        )
+        status, reason = interpret.classify(record)
+
+        self.assertEqual(status, "fatal")
+        self.assertTrue(_quota_diagnostic(record, status, reason))
+
+    def test_a_context_management_refusal_is_the_mirror_exclusion(self):
+        """🔴 The other direction, one branch up, and also correct.
+
+        The refusal branch sits ABOVE the quota branch in `_write_diagnostic`, so a
+        record matching the refusal and a quota word gets refusal advice and no
+        top-up paragraph -- while `classify` may still resolve it through quota. The
+        refusal advice is the more useful of the two, so the requirement is what
+        yields here, not the code.
+        """
+
+        record = (
+            "API Error: context-management-2025-06-27 is not supported by this "
+            "endpoint. No quota was consumed for this request."
+        )
+        status, reason = interpret.classify(record)
+
+        self.assertEqual(status, "exhausted")
+        self.assertTrue(reason.startswith("provider quota exhausted"))
+        self.assertFalse(
+            _quota_diagnostic(record, status, reason),
+            "the refusal branch must win over the quota paragraph",
+        )
+
+def fail_job_annotation(result, attempts="1", diagnostic="(diagnostic body)"):
+    """Execute the real `Fail when no review was produced` step and capture its output.
+
+    🔴 **A text assertion over this step's body cannot fail, which is why this
+    executor exists.** The step is one ``if``/``else`` carrying BOTH ``::error::``
+    lines unconditionally -- `test_the_error_line_states_the_attempt_count_on_both_branches`
+    asserts exactly that, with ``len(errors) == 2``. So ``assertIn("Top up or wait",
+    _step(...))`` is satisfied by the source on every branch, before any fix and under
+    every mutant. :func:`resolve_outcome` cannot stand in either: it asserts exit 0,
+    and this step ends ``exit 1``.
+
+    Args:
+        result: The resolved outcome the step is handed, ``exhausted`` or ``fatal``.
+        attempts: How many attempts the run made, as the step receives it.
+        diagnostic: Body written to the diagnostic file the step reads.
+
+    Returns:
+        Everything the step printed to stdout, annotations included.
+    """
+
+    script = _workflow_step_script("Fail when no review was produced")
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        (root / "artifacts").mkdir()
+        (root / "artifacts" / "claude_diagnostic.txt").write_text(
+            diagnostic, encoding="utf-8"
+        )
+        env = dict(os.environ, RESULT=result, ATTEMPTS=attempts)
+        proc = subprocess.run(
+            ["bash", "-c", script],
+            cwd=root,
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+    # The step fails the job by design, so a non-zero exit is the expected path and
+    # only a missing annotation is a defect.
+    return proc.stdout
+
+
+class OperatorSurfacesAgreeTests(unittest.TestCase):
+    """KBR-145. Every surface an operator reads must name the same cause.
+
+    The workflow treats the annotation and the pull request comment as one voice --
+    its own comment says they "must not disagree". The job summary is the third.
+    All three are driven from `Resolve outcome`'s real output here, never hand-fed:
+    a hand-fed outcome tests the renderer and says nothing about the fix.
+    """
+
+    def _resolved(self):
+        """Run the observed payload through the classifier and the resolve step.
+
+        Returns:
+            A ``(interpret outputs, resolve outputs)`` pair.
+        """
+
+        record = json.dumps(
+            [
+                {
+                    "type": "result",
+                    "subtype": "success",
+                    "api_error_status": 402,
+                    "terminal_reason": "api_error",
+                    "result": DEEPSEEK_NO_BALANCE,
+                }
+            ]
+        )
+        interpreted = _interpret_outputs(record=record)
+        return interpreted, resolve_outcome(status=interpreted["status"])
+
+    def test_the_observed_payload_is_retried_rather_than_abandoned(self):
+        """KBR-145's AC4, in this repository's terms.
+
+        The ticket asks that "the fallback chain advances to the next provider".
+        There is no chain here -- the module says so -- and the equivalent is that
+        the workflow's one automatic retry runs instead of the attempt being
+        abandoned. A 402 bills nothing, so that retry costs runner minutes only.
+        """
+
+        interpreted, _ = self._resolved()
+
+        self.assertEqual(interpreted["status"], "exhausted")
+        self.assertEqual(interpreted["retryable"], "true")
+
+    def test_the_pull_request_notice_names_the_balance(self):
+        """Asserted on a string only `build`'s exhausted branch can produce.
+
+        🔴 NOT on "top up": that phrase reaches the notice through
+        `embed_diagnostic` from the diagnostic's own quota paragraph, so it is
+        present under `outcome="fatal"` too and would pass whether the fix worked or
+        not.
+        """
+
+        _, resolved = self._resolved()
+        notice = build_failure_notice.build(
+            resolved["result"], ["Kitty Bridge (attempt 1)"], "(diagnostic body)"
+        )
+
+        self.assertIn("the provider quota needs topping up", notice)
+        self.assertNotIn("## Automatic code review failed", notice)
+
+    def test_the_job_summary_headline_names_the_provider(self):
+        """Asserted positively; a negative alone is satisfied by `ok` and `cancelled`."""
+
+        _, resolved = self._resolved()
+        summary = build_run_summary.build(
+            resolved["result"],
+            "",
+            [
+                build_run_summary.Tier(
+                    "Kitty Bridge (attempt 1)",
+                    "true",
+                    "exhausted",
+                    "provider quota exhausted",
+                )
+            ],
+        )
+
+        self.assertIn("## No review this run — the provider was unavailable", summary)
+        self.assertNotIn("## Review failed — the workflow needs fixing", summary)
+
+    def test_the_job_annotation_tells_the_operator_to_top_up(self):
+        """The third surface, executed rather than read."""
+
+        _, resolved = self._resolved()
+        printed = fail_job_annotation(resolved["result"])
+
+        self.assertIn("Top up or wait, then re-run", printed)
+        self.assertNotIn("the workflow", printed.split("::error::")[-1].lower())
+
+class QuotaAdviceNamesNoRetiredProviderTests(unittest.TestCase):
+    """KBR-145. The most-read failure paragraph must not name a provider we dropped.
+
+    Fixing the classifier promotes this branch from rarely-reached to the text an
+    operator sees on the commonest failure, so a stale provider name stops being
+    cosmetic and becomes a wrong instruction at the worst moment.
+    """
+
+    def test_the_advice_still_tells_the_operator_what_to_do(self):
+        """The actionable half must survive the rewording.
+
+        Asserted first and separately, because a paragraph can be made neutral by
+        being emptied, and the absence test below would pass for that too.
+        """
+
+        for name, record in QUOTA_FIXTURES:
+            with self.subTest(fixture=name):
+                status, reason = interpret.classify(record)
+                self.assertTrue(_quota_diagnostic(record, status, reason), name)
+
+    def test_the_advice_names_no_retired_provider(self):
+        """OpenRouter has not been the configured gateway since 2026-07-28."""
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "diagnostic.txt"
+            interpret._write_diagnostic(
+                str(path),
+                tier="kitty-bridge",
+                status="exhausted",
+                reason="provider quota exhausted: 'insufficient balance'",
+                retryable=True,
+                record_present=True,
+                execution_text=DEEPSEEK_NO_BALANCE,
+            )
+            body = path.read_text(encoding="utf-8")
+
+        advice = body.split("--- execution record (tail) ---")[0]
+        self.assertNotIn("OpenRouter", advice)
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/.github/review/tests/test_review_scripts.py
+++ b/.github/review/tests/test_review_scripts.py
@@ -16189,12 +16189,13 @@ class QuotaVocabularyTests(unittest.TestCase):
         whose message tells them the number may only go down, and why.
         """
 
-        self.assertLessEqual(
+        self.assertEqual(
             len(QUOTA_PATTERNS_WITHOUT_FIXTURES),
             4,
             "this list may only shrink -- KBR-166 removes `quota` and `\\bbilling\\b`; "
             "a NEW quota pattern needs a verbatim fixture, not an exemption",
         )
+
 
 def _quota_diagnostic(execution_text, status, reason):
     """Render a diagnostic for one attempt and report whether it advises a top-up.
@@ -16219,7 +16220,12 @@ def _quota_diagnostic(execution_text, status, reason):
             record_present=True,
             execution_text=execution_text,
         )
-        return "Top up the balance" in path.read_text(encoding="utf-8")
+        body = path.read_text(encoding="utf-8")
+
+    # Split the record echo off first: it reproduces `execution_text` verbatim, so
+    # a fixture that happened to contain this phrase would satisfy the search
+    # through its own text rather than through the advice branch.
+    return "Top up the balance" in body.split("--- execution record (tail) ---")[0]
 
 
 class SpentBalanceIsNotAWorkflowFaultTests(unittest.TestCase):
@@ -16474,6 +16480,7 @@ class VerdictAndAdviceAgreeTests(unittest.TestCase):
             "the refusal branch must win over the quota paragraph",
         )
 
+
 def fail_job_annotation(result, attempts="1", diagnostic="(diagnostic body)"):
     """Execute the real `Fail when no review was produced` step and capture its output.
 
@@ -16503,7 +16510,7 @@ def fail_job_annotation(result, attempts="1", diagnostic="(diagnostic body)"):
         )
         env = dict(os.environ, RESULT=result, ATTEMPTS=attempts)
         proc = subprocess.run(
-            ["bash", "-c", script],
+            [BASH, "-c", script],
             cwd=root,
             env=env,
             capture_output=True,
@@ -16514,6 +16521,7 @@ def fail_job_annotation(result, attempts="1", diagnostic="(diagnostic body)"):
     return proc.stdout
 
 
+@unittest.skipIf(BASH is None, "bash is required to run workflow steps")
 class OperatorSurfacesAgreeTests(unittest.TestCase):
     """KBR-145. Every surface an operator reads must name the same cause.
 
@@ -16575,7 +16583,7 @@ class OperatorSurfacesAgreeTests(unittest.TestCase):
         self.assertIn("the provider quota needs topping up", notice)
         self.assertNotIn("## Automatic code review failed", notice)
 
-    def test_the_job_summary_headline_names_the_provider(self):
+    def test_the_job_summary_headline_says_the_provider_was_unavailable(self):
         """Asserted positively; a negative alone is satisfied by `ok` and `cancelled`."""
 
         _, resolved = self._resolved()
@@ -16604,6 +16612,7 @@ class OperatorSurfacesAgreeTests(unittest.TestCase):
         self.assertIn("Top up or wait, then re-run", printed)
         self.assertNotIn("the workflow", printed.split("::error::")[-1].lower())
 
+
 class QuotaAdviceNamesNoRetiredProviderTests(unittest.TestCase):
     """KBR-145. The most-read failure paragraph must not name a provider we dropped.
 
@@ -16615,14 +16624,42 @@ class QuotaAdviceNamesNoRetiredProviderTests(unittest.TestCase):
     def test_the_advice_still_tells_the_operator_what_to_do(self):
         """The actionable half must survive the rewording.
 
-        Asserted first and separately, because a paragraph can be made neutral by
-        being emptied, and the absence test below would pass for that too.
+        🔴 **This asserted the WRONG SENTENCE and could not fail.** It checked for
+        "Top up the balance and re-run", which is the third sentence of the branch
+        and is not what KBR-145 rewrote; blanking the rewritten sentence entirely
+        left all 642 tests green. That is the same "assertion through a proxy" this
+        file documents twice, committed inside the test whose own docstring claimed
+        to guard against being emptied. It now asserts the replacement text.
         """
 
         for name, record in QUOTA_FIXTURES:
             with self.subTest(fixture=name):
                 status, reason = interpret.classify(record)
                 self.assertTrue(_quota_diagnostic(record, status, reason), name)
+                self.assertIn("the active kitty profile points at", self._advice())
+                self.assertIn("topped up", self._advice())
+
+    def _advice(self):
+        """Render a spent-balance diagnostic and return only its advice section.
+
+        Returns:
+            Everything above the execution-record echo, which is where the branch
+            under test writes and where the record cannot contaminate the match.
+        """
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "diagnostic.txt"
+            interpret._write_diagnostic(
+                str(path),
+                tier="kitty-bridge",
+                status="exhausted",
+                reason="provider quota exhausted: 'insufficient balance'",
+                retryable=True,
+                record_present=True,
+                execution_text=DEEPSEEK_NO_BALANCE,
+            )
+            body = path.read_text(encoding="utf-8")
+        return body.split("--- execution record (tail) ---")[0]
 
     def test_the_advice_names_no_retired_provider(self):
         """OpenRouter has not been the configured gateway since 2026-07-28."""

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       contents: read
     uses: ./.github/workflows/tests.yml
 
-  # The review system's own suite: 620 tests over the rule selector, the result
+  # The review system's own suite: 642 tests over the rule selector, the result
   # classifier, the failure and superseded notices, the prompt redactor, the
   # findings schema, and the wiring of `claude-code-review.yml` and this file.
   #

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,7 +125,7 @@ target-version = "py310"
 # next carried-across fix would arrive as a conflict. `.github/review/rules/ci.md`
 # records the same rule for anyone reviewing a change there.
 #
-# NOTE: this is not "that code is unchecked". `ci.yml` runs its 620-case suite
+# NOTE: this is not "that code is unchecked". `ci.yml` runs its 642-case suite
 # on every pull request, and that suite carries guards this linter could not
 # express - the private-reference sweep, the runner-ceiling pairing, the
 # aggregate's dependency set.


### PR DESCRIPTION
Fixes [KBR-145](https://shelpuk.atlassian.net/browse/KBR-145). Files [KBR-166](https://shelpuk.atlassian.net/browse/KBR-166) for the residue it deliberately does not close.

## Context for the Product Owner

**What was broken, in plain terms.** When the automated code reviewer fails, it posts a notice telling the engineer what to do next. If the DeepSeek account simply ran out of money, that notice said **"the workflow is misconfigured"** and handed over a list of settings to check — all of which were correct. The one action that actually fixes it, topping up the account, was the one the headline never mentioned.

Worse, the same message contradicted itself. A paragraph further down already said *"top up the balance and re-run"*, directly beneath a header saying *"another attempt could not help"*. Two halves of the system were reading two different signals.

**Why it was High priority.** [KBR-11](https://shelpuk.atlassian.net/browse/KBR-11) makes this reviewer a **required** check before anything merges to `main`. A spent balance freezes the repository either way — an unreviewed change should not merge — but this defect decided whether the notice **names the action that lifts the freeze** or sends the engineer to edit a file that is fine. It also marked the failure "not worth retrying", so the workflow's automatic second attempt never ran.

**What also got fixed, unasked.** A **rejected API key** hit the identical defect. OpenAI and Fireworks both report a dead key with the same generic error code DeepSeek uses for an empty wallet — confirmed in this repository's own provider fixtures. The same one-line move fixes both.

**What this does not fix, stated plainly.** This is a trade, not a clean win. It corrects the two failures anyone has actually observed and newly mishandles four text patterns nobody has ever seen. That residue is filed as KBR-166 with the measurements, and the code says so beside the change rather than burying it.

---

## The defect

`interpret_claude_result.classify` checked `FATAL_PATTERNS` before `QUOTA_PATTERNS`, deliberately — *"a rejected schema can coexist with other noise in the record"*. DeepSeek reports a spent prepaid balance as HTTP 402 whose body carries OpenAI's **generic** error code:

```
API Error: 402 {"error":{"message":"Insufficient Balance","type":"unknown_error","param":null,"code":"invalid_request_error"}}
```

`invalid_request_error` matched `r"invalid[_ ]request"` and short-circuited before the quota set — which does contain `insufficient balance` and does match — was ever consulted.

Observed live on PR #54, run `34622141943`:

```
TIER1: Kitty Bridge (attempt 1)|true|fatal|workflow-level failure: 'invalid_request'
```

Confirmed independently against DeepSeek's own error-code documentation and a third-party report quoting the body byte-for-byte.

### Why the tests missed it

```python
DEEPSEEK_NO_BALANCE = 'API Error: 402 {"error":{"message":"Insufficient Balance"}}'
```

Real, but **abridged** — and the abridged part is the part that changes the answer. The hazard was written down, about a *different* fixture, in `test_an_object_shaped_provider_error_is_still_recognised`, and never applied to the one that mattered.

## The fix

Exactly one pattern moves, into `FATAL_UNLESS_PROVIDER_NAMED_PATTERNS`, consulted after quota and credentials and before transients. Measured against six payloads; each alternative fails one:

| Payload | today | demote `400` too | **this PR** | demote past transients |
|---|---|---|---|---|
| Observed 402 | fatal ❌ | exhausted ✅ | **exhausted ✅** | exhausted ✅ |
| Billed `invalid_request` ($1.79) | fatal ✅ | fatal ✅ | **fatal ✅** | fatal ✅ |
| Context-management 400 refusal | fatal ✅ | exhausted ❌ | **fatal ✅** | exhausted ❌ |
| Rejected `--json-schema` | fatal ✅ | fatal ✅ | **fatal ✅** | fatal ✅ |
| 401 + generic code | fatal ❌ | fatal ❌ | **exhausted ✅** | exhausted ✅ |
| Billed, prose says *"timeout"* | fatal ✅ | fatal ✅ | **fatal ✅** | exhausted ❌ |

**The ticket's own suggested fix was measured and rejected.** Narrowing the pattern reclassifies `BILLED_INVALID_REQUEST` — an observed failure that billed **$1.79 across 24 turns** — as exhausted *and retryable*, spending it twice.

`\b400\b` stays in tier 1 because the context-management refusal's body says *"No quota was consumed for this request"*. `_write_diagnostic` already encodes that same precedence.

## AC4 — scope note

AC4 asks that *"the fallback chain advances to the next provider"*. **This repository has no fallback chain**; the module says so and the workflow wires one automatic retry gated on `retryable`. Satisfied here as `retryable=true`, confirmed with the product owner before implementation.

## Verification

| Check | Result |
|---|---|
| `.github/review/tests/` | **642 passed**, 1023 subtests |
| Tests added / removed | **22 / 0** (620 → 642, node IDs diffed against `main`) |
| Mutants applied and **watched** to fail | **11 / 11 killed** |
| `ruff`, `lint-imports`, `mypy`, `tests/test_github_actions.py` | green |

Every new guard was proven by applying a deliberate defect and watching it fail, per the harness rule — never by reasoning that it would.

## Three traps caught before merge, on the record

This PR's own review cycle caught the same class of defect the ticket is about, three times:

1. A justification claiming the chosen tier position was the only one that worked — **measurably false**; two others worked equally on the payloads tabled. Chasing it down found the 401 case.
2. An "it strictly reduces the misclassification set" claim — **also false**; it is a trade. A Jira table built on that error was filed and has been [corrected in a comment](https://shelpuk.atlassian.net/browse/KBR-166).
3. A test asserting the *neighbouring* sentence to the one the change rewrote — blanking the rewritten sentence left **all 642 green**. Fixed, and the mutant that survived now kills.

Each was found by measurement, not by reading. That is the same failure the original bug is made of.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019QjGt96ao62Hcf21R4n28G


[KBR-145]: https://shelpuk.atlassian.net/browse/KBR-145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KBR-166]: https://shelpuk.atlassian.net/browse/KBR-166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KBR-11]: https://shelpuk.atlassian.net/browse/KBR-11?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ