### PR TITLE
T-A3 — OpenAI Responses reader (KBR-35)

### DIFF
--- a/.system_design/TEST_SUITE.md
+++ b/.system_design/TEST_SUITE.md
@@ -596,6 +596,16 @@ agree on a canonical form. They are six separate tasks, so the agreement is part
   still projects, in the turn where it occurred* — M7 exists to drop orphans, so a reader that
   raised on one would fail instead of producing the delta that names it.
 
+  **The four clauses are an ordered pipeline.** `ToolResult` parts come first *within the turn the
+  **run** and **following-message** clauses build*, never as a re-sort after the same-role merge —
+  so `ToolResult → user text → ToolResult` projects as `[ToolResult, Text, ToolResult]`: two runs,
+  the first absorbing the text that follows it, then concatenated. Re-sorting afterwards would
+  hoist a result ahead of text the agent sent **before** it — moving history the bridge did not
+  move — and because paths are index-based the invented delta would land on every part of that
+  turn and every turn after it. The rule gives a run of results one home; it does not reorder
+  history. Clause 3 is not thereby idle: it governs the formats that carry text and results inside
+  **one message**, where the run has no natural boundary.
+
   A lift rule ("into the user turn that follows the assistant turn") does **not** work: the standard
   Chat Completions exchange ends `assistant(tool_calls) → tool → tool`, with no following user
   message at all. And because paths are index-based, any disagreement about turn boundaries reports
@@ -624,6 +634,24 @@ agree on a canonical form. They are six separate tasks, so the agreement is part
   compares its value whole. No reader emits `envelope.extra[<key>.<subkey>]`; nesting belongs to
   the residual (§3.3.1a). Six readers cannot quietly disagree about whether `thinking.budget_tokens`
   has an address of its own.
+- **Tool-call arguments decode through one shared rule.** Chat Completions and Responses both
+  carry them as a JSON *string*. Absent, `null`, empty or whitespace decodes to `{}`; a value that
+  is valid JSON but not an object, or not valid JSON at all, decodes to `{}` **and residualises at
+  that argument's own path**. Never raises.
+
+  **Why an absent `arguments` does not residualise though an absent `name` does**, the schema
+  requiring both: the test is whether the projection can represent the absence *losslessly*.
+  `ToolUse.arguments` is a mapping defaulting to empty, and `{}` is a true statement about the
+  call — seen and classified, therefore accounted for, the same ground on which `STOP_REASONS`
+  gives `other` its escape instead of the residual. `ToolUse.name` is a `str` with no such value:
+  `""` claims a tool *named* empty-string, and a call nobody can name cannot be paired or
+  addressed. Apply that test to every required field, not only these two.
+
+  Six readers cannot quietly disagree about what `arguments: ""` means, and it is not
+  hypothetical — `openai_subscription.py:OpenAISubscriptionAdapter._cc_to_responses` writes
+  `func.get("arguments", "")`. The residual *path* is format-specific and stays each reader's own;
+  only the decode and the fail-closed policy are shared. Tracked for pinning as code beside
+  `image_digest` — KBR-174.
 - **`tool_choice`** unifies four wire keys — CC/Messages `tool_choice`, Converse's
   `toolConfig.toolChoice`, Gemini's `functionCallingConfig.mode` — onto
   `envelope.extra["tool_choice"]`, with the **value** normalised to `auto` · `any` · `none` ·

--- a/tests/harness/reader_responses.py
+++ b/tests/harness/reader_responses.py
@@ -1,0 +1,1185 @@
+"""The OpenAI Responses wire projection — one of the six independent readers.
+
+`.system_design/TEST_SUITE.md` §3.3.1, §3.3.1a, §3.3.1b · plan task **T-A3** (KBR-35).
+
+Projects an OpenAI Responses request body into :class:`harness.contract.Request`,
+so the fidelity oracle can compare what an agent sent against what kitty actually
+put on the wire.  This is the format the Codex path speaks, both as an inbound
+shape and as the upstream shape of the ChatGPT-subscription provider.
+
+**Written against the published schema, never against kitty's output.**  Every
+key, item type and union member below was read from ``openai/openai-openapi``,
+``openapi.yaml``, ``info.version`` :data:`SCHEMA_VERSION` — not from a kitty
+request and not from memory.  §3.3.1's independent-oracle rule: a reader
+validated against kitty's output inherits kitty's bugs, and the whole of I1 then
+proves only that kitty agrees with itself.
+
+**It imports nothing from ``src/kitty``, and must not.**
+``test_reader_responses.py`` asserts the absence structurally.
+
+**What totality means here, and where it stops.**  Every one of the 31 published
+top-level keys is classified into the envelope, the conversation, or the
+residual, and :func:`harness.contract.verify_total` fails the run on anything
+left over.  But ``consumed`` covers *top-level* keys only (§3.3.1's stated
+boundary), so a value dropped from *inside* a key this module claims is not
+caught here.  Two such blind spots are deliberate and are named in the task's
+requirements rather than left implied: the internals of the 27 opaque item types
+(a mutated shell command inside a ``local_shell_call`` is invisible), and
+``previous_response_id`` / ``conversation``, which move history server-side so a
+formally total projection can still be missing turns.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import json
+import re
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from harness import contract as c
+
+#: The published schema version every table in this module was derived from.
+#: Recorded so a future divergence is traceable rather than mysterious: when
+#: OpenAI adds a top-level key or an item type, the falsification tests go red
+#: and this string says which revision the reader last agreed with.
+SCHEMA_VERSION = "2.3.0"
+
+# --------------------------------------------------------------------------
+# Top-level key classification — `CreateResponse`, 31 keys
+# --------------------------------------------------------------------------
+
+#: Control fields the projection names in their own right.
+_ENVELOPE_NAMED = frozenset({"model", "stream", "store"})
+
+#: Sampling parameters whose Responses spelling is already canonical.
+_SAMPLING_DIRECT = frozenset({"temperature", "top_p", "top_logprobs", "stream_options"})
+
+#: The one sampling rename §3.3.1b mandates.  ``max_completion_tokens`` is
+#: deliberately absent: P13 drops it in its own right, so collapsing both onto
+#: one canonical key would make two register rows indistinguishable.
+_SAMPLING_RENAMED: Mapping[str, str] = {"max_output_tokens": "max_tokens"}
+
+#: Keys carrying semantic content rather than control.
+_CONVERSATION_KEYS = frozenset({"input", "instructions", "tools"})
+
+#: Every remaining published control field.  These project to
+#: ``envelope.extra[<wire key>]`` per §3.3.1b, which is what makes them
+#: addressable by a register row — see KBR-171, which records that sixteen of
+#: them are dropped by the Codex allowlist with no row claiming the delta.
+_EXTRA_KEYS = frozenset(
+    {
+        "background",
+        "context_management",
+        "conversation",
+        "include",
+        "max_tool_calls",
+        "metadata",
+        "moderation",
+        "parallel_tool_calls",
+        "previous_response_id",
+        "prompt",
+        "prompt_cache_key",
+        "prompt_cache_options",
+        "prompt_cache_retention",
+        "reasoning",
+        "safety_identifier",
+        "service_tier",
+        "text",
+        "tool_choice",
+        "truncation",
+        "user",
+    }
+)
+
+#: All 31, for the totality check and for the test that asserts this module's
+#: tables still agree with the published schema.
+PUBLISHED_TOP_LEVEL_KEYS = (
+    _ENVELOPE_NAMED | _SAMPLING_DIRECT | frozenset(_SAMPLING_RENAMED) | _CONVERSATION_KEYS | _EXTRA_KEYS
+)
+
+# --------------------------------------------------------------------------
+# Item types — `InputItem`, walked transitively, 31 discriminator values
+# --------------------------------------------------------------------------
+
+#: The four types this reader models semantically.
+_MODELLED_ITEMS = frozenset({"message", "function_call", "function_call_output", "reasoning"})
+
+#: Opaque item types that are client-supplied, and therefore project into a
+#: ``user`` turn.  The mechanical rule is "a type ending ``_output``"; the five
+#: after it are named exceptions, each for a stated reason rather than by
+#: falling through a default:
+#:
+#: - ``mcp_approval_response`` answers the model's request;
+#: - ``compaction_trigger`` is client-initiated;
+#: - ``additional_tools`` carries its own ``role``, whose only published value is
+#:   ``developer`` — client-supplied, but :class:`harness.contract.Opaque` cannot
+#:   live in ``conversation.system``, so it lands in a ``user`` turn;
+#: - ``item_reference`` is client-supplied history addressing;
+#: - ``configuration_update`` carries ``reasoning`` — the same control field
+#:   ``CreateResponse`` carries at top level — so it is client-supplied
+#:   configuration, not model output.
+_OPAQUE_USER_ITEMS = frozenset(
+    {
+        "apply_patch_call_output",
+        "computer_call_output",
+        "custom_tool_call_output",
+        "local_shell_call_output",
+        "program_output",
+        "shell_call_output",
+        "tool_search_output",
+        "mcp_approval_response",
+        "compaction_trigger",
+        "additional_tools",
+        "item_reference",
+        "configuration_update",
+    }
+)
+
+#: Opaque item types the model produced, which project into an ``assistant`` turn.
+_OPAQUE_ASSISTANT_ITEMS = frozenset(
+    {
+        "apply_patch_call",
+        "code_interpreter_call",
+        "compaction",
+        "computer_call",
+        "custom_tool_call",
+        "file_search_call",
+        "image_generation_call",
+        "local_shell_call",
+        "mcp_approval_request",
+        "mcp_call",
+        "mcp_list_tools",
+        "program",
+        "shell_call",
+        "tool_search_call",
+        "web_search_call",
+    }
+)
+
+#: Every published ``type`` an ``input`` array member may carry.
+#:
+#: **Derived from ``InputItem``, not from ``Item``.**  ``Item.oneOf`` has 28
+#: members but omits ``compaction_trigger``, ``program``, ``program_output`` and
+#: ``item_reference``, which reach the wire only through ``InputItem``.  A reader
+#: whose closed set came from ``Item`` would residualise all four and go red on
+#: legal traffic — the outcome the "placeholder the rest" decision exists to
+#: avoid.
+PUBLISHED_ITEM_TYPES = _MODELLED_ITEMS | _OPAQUE_USER_ITEMS | _OPAQUE_ASSISTANT_ITEMS
+
+#: The content types a ``function_call_output``'s array branch may carry.
+#: Deliberately narrower than a message's set — the published union is
+#: ``InputTextContentParam | InputImageContentParamAutoParam |
+#: InputFileContentParam``, with no ``refusal`` and no ``output_text``.
+_TOOL_OUTPUT_CONTENT_TYPES = frozenset({"input_text", "input_image", "input_file"})
+
+#: Message roles that lift into ``conversation.system`` rather than becoming a
+#: turn (§3.3.1b R8.2).
+_SYSTEM_ROLES = frozenset({"system", "developer"})
+
+#: Every role a published ``message`` item may carry.  Anything else is a body
+#: this reader cannot read — :class:`harness.contract.UnreadableBodyError`'s own
+#: documented case, "a role no format defines".
+_MESSAGE_ROLES = _SYSTEM_ROLES | {"user", "assistant"}
+
+# --------------------------------------------------------------------------
+# Tool choice — `ToolChoiceParam`, nine published forms
+# --------------------------------------------------------------------------
+
+#: ``ToolChoiceOptions`` string values, mapped onto the canonical vocabulary.
+#: ``required`` becomes ``any``; the other two already agree.
+_TOOL_CHOICE_STRINGS: Mapping[str, str] = {"none": "none", "auto": "auto", "required": "any"}
+
+#: Object forms whose ``name`` field selects one tool.
+_TOOL_CHOICE_BY_NAME = frozenset({"function", "custom"})
+
+#: Object forms that select a tool by their ``type`` alone — the eight
+#: ``ToolChoiceTypes`` built-ins plus the three ``Specific*`` singletons.
+_TOOL_CHOICE_BY_TYPE = frozenset(
+    {
+        "file_search",
+        "web_search_preview",
+        "computer",
+        "computer_use_preview",
+        "computer_use",
+        "web_search_preview_2025_03_11",
+        "image_generation",
+        "code_interpreter",
+        "programmatic_tool_calling",
+        "apply_patch",
+        "shell",
+    }
+)
+
+#: A ``data:`` URL carrying base64 image bytes, with its media type.
+_DATA_URL = re.compile(r"^data:([^;,]+);base64,(.*)$", re.DOTALL)
+
+#: Any ``data:`` URL at all.  Matched separately so that a *non*-base64 data URL
+#: — ``data:image/png,abc`` — residualises instead of falling through to
+#: :attr:`harness.contract.Image.ref`.  Leaving a data URL in ``ref`` is exactly
+#: the shape pinning :func:`harness.contract.image_digest` exists to prevent:
+#: another reader decoding the same bytes would produce a digest, and the two
+#: projections would differ on an unchanged image.
+_ANY_DATA_URL = re.compile(r"^data:", re.IGNORECASE)
+
+
+def _mcp_tool_name(server_label: str) -> str:
+    """Return the projected name of an MCP tool declaration.
+
+    Spelled once, because two callers must agree exactly: the ``tools`` reader
+    names the declaration, and ``tool_choice`` names a selection of it. A
+    selection naming a tool the declaration list holds under a different
+    spelling would correspond to nothing, and §3.3.1a's by-name addressing has
+    no index to fall back on.
+
+    Args:
+        server_label: The MCP server's label, which its schema requires.
+
+    Returns:
+        The projected tool name.
+    """
+    return f"mcp:{server_label}"
+
+
+class ResponsesProjection:
+    """Reads an OpenAI Responses request into the wire-independent form.
+
+    Implements :class:`harness.contract.Projection` for
+    :attr:`harness.contract.WireFormat.OPENAI_RESPONSES`.
+
+    The reader is stateless; every method takes what it needs and returns what it
+    produced, so one instance is safe to share across a whole corpus run.
+    """
+
+    wire_format = c.WireFormat.OPENAI_RESPONSES
+
+    def read_request(self, captured: c.CapturedRequest) -> c.Request:
+        """Project a captured Responses request.
+
+        Args:
+            captured: The request as observed on the wire. Only the body is
+                consulted — unlike Gemini, Responses carries neither the model
+                nor the operation in the URL.
+
+        Returns:
+            The wire-independent projection, with ``consumed`` naming every
+            top-level key accounted for and ``residual`` everything else.
+
+            **A top-level key stays in ``consumed`` even when a value beneath it
+            residualises.**  ``consumed`` records that the reader *read* the key;
+            the nested residual records what inside it could not be classified.
+            Only a key the reader did not read at all is omitted.  The asymmetry
+            matters and is easy to get wrong: for a *top-level* residual either
+            choice works, because :func:`harness.contract.verify_total` counts a
+            key claimed in both accounts as a residual — but for a *nested* one,
+            dropping the parent from ``consumed`` makes ``verify_total`` report
+            ``DroppedFieldsError: reader dropped ['input']``, the wrong
+            diagnosis for a reader that read the body fine.
+
+        Raises:
+            UnreadableBodyError: When the body is not a JSON object, when
+                ``input`` is neither a string nor an array, or when a ``message``
+                item carries a role no published schema defines.
+        """
+        body = self._parse(captured.body)
+
+        residual: dict[str, Any] = {}
+        consumed: set[str] = set()
+
+        envelope = self._read_envelope(body, consumed, residual)
+        conversation = self._read_conversation(body, consumed, residual)
+
+        # Anything the tables above did not recognise is unaccounted for, and a
+        # non-empty residual fails the run. This is the fail-closed half of
+        # §3.3.1: an unmapped field is exactly where an unregistered mutation
+        # hides.
+        for key, value in body.items():
+            if key not in consumed and key not in residual:
+                residual[key] = value
+
+        return c.Request(
+            envelope=envelope,
+            conversation=conversation,
+            residual=residual,
+            consumed=frozenset(consumed),
+            source=body,
+        )
+
+    # ----------------------------------------------------------------
+    # Body
+    # ----------------------------------------------------------------
+
+    @staticmethod
+    def _parse(raw: bytes) -> Mapping[str, Any]:
+        """Decode the request body into a JSON object.
+
+        Args:
+            raw: The undecoded body bytes.
+
+        Returns:
+            The parsed body.
+
+        Raises:
+            UnreadableBodyError: When the bytes are not UTF-8, not JSON, or not
+                a JSON *object*. Raised rather than returned because §3.3.1
+                separates "this body was unreadable" from "this is an I1
+                breach", and T-D1 cannot tell them apart from a bare exception.
+        """
+        try:
+            decoded = json.loads(raw.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise c.UnreadableBodyError(f"body is not JSON: {exc}") from exc
+
+        if not isinstance(decoded, dict):
+            raise c.UnreadableBodyError(f"body must be a JSON object, got {type(decoded).__name__}")
+
+        return decoded
+
+    # ----------------------------------------------------------------
+    # Envelope
+    # ----------------------------------------------------------------
+
+    def _read_envelope(self, body: Mapping[str, Any], consumed: set[str], residual: dict[str, Any]) -> c.Envelope:
+        """Map the control fields onto the envelope.
+
+        Args:
+            body: The parsed request body.
+            consumed: Accumulator of top-level keys accounted for, mutated here.
+            residual: Accumulator of unclassifiable values, mutated here.
+
+        Returns:
+            The populated envelope.
+        """
+        extra: dict[str, Any] = {}
+
+        # `extra` is keyed by the wire key and compared whole (§3.3.1b), so no
+        # entry is ever nested: a register row addresses `envelope.extra[text]`,
+        # never `envelope.extra[text.format]`.
+        for key in sorted(_EXTRA_KEYS):
+            if key not in body:
+                continue
+            consumed.add(key)
+            if key == "tool_choice":
+                self._read_tool_choice(body[key], extra, residual)
+            else:
+                extra[key] = body[key]
+
+        for key in sorted(_ENVELOPE_NAMED):
+            if key in body:
+                consumed.add(key)
+
+        return c.Envelope(
+            model=body.get("model"),
+            stream=body.get("stream"),
+            store=body.get("store"),
+            extra=extra,
+        )
+
+    def _read_tool_choice(self, choice: Any, extra: dict[str, Any], residual: dict[str, Any]) -> None:
+        """Normalise ``tool_choice`` onto the canonical vocabulary.
+
+        Four wire keys across four formats name one concept, so §3.3.1b makes
+        this the single deliberate exception to keying ``extra`` by the wire key
+        and pins the *value* to ``auto`` · ``any`` · ``none`` · ``tool:<name>``.
+
+        Args:
+            choice: The raw ``tool_choice`` value.
+            extra: The envelope's extra mapping, mutated here.
+            residual: Accumulator of unclassifiable values, mutated here.
+        """
+        normalised = self._normalise_tool_choice(choice)
+
+        # An unrecognised selector is residualised rather than guessed into
+        # `any`: guessing would silently equate a shape nobody has looked at
+        # with a real selection, which is the blindness the residual exists to
+        # prevent.
+        if normalised is None:
+            residual["tool_choice"] = choice
+            return
+
+        extra[c.TOOL_CHOICE_KEY] = normalised
+
+    @staticmethod
+    def _normalise_tool_choice(choice: Any) -> str | None:
+        """Return the canonical form of one published ``tool_choice`` value.
+
+        Args:
+            choice: The raw value, in any of the nine published shapes.
+
+        Returns:
+            The canonical string, or ``None`` when the shape is unrecognised.
+        """
+        if isinstance(choice, str):
+            return _TOOL_CHOICE_STRINGS.get(choice)
+
+        if not isinstance(choice, dict):
+            return None
+
+        # Every branch below tests `kind` for set membership, so it must be
+        # hashable first: a JSON body may legally carry a list here, and
+        # `["function"] in frozenset(...)` raises TypeError — an exception shape
+        # R11 forbids the reader from letting out.
+        kind = choice.get("type")
+        if not isinstance(kind, str):
+            return None
+
+        # `allowed_tools` maps by its own `mode`, not to a flat `any`: collapsing
+        # it would make a `mode: auto -> required` mutation invisible, in the very
+        # field whose job is constraining what the model may call. Its `tools`
+        # list has no home in the canonical vocabulary and is not modelled.
+        if kind == "allowed_tools":
+            mode = choice.get("mode")
+            return _TOOL_CHOICE_STRINGS.get(mode) if isinstance(mode, str) else None
+
+        # MCP is selected by server, optionally narrowed to one tool. Two servers
+        # would otherwise both normalise to a bare `tool:mcp`.
+        #
+        # The spelling deliberately embeds `_mcp_tool_name`'s output, so that the
+        # selected value contains the *declaration's* name as a prefix. §3.3.1a
+        # addresses tools by name, and a `tool_choice` naming a tool that
+        # `conversation.tools` holds under a different spelling would correspond
+        # to nothing.
+        if kind == "mcp":
+            label = choice.get("server_label")
+            if not isinstance(label, str):
+                return None
+            name = choice.get("name")
+            declared = _mcp_tool_name(label)
+            return f"tool:{declared}:{name}" if isinstance(name, str) else f"tool:{declared}"
+
+        if kind in _TOOL_CHOICE_BY_NAME:
+            name = choice.get("name")
+            return f"tool:{name}" if isinstance(name, str) else None
+
+        if kind in _TOOL_CHOICE_BY_TYPE:
+            return f"tool:{kind}"
+
+        return None
+
+    # ----------------------------------------------------------------
+    # Conversation
+    # ----------------------------------------------------------------
+
+    def _read_conversation(
+        self, body: Mapping[str, Any], consumed: set[str], residual: dict[str, Any]
+    ) -> c.Conversation:
+        """Map the semantic content onto the conversation.
+
+        Args:
+            body: The parsed request body.
+            consumed: Accumulator of top-level keys accounted for, mutated here.
+            residual: Accumulator of unclassifiable values, mutated here.
+
+        Returns:
+            The populated conversation.
+
+        Raises:
+            UnreadableBodyError: When ``input`` is neither a string nor an array.
+        """
+        system: list[c.Text] = []
+        turns: list[c.Turn] = []
+
+        # `instructions` is one of the four carriers §3.3.1b lifts into
+        # `conversation.system`, and it comes before the input array.
+        if "instructions" in body:
+            consumed.add("instructions")
+            instructions = body["instructions"]
+            if isinstance(instructions, str):
+                system.append(c.Text(instructions))
+            elif instructions is not None:
+                residual["instructions"] = instructions
+
+        if "input" in body:
+            consumed.add("input")
+            self._read_input(body["input"], system, turns, residual)
+
+        tools = self._read_tools(body, consumed, residual)
+
+        return c.Conversation(
+            system=system,
+            turns=self._merge(turns),
+            tools=tools,
+            sampling=self._read_sampling(body, consumed),
+        )
+
+    @staticmethod
+    def _read_sampling(body: Mapping[str, Any], consumed: set[str]) -> dict[str, Any]:
+        """Collect the sampling parameters under their canonical names.
+
+        Args:
+            body: The parsed request body.
+            consumed: Accumulator of top-level keys accounted for, mutated here.
+
+        Returns:
+            The sampling mapping, keyed by :data:`harness.contract.SAMPLING_KEYS`.
+        """
+        sampling: dict[str, Any] = {}
+
+        for key in sorted(_SAMPLING_DIRECT):
+            if key in body:
+                consumed.add(key)
+                sampling[key] = body[key]
+
+        # `max_output_tokens` -> `max_tokens` is the one rename §3.3.1b mandates,
+        # and register row P14 is written against exactly this mapping.
+        for wire_key, canonical in _SAMPLING_RENAMED.items():
+            if wire_key in body:
+                consumed.add(wire_key)
+                sampling[canonical] = body[wire_key]
+
+        return sampling
+
+    def _read_input(
+        self,
+        raw: Any,
+        system: list[c.Text],
+        turns: list[c.Turn],
+        residual: dict[str, Any],
+    ) -> None:
+        """Read the ``input`` field in either of its two published shapes.
+
+        Args:
+            raw: The ``input`` value — a string or an array of items.
+            system: Accumulator of lifted system text, mutated here.
+            turns: Accumulator of turns, mutated here.
+            residual: Accumulator of unclassifiable values, mutated here.
+
+        Raises:
+            UnreadableBodyError: When ``input`` is neither a string nor a list.
+        """
+        # `InputParam` is `oneOf[string, array]`; the bare string is "equivalent
+        # to a text input with the user role" in the schema's own words.
+        if isinstance(raw, str):
+            turns.append(c.Turn("user", [c.Text(raw)]))
+            return
+
+        if not isinstance(raw, list):
+            raise c.UnreadableBodyError(f"input must be a string or an array of items, got {type(raw).__name__}")
+
+        for index, item in enumerate(raw):
+            self._read_item(item, index, system, turns, residual)
+
+    def _read_item(
+        self,
+        item: Any,
+        index: int,
+        system: list[c.Text],
+        turns: list[c.Turn],
+        residual: dict[str, Any],
+    ) -> None:
+        """Read one member of the ``input`` array.
+
+        Args:
+            item: The raw item.
+            index: Its position, for residual paths.
+            system: Accumulator of lifted system text, mutated here.
+            turns: Accumulator of turns, mutated here.
+            residual: Accumulator of unclassifiable values, mutated here.
+
+        Raises:
+            UnreadableBodyError: When a ``message`` item carries an undefined role.
+        """
+        path = f"input[{index}]"
+
+        if not isinstance(item, dict):
+            residual[path] = item
+            return
+
+        kind = self._item_type(item)
+
+        if kind == "message":
+            self._read_message(item, path, system, turns, residual)
+        elif kind == "function_call":
+            turns.append(c.Turn("assistant", [self._read_function_call(item, path, residual)]))
+        elif kind == "function_call_output":
+            turns.append(c.Turn("user", [self._read_function_output(item, path, residual)]))
+        elif kind == "reasoning":
+            turns.append(c.Turn("assistant", self._read_reasoning(item, path, residual)))
+        elif kind in _OPAQUE_USER_ITEMS:
+            turns.append(c.Turn("user", [c.Opaque(kind)]))
+        elif kind in _OPAQUE_ASSISTANT_ITEMS:
+            turns.append(c.Turn("assistant", [c.Opaque(kind)]))
+        else:
+            # An item type outside all 31 published values. §3.3.1: adding a
+            # shape to a wire format must force a deliberate decision, so this
+            # fails the run rather than being silently placeheld.
+            residual[path] = item
+
+    @staticmethod
+    def _item_type(item: Mapping[str, Any]) -> str | None:
+        """Return an item's discriminator, inferring it when the wire omits it.
+
+        ``EasyInputMessage``, ``FunctionCallOutputItemParam`` and
+        ``ItemReferenceParam`` all make ``type`` optional or nullable, so
+        dispatch cannot key on it alone.
+
+        Args:
+            item: The raw item.
+
+        Returns:
+            The item's type, or ``None`` when it cannot be inferred.
+        """
+        declared = item.get("type")
+        if isinstance(declared, str):
+            return declared
+
+        # A `role` makes it a message — the published `EasyInputMessage`, which
+        # is the shape every hand-written example uses. An `id` alone is an item
+        # reference, whose `type` is explicitly nullable.
+        if "role" in item:
+            return "message"
+        if "id" in item:
+            return "item_reference"
+
+        return None
+
+    # ----------------------------------------------------------------
+    # Items
+    # ----------------------------------------------------------------
+
+    def _read_message(
+        self,
+        item: Mapping[str, Any],
+        path: str,
+        system: list[c.Text],
+        turns: list[c.Turn],
+        residual: dict[str, Any],
+    ) -> None:
+        """Read a ``message`` item into the system text or a turn.
+
+        Args:
+            item: The raw message item.
+            path: Its residual path prefix.
+            system: Accumulator of lifted system text, mutated here.
+            turns: Accumulator of turns, mutated here.
+            residual: Accumulator of unclassifiable values, mutated here.
+
+        Raises:
+            UnreadableBodyError: When the role is outside the published set.
+        """
+        role = item.get("role")
+
+        # The isinstance check is not redundant with the membership test: a role
+        # of `["user"]` is outside the set, but testing membership of an
+        # unhashable value raises TypeError, which `contract` defines as a reader
+        # bug rather than a bad body. R11 names this exact case.
+        if not isinstance(role, str) or role not in _MESSAGE_ROLES:
+            raise c.UnreadableBodyError(f"{path}: message role must be one of {sorted(_MESSAGE_ROLES)}, got {role!r}")
+
+        raw_content = item.get("content")
+        parts = self._read_content(raw_content, f"{path}.content", residual)
+
+        # System and developer instructions lift into `conversation.system`
+        # rather than becoming a turn (§3.3.1b R8.2).
+        if role in _SYSTEM_ROLES:
+            entries = raw_content if isinstance(raw_content, list) else []
+            for wire_index, part in parts:
+                # `Conversation.system` is enforced Text-only, so there is
+                # nowhere to put an image a developer message may legally carry.
+                # Residualising fails closed; letting the contract's TypeError
+                # out would add a fourth failure shape beside the three §3.3.1
+                # defines on purpose.
+                if isinstance(part, c.Text):
+                    system.append(part)
+                else:
+                    # Keyed by the WIRE index and holding the WIRE value. Using
+                    # the projected offset would name the wrong element whenever
+                    # an earlier part residualised, and would collide with the
+                    # key `_read_content` already wrote — silently destroying one
+                    # of two unclassified values.
+                    residual[f"{path}.content[{wire_index}]"] = entries[wire_index]
+            return
+
+        turns.append(c.Turn(role, [part for _, part in parts]))
+
+    def _read_content(
+        self, raw: Any, path: str, residual: dict[str, Any], allowed: frozenset[str] | None = None
+    ) -> list[tuple[int, c.Part]]:
+        """Read a message's ``content`` in either published shape.
+
+        Returns each part beside its **wire index**, not merely in order: the
+        caller that lifts system text needs to residualise at the index the body
+        actually used, and a projected offset drifts from it as soon as one
+        entry residualises.
+
+        Args:
+            raw: A string, or a list of content parts.
+            path: The residual path prefix for this content list.
+            residual: Accumulator of unclassifiable values, mutated here.
+            allowed: The content types permitted here, or ``None`` for a
+                message's full set.
+
+        Returns:
+            ``(wire index, part)`` pairs, in wire order. A string ``content``
+            yields one pair at index 0.
+        """
+        if isinstance(raw, str):
+            return [(0, c.Text(raw))]
+
+        if not isinstance(raw, list):
+            residual[path] = raw
+            return []
+
+        parts: list[tuple[int, c.Part]] = []
+        for offset, entry in enumerate(raw):
+            part = self._read_content_part(entry, f"{path}[{offset}]", residual, allowed)
+            if part is not None:
+                parts.append((offset, part))
+
+        return parts
+
+    def _read_content_part(
+        self, entry: Any, path: str, residual: dict[str, Any], allowed: frozenset[str] | None = None
+    ) -> c.Part | None:
+        """Read one content part of a message.
+
+        Args:
+            entry: The raw content part.
+            path: Its residual path.
+            residual: Accumulator of unclassifiable values, mutated here.
+            allowed: The content types permitted in this position, or ``None``
+                for a message's full set. A tool output's array branch publishes
+                only three of them, and accepting the others there would let a
+                shape the schema forbids pass unremarked.
+
+        Returns:
+            The projected part, or ``None`` when it was residualised.
+        """
+        if not isinstance(entry, dict):
+            residual[path] = entry
+            return None
+
+        # Hashable before any set membership test: a JSON body may legally carry
+        # a dict here, and `{"a": 1} in {"input_text", ...}` raises TypeError.
+        kind = entry.get("type")
+        if not isinstance(kind, str) or (allowed is not None and kind not in allowed):
+            residual[path] = entry
+            return None
+
+        # `input_text` and `output_text` both project to a bare `Text`. That is
+        # what makes register row P16 NOT_PROJECTABLE: the tag is redundant with
+        # the turn's role, and carrying it would put one vendor's spelling into a
+        # form whose whole purpose is wire independence.
+        if kind in {"input_text", "output_text"}:
+            text = entry.get("text")
+            if isinstance(text, str):
+                return c.Text(text)
+            residual[path] = entry
+            return None
+
+        # `refusal` is NOT collapsed into Text. Unlike the input/output tag, it
+        # is not recoverable from the role: an assistant refusal and an assistant
+        # answer would project identically, so a bridge that turned one into the
+        # other would be invisible.
+        #
+        # The digest carries the text's identity without the grammar having a
+        # refusal type: `kind` alone would make a *rewritten* refusal invisible,
+        # which is the same blindness one step down.
+        if kind == "refusal":
+            text = entry.get("refusal")
+            if not isinstance(text, str):
+                residual[path] = entry
+                return None
+            return c.Opaque("refusal", digest=c.image_digest(text.encode("utf-8")))
+
+        if kind == "input_image":
+            return self._read_image(entry, path, residual)
+
+        if kind == "input_file":
+            return c.Opaque("file")
+
+        residual[path] = entry
+        return None
+
+    @staticmethod
+    def _read_image(entry: Mapping[str, Any], path: str, residual: dict[str, Any]) -> c.Part | None:
+        """Project an ``input_image`` content part.
+
+        ``contract.image_digest`` is pinned so six independently written readers
+        agree on one digest for one image; a reader that left a data URL in
+        ``ref`` while another decoded it would reproduce exactly the disagreement
+        that pinning exists to prevent.
+
+        Args:
+            entry: The raw ``input_image`` part.
+            path: Its residual path.
+            residual: Accumulator of unclassifiable values, mutated here.
+
+        Returns:
+            The projected image, or ``None`` when it was residualised.
+        """
+        url = entry.get("image_url")
+
+        if isinstance(url, str):
+            found = _DATA_URL.match(url)
+            if found:
+                media_type, payload = found.group(1), found.group(2)
+                try:
+                    raw = base64.b64decode(payload, validate=True)
+                except (binascii.Error, ValueError):
+                    # Undecodable bytes are not an image this reader can digest,
+                    # and inventing a digest would make two unequal images
+                    # compare equal.
+                    residual[path] = entry
+                    return None
+                return c.Image(digest=c.image_digest(raw), media_type=media_type)
+
+            # A data URL that is not base64 carries bytes this reader cannot
+            # canonicalise; putting it in `ref` would make it compare unequal to
+            # another reader's digest of the same image.
+            if _ANY_DATA_URL.match(url):
+                residual[path] = entry
+                return None
+
+            # A remote image has no bytes to digest; the URI is the identity, the
+            # same shape §3.3.1 gives Gemini's `fileData.fileUri`.
+            return c.Image(ref=url)
+
+        file_id = entry.get("file_id")
+        if isinstance(file_id, str):
+            return c.Image(ref=file_id)
+
+        residual[path] = entry
+        return None
+
+    def _read_function_call(self, item: Mapping[str, Any], path: str, residual: dict[str, Any]) -> c.ToolUse:
+        """Project a ``function_call`` item.
+
+        Args:
+            item: The raw item.
+            path: Its residual path prefix.
+            residual: Accumulator of unclassifiable values, mutated here.
+
+        Returns:
+            The projected tool call.
+        """
+        # A wrongly-typed id or name is residualised rather than coerced: `str(7)`
+        # and `str(None)` invent a value the agent never sent, and `verify_total`
+        # cannot see a nested coercion because `consumed` is top-level only.
+        call_id = item.get("call_id")
+        if call_id is not None and not isinstance(call_id, str):
+            residual[f"{path}.call_id"] = call_id
+            call_id = None
+
+        # `name` is required by `FunctionToolCall` and, unlike the id, there is
+        # no format that omits it — a call nobody can name cannot be paired with
+        # its result or addressed by a register row. So `null` and absent are
+        # residualised too, not just a wrong type.
+        name = item.get("name")
+        if not isinstance(name, str):
+            residual[f"{path}.name"] = name
+            name = ""
+
+        return c.ToolUse(
+            name=name,
+            arguments=self._read_arguments(item.get("arguments"), f"{path}.arguments", residual),
+            id=call_id,
+        )
+
+    @staticmethod
+    def _read_arguments(raw: Any, path: str, residual: dict[str, Any]) -> Mapping[str, Any]:
+        """Decode a tool call's JSON-string arguments.
+
+        Chat Completions and Responses both encode arguments as a *string*, while
+        Messages sends an object; normalising here stops a spurious delta on
+        every cross-format comparison.
+
+        Only an absent or blank value is silently empty — an absent ``arguments``
+        honestly means *no arguments*, which is why it does **not** residualise
+        the way an absent tool ``name`` does even though the schema requires
+        both: a name is unrecoverable, an empty argument set is not. And kitty
+        already emits the blank form: its Responses builder writes ``arguments`` as ``""`` whenever a
+        Chat Completions tool call carried none, so the empty string is real
+        corpus traffic rather than a hypothetical. Every other shape the schema
+        forbids residualises, because mapping it to ``{}`` would claim the agent
+        sent no arguments when it sent something — and would hide the breach
+        where kitty *drops* them.
+
+        Args:
+            raw: The wire value.
+            path: The residual path for this field.
+            residual: Accumulator of unclassifiable values, mutated here.
+
+        Returns:
+            The decoded arguments, empty when the wire value carried none.
+        """
+        if raw is None:
+            return {}
+
+        # `FunctionToolCall.arguments` is a string in the published schema. A
+        # decoded object is NOT accepted: it would make a bridge that emitted the
+        # object form instead of the string invisible to the oracle, which is the
+        # wire-format breach this reader exists to see.
+        if not isinstance(raw, str):
+            residual[path] = raw
+            return {}
+
+        if not raw.strip():
+            return {}
+
+        try:
+            decoded = json.loads(raw)
+        except json.JSONDecodeError:
+            # Never an exception: `contract` defines a reader-raised ValueError
+            # as "the reader mis-routed a field", so failing closed into the
+            # residual keeps the diagnosis honest.
+            residual[path] = raw
+            return {}
+
+        if not isinstance(decoded, dict):
+            residual[path] = raw
+            return {}
+
+        return decoded
+
+    def _read_function_output(self, item: Mapping[str, Any], path: str, residual: dict[str, Any]) -> c.ToolResult:
+        """Project a ``function_call_output`` item.
+
+        Args:
+            item: The raw item.
+            path: Its residual path prefix.
+            residual: Accumulator of unclassifiable values, mutated here.
+
+        Returns:
+            The projected tool result.
+        """
+        call_id = item.get("call_id")
+        raw = item.get("output")
+
+        content: list[c.Text | c.Image | c.Json | c.Opaque] = []
+
+        if isinstance(raw, str):
+            content.append(self._read_output_string(raw))
+        elif isinstance(raw, list):
+            # The array branch publishes only these three content types, so the
+            # message set is narrowed here: accepting `refusal` or `output_text`
+            # in a tool result would let a shape the schema forbids pass
+            # unremarked. `_read_content_part` returns only members of
+            # `RESULT_PART_TYPES`, so no further narrowing is needed after it.
+            for _offset, part in self._read_content(
+                raw, f"{path}.output", residual, allowed=_TOOL_OUTPUT_CONTENT_TYPES
+            ):
+                content.append(part)  # type: ignore[arg-type]
+        elif raw is not None:
+            residual[f"{path}.output"] = raw
+
+        # Responses carries no error flag on a function output, so `is_error` is
+        # always False here. Written down rather than left as silence: the field
+        # exists on the contract because Messages has one.
+        return c.ToolResult(
+            content=content,
+            tool_use_id=call_id if isinstance(call_id, str) else None,
+            is_error=False,
+        )
+
+    @staticmethod
+    def _read_output_string(raw: str) -> c.Text | c.Json:
+        """Project a string tool output, preferring its structured form.
+
+        Args:
+            raw: The wire value — "a JSON string of the output" per the schema,
+                though tools routinely return prose.
+
+        Returns:
+            A :class:`harness.contract.Json` when the string parses as JSON,
+            otherwise a :class:`harness.contract.Text`.
+        """
+        try:
+            return c.Json(json.loads(raw))
+        except json.JSONDecodeError:
+            return c.Text(raw)
+
+    @staticmethod
+    def _read_reasoning(item: Mapping[str, Any], path: str, residual: dict[str, Any]) -> list[c.Part]:
+        """Project a ``reasoning`` item into thinking parts.
+
+        One part per ``summary`` entry, then one per ``content`` entry, in wire
+        order, so dropping one entry of three is a visible delta rather than
+        changed text. ``encrypted_content`` rides on the first part as its
+        signature — it is what M8's carrier repair manipulates.
+
+        Args:
+            item: The raw reasoning item.
+            path: Its residual path prefix.
+            residual: Accumulator of unclassifiable values, mutated here.
+
+        Returns:
+            The projected parts, never empty.
+        """
+        # `Thinking.text` is declared `str` but unvalidated, so a non-string
+        # `text` cannot simply flow into the projection — and it cannot simply be
+        # skipped either. Skipping performs exactly the loss this fan-out exists
+        # to make visible: an item carrying two summary entries would project one
+        # part with nothing to say the other vanished, and `consumed` is
+        # top-level only so `verify_total` could never see it.
+        texts: list[str] = []
+        for field_name in ("summary", "content"):
+            entries = item.get(field_name)
+            if entries is None:
+                continue
+
+            if not isinstance(entries, list):
+                residual[f"{path}.{field_name}"] = entries
+                continue
+
+            for offset, entry in enumerate(entries):
+                text = entry.get("text") if isinstance(entry, dict) else None
+                if isinstance(text, str):
+                    texts.append(text)
+                else:
+                    residual[f"{path}.{field_name}[{offset}]"] = entry
+
+        signature = item.get("encrypted_content")
+        if not isinstance(signature, str):
+            signature = None
+
+        # An empty block is a part with an empty string, never nothing: without
+        # one, a reasoning item carrying only an encrypted blob would vanish and
+        # its presence would stop being observable.
+        if not texts:
+            return [c.Thinking("", signature=signature)]
+
+        return [c.Thinking(text, signature=signature if offset == 0 else None) for offset, text in enumerate(texts)]
+
+    # ----------------------------------------------------------------
+    # Tools
+    # ----------------------------------------------------------------
+
+    def _read_tools(self, body: Mapping[str, Any], consumed: set[str], residual: dict[str, Any]) -> list[c.ToolDecl]:
+        """Project the ``tools`` array.
+
+        Args:
+            body: The parsed request body.
+            consumed: Accumulator of top-level keys accounted for, mutated here.
+            residual: Accumulator of unclassifiable values, mutated here.
+
+        Returns:
+            The projected declarations, in wire order.
+        """
+        if "tools" not in body:
+            return []
+
+        consumed.add("tools")
+        raw = body["tools"]
+
+        if not isinstance(raw, list):
+            residual["tools"] = raw
+            return []
+
+        tools: list[c.ToolDecl] = []
+        for index, entry in enumerate(raw):
+            # A declaration whose `type` is not a string is not a published tool
+            # shape at all, so it residualises whole rather than being read as a
+            # built-in named `str(kind)`.
+            if not isinstance(entry, dict) or not isinstance(entry.get("type"), str):
+                residual[f"tools[{index}]"] = entry
+                continue
+            tools.append(self._read_tool(entry, f"tools[{index}]", residual))
+
+        return tools
+
+    @staticmethod
+    def _read_tool(entry: Mapping[str, Any], path: str, residual: dict[str, Any]) -> c.ToolDecl:
+        """Project one tool declaration.
+
+        Args:
+            entry: The raw declaration.
+            path: Its residual path prefix.
+            residual: Accumulator of unclassifiable values, mutated here.
+
+        Returns:
+            The projected declaration.
+        """
+        kind = entry.get("type")
+
+        if kind == "function":
+            # A wrongly-typed description or schema residualises rather than
+            # becoming `None`. Both fields carry register weight — P15 strips
+            # `strict`, and §3.3.1's oracle falsification set deletes a
+            # description — so a silent `None` here would look exactly like the
+            # mutation those checks exist to catch.
+            description = entry.get("description")
+            if description is not None and not isinstance(description, str):
+                residual[f"{path}.description"] = description
+                description = None
+
+            parameters = entry.get("parameters")
+            if parameters is not None and not isinstance(parameters, dict):
+                residual[f"{path}.parameters"] = parameters
+                parameters = None
+
+            # Same rule as `_read_function_call`, and for a stronger reason:
+            # `FunctionTool.required` includes `name`, and §3.3.1a addresses
+            # tools by name with no index to fall back on. Two unnamed
+            # declarations would both sit at `conversation.tools[]` — which
+            # `path_matches` accepts as the legacy wildcard spelling, so a
+            # register row would match them by accident rather than by name.
+            name = entry.get("name")
+            if not isinstance(name, str):
+                residual[f"{path}.name"] = name
+                name = ""
+
+            strict = entry.get("strict")
+            return c.ToolDecl(
+                name=name,
+                description=description,
+                schema=parameters,
+                # `strict` is a tri-state, and the published schema spells "no
+                # strict" as null rather than as omission. `None` must stay
+                # distinct from `False` or register row P15's presence and
+                # absence become indistinguishable.
+                strict=strict if isinstance(strict, bool) else None,
+            )
+
+        # A built-in tool is still addressable by name, so its whole declaration
+        # becomes the schema and nothing is lost. MCP is named by its server: two
+        # servers named by bare `type` would both occupy `conversation.tools[mcp]`,
+        # a collision §3.3.1a's by-name addressing cannot recover from.
+        name = entry.get("name")
+        if kind == "mcp":
+            label = entry.get("server_label")
+            name = _mcp_tool_name(label) if isinstance(label, str) else "mcp"
+        elif not isinstance(name, str):
+            name = str(kind)
+
+        return c.ToolDecl(name=name, schema=dict(entry))
+
+    # ----------------------------------------------------------------
+    # Turns
+    # ----------------------------------------------------------------
+
+    @staticmethod
+    def _merge(turns: Sequence[c.Turn]) -> list[c.Turn]:
+        """Merge consecutive same-role turns, preserving wire order.
+
+        §3.3.1b's merge rule has four clauses, and on this format three of them
+        reduce to this one. A maximal run of consecutive tool results forms one
+        ``user`` turn, and an immediately following user message merges into it —
+        both are consecutive ``user`` emissions. "``ToolResult`` parts come
+        first" is then satisfied **vacuously**, because every member of a run
+        *is* a tool result: Responses delivers results contiguously in the input
+        array, so there is nothing to reorder.
+
+        Reordering was rejected deliberately. Hoisting results ahead of a
+        *preceding* user message would move text the agent sent first to sit
+        after the result, inventing a delta on every such turn — and because
+        paths are index-based, a disagreement about turn boundaries reports a
+        delta on every subsequent turn too.
+
+        Args:
+            turns: The turns in wire order, one per input item.
+
+        Returns:
+            The merged turns.
+        """
+        merged: list[c.Turn] = []
+
+        for turn in turns:
+            if merged and merged[-1].role == turn.role:
+                previous = merged[-1]
+                merged[-1] = c.Turn(previous.role, [*previous.parts, *turn.parts])
+            else:
+                merged.append(turn)
+
+        return merged

--- a/tests/harness/test_reader_responses.py
+++ b/tests/harness/test_reader_responses.py
@@ -167,7 +167,15 @@ class TestEnvelope:
 
 
 class TestToolChoiceNormalisation:
-    """All nine published `ToolChoiceParam` forms, onto the canonical vocabulary."""
+    """All nine published `ToolChoiceParam` forms, onto the canonical vocabulary.
+
+    Nine *forms* — the members of `ToolChoiceParam.oneOf` — but twenty *values*,
+    because three of them carry closed enumerations of their own:
+    `ToolChoiceOptions` has three strings, `ToolChoiceAllowed` two modes, and
+    `ToolChoiceTypes` eight built-in tool types. Every value is exercised, not
+    one representative per form, because the normalisation differs *within*
+    those enumerations — `required` becomes `any` while `auto` does not.
+    """
 
     @pytest.mark.parametrize(
         ("choice", "expected"),
@@ -948,6 +956,25 @@ class TestOpaqueItems:
         projected = project({"input": [{"id": "msg_1", "type": None}]})
 
         assert projected.conversation.turns == (c.Turn("user", [c.Opaque("item_reference")]),)
+
+    def test_additional_tools_lands_in_a_user_turn_despite_declaring_developer(self) -> None:
+        """The named exception whose reasoning is hardest to guess from the rule.
+
+        `AdditionalToolsItemParam` is the only opaque item carrying a `role` of
+        its own, and its sole published value is `developer` — which everywhere
+        else in this reader lifts into `conversation.system`. It cannot here:
+        `Conversation.system` is enforced `Text`-only and an `Opaque` has no home
+        in it. So the item lands in a `user` turn, on the ground that
+        `developer` is client-supplied.
+
+        Worth its own test rather than only the parametrised sweep, because a
+        future reader seeing `role: "developer"` would reasonably try to lift it
+        and would then be changing turn indices for every later turn.
+        """
+        projected = project({"input": [{"type": "additional_tools", "role": "developer"}]})
+
+        assert projected.conversation.system == ()
+        assert projected.conversation.turns == (c.Turn("user", [c.Opaque("additional_tools")]),)
 
     def test_an_item_reference_is_recognised_without_a_type(self) -> None:
         """`ItemReferenceParam.type` is nullable, so `{"id": ...}` alone is legal."""

--- a/tests/harness/test_reader_responses.py
+++ b/tests/harness/test_reader_responses.py
@@ -982,17 +982,34 @@ class TestOpaqueItems:
 
         assert projected.conversation.turns == (c.Turn("user", [c.Opaque("item_reference")]),)
 
-    def test_the_closed_set_matches_the_published_schema_counts(self) -> None:
-        """A guard on the tables themselves.
+    def test_the_closed_sets_are_internally_consistent_and_sized_as_recorded(self) -> None:
+        """A guard on the module's own tables — **not** on OpenAI's schema.
 
-        The counts are the ones §3.3.1's "map it, or declare it ignored" rule
-        turns into a decision; if OpenAI adds an item type, this fails here
-        rather than silently widening the residual in T-D5.
+        Worth being exact about, because the obvious reading is wrong and an
+        earlier version of this docstring made the claim: the suite has no
+        network and vendors no copy of `openapi.yaml`, so nothing here can
+        notice OpenAI *adding* an item type. What this catches is an edit to
+        this module — a type moved between the role tables, or dropped — which
+        is the direction a maintainer can cause.
+
+        **Spec drift is caught elsewhere, and loudly.** A type outside these
+        sets residualises, and a non-empty residual fails the run (§3.3.1) — so
+        the first request carrying a new item type fails at the point it
+        matters, rather than being quietly absorbed. That is the designed
+        behaviour, not a gap: §3.3.1 wants a new wire field to *force a
+        deliberate decision*. `SCHEMA_VERSION` records which revision these
+        tables were derived from so the decision has a starting point.
         """
         assert len(r.PUBLISHED_ITEM_TYPES) == 31
         assert len(r._OPAQUE_USER_ITEMS) == 12
         assert len(r._OPAQUE_ASSISTANT_ITEMS) == 15
         assert r._OPAQUE_USER_ITEMS.isdisjoint(r._OPAQUE_ASSISTANT_ITEMS)
+
+        # The modelled four and the opaque twenty-seven must partition the set,
+        # or a type could be both modelled and placeheld and the dispatch order
+        # would silently decide which wins.
+        assert r._MODELLED_ITEMS.isdisjoint(r._OPAQUE_USER_ITEMS | r._OPAQUE_ASSISTANT_ITEMS)
+        assert len(r._MODELLED_ITEMS) + len(r._OPAQUE_USER_ITEMS) + len(r._OPAQUE_ASSISTANT_ITEMS) == 31
 
     def test_the_mechanical_role_rule_reproduces_the_table(self) -> None:
         """The rule in the docstring and the table must not drift apart.

--- a/tests/harness/test_reader_responses.py
+++ b/tests/harness/test_reader_responses.py
@@ -1,0 +1,1698 @@
+"""L1 tests for the OpenAI Responses projection.
+
+`.system_design/TEST_SUITE.md` §3.3.1, §3.3.1a, §3.3.1b · plan task **T-A3** (KBR-35).
+
+**Every fixture is a published example.**  The eight bodies in
+:class:`TestPublishedExamples` are the ``x-oaiMeta`` request examples carried by
+``openai/openai-openapi``'s own ``openapi.yaml`` at ``info.version``
+:data:`~harness.reader_responses.SCHEMA_VERSION`, **adapted only by substituting
+``example.test`` for the third-party image and file URLs** so the suite names no
+host it does not control; the rest are assembled from
+``CreateResponse`` and its referenced schemas in that same file.  None is copied
+from kitty's output — §3.3.1's independent-oracle rule makes a reader validated
+against kitty's output circular, because it would inherit kitty's bugs and the
+oracle would then prove only that kitty agrees with itself.
+
+**The falsification set is required, not decorative.**  Plan §1.4: the first
+working version of every harness ships with at least one deliberate defect it
+must detect, running in the suite.  :class:`TestFalsification` holds three — an
+unrecognised top-level key, an unrecognised item type, and a *dropping* reader
+that residualises nothing.  The third is the one a "residual must be empty" rule
+cannot catch, which is why :attr:`harness.contract.Request.consumed` exists.
+
+**Two guards this module owns on behalf of others.**  Register row **P16** is
+``NOT_PROJECTABLE``, and ``contract.py`` names "the Responses reader's own L1
+test" as one of its two guards — :class:`TestP16StaysInvisible` is it.  And the
+31 published top-level keys and 31 item types are asserted against the reader's
+own tables, so a schema revision that adds one fails here rather than silently
+widening the residual in T-D5.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from harness import contract as c
+from harness import reader_responses as r
+
+
+def captured(body: Any) -> c.CapturedRequest:
+    """Wrap a body as a capture aimed at the published Responses endpoint.
+
+    Args:
+        body: A mapping to encode as JSON, or raw bytes to pass through
+            undecoded for the failure-shape tests.
+
+    Returns:
+        A capture the reader can be handed directly.
+    """
+    raw = body if isinstance(body, bytes) else json.dumps(body).encode("utf-8")
+
+    return c.CapturedRequest(
+        method="POST",
+        scheme="https",
+        host="api.openai.com",
+        path="/v1/responses",
+        query="",
+        headers=(("content-type", "application/json"),),
+        body=raw,
+    )
+
+
+def project(body: Any) -> c.Request:
+    """Project a body and assert it accounted for itself.
+
+    Every caller wants both, and running :func:`harness.contract.verify_total`
+    here rather than in each test means no test can pass while quietly leaving a
+    key unaccounted for.
+
+    Args:
+        body: The request body.
+
+    Returns:
+        The projection.
+    """
+    projected = r.ResponsesProjection().read_request(captured(body))
+    c.verify_total(projected)
+
+    return projected
+
+
+# --------------------------------------------------------------------------
+# R1 — protocol conformance
+# --------------------------------------------------------------------------
+
+
+class TestProtocolConformance:
+    """The reader is a `Projection` for the Responses format."""
+
+    def test_it_declares_the_responses_wire_format(self) -> None:
+        """A `str` would let six authors spell one format three ways (§7.4)."""
+        assert r.ResponsesProjection.wire_format is c.WireFormat.OPENAI_RESPONSES
+
+    def test_it_satisfies_the_projection_protocol(self) -> None:
+        """`isinstance`, never `issubclass` — the protocol carries a data member."""
+        assert isinstance(r.ResponsesProjection(), c.Projection)
+
+    def test_it_actually_projects_rather_than_merely_having_the_members(self) -> None:
+        """The paired assertion `isinstance` cannot make.
+
+        `contract.Projection` checks member *presence* only, never signatures,
+        so the test above passes against any object with two attributes. Without
+        this, "conforms to the protocol" would be satisfied by a stub.
+        """
+        projected = project({"model": "gpt-6-astra", "input": "hello"})
+
+        assert projected.envelope.model == "gpt-6-astra"
+        assert projected.conversation.turns == (c.Turn("user", [c.Text("hello")]),)
+
+
+# --------------------------------------------------------------------------
+# R2 — envelope and tool_choice
+# --------------------------------------------------------------------------
+
+
+class TestEnvelope:
+    """Control fields land on the envelope, keyed by the wire key."""
+
+    def test_the_three_named_control_fields(self) -> None:
+        """M1 replaces `model`; P17 injects `stream` and `store`."""
+        projected = project({"model": "gpt-6-astra", "input": "hi", "stream": True, "store": False})
+
+        assert projected.envelope.model == "gpt-6-astra"
+        assert projected.envelope.stream is True
+        assert projected.envelope.store is False
+
+    def test_a_format_specific_control_field_keeps_its_wire_key(self) -> None:
+        """P3/P4's register rows address `envelope.extra[reasoning]` by that name."""
+        projected = project({"input": "hi", "reasoning": {"effort": "high"}})
+
+        assert projected.envelope.extra["reasoning"] == {"effort": "high"}
+
+    def test_extra_is_keyed_and_never_nested(self) -> None:
+        """§3.3.1b: the oracle compares an extra entry whole.
+
+        Six readers cannot quietly disagree about whether `reasoning.effort` has
+        an address of its own, so no reader may emit one.
+        """
+        projected = project(
+            {
+                "input": "hi",
+                "reasoning": {"effort": "high", "summary": "concise"},
+                "text": {"format": {"type": "json_object"}},
+            }
+        )
+
+        # Asserted non-empty first: "no key contains a dot" is vacuously true of
+        # an empty mapping, so the flatness check alone passes against a reader
+        # that populated nothing.
+        assert set(projected.envelope.extra) == {"reasoning", "text"}
+
+        nested = [key for key in projected.envelope.extra if "." in key]
+        assert nested == [], f"extra must be flat, found nested keys: {nested}"
+
+    def test_an_absent_control_field_is_absent_rather_than_none(self) -> None:
+        """P17 injects `store`, so its absence must be observable (§3.3.2 assertion 2)."""
+        projected = project({"input": "hi"})
+
+        assert projected.envelope.store is None
+        assert "reasoning" not in projected.envelope.extra
+
+
+class TestToolChoiceNormalisation:
+    """All nine published `ToolChoiceParam` forms, onto the canonical vocabulary."""
+
+    @pytest.mark.parametrize(
+        ("choice", "expected"),
+        [
+            # ToolChoiceOptions — the three bare strings.
+            ("none", "none"),
+            ("auto", "auto"),
+            ("required", "any"),
+            # ToolChoiceAllowed — by its own mode, not flattened to `any`.
+            ({"type": "allowed_tools", "mode": "auto", "tools": [{"type": "function"}]}, "auto"),
+            ({"type": "allowed_tools", "mode": "required", "tools": []}, "any"),
+            # ToolChoiceFunction and ToolChoiceCustom — by name.
+            ({"type": "function", "name": "get_weather"}, "tool:get_weather"),
+            ({"type": "custom", "name": "my_tool"}, "tool:my_tool"),
+            # ToolChoiceMCP — by server, optionally narrowed to one tool. The
+            # spelling embeds the declaration's own name (`mcp:<label>`) so the
+            # selection corresponds to something `conversation.tools` holds.
+            ({"type": "mcp", "server_label": "docs"}, "tool:mcp:docs"),
+            ({"type": "mcp", "server_label": "docs", "name": "search"}, "tool:mcp:docs:search"),
+            # ToolChoiceTypes — the eight built-ins.
+            ({"type": "file_search"}, "tool:file_search"),
+            ({"type": "web_search_preview"}, "tool:web_search_preview"),
+            ({"type": "computer"}, "tool:computer"),
+            ({"type": "computer_use_preview"}, "tool:computer_use_preview"),
+            ({"type": "computer_use"}, "tool:computer_use"),
+            ({"type": "web_search_preview_2025_03_11"}, "tool:web_search_preview_2025_03_11"),
+            ({"type": "image_generation"}, "tool:image_generation"),
+            ({"type": "code_interpreter"}, "tool:code_interpreter"),
+            # The three Specific* singletons.
+            ({"type": "programmatic_tool_calling"}, "tool:programmatic_tool_calling"),
+            ({"type": "apply_patch"}, "tool:apply_patch"),
+            ({"type": "shell"}, "tool:shell"),
+        ],
+    )
+    def test_each_published_form_normalises(self, choice: Any, expected: str) -> None:
+        """§3.3.1b R8.6 pins the value to auto / any / none / tool:<name>."""
+        projected = project({"input": "hi", "tool_choice": choice})
+
+        assert projected.envelope.extra[c.TOOL_CHOICE_KEY] == expected
+
+    def test_allowed_tools_distinguishes_its_two_modes(self) -> None:
+        """The mutation a flat `any` would hide.
+
+        `allowed_tools` is the one object form carrying a mode of its own.
+        Collapsing both to `any` would make a `mode: auto -> required` rewrite
+        invisible — in the field whose job is constraining what the model may
+        call.
+        """
+        permissive = project({"input": "hi", "tool_choice": {"type": "allowed_tools", "mode": "auto", "tools": []}})
+        forced = project({"input": "hi", "tool_choice": {"type": "allowed_tools", "mode": "required", "tools": []}})
+
+        assert permissive.envelope.extra[c.TOOL_CHOICE_KEY] != forced.envelope.extra[c.TOOL_CHOICE_KEY]
+
+    def test_two_mcp_servers_do_not_collide(self) -> None:
+        """A bare `tool:mcp` would equate two different servers."""
+        first = project({"input": "hi", "tool_choice": {"type": "mcp", "server_label": "docs"}})
+        second = project({"input": "hi", "tool_choice": {"type": "mcp", "server_label": "wiki"}})
+
+        assert first.envelope.extra[c.TOOL_CHOICE_KEY] != second.envelope.extra[c.TOOL_CHOICE_KEY]
+
+    def test_an_unrecognised_selector_residualises_rather_than_being_guessed(self) -> None:
+        """Guessing would equate a shape nobody has looked at with a real selection."""
+        projected = r.ResponsesProjection().read_request(
+            captured({"input": "hi", "tool_choice": {"type": "telepathy"}})
+        )
+
+        assert projected.residual == {"tool_choice": {"type": "telepathy"}}
+        with pytest.raises(c.ResidualFieldsError):
+            c.verify_total(projected)
+
+
+# --------------------------------------------------------------------------
+# R3 — sampling
+# --------------------------------------------------------------------------
+
+
+class TestSampling:
+    """Sampling normalises to the Chat Completions spelling (§3.3.1b)."""
+
+    def test_max_output_tokens_becomes_max_tokens(self) -> None:
+        """Register row P14 is written against exactly this mapping."""
+        projected = project({"input": "hi", "max_output_tokens": 2048})
+
+        assert projected.conversation.sampling == {"max_tokens": 2048}
+
+    def test_the_parameters_already_spelled_canonically(self) -> None:
+        """All four are in `SAMPLING_KEYS`, so they map by their own names."""
+        projected = project(
+            {
+                "input": "hi",
+                "temperature": 0.2,
+                "top_p": 0.9,
+                "top_logprobs": 5,
+                "stream_options": {"include_obfuscation": False},
+            }
+        )
+
+        assert projected.conversation.sampling == {
+            "temperature": 0.2,
+            "top_p": 0.9,
+            "top_logprobs": 5,
+            "stream_options": {"include_obfuscation": False},
+        }
+
+    def test_text_is_not_folded_onto_response_format(self) -> None:
+        """§3.3.1b mandates only the `max_output_tokens` rename.
+
+        `text` is Responses' own spelling of a related but not identical
+        concept; folding it would manufacture a false equality with a Chat
+        Completions `response_format` and hide a real translation step.
+        """
+        projected = project({"input": "hi", "text": {"format": {"type": "json_object"}}})
+
+        assert projected.envelope.extra["text"] == {"format": {"type": "json_object"}}
+        assert "response_format" not in projected.conversation.sampling
+
+
+# --------------------------------------------------------------------------
+# R4 — system lifting
+# --------------------------------------------------------------------------
+
+
+class TestSystemLifting:
+    """All three carriers lift into `conversation.system`, never into a turn."""
+
+    def test_instructions_and_both_system_roles_lift_in_order(self) -> None:
+        """§3.3.1b R8.2 names four carriers; Responses uses three of them."""
+        projected = project(
+            {
+                "instructions": "You are terse.",
+                "input": [
+                    {"role": "developer", "content": "Prefer SI units."},
+                    {"role": "system", "content": "Never apologise."},
+                    {"role": "user", "content": "hi"},
+                ],
+            }
+        )
+
+        assert projected.conversation.system == (
+            c.Text("You are terse."),
+            c.Text("Prefer SI units."),
+            c.Text("Never apologise."),
+        )
+        assert [turn.role for turn in projected.conversation.turns] == ["user"]
+
+    def test_null_instructions_contribute_nothing(self) -> None:
+        """`CreateResponse.instructions` is `anyOf[string, null]`.
+
+        `Text.text` is unvalidated, so a naive reader would put `Text(None)` into
+        `conversation.system` — a system entry carrying a `None` where a `str` is
+        declared, present on one side of a diff and absent on the other.
+        """
+        projected = project({"instructions": None, "input": "hi"})
+
+        assert projected.conversation.system == ()
+
+    def test_empty_instructions_do_contribute_an_empty_part(self) -> None:
+        """The deliberate asymmetry with `null`, and the reason for it.
+
+        An empty string is a value the agent sent, so it stays observable — the
+        same posture the contract takes on empty thinking blocks, where "an empty
+        block is a part with an empty string, never nothing". A bridge dropping
+        an empty `instructions` is then a visible delta.
+        """
+        projected = project({"instructions": "", "input": "hi"})
+
+        assert projected.conversation.system == (c.Text(""),)
+
+    def test_a_non_text_part_in_a_lifted_message_residualises(self) -> None:
+        """`Conversation.system` is enforced Text-only, and a developer message may carry an image.
+
+        Residualising fails closed. Letting the contract's `TypeError` out would
+        add a **fourth** failure shape beside the three §3.3.1 defines on
+        purpose, and T-D1 could not classify it.
+        """
+        projected = r.ResponsesProjection().read_request(
+            captured(
+                {
+                    "input": [
+                        {
+                            "role": "developer",
+                            "content": [
+                                {"type": "input_text", "text": "Use this diagram."},
+                                {"type": "input_image", "image_url": "https://example.test/d.png"},
+                            ],
+                        }
+                    ]
+                }
+            )
+        )
+
+        assert projected.conversation.system == (c.Text("Use this diagram."),)
+        assert set(projected.residual) == {"input[0].content[1]"}
+        with pytest.raises(c.ResidualFieldsError):
+            c.verify_total(projected)
+
+    def test_the_lifted_residual_is_keyed_by_the_wire_index_not_the_projected_offset(self) -> None:
+        """Two unclassifiable parts must produce two residual entries, correctly named.
+
+        The projected list is shorter than the wire list as soon as anything
+        residualises, so indexing the residual by the projected offset both
+        names the wrong element *and* collides with the key the content reader
+        already wrote — silently destroying one of the two values. The offending
+        entry is deliberately first, so the two indices cannot coincide by luck.
+        """
+        projected = r.ResponsesProjection().read_request(
+            captured(
+                {
+                    "input": [
+                        {
+                            "role": "developer",
+                            "content": [
+                                {"type": "unheard_of", "x": 1},
+                                {"type": "input_image", "image_url": "https://example.test/a.png"},
+                            ],
+                        }
+                    ]
+                }
+            )
+        )
+
+        assert set(projected.residual) == {"input[0].content[0]", "input[0].content[1]"}
+
+        # The wire value is stored, not the projected object: every other
+        # residual site stores what was on the wire, and T-D8 compares them.
+        assert projected.residual["input[0].content[0]"] == {"type": "unheard_of", "x": 1}
+        assert projected.residual["input[0].content[1]"] == {
+            "type": "input_image",
+            "image_url": "https://example.test/a.png",
+        }
+
+
+# --------------------------------------------------------------------------
+# R5 — the two published `input` shapes
+# --------------------------------------------------------------------------
+
+
+class TestInputShapes:
+    """`InputParam` is `oneOf[string, array]`, and both are real traffic."""
+
+    def test_a_bare_string_is_one_user_turn(self) -> None:
+        """The schema calls it "equivalent to a text input with the user role"."""
+        projected = project({"input": "Tell me a story."})
+
+        assert projected.conversation.turns == (c.Turn("user", [c.Text("Tell me a story.")]),)
+
+    def test_the_string_and_array_forms_agree(self) -> None:
+        """The same conversation, spelled two ways the schema both permits.
+
+        KBR-144 is a live 500 on the string form, so this is not hypothetical.
+        The array fixture also carries no `type`, which is the `EasyInputMessage`
+        dispatch case.
+        """
+        from_string = project({"input": "hello"})
+        from_array = project({"input": [{"role": "user", "content": "hello"}]})
+
+        # Pinned to a concrete expectation for the same reason as P16's guard:
+        # two empty conversations are also equal.
+        expected = c.Conversation(turns=[c.Turn("user", [c.Text("hello")])])
+        assert from_string.conversation == expected
+        assert from_array.conversation == expected
+
+
+# --------------------------------------------------------------------------
+# R6 / R7 — items and content parts
+# --------------------------------------------------------------------------
+
+
+class TestP16StaysInvisible:
+    """The guard `contract.py` delegates to this module by name."""
+
+    def test_input_text_and_output_text_project_identically(self) -> None:
+        """Register row P16 is `NOT_PROJECTABLE`, and this is what makes it so.
+
+        P16 rewrites `input_text` to `output_text` unconditionally on the
+        Responses-origin path. The tag is redundant with the turn's role, so
+        carrying it would put one vendor's spelling into a form whose purpose is
+        wire independence — and would make a deliberate, registered mutation
+        show as an unclaimed delta on every request.
+        """
+        inbound = project({"input": [{"role": "assistant", "content": [{"type": "input_text", "text": "ok"}]}]})
+        upstream = project({"input": [{"role": "assistant", "content": [{"type": "output_text", "text": "ok"}]}]})
+
+        # Asserted against a concrete expectation, not only against each other:
+        # a reader returning an empty conversation for both would satisfy the
+        # equality while projecting nothing. `contract.py` names this test by
+        # name as one of P16's two guards, so a vacuous version of it is the
+        # worst place for that shape.
+        expected = c.Conversation(turns=[c.Turn("assistant", [c.Text("ok")])])
+        assert inbound.conversation == expected
+        assert upstream.conversation == expected
+
+
+class TestContentParts:
+    """Each published content type projects to its grammar counterpart."""
+
+    def test_a_refusal_is_not_collapsed_into_text(self) -> None:
+        """Unlike P16's tag, refusal-ness is not recoverable from the role.
+
+        An assistant refusal and an assistant answer would project identically,
+        so a bridge that turned one into the other would be invisible.
+        """
+        refusal = project({"input": [{"role": "assistant", "content": [{"type": "refusal", "refusal": "no"}]}]})
+        answer = project({"input": [{"role": "assistant", "content": [{"type": "output_text", "text": "no"}]}]})
+
+        assert refusal.conversation != answer.conversation
+        assert refusal.conversation.turns[0].parts == (c.Opaque("refusal", digest=c.image_digest(b"no")),)
+
+    def test_a_rewritten_refusal_is_visible(self) -> None:
+        """`kind` alone would make a rewritten refusal invisible.
+
+        `Opaque` carries a digest for exactly this: naming the *kind* restores
+        refusal-ness, but without the digest a bridge that changed the refusal's
+        wording would still project identically.
+        """
+        original = project({"input": [{"role": "assistant", "content": [{"type": "refusal", "refusal": "no"}]}]})
+        rewritten = project(
+            {
+                "input": [
+                    {
+                        "role": "assistant",
+                        "content": [{"type": "refusal", "refusal": "absolutely not"}],
+                    }
+                ]
+            }
+        )
+
+        assert original.conversation != rewritten.conversation
+
+    def test_an_input_file_is_opaque_rather_than_dropped(self) -> None:
+        """`Opaque` keeps content the grammar cannot express *detectable*."""
+        projected = project(
+            {
+                "input": [
+                    {
+                        "role": "user",
+                        "content": [{"type": "input_file", "file_id": "file-123"}],
+                    }
+                ]
+            }
+        )
+
+        assert projected.conversation.turns[0].parts == (c.Opaque("file"),)
+
+    def test_a_data_url_image_is_digested(self) -> None:
+        """`image_digest` is pinned so six readers agree on one image.
+
+        A reader that left the data URL in `ref` while T-A2 decoded it would
+        reproduce exactly the disagreement the pinning exists to prevent.
+        """
+        raw = b"\x89PNG\r\n\x1a\nfake"
+        url = "data:image/png;base64," + base64.b64encode(raw).decode("ascii")
+
+        projected = project({"input": [{"role": "user", "content": [{"type": "input_image", "image_url": url}]}]})
+
+        assert projected.conversation.turns[0].parts == (
+            c.Image(digest=hashlib.sha256(raw).hexdigest(), media_type="image/png"),
+        )
+
+    def test_the_media_type_is_excluded_from_the_digest(self) -> None:
+        """So a changed media type is its own delta, not an unexplained digest change."""
+        raw = b"bytes"
+        payload = base64.b64encode(raw).decode("ascii")
+
+        as_png = project(
+            {
+                "input": [
+                    {
+                        "role": "user",
+                        "content": [{"type": "input_image", "image_url": f"data:image/png;base64,{payload}"}],
+                    }
+                ]
+            }
+        )
+        as_jpeg = project(
+            {
+                "input": [
+                    {
+                        "role": "user",
+                        "content": [{"type": "input_image", "image_url": f"data:image/jpeg;base64,{payload}"}],
+                    }
+                ]
+            }
+        )
+
+        first = as_png.conversation.turns[0].parts[0]
+        second = as_jpeg.conversation.turns[0].parts[0]
+        assert isinstance(first, c.Image) and isinstance(second, c.Image)
+        assert first.digest == second.digest
+        assert first.media_type != second.media_type
+
+    def test_a_remote_image_carries_its_uri_instead_of_a_digest(self) -> None:
+        """There are no bytes to digest — the shape §3.3.1 gives Gemini's `fileUri`."""
+        projected = project(
+            {
+                "input": [
+                    {
+                        "role": "user",
+                        "content": [{"type": "input_image", "image_url": "https://example.test/cat.png"}],
+                    }
+                ]
+            }
+        )
+
+        assert projected.conversation.turns[0].parts == (c.Image(ref="https://example.test/cat.png"),)
+
+    def test_a_data_url_that_is_not_base64_residualises_rather_than_becoming_a_ref(self) -> None:
+        """Putting a data URL in `ref` is the shape the pinned digest exists to prevent.
+
+        Another reader decoding the same bytes would produce a digest, and the
+        two projections would then differ on an unchanged image — a permanent
+        unclaimed delta that no register row could ever explain.
+        """
+        projected = r.ResponsesProjection().read_request(
+            captured(
+                {
+                    "input": [
+                        {
+                            "role": "user",
+                            "content": [{"type": "input_image", "image_url": "data:image/png,abc"}],
+                        }
+                    ]
+                }
+            )
+        )
+
+        assert set(projected.residual) == {"input[0].content[0]"}
+
+    def test_an_image_given_only_by_file_id_carries_the_id_as_its_reference(self) -> None:
+        """`InputImageContent` permits `file_id` instead of `image_url`."""
+        projected = project(
+            {
+                "input": [
+                    {
+                        "role": "user",
+                        "content": [{"type": "input_image", "file_id": "file-9", "detail": "auto"}],
+                    }
+                ]
+            }
+        )
+
+        assert projected.conversation.turns[0].parts == (c.Image(ref="file-9"),)
+
+
+class TestFunctionCall:
+    """`function_call` items and their JSON-string arguments."""
+
+    def test_a_function_call_projects_with_its_call_id(self) -> None:
+        """`ToolUse.id` pairs the call with its result."""
+        projected = project(
+            {
+                "input": [
+                    {
+                        "type": "function_call",
+                        "call_id": "call_1",
+                        "name": "get_weather",
+                        "arguments": '{"location": "Boston"}',
+                    }
+                ]
+            }
+        )
+
+        assert projected.conversation.turns == (
+            c.Turn(
+                "assistant",
+                [c.ToolUse(name="get_weather", arguments={"location": "Boston"}, id="call_1")],
+            ),
+        )
+
+    def test_an_empty_arguments_string_is_no_arguments(self) -> None:
+        """Real corpus traffic, not a hypothetical.
+
+        kitty's own Responses builder writes `arguments` as `""` whenever a Chat
+        Completions tool call carried none, so `json.loads("")` would raise on a
+        body the bridge itself produces.
+        """
+        projected = project({"input": [{"type": "function_call", "call_id": "c", "name": "ping", "arguments": ""}]})
+
+        call = projected.conversation.turns[0].parts[0]
+        assert isinstance(call, c.ToolUse)
+        assert call.arguments == {}
+
+    @pytest.mark.parametrize("arguments", ["[1, 2]", '"a string"', "{oops"])
+    def test_arguments_that_are_not_a_json_object_residualise_without_raising(self, arguments: str) -> None:
+        """Three shapes the contract would turn into a misdiagnosis.
+
+        `_freeze_mapping` does `dict(value or {})`, so a list raises `ValueError`
+        and a string `TypeError` — and `contract` defines a reader-raised
+        `ValueError` as "the reader mis-routed a field", i.e. a reader bug rather
+        than a bad body. Failing closed into the residual keeps the diagnosis
+        honest.
+        """
+        projected = r.ResponsesProjection().read_request(
+            captured(
+                {
+                    "input": [
+                        {
+                            "type": "function_call",
+                            "call_id": "c",
+                            "name": "ping",
+                            "arguments": arguments,
+                        }
+                    ]
+                }
+            )
+        )
+
+        call = projected.conversation.turns[0].parts[0]
+        assert isinstance(call, c.ToolUse)
+        assert call.arguments == {}
+        assert projected.residual == {"input[0].arguments": arguments}
+
+    def test_arguments_sent_as_an_object_rather_than_a_string_residualise(self) -> None:
+        """`FunctionToolCall.arguments` is a *string* in the published schema.
+
+        Accepting the decoded object would make a bridge that emitted the object
+        form instead of the string invisible — a wire-format breach this oracle
+        exists to see. It is also the shape that hides a string↔object rewrite:
+        both would project identically.
+        """
+        projected = r.ResponsesProjection().read_request(
+            captured(
+                {
+                    "input": [
+                        {
+                            "type": "function_call",
+                            "call_id": "c",
+                            "name": "ping",
+                            "arguments": {"a": 1},
+                        }
+                    ]
+                }
+            )
+        )
+
+        assert projected.residual == {"input[0].arguments": {"a": 1}}
+
+    def test_a_wrongly_typed_call_id_or_name_residualises_rather_than_being_coerced(self) -> None:
+        """`str(7)` and `str(None)` invent a value the agent never sent.
+
+        `verify_total` cannot see a nested coercion, because `consumed` covers
+        top-level keys only — so a silent `"None"` would be a projection the
+        oracle trusts and nobody can falsify.
+        """
+        projected = r.ResponsesProjection().read_request(
+            captured({"input": [{"type": "function_call", "call_id": 7, "name": None, "arguments": "{}"}]})
+        )
+
+        assert set(projected.residual) == {"input[0].call_id", "input[0].name"}
+
+
+class TestFunctionCallOutput:
+    """`function_call_output` in both published `output` shapes."""
+
+    def test_a_json_string_output_keeps_its_structure(self) -> None:
+        """`Json` exists because a structured result is the common case."""
+        projected = project({"input": [{"type": "function_call_output", "call_id": "c1", "output": '{"temp": 12}'}]})
+
+        assert projected.conversation.turns == (
+            c.Turn("user", [c.ToolResult(content=[c.Json({"temp": 12})], tool_use_id="c1")]),
+        )
+
+    def test_a_prose_output_stays_text(self) -> None:
+        """The schema calls `output` a JSON string, but tools return prose."""
+        projected = project({"input": [{"type": "function_call_output", "call_id": "c1", "output": "it is cold"}]})
+
+        result = projected.conversation.turns[0].parts[0]
+        assert isinstance(result, c.ToolResult)
+        assert result.content == (c.Text("it is cold"),)
+
+    def test_the_array_output_branch_projects_all_three_published_types_in_order(self) -> None:
+        """`output` is `oneOf[string, array]`, and the array carries three types.
+
+        The image leg matters on its own: R6a's digest rules must apply here too,
+        or a tool returning a screenshot would project differently depending on
+        where in the body it appeared.
+        """
+        raw = b"screenshot-bytes"
+        payload = base64.b64encode(raw).decode("ascii")
+
+        projected = project(
+            {
+                "input": [
+                    {
+                        "type": "function_call_output",
+                        "call_id": "c1",
+                        "output": [
+                            {"type": "input_text", "text": "see attached"},
+                            {
+                                "type": "input_image",
+                                "image_url": f"data:image/png;base64,{payload}",
+                            },
+                            {"type": "input_file", "file_id": "file-1"},
+                        ],
+                    }
+                ]
+            }
+        )
+
+        result = projected.conversation.turns[0].parts[0]
+        assert isinstance(result, c.ToolResult)
+        assert result.content == (
+            c.Text("see attached"),
+            c.Image(digest=hashlib.sha256(raw).hexdigest(), media_type="image/png"),
+            c.Opaque("file"),
+        )
+
+    def test_a_content_type_the_output_branch_does_not_publish_residualises(self) -> None:
+        """The array's union is narrower than a message's.
+
+        `FunctionCallOutputItemParam.output` publishes only `input_text`,
+        `input_image` and `input_file` — no `refusal`, no `output_text`.
+        Accepting a message's full set here would let a shape the schema forbids
+        pass unremarked.
+        """
+        projected = r.ResponsesProjection().read_request(
+            captured(
+                {
+                    "input": [
+                        {
+                            "type": "function_call_output",
+                            "call_id": "c1",
+                            "output": [{"type": "refusal", "refusal": "no"}],
+                        }
+                    ]
+                }
+            )
+        )
+
+        assert set(projected.residual) == {"input[0].output[0]"}
+
+    def test_is_error_is_always_false_because_the_format_carries_no_flag(self) -> None:
+        """Written down as a decision rather than left as silence."""
+        projected = project({"input": [{"type": "function_call_output", "call_id": "c1", "output": "boom"}]})
+
+        result = projected.conversation.turns[0].parts[0]
+        assert isinstance(result, c.ToolResult)
+        assert result.is_error is False
+
+    def test_an_output_without_a_call_id_still_projects(self) -> None:
+        """`call_id` is not required by the schema, and KBR-159 saw this shape live."""
+        projected = project({"input": [{"type": "function_call_output", "output": "ok"}]})
+
+        result = projected.conversation.turns[0].parts[0]
+        assert isinstance(result, c.ToolResult)
+        assert result.tool_use_id is None
+
+
+class TestReasoning:
+    """One `Thinking` part per text entry, so a dropped entry is a visible delta."""
+
+    def test_summary_then_content_in_wire_order_with_the_signature_on_the_first(self) -> None:
+        """The fan-out the alternative would blur.
+
+        Collapsing the item into one joined part would show a dropped summary
+        entry as *changed text* rather than a missing part, and would require
+        inventing a separator that is not on the wire.
+        """
+        projected = project(
+            {
+                "input": [
+                    {
+                        "type": "reasoning",
+                        "id": "rs_1",
+                        "summary": [
+                            {"type": "summary_text", "text": "Weighing A"},
+                            {"type": "summary_text", "text": "Then B"},
+                        ],
+                        "content": [{"type": "reasoning_text", "text": "full trace"}],
+                        "encrypted_content": "gAAAA",
+                    }
+                ]
+            }
+        )
+
+        assert projected.conversation.turns == (
+            c.Turn(
+                "assistant",
+                [
+                    c.Thinking("Weighing A", signature="gAAAA"),
+                    c.Thinking("Then B"),
+                    c.Thinking("full trace"),
+                ],
+            ),
+        )
+
+    def test_dropping_one_summary_entry_is_visible(self) -> None:
+        """The property the fan-out exists to give the oracle."""
+        both = project(
+            {
+                "input": [
+                    {
+                        "type": "reasoning",
+                        "id": "rs_1",
+                        "summary": [{"text": "one"}, {"text": "two"}],
+                    }
+                ]
+            }
+        )
+        one = project({"input": [{"type": "reasoning", "id": "rs_1", "summary": [{"text": "one"}]}]})
+
+        assert both.conversation != one.conversation
+
+    @pytest.mark.parametrize(
+        ("summary", "expected_texts", "expected_residual"),
+        [
+            pytest.param(
+                [{"text": "real"}, {"text": 5}],
+                ["real"],
+                {"input[0].summary[1]"},
+                id="one-good-one-ill-typed",
+            ),
+            pytest.param([{"text": 5}], [], {"input[0].summary[0]"}, id="only-ill-typed"),
+            pytest.param(["plain string"], [], {"input[0].summary[0]"}, id="entry-not-a-dict"),
+            pytest.param("oops", [], {"input[0].summary"}, id="summary-not-a-list"),
+        ],
+    )
+    def test_an_unreadable_reasoning_entry_residualises_instead_of_vanishing(
+        self, summary: Any, expected_texts: list[str], expected_residual: set[str]
+    ) -> None:
+        """Skipping a bad entry performs the exact loss the fan-out exists to expose.
+
+        The first case is the sharp one: the reader would project a single
+        `Thinking("real")` and say nothing about the second entry — which is
+        precisely what `test_dropping_one_summary_entry_is_visible` is there to
+        catch a *bridge* doing. `consumed` is top-level only, so `verify_total`
+        could never see it.
+
+        It is also the `{}`-is-a-lie shape R6d forbids for a modelled type: a
+        lone `Thinking("")` asserts "an empty reasoning block" about an item that
+        carried content.
+        """
+        projected = r.ResponsesProjection().read_request(
+            captured({"input": [{"type": "reasoning", "id": "r1", "summary": summary}]})
+        )
+
+        thinking = [part.text for part in projected.conversation.turns[0].parts]
+        assert thinking == (expected_texts or [""])
+        assert set(projected.residual) == expected_residual
+        with pytest.raises(c.ResidualFieldsError):
+            c.verify_total(projected)
+
+    def test_an_item_with_no_text_still_projects_one_empty_part(self) -> None:
+        """Keep an empty reasoning block observable as a part.
+
+        A reasoning item carrying only an encrypted blob would otherwise vanish,
+        and its presence would stop being observable.
+        """
+        projected = project({"input": [{"type": "reasoning", "id": "rs_1", "summary": [], "encrypted_content": "x"}]})
+
+        assert projected.conversation.turns == (c.Turn("assistant", [c.Thinking("", signature="x")]),)
+
+
+class TestOpaqueItems:
+    """The 27 published item types the grammar does not model semantically."""
+
+    @pytest.mark.parametrize("kind", sorted(r._OPAQUE_USER_ITEMS))
+    def test_a_client_supplied_item_lands_in_a_user_turn(self, kind: str) -> None:
+        """Because paths are index-based, one wrong role corrupts every later path."""
+        projected = project({"input": [{"type": kind}]})
+
+        assert projected.conversation.turns == (c.Turn("user", [c.Opaque(kind)]),)
+
+    @pytest.mark.parametrize("kind", sorted(r._OPAQUE_ASSISTANT_ITEMS))
+    def test_a_model_produced_item_lands_in_an_assistant_turn(self, kind: str) -> None:
+        """The other half of the role table, asserted per type rather than in prose."""
+        projected = project({"input": [{"type": kind}]})
+
+        assert projected.conversation.turns == (c.Turn("assistant", [c.Opaque(kind)]),)
+
+    def test_a_null_type_counts_as_absent_rather_than_as_an_unknown_type(self) -> None:
+        """`ItemReferenceParam.type` is `anyOf[enum, null]`, so this is legal traffic.
+
+        A reader dispatching on `"type" in item` rather than on the value being a
+        string would residualise this and fail the run on a valid body. The
+        `type`-absent test cannot catch that regression; this one can.
+        """
+        projected = project({"input": [{"id": "msg_1", "type": None}]})
+
+        assert projected.conversation.turns == (c.Turn("user", [c.Opaque("item_reference")]),)
+
+    def test_an_item_reference_is_recognised_without_a_type(self) -> None:
+        """`ItemReferenceParam.type` is nullable, so `{"id": ...}` alone is legal."""
+        projected = project({"input": [{"id": "msg_1"}]})
+
+        assert projected.conversation.turns == (c.Turn("user", [c.Opaque("item_reference")]),)
+
+    def test_the_closed_set_matches_the_published_schema_counts(self) -> None:
+        """A guard on the tables themselves.
+
+        The counts are the ones §3.3.1's "map it, or declare it ignored" rule
+        turns into a decision; if OpenAI adds an item type, this fails here
+        rather than silently widening the residual in T-D5.
+        """
+        assert len(r.PUBLISHED_ITEM_TYPES) == 31
+        assert len(r._OPAQUE_USER_ITEMS) == 12
+        assert len(r._OPAQUE_ASSISTANT_ITEMS) == 15
+        assert r._OPAQUE_USER_ITEMS.isdisjoint(r._OPAQUE_ASSISTANT_ITEMS)
+
+    def test_the_mechanical_role_rule_reproduces_the_table(self) -> None:
+        """The rule in the docstring and the table must not drift apart.
+
+        The rule is "a type ending `_output`, plus five named exceptions"; if
+        somebody adds a type to one and not the other, the prose stops
+        describing the code.
+        """
+        exceptions = {
+            "mcp_approval_response",
+            "compaction_trigger",
+            "additional_tools",
+            "item_reference",
+            "configuration_update",
+        }
+        by_rule = {k for k in r.PUBLISHED_ITEM_TYPES if k.endswith("_output")} | exceptions
+
+        assert by_rule - r._MODELLED_ITEMS == r._OPAQUE_USER_ITEMS
+
+
+# --------------------------------------------------------------------------
+# R8 — tool declarations
+# --------------------------------------------------------------------------
+
+
+class TestToolDeclarations:
+    """`tools[]`, addressed by name because translators reorder them (§3.3.1a)."""
+
+    def test_a_function_tool_projects_every_field(self) -> None:
+        """One oracle falsification case deletes the description (§3.3.1)."""
+        schema = {"type": "object", "properties": {"location": {"type": "string"}}}
+        projected = project(
+            {
+                "input": "hi",
+                "tools": [
+                    {
+                        "type": "function",
+                        "name": "get_weather",
+                        "description": "Get the weather",
+                        "parameters": schema,
+                        "strict": True,
+                    }
+                ],
+            }
+        )
+
+        assert projected.conversation.tools == (
+            c.ToolDecl(name="get_weather", description="Get the weather", schema=schema, strict=True),
+        )
+
+    @pytest.mark.parametrize(
+        ("declared", "expected"),
+        [({"strict": True}, True), ({"strict": False}, False), ({"strict": None}, None), ({}, None)],
+    )
+    def test_strict_is_a_four_case_tri_state(self, declared: dict[str, Any], expected: bool | None) -> None:
+        """`FunctionTool.required` includes `strict`, typed `anyOf[boolean, null]`.
+
+        So against the published schema "no strict" is spelled `null`, not
+        omission — and register row P15 strips this field, so `None` must stay
+        distinct from `False` or that row's presence and absence become
+        indistinguishable.
+        """
+        projected = project({"input": "hi", "tools": [{"type": "function", "name": "f", **declared}]})
+
+        assert projected.conversation.tools[0].strict is expected
+
+    def test_a_wrongly_typed_description_or_schema_residualises(self) -> None:
+        """Both fields carry register weight, so a silent `None` is dangerous.
+
+        P15 strips `strict` and §3.3.1's oracle falsification set deletes a tool
+        description — so a reader that quietly turned a malformed description
+        into `None` would produce exactly the shape those checks exist to catch,
+        with nothing to distinguish it from the real mutation.
+        """
+        projected = r.ResponsesProjection().read_request(
+            captured(
+                {
+                    "input": "hi",
+                    "tools": [
+                        {
+                            "type": "function",
+                            "name": "f",
+                            "description": 123,
+                            "parameters": "not-an-object",
+                        }
+                    ],
+                }
+            )
+        )
+
+        assert set(projected.residual) == {"tools[0].description", "tools[0].parameters"}
+
+    def test_a_function_tool_without_a_name_residualises(self) -> None:
+        """The same rule as a `function_call`, for a stronger reason.
+
+        `FunctionTool.required` includes `name`, and §3.3.1a addresses tools by
+        name with no index to fall back on. Two unnamed declarations would both
+        sit at `conversation.tools[]` — and `path_matches` accepts `[]` as the
+        **legacy wildcard spelling**, so a register row anchored at
+        `conversation.tools[*].strict` would match them by accident rather than
+        by name. That is the collision the MCP naming rule exists to prevent,
+        reached by a different route.
+        """
+        projected = r.ResponsesProjection().read_request(
+            captured({"input": "hi", "tools": [{"type": "function", "parameters": {}}]})
+        )
+
+        assert set(projected.residual) == {"tools[0].name"}
+        with pytest.raises(c.ResidualFieldsError):
+            c.verify_total(projected)
+
+    def test_a_custom_tool_is_named_by_its_own_name(self) -> None:
+        """`CustomToolParam` makes `name` required; using `type` would discard it."""
+        projected = project({"input": "hi", "tools": [{"type": "custom", "name": "run_python"}]})
+
+        assert projected.conversation.tools[0].name == "run_python"
+
+    def test_two_mcp_servers_get_distinct_names(self) -> None:
+        """Naming both `mcp` would put two declarations at one path.
+
+        §3.3.1a addresses tools by name *because* positions are unstable, so a
+        name collision is not recoverable by falling back to an index.
+        """
+        projected = project(
+            {
+                "input": "hi",
+                "tools": [
+                    {"type": "mcp", "server_label": "docs"},
+                    {"type": "mcp", "server_label": "wiki"},
+                ],
+            }
+        )
+
+        names = [tool.name for tool in projected.conversation.tools]
+        assert names == ["mcp:docs", "mcp:wiki"]
+        assert len(set(names)) == 2
+
+    def test_a_builtin_tool_keeps_its_whole_declaration_as_the_schema(self) -> None:
+        """So a changed `vector_store_ids` is still a visible delta."""
+        declaration = {"type": "file_search", "vector_store_ids": ["vs_1"], "max_num_results": 20}
+        projected = project({"input": "hi", "tools": [declaration]})
+
+        assert projected.conversation.tools[0].name == "file_search"
+        assert projected.conversation.tools[0].schema == declaration
+
+
+# --------------------------------------------------------------------------
+# R9 — turn merging
+# --------------------------------------------------------------------------
+
+
+class TestTurnMerging:
+    """§3.3.1b's merge rule, and the reordering it must not do."""
+
+    def test_a_run_of_tool_results_forms_one_user_turn(self) -> None:
+        """The standard exchange ends `assistant(calls) -> output -> output`.
+
+        A "lift into the following user turn" rule does not work, because there
+        is no following user message at all.
+        """
+        projected = project(
+            {
+                "input": [
+                    {"type": "function_call", "call_id": "a", "name": "f", "arguments": "{}"},
+                    {"type": "function_call", "call_id": "b", "name": "g", "arguments": "{}"},
+                    {"type": "function_call_output", "call_id": "a", "output": "1"},
+                    {"type": "function_call_output", "call_id": "b", "output": "2"},
+                ]
+            }
+        )
+
+        roles = [turn.role for turn in projected.conversation.turns]
+        assert roles == ["assistant", "user"]
+        assert len(projected.conversation.turns[0].parts) == 2
+        assert len(projected.conversation.turns[1].parts) == 2
+
+    def test_a_following_user_message_merges_into_the_run(self) -> None:
+        """Merge an immediately following non-tool user message into the run."""
+        projected = project(
+            {
+                "input": [
+                    {"type": "function_call_output", "call_id": "a", "output": "1"},
+                    {"role": "user", "content": "and now?"},
+                ]
+            }
+        )
+
+        assert len(projected.conversation.turns) == 1
+        parts = projected.conversation.turns[0].parts
+        assert isinstance(parts[0], c.ToolResult)
+        assert parts[1] == c.Text("and now?")
+
+    def test_a_preceding_user_message_is_not_reordered_behind_the_result(self) -> None:
+        """The reordering §3.3.1b's rule must not be read into.
+
+        Hoisting results ahead of text the agent sent *first* would invent a
+        delta on every such turn — and because paths are index-based, a
+        disagreement about turn boundaries reports a delta on every subsequent
+        turn as well.
+        """
+        projected = project(
+            {
+                "input": [
+                    {"role": "user", "content": "here is context"},
+                    {"type": "function_call_output", "call_id": "a", "output": "1"},
+                ]
+            }
+        )
+
+        assert len(projected.conversation.turns) == 1
+        parts = projected.conversation.turns[0].parts
+        assert parts[0] == c.Text("here is context")
+        assert isinstance(parts[1], c.ToolResult)
+
+    def test_an_interleaved_result_text_result_sequence_keeps_wire_order(self) -> None:
+        """The case where the two readings of §3.3.1b's merge rule diverge.
+
+        All three items are `user`, so they merge into one turn. Read literally,
+        "`ToolResult` parts come first" would hoist both results ahead of the
+        text and produce `[TR, TR, Text]`; this reader preserves wire order and
+        produces `[TR, Text, TR]`.
+
+        The clause is pinned here because it is a *shared* rule — T-A2 reading
+        §3.3.1b literally would disagree, and because paths are index-based a
+        turn-boundary or ordering disagreement reports a delta on every
+        subsequent turn. Raised for the design owner as open item 4a.
+        """
+        projected = project(
+            {
+                "input": [
+                    {"type": "function_call_output", "call_id": "a", "output": "1"},
+                    {"role": "user", "content": "and now?"},
+                    {"type": "function_call_output", "call_id": "b", "output": "2"},
+                ]
+            }
+        )
+
+        assert len(projected.conversation.turns) == 1
+        parts = projected.conversation.turns[0].parts
+        assert [type(part).__name__ for part in parts] == ["ToolResult", "Text", "ToolResult"]
+
+    def test_an_orphan_tool_result_projects_rather_than_raising(self) -> None:
+        """Register row M7 exists to *drop* orphans.
+
+        A reader that raised on one would fail the run instead of producing the
+        delta that names the mutation.
+        """
+        projected = project({"input": [{"type": "function_call_output", "call_id": "nobody", "output": "1"}]})
+
+        # What it projects *to* is asserted, not merely that nothing raised: a
+        # reader that swallowed the item would also "not raise".
+        assert projected.conversation.turns == (
+            c.Turn("user", [c.ToolResult(content=[c.Json(1)], tool_use_id="nobody")]),
+        )
+
+    def test_consecutive_same_role_messages_merge(self) -> None:
+        """Otherwise every later turn index shifts against another reader's."""
+        projected = project(
+            {
+                "input": [
+                    {"role": "user", "content": "one"},
+                    {"role": "user", "content": "two"},
+                    {"role": "assistant", "content": [{"type": "output_text", "text": "three"}]},
+                ]
+            }
+        )
+
+        assert projected.conversation.turns == (
+            c.Turn("user", [c.Text("one"), c.Text("two")]),
+            c.Turn("assistant", [c.Text("three")]),
+        )
+
+
+# --------------------------------------------------------------------------
+# R10 — totality
+# --------------------------------------------------------------------------
+
+#: Every published top-level key, with the bucket and path it must land in.
+#: Table-driven because the bare totality check is satisfied by a reader that
+#: dumps everything into `extra` and claims `consumed=frozenset(body)` — it
+#: checks bookkeeping, not classification.
+_TOP_LEVEL_EXPECTATIONS: tuple[tuple[str, Any, str], ...] = (
+    ("model", "gpt-6-astra", "envelope.model"),
+    ("stream", True, "envelope.stream"),
+    ("store", False, "envelope.store"),
+    ("max_output_tokens", 512, "conversation.sampling[max_tokens]"),
+    ("temperature", 0.5, "conversation.sampling[temperature]"),
+    ("top_p", 0.8, "conversation.sampling[top_p]"),
+    ("top_logprobs", 3, "conversation.sampling[top_logprobs]"),
+    ("stream_options", {"include_obfuscation": True}, "conversation.sampling[stream_options]"),
+    ("input", "hi", "conversation.turns"),
+    ("instructions", "be terse", "conversation.system"),
+    ("tools", [], "conversation.tools"),
+    ("tool_choice", "auto", "envelope.extra[tool_choice]"),
+    ("background", False, "envelope.extra[background]"),
+    ("context_management", [], "envelope.extra[context_management]"),
+    ("conversation", "conv_1", "envelope.extra[conversation]"),
+    ("include", [], "envelope.extra[include]"),
+    ("max_tool_calls", 4, "envelope.extra[max_tool_calls]"),
+    ("metadata", {"k": "v"}, "envelope.extra[metadata]"),
+    ("moderation", {}, "envelope.extra[moderation]"),
+    ("parallel_tool_calls", True, "envelope.extra[parallel_tool_calls]"),
+    ("previous_response_id", "resp_1", "envelope.extra[previous_response_id]"),
+    ("prompt", {"id": "p_1"}, "envelope.extra[prompt]"),
+    ("prompt_cache_key", "ck", "envelope.extra[prompt_cache_key]"),
+    ("prompt_cache_options", {}, "envelope.extra[prompt_cache_options]"),
+    ("prompt_cache_retention", "24h", "envelope.extra[prompt_cache_retention]"),
+    ("reasoning", {"effort": "high"}, "envelope.extra[reasoning]"),
+    ("safety_identifier", "sid", "envelope.extra[safety_identifier]"),
+    ("service_tier", "auto", "envelope.extra[service_tier]"),
+    ("text", {"format": {"type": "text"}}, "envelope.extra[text]"),
+    ("truncation", "auto", "envelope.extra[truncation]"),
+    ("user", "u_1", "envelope.extra[user]"),
+)
+
+
+def _resolve(projected: c.Request, path: str) -> Any:
+    """Read the value a projection carries at one of the paths above.
+
+    Args:
+        projected: The projection.
+        path: One of the path strings in :data:`_TOP_LEVEL_EXPECTATIONS`.
+
+    Returns:
+        The value found there.
+    """
+    found = re.fullmatch(r"(\w+)\.(\w+)(?:\[(\w+)\])?", path)
+    assert found, f"unparsable expectation path {path!r}"
+
+    section, field_name, key = found.groups()
+    holder = getattr(projected.envelope if section == "envelope" else projected.conversation, field_name)
+
+    return holder[key] if key else holder
+
+
+class TestTotality:
+    """Every published key is classified, and into the right bucket."""
+
+    def test_the_table_covers_the_published_schema_exactly(self) -> None:
+        """A guard on the guard: a key missing from the table is untested."""
+        assert {key for key, _, _ in _TOP_LEVEL_EXPECTATIONS} == set(r.PUBLISHED_TOP_LEVEL_KEYS)
+        assert len(r.PUBLISHED_TOP_LEVEL_KEYS) == 31
+
+    def test_a_body_using_every_published_key_is_total(self) -> None:
+        """`verify_total` passing is necessary but nowhere near sufficient."""
+        body = {key: value for key, value, _ in _TOP_LEVEL_EXPECTATIONS}
+        projected = project(body)
+
+        assert projected.residual == {}
+        assert projected.consumed == set(body)
+
+    @pytest.mark.parametrize(
+        ("key", "value", "path"),
+        [(key, value, path) for key, value, path in _TOP_LEVEL_EXPECTATIONS],
+    )
+    def test_each_published_key_lands_at_its_stated_path(self, key: str, value: Any, path: str) -> None:
+        """The companion the bare totality check needs.
+
+        Without this, a reader that swept all 31 keys into `envelope.extra` and
+        claimed `consumed=frozenset(body)` would pass every totality assertion
+        while classifying nothing — and M1, the model override that is the
+        product's whole purpose, would be unreadable.
+        """
+        body = {key: value for key, value, _ in _TOP_LEVEL_EXPECTATIONS}
+        projected = project(body)
+
+        found = _resolve(projected, path)
+
+        # The three collection paths are asserted by their own tests; here it is
+        # enough that the key reached a populated collection rather than `extra`.
+        if path in {"conversation.turns", "conversation.system", "conversation.tools"}:
+            assert key not in projected.envelope.extra
+        else:
+            assert found == value
+
+    def test_a_key_stays_consumed_when_a_value_beneath_it_residualises(self) -> None:
+        """The rule six readers and T-D8 must agree on, pinned by a test.
+
+        `verify_total` computes `dropped = source - (consumed | residual)`, and
+        `"input[0].arguments"` is not the key `"input"`. So a reader that removed
+        `input` from `consumed` because something beneath it residualised would
+        be reported as having *dropped* `input` — the wrong diagnosis for a
+        reader that read the body fine and could not classify one field.
+
+        For a *top-level* residual either choice works, because a key claimed in
+        both accounts counts as a residual. For a nested one only this does.
+        """
+        projected = r.ResponsesProjection().read_request(
+            captured({"input": [{"type": "function_call", "call_id": "c", "name": "f", "arguments": "{oops"}]})
+        )
+
+        assert "input" in projected.consumed
+        assert set(projected.residual) == {"input[0].arguments"}
+
+        # The diagnosis must be "could not classify", never "dropped".
+        with pytest.raises(c.ResidualFieldsError):
+            c.verify_total(projected)
+
+    def test_source_carries_the_body_the_reader_parsed(self) -> None:
+        """So `verify_total` needs no second parse that could disagree about duplicates."""
+        body = {"model": "m", "input": "hi"}
+        projected = project(body)
+
+        assert dict(projected.source) == body
+
+
+# --------------------------------------------------------------------------
+# R11 — failure shapes
+# --------------------------------------------------------------------------
+
+
+class TestFailureShapes:
+    """One exception type across six readers, so T-D1 can classify a failure."""
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            pytest.param(b"not json", id="not-json"),
+            pytest.param(b"[]", id="json-but-not-an-object"),
+            pytest.param(b'{"input": 7}', id="input-neither-string-nor-array"),
+            pytest.param(b'{"input": [{"role": "tool", "content": "x"}]}', id="role-no-format-defines"),
+        ],
+    )
+    def test_an_unreadable_body_raises_the_contract_s_own_error(self, body: bytes) -> None:
+        """§3.3.1 keeps three failure shapes distinct on purpose.
+
+        `UnreadableBodyError` means *the body* is wrong; a `ValueError` escaping
+        a reader means the reader mis-routed a field, which is a different
+        diagnosis. Handing a bad role straight to `Turn(role=...)` would raise
+        the wrong one.
+        """
+        with pytest.raises(c.UnreadableBodyError):
+            r.ResponsesProjection().read_request(captured(body))
+
+    @pytest.mark.parametrize(
+        ("body", "expected_key"),
+        [
+            pytest.param(
+                {"tool_choice": {"type": "allowed_tools", "mode": ["a"]}},
+                "tool_choice",
+                id="tool-choice-mode",
+            ),
+            pytest.param(
+                {"tool_choice": {"type": ["function"], "name": "f"}},
+                "tool_choice",
+                id="tool-choice-type",
+            ),
+            pytest.param(
+                {"input": [{"role": "user", "content": [{"type": {"a": 1}}]}]},
+                "input[0].content[0]",
+                id="content-type",
+            ),
+            pytest.param({"input": [{"type": ["reasoning"]}]}, "input[0]", id="item-type"),
+            pytest.param({"tools": [{"type": ["function"], "name": "f"}]}, "tools[0]", id="tool-type"),
+        ],
+    )
+    def test_an_ill_typed_nested_value_never_raises_a_bare_type_error(self, body: Any, expected_key: str) -> None:
+        """Every set-membership test needs a hashability guard before it.
+
+        A JSON body may legally carry a list or an object where the schema
+        declares a string, and `["function"] in frozenset(...)` raises
+        `TypeError`. `contract` defines a reader-raised `TypeError` as "the
+        reader mis-routed a field — a reader bug", so letting one out would make
+        T-D1 diagnose a malformed body (T-C6 contributes one to the corpus) as a
+        defect in the harness itself.
+
+        These bodies are unclassifiable, not unreadable, so the required outcome
+        is a residual — never an exception of any kind.
+        """
+        projected = r.ResponsesProjection().read_request(captured(body))
+
+        # The exact key, not merely "something residualised": a guard that
+        # residualised the *wrong* thing would otherwise pass.
+        assert set(projected.residual) == {expected_key}
+        with pytest.raises(c.ResidualFieldsError):
+            c.verify_total(projected)
+
+    def test_a_message_role_that_is_not_even_a_string_is_an_unreadable_body(self) -> None:
+        """R11's named case, in the shape that breaks a naive membership test.
+
+        A role of `["user"]` *is* outside the published set, so the requirement
+        applies — but testing membership of an unhashable value raises the one
+        exception type R11 forbids.
+        """
+        with pytest.raises(c.UnreadableBodyError):
+            r.ResponsesProjection().read_request(captured({"input": [{"role": ["user"], "content": "x"}]}))
+
+
+# --------------------------------------------------------------------------
+# §1.4 — the falsification set
+# --------------------------------------------------------------------------
+
+
+class TestFalsification:
+    """Three deliberate defects the reader must detect, running in the suite.
+
+    Plan §1.4: "a fidelity oracle never shown to fail is indistinguishable from
+    one that cannot fail."
+    """
+
+    def test_an_unrecognised_top_level_key_fails_closed(self) -> None:
+        """The fifth of §3.3.1's five oracle falsification cases.
+
+        Bridge-added metadata the projection discarded could never have been
+        scanned for a vendor token either, so this also keeps §3.3.3 honest.
+        """
+        projected = r.ResponsesProjection().read_request(
+            captured({"model": "m", "input": "hi", "x_kitty_trace": "abc"})
+        )
+
+        assert projected.residual == {"x_kitty_trace": "abc"}
+        with pytest.raises(c.ResidualFieldsError):
+            c.verify_total(projected)
+
+    def test_an_unrecognised_item_type_fails_closed_at_its_exact_path(self) -> None:
+        """Asserted by key, not merely by non-emptiness.
+
+        Six readers and T-D8 must agree on the exact residual spelling, so a
+        test that accepted any non-empty residual would let two readers drift.
+        """
+        projected = r.ResponsesProjection().read_request(
+            captured({"input": [{"role": "user", "content": "hi"}, {"type": "brand_new_2027"}]})
+        )
+
+        assert set(projected.residual) == {"input[1]"}
+        with pytest.raises(c.ResidualFieldsError):
+            c.verify_total(projected)
+
+    def test_a_dropping_reader_is_caught_even_though_its_residual_is_empty(self) -> None:
+        """The case `consumed` exists for, and the one a residual-only rule misses.
+
+        The defect is deliberate: this stub ignores a key instead of
+        residualising it, which leaves the residual empty. "The residual must be
+        empty" would pass it.
+        """
+        body = {"model": "m", "input": "hi", "x_kitty_trace": "abc"}
+        dropping = c.Request(
+            envelope=c.Envelope(model="m"),
+            conversation=c.Conversation(turns=[c.Turn("user", [c.Text("hi")])]),
+            residual={},
+            consumed=frozenset({"model", "input"}),
+            source=body,
+        )
+
+        assert dropping.residual == {}
+        with pytest.raises(c.DroppedFieldsError):
+            c.verify_total(dropping)
+
+
+# --------------------------------------------------------------------------
+# The published examples
+# --------------------------------------------------------------------------
+
+#: The eight `x-oaiMeta` request examples carried by `openapi.yaml` itself, at
+#: `info.version` matching `reader_responses.SCHEMA_VERSION`. Vendored as
+#: literals so the suite needs no network and pins what it was validated
+#: against — §3.3.1 requires validation against the format's published examples,
+#: "never against kitty's output".
+_PUBLISHED_EXAMPLES: dict[str, Any] = {
+    "Text input": {
+        "model": "gpt-6-astra",
+        "input": "Tell me a three sentence bedtime story about a unicorn.",
+    },
+    "Image input": {
+        "model": "gpt-6-astra",
+        "input": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "input_text", "text": "what is in this image?"},
+                    {"type": "input_image", "image_url": "https://example.test/boardwalk.jpg"},
+                ],
+            }
+        ],
+    },
+    "File input": {
+        "model": "gpt-6-astra",
+        "input": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "input_text", "text": "what is in this file?"},
+                    {
+                        "type": "input_file",
+                        "file_url": "https://example.test/2024ltr.pdf",
+                        "detail": "auto",
+                    },
+                ],
+            }
+        ],
+    },
+    "Web search": {
+        "model": "gpt-6-astra",
+        "tools": [{"type": "web_search_preview"}],
+        "input": "What was a positive news story from today?",
+    },
+    "File search": {
+        "model": "gpt-6-astra",
+        "tools": [{"type": "file_search", "vector_store_ids": ["vs_1234567890"], "max_num_results": 20}],
+        "input": "What are the attributes of an ancient brown dragon?",
+    },
+    "Streaming": {
+        "model": "gpt-6-astra",
+        "instructions": "You are a helpful assistant.",
+        "input": "Hello!",
+        "stream": True,
+    },
+    "Functions": {
+        "model": "gpt-6-astra",
+        "input": "What is the weather like in Boston today?",
+        "tools": [
+            {
+                "type": "function",
+                "name": "get_current_weather",
+                "description": "Get the current weather in a given location",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "location": {"type": "string", "description": "The city and state"},
+                        "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
+                    },
+                    "required": ["location", "unit"],
+                },
+            }
+        ],
+        "tool_choice": "auto",
+    },
+    "Reasoning": {
+        "model": "gpt-6-astra",
+        "input": "How much wood would a woodchuck chuck?",
+        "reasoning": {"effort": "high"},
+    },
+}
+
+
+class TestPublishedExamples:
+    """The acceptance criterion the task's own ticket names."""
+
+    @pytest.mark.parametrize("title", sorted(_PUBLISHED_EXAMPLES))
+    def test_each_published_example_round_trips_with_an_empty_residual(self, title: str) -> None:
+        """Round-trip the format's published examples with an empty residual.
+
+        Validated against the published schema, never against kitty's output: a
+        reader validated against kitty's output inherits kitty's bugs and the
+        oracle becomes circular.
+        """
+        projected = project(_PUBLISHED_EXAMPLES[title])
+
+        assert projected.residual == {}
+        assert projected.envelope.model == "gpt-6-astra"
+        assert projected.conversation.turns, "every published example carries input"
+
+    def test_the_schema_version_this_reader_agrees_with_is_recorded(self) -> None:
+        """A change detector, deliberately — and no more than that.
+
+        It does not verify the examples against the live schema; the suite has
+        no network. What it gives is an audit trail: when the reader is updated
+        for a newer revision, this fails and forces the version in the module
+        docstring to move with it, so "which schema was this validated against"
+        always has an answer.
+        """
+        assert r.SCHEMA_VERSION == "2.3.0"
+
+
+# --------------------------------------------------------------------------
+# R12 — independence
+# --------------------------------------------------------------------------
+
+#: Anchored at line start, so prose mentioning an import cannot trip it; the two
+#: dynamic forms stay unanchored because they appear mid-expression. Mirrors
+#: `test_contract.py`'s guard deliberately — one spelling for one rule.
+_KITTY_IMPORT = re.compile(
+    r"^\s*(?:from|import)\s+(?:src\.)?kitty\b"
+    r"|import_module\(\s*[\"'](?:src\.)?kitty"
+    r"|__import__\(\s*[\"'](?:src\.)?kitty"
+)
+
+
+def test_the_reader_imports_nothing_from_kitty() -> None:
+    """§3.3.1's independent-oracle rule, enforced structurally rather than by review.
+
+    This is the single structural guarantee the whole I1 claim rests on. A
+    projection that asked kitty how to read a body would inherit kitty's bugs,
+    and the oracle would prove self-consistency rather than fidelity.
+
+    The stricter of the two readings in the design is taken deliberately:
+    §3.3.1b and §7.4 say `src/kitty/bridge`, `contract.py` says `src/kitty`. A
+    reader importing `src/kitty/providers` would be just as circular.
+    """
+    source = Path(r.__file__).read_text(encoding="utf-8")
+
+    # Assert the subject was actually read: a guard that passes on an empty
+    # string is indistinguishable from one that cannot fail.
+    assert len(source) > 1000, "read no meaningful source; the guard would pass vacuously"
+
+    offending = [line.strip() for line in source.splitlines() if _KITTY_IMPORT.search(line)]
+
+    assert offending == [], f"reader_responses.py must not import kitty: {offending}"
+
+
+def test_the_import_guard_fires_on_every_form_it_claims_to_catch() -> None:
+    """The positive control.
+
+    Without it, a pattern that had stopped matching anything would read as a
+    clean bill of health forever.
+    """
+    forms = [
+        "from kitty.bridge import server",
+        "import kitty",
+        "from src.kitty import server",
+        "import  kitty.providers",
+        'importlib.import_module("kitty.bridge.server")',
+        '__import__("kitty")',
+        'importlib.import_module("src.kitty.providers.openai_subscription")',
+    ]
+
+    undetected = [form for form in forms if not _KITTY_IMPORT.search(form)]
+
+    assert undetected == [], f"the guard would miss these: {undetected}"
+
+
+def test_the_import_guard_does_not_fire_on_innocent_text() -> None:
+    """The negative control: a pattern matching everything would also pass above."""
+    innocent = [
+        "# kitty-bridge is the product under test",
+        "from harness import contract as c",
+        "# never write `import kitty` in this module",
+    ]
+
+    assert [line for line in innocent if _KITTY_IMPORT.search(line)] == []


### PR DESCRIPTION
## Context for the Product Owner

Kitty Bridge sits on the wire between a coding agent and an LLM provider. Its commercial promise is that it does **not** secretly change what the agent asked for — it may swap the model and the credentials, but the conversation must arrive intact. Today nothing checks that claim.

Checking it needs a comparison the bridge cannot fake: read the agent's inbound request **and** the bytes that actually went upstream into one neutral form, then diff them. Those two bodies are often in *different* wire formats, so they cannot be compared as JSON — only as projections. Six such readers are planned, one per format.

**This PR delivers the reader for OpenAI Responses — the format Codex speaks.** It ships no user-facing behaviour and changes no production code. What it buys is the ability, once the oracle lands, to answer "did the bridge alter this request?" with evidence instead of assurance. It unblocks T-D5 (KBR-55) and T-D9 (KBR-58).

Two things worth the Product Owner's attention:

- **It found two register gaps that would have produced false alarms.** The mutation register lists every change the bridge is *allowed* to make; anything unregistered reads as a breach. Sixteen fields the Codex backend legitimately drops are claimed by no register row — so the first fidelity run would have accused the bridge of tampering it never did. Filed as **KBR-171**, linked as blocking KBR-55, not fixed here because the register is a different task's to edit. **KBR-149** already covered a sibling gap; I checked before filing rather than adding a duplicate.
- **It is deliberately written against OpenAI's published schema and forbidden from importing any bridge code.** A reader that asked kitty how to read a body would inherit kitty's bugs, and the whole check would prove only that kitty agrees with itself.

---

## What this is

Plan task **T-A3** ([KBR-35](https://shelpuk.atlassian.net/browse/KBR-35)), design `.system_design/TEST_SUITE.md` §3.3.1/§3.3.1a/§3.3.1b. Depends on T-W2 (KBR-25, **Done**).

`tests/harness/reader_responses.py` exposes `ResponsesProjection`, satisfying `contract.Projection` for `WireFormat.OPENAI_RESPONSES`: a `CapturedRequest` in, a `contract.Request` out — envelope, conversation, residual, consumed.

Written against `openai/openai-openapi` `openapi.yaml` **v2.3.0**, pinned in the module docstring. Fixtures are the eight `x-oaiMeta` request examples the spec itself carries, adapted only to substitute `example.test` for third-party hosts.

**Three files. No production code is touched.**

| File | |
|---|---|
| `tests/harness/reader_responses.py` | the reader |
| `tests/harness/test_reader_responses.py` | 176 tests |
| `.system_design/TEST_SUITE.md` | **+28 lines** — see below |

### The design-doc change, called out explicitly

This PR edits a **shared** design document, which is easy to miss inside a code commit. Two insertions in §3.3.1b, nothing rewritten:

1. **The merge rule's four clauses are an ordered pipeline** — so `ToolResult → user text → ToolResult` keeps wire order rather than hoisting results over history the bridge did not move.
2. **Tool-call arguments decode through one shared rule**, with the test for *why* an absent `arguments` is accepted while an absent tool `name` is not: can the projection represent the absence losslessly?

Both were ambiguities in rules **five other readers** will implement, and a turn-ordering disagreement between two readers reports a false delta on every subsequent turn. They lived in this task's requirements until the design reviewer confirmed they belong where the other authors will actually read them. The code pin for the decode is filed as **KBR-174**, blocking T-A2 (KBR-34).

## What it classifies

All **31** published top-level keys. All **31** item types — four modelled semantically (`message`, `function_call`, `function_call_output`, `reasoning`), 27 kept as detectable placeholders. Nine `tool_choice` forms. Both `input` shapes. Anything outside those closed sets residualises, which fails the run: adding a field to a wire format must force a decision, not widen a blind spot.

Three choices worth their reasons:

- `max_output_tokens` normalises onto `max_tokens` and `strict` stays a tri-state, because register rows **P14** and **P15** are written against exactly those. `input_text` and `output_text` project identically, which is what makes **P16** `NOT_PROJECTABLE` — `contract.py` names this module's L1 test as one of that row's two guards, and it is here.
- **A field a modelled type declares either projects or residualises.** Never coerced, never skipped. `str(7)` invents a value the agent did not send; skipping an unreadable reasoning entry performs the very loss the per-entry fan-out exists to expose when a *bridge* does it.
- **A top-level key stays in `consumed` when a value beneath it residualises**, or `verify_total` reports a drop — the wrong diagnosis for a reader that read the body fine.

## Verification

- **176 tests**; 564 across `tests/harness/` plus the layer modules.
- `ruff check`, `ruff format --check`, `mypy src`, `lint-imports` 4/4 — all clean.
- **14 deliberate defects injected into the reader; 14 caught.** Tests that have never failed prove nothing.
- Merged `origin/main` (14 commits, incl. KBR-144/146/147) and re-verified; no conflicts.

Two design-review rounds and three code-review rounds found **five real defects**, every one of which passed a green test run:

| Defect | Why it mattered |
|---|---|
| `TypeError` escaping five unguarded membership tests | a malformed *client request* would have been diagnosed as a defect in our own harness |
| A lifted-message residual overwrote one of two entries and mislabelled the other | silent evidence loss, in a tool whose job is preserving evidence |
| Tool arguments in the wrong wire form compared equal | hid a real class of wire-format breach |
| Reasoning entries vanished silently | **introduced by me** while fixing something smaller |
| An unnamed tool sat at `conversation.tools[]`, which `path_matches` treats as a wildcard | register rows would have matched it by accident |

Each is fixed, and each has a test that fails if it returns.

Reviews: `code-reviewer` **APPROVE**; `system-design-reviewer` — no blocking findings, all wording feedback applied.

Refs KBR-35 · files KBR-171, KBR-174

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J2sAEXym49SsSKWadFLDqf

[KBR-35]: https://shelpuk.atlassian.net/browse/KBR-35?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ