### PR TITLE
T-W8 (KBR-31): bridge fixture core and the transport extension interface

### DIFF
--- a/.system_design/TEST_SUITE.md
+++ b/.system_design/TEST_SUITE.md
@@ -2211,7 +2211,7 @@ transport (below).
 
 | Piece | What it is |
 |---|---|
-| `UpstreamTransport` | The **extension interface**: `name`, `format`, `start`, `stop`, `bind`, `captures`, `connections`, `assert_teardown_clean` |
+| `UpstreamTransport` | The **extension interface**: `name`, `format`, `start`, `stop`, `bind`, `captures`, `connections`, `assert_teardown_clean`. **Open question for T-B1:** `format` is typed `WireFormat`, which §3.3.1 closes at six — and the `openai_subscription` **OAuth token leg** §7.2 assigns it is none of them. T-B1 decides whether that leg is a separate transport, a recorder outside this interface, or a seventh format; named here so the decision is deliberate |
 | The registry | `register_transport` / `transport(name, fmt, *, responder)` / `registered_transports` |
 | `AiohttpTransport` | The **only** transport registered here, over §7.2's `RecordingUpstream` |
 | `redirected(adapter, origin, provider_config)` | Re-hosts any **default-transport** adapter onto a recorder, keeping path and query |
@@ -2219,7 +2219,9 @@ transport (below).
 | `pin_backend_order` | The determinism seam for balancing mode |
 | `InboundProtocol`, `inbound_path`, `minimal_inbound_body` | The agent-facing side: route and smallest body per inbound protocol |
 | `BridgeFixture` | An async context manager: a real `BridgeServer`, single-backend or balancing, against a started transport |
-| `assert_transport_reaches_its_recorder` | The **integration conformance check**, run over every registered transport by a meta-test |
+| `assert_transport_reaches_its_recorder(transport, *, protocol=None)` | The **integration conformance check**, run over every registered transport by a meta-test. Takes a transport **instance**, not a registry name — so the falsification defects need never be registered, and an author whose format has no matching inbound route names one |
+| `marker()`, `protocol_for()` | The per-request marker, and the inbound route matching an upstream format |
+| `MisdeclaredFormatError`, `TransportTimeout` | What a teardown check and a timed-out request raise |
 
 **Naming.** One list of captured requests, spelled `captures` on a transport and `requests` on
 `RecordingUpstream` (§7.2's own name, unchanged). `CapturedRequest` is the element type.
@@ -2285,6 +2287,11 @@ Vertex raises `ProviderError("Vertex AI requires 'project_id' …")` from inside
 adapter raises that at redirect time and no longer raises it per request. A test meaning to
 exercise pre-flight validation must call the adapter, not the redirected copy.
 
+**The default transport never uses `redirected()`.** It binds `custom_anthropic` or
+`custom_openai` precisely because those two honour the product's own channel, so the default path
+exercises that channel and the helper is exercised separately — it exists for the ~14 adapters
+that honour no key.
+
 **This applies to default-transport adapters.** The three custom-transport adapters never call
 `build_base_url` at all: `ollama_cloud` resolves the key inside its own request path,
 `openai_subscription` uses a module constant, and `bedrock` takes a botocore endpoint override.
@@ -2297,6 +2304,13 @@ not a base-URL helper, is the interface.
 a loopback recorder serving `http://` cannot satisfy. The fixture also encapsulates the
 constructor's `adapter=None` positional and its `# type: ignore[arg-type]`, which 38 modules
 currently repeat.
+
+**No pytest fixture, and not in `pytest_plugins`.** T-W5's proxy is published that way because
+a test asks for `connect_proxy` by name and cannot construct one. This module is different on
+both counts: a test must choose a wire format and a bridge shape anyway, so
+`BridgeFixture(transport("aiohttp", fmt))` says more than a fixture name would — and importing it
+pulls in `server.py`, measured at **0.72 s**, which a global plugin charges to every pytest
+invocation including those that never start a bridge.
 
 **No `host=` on the factory.** An earlier draft added one "so T-E1 can rebind to §5.3's
 non-loopback name". It cannot be justified: §7.3 gives T-E1 non-loopback addressing by
@@ -2318,7 +2332,16 @@ a seam may never try the backend it is about to assert on. That is not hypotheti
 with the refusal handler deleted, **which is how this was found**". `pin_backend_order` ships the
 round-robin seam once, rather than four Epic I tickets re-deriving the same monkeypatch. It takes
 a `monkeypatch` and is therefore callable only from a test; the conformance check below is
-single-backend and never needs it.
+single-backend and never needs it. It patches `random.choices` on the **stdlib module object**
+reached through `kitty.bridge.server.random`, so for the duration every caller in the process gets
+round-robin, not only the bridge; `monkeypatch` reverting it is what contains that.
+
+**All members share the fixture's one transport, and therefore one recorder.** Distinct models per
+member are what make the selection observable. A test needing members on *separate* recorders
+builds its own `backends` list from `backend_for`; per-backend upstream *behaviour* — T-I8's
+blip-then-success, T-I11's mid-stream failover — is scripted through a stateful `responder` under
+`pin_backend_order`, not through separate transports. Stated here so four Epic I tickets inherit
+the shape rather than each rediscovering its limit.
 
 #### 7.5.4 Why the fixture carries its own conformance check
 
@@ -2341,21 +2364,33 @@ a promise.
 
 `assert_transport_reaches_its_recorder` drives one request and asserts four things. Each is
 paired with a defect the **other three pass** — the only argument that establishes
-non-redundancy — and each defect is a **registered transport**, running in the suite:
+non-redundancy — and each defect is a **real transport instance**, driven through the real check
+and running in the suite. They are deliberately **not** registered: the check takes an instance,
+so a shared registry never holds four things that are wrong on purpose — which would otherwise
+force the completeness meta-test below to carry a skip-list, the one mechanism it exists to
+forbid:
 
 | # | Assertion | The defect only it catches |
 |---|---|---|
 | 1 | Exactly one capture | **The decoy**: `bind()` points the bridge at a different live recorder. Status 200, teardown clean, and this transport's capture list is empty |
 | 2 | The marker is in the capture's body | **The blind capture**: a recorder that counts the request and stores no body — §1.4's "projection that could not see the model name" |
 | 3 | The inbound status is 200 | **The refusal**: upstream answers 400. Measured at one capture, marker present, teardown clean, downstream 400 — the request arrived correctly and the client was still failed |
-| 4 | `assert_teardown_clean()` | **The mis-declared format**: a transport declaring one format while binding an adapter that posts to the other. The recorder dispatches by path **suffix**, so it replies in the format the *path* named, the adapter parses it, `unmatched` stays empty — one correct capture, marker present, 200, and the declared `format` was never under test |
+| 4 | `assert_teardown_clean()`, run by the **fixture's** `__aexit__` | **The mis-declared format**: a transport declaring one format while binding an adapter that posts to the other. The recorder dispatches by path **suffix**, so it replies in the format the *path* named, the adapter parses it, `unmatched` stays empty — one correct capture, marker present, 200, and the declared `format` was never under test |
 
 Row 4 is why the fourth defect is a transport and not a unit test on
-`assert_teardown_clean()`. A unit test proves that function raises; it does not prove the
-conformance check **calls** it — and plan §1.4's own list of past harness failures includes "a
-guard proving a function was *called* when the enforcement was the branch after it". Row 1 and
-row 4 are as far apart as row 1 and row 2: one fails with an **empty** capture list, the other
-with a **complete and correct** one.
+`assert_teardown_clean()`. A unit test proves that function raises; it does not prove anything
+**calls** it — and plan §1.4's own list of past harness failures includes "a guard proving a
+function was *called* when the enforcement was the branch after it". Row 1 and row 4 are as far
+apart as row 1 and row 2: one fails with an **empty** capture list, the other with a **complete
+and correct** one.
+
+**Row 4 is asserted once, by the fixture, and deliberately not repeated inside the conformance
+check.** An earlier draft did both. Running the falsification procedure on it — delete each
+assertion, confirm exactly its own case goes red — showed the repeat was an assertion **no defect
+could falsify**: `__aexit__` raises first either way, so removing it changed nothing. An
+assertion nothing can kill is the thing §1.4 objects to, so it went. The teardown call is
+falsified instead by `_MisdeclaredTransport`, and a separate case asserts the fixture makes that
+call on the clean path.
 
 **An upstream 500 is deliberately not one of the defects.** Measured at four captures and seven
 seconds, it also trips assertion 1, so it would not be orthogonal. A 400 is the clean one.
@@ -2375,9 +2410,17 @@ the check over every registered transport**, so an Epic B author gets the confor
 registering rather than by remembering. But "iterate whatever is registered" is not enough:
 under a selective run or a per-file invocation the registering module may never be imported in
 that process, and the meta-test would pass over a set of one while reporting success for a
-category it never ran — the failure `--require-category` exists to prevent. So the meta-test
-imports an explicit `TRANSPORT_MODULES` tuple, one line per Epic B ticket, and asserts the
-registered set **equals** the expected one. T-W8's structural guard is separate and pins what
+category it never ran — the failure `--require-category` exists to prevent. So the meta-test iterates an explicit
+`CONFORMANCE_CASES` table — one row per Epic B ticket, carrying the registering module, the
+registry name, **the upstream format to construct with, and the inbound route that exercises
+it** — imports every row's module, and asserts the registered set **equals** the expected one.
+
+The last two fields are not decoration. The bridge *translates*, so the inbound route cannot be
+derived from the upstream format: `BEDROCK_CONVERSE` (T-B3) and `OLLAMA_CHAT` (half of T-B1) have
+no inbound route at all. And a single hardcoded format — the first draft — raises `ValueError` at
+construction for **all three** Epic B transports, since none of them serves Anthropic Messages.
+"Inherits the check by registering" was false for every author it was written for until the row
+carried both. T-W8's structural guard is separate and pins what
 *this module* registers, against a module-local constant and an AST scan, never against global
 registry state.
 
@@ -2399,7 +2442,9 @@ the transport, the elapsed time, the captures so far and the 30 s / 80 s referen
 `wait_closed` split §7.3 handles for the proxy, and the reason the support matrix is
 3.10–3.13. `assert_teardown_clean()` runs only on the clean path: raised from `__aexit__` over a
 failing body it would replace the assertion the test was making, and the falsification cases
-assert on message content. The conformance check therefore calls it **inside** the block.
+assert on message content. The conformance check does **not** call it as well: `__aexit__` runs
+before the check returns either way, so a repeat inside the block would be an assertion no defect
+could falsify — which is how the repeat was found and removed.
 
 **`assert_teardown_clean()` is stated for every transport, not just this one.** Its obligation is
 "every request I received was answered in the format I declare"; how a transport knows that is its
@@ -2588,8 +2633,11 @@ business, together with the job that runs them; doing it earlier would remove th
 gate. T-H1 must take that reclassification into account before it measures a mutation
 baseline, because it selects on `l1`.
 
-**Four modules have been added to that set since, and they are named here so T-K6 inherits a
-list rather than a search** — the count is what T-K6 and T-H1 plan against.
+**Six modules are bulleted below, and `tests/cli/test_stream_encoding.py` (KBR-10) is described
+after them — seven in all, named here so T-K6 inherits a list rather than a search** — the count
+is what T-K6 and T-H1 plan against. (The bullet count and the KBR-10 paragraph were already
+drifting apart before T-W8 added two; spelling out both is what stops the next addition
+guessing which set it joins.)
 
 - **KBR-132:** `tests/bridge/test_tls_certs.py` spawns a real `openssl` in one of its five cases.
   KBR-132 deliberately did **not** move it — the rule above applies to a test fixing a skip defect
@@ -2599,6 +2647,13 @@ list rather than a search** — the count is what T-K6 and T-H1 plan against.
   `tests/harness/test_recorder_conformance.py` is genuinely `l1` — its checks are pure functions
   over data and it opens nothing. The two socket-binding modules together run in **~1 second**,
   measured, which is the number the fast-gate budget should carry until T-K6 moves them.
+- **T-W8 (KBR-31):** `tests/harness/test_bridge.py` and
+  `tests/harness/test_bridge_falsification.py` each start a real `BridgeServer` **and** a
+  recorder, most cases one of each. Together they run in **~1.6 seconds**, measured (1.1 s and
+  0.5 s), which is the number the fast-gate budget should carry until T-K6 moves them. Worth
+  knowing while planning that move: the timeout case cost **30 seconds** until its responder was
+  released explicitly, because `stop_async` waits for in-flight upstream handlers rather than
+  aborting them — the same property §7.3 handles deliberately for the proxy.
 - **KBR-144:** `tests/bridge/test_responses_string_input.py` starts a real `BridgeServer` on an
   ephemeral port in four of its classes, following the existing convention of
   `tests/bridge/test_crash_resilience.py` rather than inventing a second one. The whole module

--- a/.system_design/TEST_SUITE.md
+++ b/.system_design/TEST_SUITE.md
@@ -2189,6 +2189,242 @@ oracle must not ask the code under test what it did, and a **boolean** declarati
 select among the six projections listed above in any case. A new corpus entry, adapter, model
 route or transport costs one parametrisation, not a new test.
 
+### 7.5 The bridge fixture
+
+`tests/harness/bridge.py` — plan task **T-W8** ([KBR-31]). The counterpart of §7.2 on the
+inbound side: §7.2 says what a recording upstream must observe, this says how a **real
+`BridgeServer`** is put in front of one. Around fifteen tasks across Epics D, E, G, I, J and K
+need it, and `tests/conftest.py` offers only `unused_tcp_port` today. Measured in-repo: of the
+**62** test modules under `tests/bridge/`, **38** start a real `BridgeServer` and most build
+their own stub adapter, fake upstream and `post()` helper; 25 of those *also* intercept the
+upstream with `aioresponses` rather than a real socket, and 24 start no server at all.
+
+**This is the one `tests/harness/` module that imports the product.** `contract.py` and
+`recorder.py` each carry a structural guard forbidding any `kitty` import, because §3.3.1's
+independent-oracle rule says a reader that asked kitty how to parse a body would inherit
+kitty's bugs. That rule governs what *judges* a request. This module *starts* the thing under
+test, so it must import `kitty.bridge.server`; the guards are per-module and nothing here
+weakens them. Its own structural guard is a different claim — that it registers no Epic B
+transport (below).
+
+**What it delivers.**
+
+| Piece | What it is |
+|---|---|
+| `UpstreamTransport` | The **extension interface**: `name`, `format`, `start`, `stop`, `bind`, `captures`, `connections`, `assert_teardown_clean` |
+| The registry | `register_transport` / `transport(name, fmt, *, responder)` / `registered_transports` |
+| `AiohttpTransport` | The **only** transport registered here, over §7.2's `RecordingUpstream` |
+| `redirected(adapter, origin, provider_config)` | Re-hosts any **default-transport** adapter onto a recorder, keeping path and query |
+| `profile_for` / `backend_for` | Valid `Profile` objects and `(adapter, key, profile)` backend triples already pointed at a transport |
+| `pin_backend_order` | The determinism seam for balancing mode |
+| `InboundProtocol`, `inbound_path`, `minimal_inbound_body` | The agent-facing side: route and smallest body per inbound protocol |
+| `BridgeFixture` | An async context manager: a real `BridgeServer`, single-backend or balancing, against a started transport |
+| `assert_transport_reaches_its_recorder` | The **integration conformance check**, run over every registered transport by a meta-test |
+
+**Naming.** One list of captured requests, spelled `captures` on a transport and `requests` on
+`RecordingUpstream` (§7.2's own name, unchanged). `CapturedRequest` is the element type.
+`assert_teardown_clean` is deliberately *not* called `check`: `recorder_conformance.py` already
+owns `check_*` for "the contract every recorder is judged against" (§7.2.1), and an Epic B author
+told to "implement `check()`" would reasonably read it as that suite.
+
+#### 7.5.1 Two axes, not one: inbound protocol and upstream format
+
+They are independent, and translating between them is what the bridge *is*. `WireFormat`
+(six values) describes what a **recorder** serves; `InboundProtocol` (four —
+`chat_completions`, `messages`, `responses`, `gemini`) describes the **bridge route an agent
+posts to**. `BEDROCK_CONVERSE` and `OLLAMA_CHAT` have no inbound route at all, and the oracle
+(§3.3) exists precisely because the two sides differ. A single parameter for both would work
+only for the pass-through pairs T-W8 happens to ship and would mislead every reader after that,
+so the fixture keeps two vocabularies.
+
+#### 7.5.2 `bind()` is the seam, and redirection **re-hosts** rather than replaces
+
+A transport returns the `(ProviderAdapter, provider_config)` pair that points a bridge at *its
+own* recorder. The obvious alternative — the fixture reading `recorder.base_url` and building the
+config itself — works for the one transport T-W8 ships and for none of the other three: botocore
+takes an **endpoint override**, curl_cffi terminates TLS with the harness certificate, and the
+`openai_subscription` OAuth leg is a different session entirely (§7.2). Defining the interface
+here is what lets T-B1–T-B3 register a transport without editing a module fifteen tickets consume.
+
+**`provider_config["base_url"]` is the product's own channel, and it reaches five adapters.**
+Read from every file under `src/kitty/providers/`: `ProviderAdapter.build_base_url` ignores
+`provider_config` and returns `default_base_url`. Four adapters override it to read that key —
+`custom_anthropic`, `custom_openai`, `ollama`, `minimax` — and **`ollama_cloud` honours the same
+key by a different route**, resolving it inside its own custom transport rather than through
+`build_base_url`, which an enumeration of `build_base_url` overrides misses. `vertex` and
+`minimax_token` override it to read *different* keys, and the remaining ~14 never override it.
+So the channel cannot redirect the "20 default-transport adapters" §7.2 names, which is the first
+thing T-D1's "per adapter × model × transport" hits.
+
+**`redirected(adapter, origin, provider_config)` closes the gap by overriding `build_base_url`** —
+the single method the bridge calls for the destination (`server.py`, `_build_upstream_url`).
+Overriding `default_base_url` instead, the convention `tests/bridge/` established by hand, is
+**not** equivalent: the six adapters that override `build_base_url` ignore it.
+
+**It substitutes scheme and authority only, and keeps path, query and fragment.** Replacing the
+whole base URL is the obvious implementation and it is wrong, for a reason §3.3.5 already states
+from the other side: T-D2 must rewrite the **authority and scheme** of its expected route before
+comparing, and "path and query need no such treatment". Some adapters put routing *in the base
+URL's path* — `vertex` returns
+`https://{location}-aiplatform.googleapis.com/{version}/projects/{project_id}/locations/{location}`,
+and §3.3.5 records that for Vertex "the account being billed is a URL component" (P21). A
+whole-URL replacement deletes that path, while T-D2's independently-derived expectation still
+carries it, so P21 would report a routing mismatch against a request that went exactly where the
+harness sent it — indistinguishable from a real misroute.
+
+The trap is that the obvious check passes: **Azure survives a whole-URL replacement**, because
+`get_upstream_path(model)` carries its deployment id and `?api-version=`, not the base URL. Azure
+is §3.3.5's lead example, so a seam validated against it looks correct and silently breaks the
+row two below. Re-hosting makes the binding side and the comparison side the same rule, which is
+a stronger guarantee than either stated alone.
+
+**The redirect runs the adapter's real `build_base_url` once, at redirect time.** Two consequences
+worth knowing. It preserves whatever the adapter computes from `provider_config`, which is the
+point. And `build_base_url` is also a **validator** — `validation.py` calls it for pre-flight, and
+Vertex raises `ProviderError("Vertex AI requires 'project_id' …")` from inside it — so a redirected
+adapter raises that at redirect time and no longer raises it per request. A test meaning to
+exercise pre-flight validation must call the adapter, not the redirected copy.
+
+**This applies to default-transport adapters.** The three custom-transport adapters never call
+`build_base_url` at all: `ollama_cloud` resolves the key inside its own request path,
+`openai_subscription` uses a module constant, and `bedrock` takes a botocore endpoint override.
+Redirecting those is T-B1–T-B3's business, through `bind()` — which is exactly why `bind()`, and
+not a base-URL helper, is the interface.
+
+**`provider_config` arrives by two routes.** In balancing mode `_get_next_backend` passes
+`profile.provider_config`; in single-backend mode the same branch returns the constructor kwarg.
+`Profile.base_url` is **neither**: the resolver never reads it, and it is typed `HttpsUrl`, which
+a loopback recorder serving `http://` cannot satisfy. The fixture also encapsulates the
+constructor's `adapter=None` positional and its `# type: ignore[arg-type]`, which 38 modules
+currently repeat.
+
+**No `host=` on the factory.** An earlier draft added one "so T-E1 can rebind to §5.3's
+non-loopback name". It cannot be justified: §7.3 gives T-E1 non-loopback addressing by
+**resolution** — `HARNESS_UPSTREAM_HOST` in the target's SAN and the proxy's `resolve` map, "the
+only place the name can be mapped" — not by a bind address, and a CI runner may have no
+non-loopback address to bind. It is dropped by the same standard that admits `responder` and
+`connections`: a seam is paid for by a named consumer, and T-E1 can add one when it has a need
+a resolver cannot serve.
+
+#### 7.5.3 Balancing is part of the core, and undisciplined balancing is vacuous
+
+`BridgeServer` has two shapes, and `_select_backend`, failover, reserve-tier selection and
+`_backend_context` isolation are unreachable through the single-backend constructor — four Epic I
+tickets would each have to build the second shape themselves.
+
+Selection is **weighted-random** (`random.choices(tier, weights=…)`), so a balancing test without
+a seam may never try the backend it is about to assert on. That is not hypothetical:
+`tests/bridge/test_opencode_responses_refusal.py` records that its two-backend test "would pass
+with the refusal handler deleted, **which is how this was found**". `pin_backend_order` ships the
+round-robin seam once, rather than four Epic I tickets re-deriving the same monkeypatch. It takes
+a `monkeypatch` and is therefore callable only from a test; the conformance check below is
+single-backend and never needs it.
+
+#### 7.5.4 Why the fixture carries its own conformance check
+
+A bridge fixture's characteristic failure is **silent**, and it is §1.4's own shape. Measured
+against `origin/main`, single-backend, non-streaming, one inbound request:
+
+| Wiring | Inbound result | Elapsed | Captures |
+|---|---|---|---|
+| Pointed at its recorder | 200 | 0.01 s | 1 |
+| Pointed at a closed port | 500 | **30 s** | 0 |
+| Pointed at a **different live** upstream | **200** | fast | **0** |
+| Recorder answers **400** | 400 | 0.00 s | 1 |
+| Recorder answers **500** | 500 | 7 s | 4 (retried) |
+
+Row 3 is the dangerous one. Nothing about the request fails, and every assertion the suite builds
+on the fixture — "no unclaimed delta" (§3.3), "zero unattributable connections" (§5.2.1), every
+cross-attempt and lifecycle claim in §6.3.1 — is then quantified over an **empty** capture list
+and passes vacuously. So T-W8 ships the check that makes the wiring a checkable claim rather than
+a promise.
+
+`assert_transport_reaches_its_recorder` drives one request and asserts four things. Each is
+paired with a defect the **other three pass** — the only argument that establishes
+non-redundancy — and each defect is a **registered transport**, running in the suite:
+
+| # | Assertion | The defect only it catches |
+|---|---|---|
+| 1 | Exactly one capture | **The decoy**: `bind()` points the bridge at a different live recorder. Status 200, teardown clean, and this transport's capture list is empty |
+| 2 | The marker is in the capture's body | **The blind capture**: a recorder that counts the request and stores no body — §1.4's "projection that could not see the model name" |
+| 3 | The inbound status is 200 | **The refusal**: upstream answers 400. Measured at one capture, marker present, teardown clean, downstream 400 — the request arrived correctly and the client was still failed |
+| 4 | `assert_teardown_clean()` | **The mis-declared format**: a transport declaring one format while binding an adapter that posts to the other. The recorder dispatches by path **suffix**, so it replies in the format the *path* named, the adapter parses it, `unmatched` stays empty — one correct capture, marker present, 200, and the declared `format` was never under test |
+
+Row 4 is why the fourth defect is a transport and not a unit test on
+`assert_teardown_clean()`. A unit test proves that function raises; it does not prove the
+conformance check **calls** it — and plan §1.4's own list of past harness failures includes "a
+guard proving a function was *called* when the enforcement was the branch after it". Row 1 and
+row 4 are as far apart as row 1 and row 2: one fails with an **empty** capture list, the other
+with a **complete and correct** one.
+
+**An upstream 500 is deliberately not one of the defects.** Measured at four captures and seven
+seconds, it also trips assertion 1, so it would not be orthogonal. A 400 is the clean one.
+
+**The marker is in the body, and that is the opposite of `recorder_conformance.py`'s rule on
+purpose.** T-W4's conformance markers travel in a **header** because the defects *it* injects
+destroy every other location, and a body marker would make correlation fail with "no capture
+found" instead of failing the named check. T-W8's marker must prove the **user's content**
+survived translation to the upstream, which a header cannot show. Both rules are right for their
+own subject; neither is a general lesson, and an author must not "fix" one to match the other.
+The marker is regenerated per call, so a capture left by an earlier fixture cannot satisfy it.
+
+**The registry earns its indirection by being iterable — and the iteration must be complete.** A
+name-keyed lookup would otherwise be equivalent to importing the class, since a name resolves only
+after something imported the module that registered it. What it buys is a **meta-test that runs
+the check over every registered transport**, so an Epic B author gets the conformance check by
+registering rather than by remembering. But "iterate whatever is registered" is not enough:
+under a selective run or a per-file invocation the registering module may never be imported in
+that process, and the meta-test would pass over a set of one while reporting success for a
+category it never ran — the failure `--require-category` exists to prevent. So the meta-test
+imports an explicit `TRANSPORT_MODULES` tuple, one line per Epic B ticket, and asserts the
+registered set **equals** the expected one. T-W8's structural guard is separate and pins what
+*this module* registers, against a module-local constant and an AST scan, never against global
+registry state.
+
+**`responder` is a hook, and scripted replies are stateful closures.** Every consumer named for it
+needs the reply to change between attempts — §6.3.1's four injection points, T-I8's
+blip-then-success, and the `empty_replies` / `error_replies` counters `tests/bridge/` already
+uses. `Responder`'s signature permits a closure over mutable state, and that is the intended
+answer; no setter is added to a Protocol fifteen tickets consume.
+
+**Timeouts bound the wait and must not destroy the diagnostic.** aiohttp's client default is
+`total=300` seconds (confirmed on the pinned 3.13.5), so a hung binding costs five minutes per
+test. `post()` defaults to **10 seconds** and converts a client timeout into an assertion naming
+the transport, the elapsed time, the captures so far and the 30 s / 80 s reference values — a bare
+`TimeoutError` keeps none of that. A test that means to observe the empty-response ladder
+(§7.2.1) raises the timeout deliberately.
+
+**Teardown releases the ports and never substitutes an exception.** Client sessions close before
+`BridgeServer.stop_async`, which cleans up the runner but does not abort live connections — the
+`wait_closed` split §7.3 handles for the proxy, and the reason the support matrix is
+3.10–3.13. `assert_teardown_clean()` runs only on the clean path: raised from `__aexit__` over a
+failing body it would replace the assertion the test was making, and the falsification cases
+assert on message content. The conformance check therefore calls it **inside** the block.
+
+**`assert_teardown_clean()` is stated for every transport, not just this one.** Its obligation is
+"every request I received was answered in the format I declare"; how a transport knows that is its
+own business, since none of the other three can consult `RecordingUpstream`'s suffix table. The
+aiohttp transport uses T-W4's `format_for_path` — the **pure** lookup, split out of
+`_format_for` for this, because `_format_for` appends to `unmatched` and an assertion must not
+mutate the evidence it judges.
+
+**What T-W8 does not settle.** The one-upstream-request assertion here is scoped to the binding
+the conformance check drives, because a check tolerating a retry ladder could not tell a working
+binding from a broken one. **T-W9** still owns it as a product claim for one request driven end
+to end, together with capture **type-compatibility with T-W2's declared contract**, the
+`has_content` cell of §7.2.1's table, and the wall-clock bound on the empty ladder; T-W9 depends
+on T-W1/T-W2/T-W4/T-W8 and no corpus task, so corpus-wide quantification is **T-D1's**, not its.
+§5.3's non-loopback addressing stays with T-E1/T-E2 — loopback is correct for this fixture and is
+not a containment decision. **T-K4** is not served by this fixture: §7.2.1's unbounded capture
+retention is acceptable for one request per test and not for a sustained load run, which needs
+its own bound.
+
+**Existing tests are not migrated.** The 38 modules that build their own bridge stay as they are;
+this fixture is for new work. Rewriting them is neither in T-W8 nor scheduled elsewhere, and
+saying so here stops a future reader reading it as an unpaid debt.
+
+[KBR-31]: https://shelpuk.atlassian.net/browse/KBR-31
+
 ---
 
 ## 8. CI cadence

--- a/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
+++ b/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
@@ -100,8 +100,8 @@ After Milestone 0, seven streams advance independently, each owning its own modu
 | **T-W5** | Shared CONNECT proxy fixture | — | §7.3 | M |
 | **T-W6** | Corpus format, capture procedure, scrubber, loader | T-W3 | §7.1 | M |
 | **T-W7** | Assertion exemption registry | T-W1 | §8 | M |
-| **T-W8** | Bridge fixture **core + transport extension interface** | T-W4 | §6.3.1 | M |
-| **T-W9** | **The proven vertical slice** | T-W1, T-W2, T-W4, T-W8 | §6.3.1 | S |
+| **T-W8** | Bridge fixture **core + transport extension interface** | T-W4 | §6.3.1, §7.5 | M |
+| **T-W9** | **The proven vertical slice** | T-W1, T-W2, T-W4, T-W8 | §6.3.1, §7.5 | S |
 
 **T-W1 — markers and CI selection.** Register `l1`, `l2`, `l3`, `acceptance`, `agent_smoke`,
 `agent_live`, `eval`, `load`; a meta-test asserts every collected test carries exactly one. **Do
@@ -231,9 +231,14 @@ must not be collapsed.
 **T-W9 inherits three obligations T-W4 could not discharge**, because T-W4 starts no
 `BridgeServer` and they are only observable with one running:
 
-1. **Exactly one upstream request per inbound request.** T-W4 proves its replies are non-empty by
-   the judgements it can call directly; that is necessary and not sufficient. A second capture in
-   the recording is the only real evidence the retry ladder never fired.
+1. **Exactly one upstream request per inbound request**, for one request driven end to end. T-W4
+   proves its replies are non-empty by the judgements it can call directly; that is necessary and
+   not sufficient. A second capture in the recording is the only real evidence the retry ladder
+   never fired. **Scope, because T-W8 also asserts a form of this:** T-W8's is scoped to the one
+   binding its conformance check drives — a check tolerating a ladder could not tell a working
+   binding from a broken one — and T-W9's is the product claim for a driven request, against
+   T-W2's declared types. Quantifying it **over the corpus** is T-D1's; T-W9 depends on no corpus
+   task and is sized S. Design §7.5.4.
 2. **The `has_content` cell of §7.2.1's table.** It is a local flag in the pass-through streaming
    loop (`server.py:5145`), not a function — unreachable except by driving a bridge. T-W4's
    streams satisfy its precondition by construction; nothing has confirmed it.
@@ -580,6 +585,7 @@ merge.** So:
 | KBR-9 | G6 | T-G1 | Atomic fix + test now |
 | KBR-132 · **CLOSED** | G21 | — | Route taken: atomic fix + regression test, red at base, evidence in the PR. The broader guard is **KBR-138**, which has no plan-task ID because it was filed after this plan was written; G21 is its design gap. (Status convention: `TEST_SUITE.md` §9.2.) |
 | KBR-146 · **CLOSED** | G25 | — | Route taken: atomic fix + regression tests, red at base on both sides of the interpreter boundary, evidence in the PR. Landed the fifth §6.2.4 contract (`tests/test_ipaddress_contract.py`) ahead of all four planned ones; no plan-task ID, filed after this plan was written. G25 records what that contract still cannot prove. Duplicates KBR-141/142/150/162. (Status convention: `TEST_SUITE.md` §9.2.) |
+| KBR-175 | — | — | Found while writing **T-W8**. A **test fixture**, not product code: `tests/conftest.py::sample_profile_dict` carries a UUIDv7 `auth_ref` where `Profile` requires v4, so it cannot build the model it describes — and no test reads it. No regression-evidence rule applies, because nothing under `src/kitty` is wrong. The decision (delete it, or repair the id) is the owner's; T-W8 ships `profile_for()` and deliberately leaves it untouched |
 
 ---
 
@@ -619,7 +625,7 @@ Every design requirement has an owner. "Existing" means the current suite alread
 | §6.4.2 | Agent smoke · precedence · **five live scenarios** | T-I5 · T-I6 · T-I14 |
 | §6.4.3 | Eval harness, task set, statistics | T-K1–T-K3 |
 | §6.4.4 | Load rig and gate | T-K4, T-K5 |
-| §7.1–§7.4 | Corpus, recorders, proxy, oracle | T-W6/Epic C, T-W4/Epic B, T-W5, T-W2/T-D1 |
+| §7.1–§7.5 | Corpus, recorders, proxy, oracle, bridge fixture | T-W6/Epic C, T-W4/Epic B, T-W5, T-W2/T-D1, T-W8 |
 | §8 | Markers, selection, job activation | T-W1, T-K6–T-K12 |
 | §8, §8.3 | Assertion exemption policy and registry | T-W7 |
 | §5.1 | Real-socket transport proof across three stacks | **Existing** — `tests/test_egress_https_proxy.py`, extended by T-W5 |

--- a/tests/harness/bridge.py
+++ b/tests/harness/bridge.py
@@ -1,0 +1,937 @@
+"""The bridge fixture: a real ``BridgeServer`` in front of a recording upstream.
+
+`.system_design/TEST_SUITE.md` §7.5 · plan task **T-W8** (KBR-31).
+
+§7.2 says what a recording upstream must *observe*; this module says how the
+product is put in front of one. Of the 62 test modules under ``tests/bridge/``,
+38 start a real :class:`~kitty.bridge.server.BridgeServer` and most build their
+own stub adapter, fake upstream and ``post()`` helper; around fifteen planned
+tasks across Epics D, E, G, I, J and K need one shared version, and three more
+(T-B1–T-B3) need to plug a **different transport** into it.
+
+**This is the one module in this package that imports the product, and it must.**
+``contract.py`` and ``recorder.py`` each carry a structural guard forbidding any
+``kitty`` import, because §3.3.1's independent-oracle rule says a reader that
+asked kitty how to parse a body would inherit kitty's bugs. That governs what
+*judges* a request. This module *starts* the thing under test. Its own guard is a
+different claim — that it registers no Epic B transport — and lives in
+``test_bridge.py`` beside :data:`REGISTERED_HERE`.
+
+**No pytest fixture, and not in ``pytest_plugins``.** T-W5's proxy is published
+that way because a test asks for ``connect_proxy`` by name and cannot construct
+one. This module is different on both counts: a test must choose a wire format
+and a bridge shape anyway, so ``BridgeFixture(transport("aiohttp", fmt))`` says
+more than a fixture name would — and importing this module pulls in
+``kitty.bridge.server``, measured at **0.72 s**, which a global plugin would
+charge to every pytest invocation including those that never start a bridge.
+
+**The failure this module exists to prevent.** A bridge pointed at the *wrong
+live* upstream answers **200**; the test sees success and this fixture's recorder
+holds **nothing**. Every assertion built on it — "no unclaimed delta" (§3.3),
+"zero unattributable connections" (§5.2.1), every §6.3.1 lifecycle claim — is
+then quantified over an empty list and passes vacuously. That is plan §1.4's own
+shape, so :func:`assert_transport_reaches_its_recorder` makes the wiring a
+checkable claim, and ``test_bridge_falsification.py`` ships the four defects it
+must catch.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import itertools
+import time
+import uuid
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Protocol, runtime_checkable
+from urllib.parse import urlsplit, urlunsplit
+
+import aiohttp
+import pytest
+
+from harness.contract import CapturedRequest, WireFormat
+from harness.recorder import ConnectionRecord, RecordingUpstream, Responder, format_for_path
+from kitty.bridge.server import BridgeServer
+from kitty.profiles.schema import Profile
+from kitty.providers.base import ProviderAdapter
+from kitty.providers.custom_anthropic import CustomAnthropicAdapter
+from kitty.providers.custom_openai import CustomOpenAIAdapter
+
+__all__ = [
+    "Backend",
+    "Binding",
+    "BridgeFixture",
+    "InboundProtocol",
+    "MisdeclaredFormatError",
+    "REGISTERED_HERE",
+    "TransportTimeout",
+    "UpstreamTransport",
+    "AiohttpTransport",
+    "assert_transport_reaches_its_recorder",
+    "backend_for",
+    "inbound_path",
+    "marker",
+    "minimal_inbound_body",
+    "pin_backend_order",
+    "profile_for",
+    "protocol_for",
+    "redirected",
+    "register_transport",
+    "registered_transports",
+    "transport",
+]
+
+#: The transports **this module** registers. Pinned by ``test_bridge.py`` against
+#: this constant and never against :func:`registered_transports`, whose contents
+#: depend on which modules the pytest session imported and which grows the moment
+#: an Epic B module is imported anywhere in the run.
+REGISTERED_HERE: tuple[str, ...] = ("aiohttp",)
+
+#: Client timeout for :meth:`BridgeFixture.post`. aiohttp's own default is
+#: ``total=300``, so a mis-wired binding would cost five minutes per test — and a
+#: closed upstream port was measured at 30 seconds even so. A test that means to
+#: observe the 80-second empty-response ladder (§7.2.1) raises this deliberately.
+DEFAULT_TIMEOUT = 10.0
+
+#: The two elapsed times a timeout message cites, so a reader knows which failure
+#: they are probably looking at rather than guessing from a bare cancellation.
+_CONNECT_LADDER_SECONDS = 30
+_EMPTY_LADDER_SECONDS = 80
+
+#: A valid UUIDv4. ``tests/conftest.py``'s `sample_profile_dict` carries a UUIDv7
+#: and therefore cannot build a ``Profile`` at all (KBR-175).
+_AUTH_REF = "6f1d4f3e-2b9a-4c1d-8f7e-5a2b3c4d5e6f"
+
+#: The resolved key every fixture profile carries. Never a real credential shape.
+_KEY = "harness-key"
+
+#: The model a fixture uses when the caller names none.
+MODEL = "harness-model"
+
+#: Which adapter serves which upstream format. Both read
+#: ``provider_config["base_url"]``, so the default transport uses the product's
+#: own redirection channel and needs no subclass — :func:`redirected` exists for
+#: the ~14 adapters that do not (§7.5.2).
+_ADAPTER_FOR_FORMAT: dict[WireFormat, type[ProviderAdapter]] = {
+    WireFormat.ANTHROPIC_MESSAGES: CustomAnthropicAdapter,
+    WireFormat.CHAT_COMPLETIONS: CustomOpenAIAdapter,
+}
+
+
+class MisdeclaredFormatError(AssertionError):
+    """Raised when a transport answered in a format it does not declare.
+
+    §7.2's recorder chooses its reply format by path **suffix** and only records
+    a miss when no suffix matches. So a transport whose bound adapter posts to
+    another format's path is answered correctly, the adapter parses the reply,
+    and nothing is recorded as unmatched — the declared format was never the
+    thing under test. This is the only signal that says so.
+    """
+
+
+class TransportTimeout(AssertionError):
+    """Raised when an inbound request outlived :data:`DEFAULT_TIMEOUT`.
+
+    An ``AssertionError`` rather than a bare ``TimeoutError`` so the failure
+    carries the transport, the elapsed time and the captures so far. A
+    cancellation on its own says only that something took too long, which is the
+    one thing the reader already knows.
+    """
+
+
+class InboundProtocol(Enum):
+    """The bridge routes an agent posts to.
+
+    Deliberately **not** :class:`~harness.contract.WireFormat`, which describes
+    what a recorder serves. The two axes are independent — translating between
+    them is what the bridge does and what §3.3's oracle exists to check — and
+    two of the six wire formats have no inbound route at all. One parameter for
+    both would work only for the pass-through pairs T-W8 happens to ship.
+    """
+
+    CHAT_COMPLETIONS = "chat_completions"
+    MESSAGES = "messages"
+    RESPONSES = "responses"
+    GEMINI = "gemini"
+
+
+#: The inbound route whose dialect matches an upstream format, for helpers that
+#: need a sensible default. **Not** an equivalence: §7.5.1 — the two axes are
+#: independent, and translating between them is what the bridge is.
+_PROTOCOL_FOR_FORMAT: dict[WireFormat, InboundProtocol] = {
+    WireFormat.ANTHROPIC_MESSAGES: InboundProtocol.MESSAGES,
+    WireFormat.CHAT_COMPLETIONS: InboundProtocol.CHAT_COMPLETIONS,
+    WireFormat.OPENAI_RESPONSES: InboundProtocol.RESPONSES,
+    WireFormat.GEMINI: InboundProtocol.GEMINI,
+}
+
+#: What a transport hands the fixture: the adapter to run, and the provider
+#: configuration that points it at that transport's own recorder.
+Binding = tuple[ProviderAdapter, dict[str, Any]]
+
+#: One member of a balancing pool, in the shape ``BridgeServer(backends=…)`` takes.
+Backend = tuple[ProviderAdapter, str, Profile]
+
+
+@runtime_checkable
+class UpstreamTransport(Protocol):
+    """What the bridge fixture needs from a recording upstream it did not write.
+
+    T-B1–T-B3 satisfy this and call :func:`register_transport`; nothing in this
+    module needs to change for them. Attributes rather than a base class so a
+    transport can be any object, including one wrapping a client library that
+    owns its own server.
+
+    Attributes:
+        name: The registry key.
+        format: The **upstream** wire format this transport serves.
+    """
+
+    name: str
+    format: WireFormat
+
+    async def start(self) -> None:
+        """Begin accepting, on a port of the transport's choosing."""
+
+    async def stop(self) -> None:
+        """Stop accepting and release the port."""
+
+    def bind(self) -> Binding:
+        """Return the adapter and provider config that reach this transport.
+
+        Returns:
+            The pair a bridge is constructed with. This is the single seam: the
+            fixture never reads a recorder's base URL itself, because botocore
+            takes an endpoint override, curl_cffi terminates TLS, and the OAuth
+            leg is a different session entirely (§7.2).
+        """
+
+    @property
+    def captures(self) -> Sequence[CapturedRequest]:
+        """Return what reached this transport, in arrival order."""
+
+    @property
+    def connections(self) -> Sequence[ConnectionRecord]:
+        """Return every accepted connection.
+
+        §5.2.1's bypass is a connection carrying **no** request, which no
+        capture list can express, and `connect_proxy.unattributable_peer_ports`
+        joins on exactly these ports.
+        """
+
+    def assert_teardown_clean(self) -> None:
+        """Assert every request was answered in the format this transport declares.
+
+        How a transport knows that is its own business — none of the other three
+        can consult :class:`~harness.recorder.RecordingUpstream`'s suffix table.
+
+        Raises:
+            AssertionError: When some request was not.
+        """
+
+
+#: Builds a transport for one upstream format. ``responder`` is T-W4's
+#: failure-library seam (T-B4, T-I7, T-I8, T-I11, T-G7): scripted replies that
+#: change between attempts are **stateful closures** over it, which is why no
+#: setter is added to a Protocol fifteen tickets consume.
+TransportFactory = Callable[..., UpstreamTransport]
+
+_TRANSPORTS: dict[str, TransportFactory] = {}
+
+
+def register_transport(name: str, factory: TransportFactory) -> None:
+    """Register a transport under ``name``.
+
+    Args:
+        name: The registry key, e.g. ``"curl_cffi"``.
+        factory: Called as ``factory(fmt, responder=…)``.
+
+    Raises:
+        ValueError: When ``name`` is already registered. Silently replacing it
+            would let two Epic B modules disagree about which recorder a name
+            means, and the loser would be whichever imported first.
+    """
+    if name in _TRANSPORTS:
+        raise ValueError(f"transport {name!r} is already registered; registered: {registered_transports()}")
+
+    _TRANSPORTS[name] = factory
+
+
+def registered_transports() -> tuple[str, ...]:
+    """Return every registered transport name, sorted.
+
+    Returns:
+        The names registered **in this process**, which is a function of which
+        modules were imported. A guard pinning what one module registers must
+        read :data:`REGISTERED_HERE` instead; a meta-test iterating this must
+        import its subjects explicitly and assert set equality, or it reports
+        success for a category it never ran.
+    """
+    return tuple(sorted(_TRANSPORTS))
+
+
+def transport(name: str, fmt: WireFormat, *, responder: Responder | None = None) -> UpstreamTransport:
+    """Build a registered transport.
+
+    Args:
+        name: A registered transport name.
+        fmt: The upstream wire format it should serve.
+        responder: What to reply with; the transport's own default when omitted.
+
+    Returns:
+        An unstarted transport.
+
+    Raises:
+        LookupError: When ``name`` is not registered.
+    """
+    try:
+        factory = _TRANSPORTS[name]
+    except KeyError:
+        raise LookupError(f"no transport named {name!r}; registered: {registered_transports()}") from None
+
+    return factory(fmt, responder=responder)
+
+
+def marker() -> str:
+    """Return a marker unique to one request.
+
+    Returns:
+        A string to carry as the user's text and look for in the captured body.
+        Regenerated per call so a capture left by an earlier fixture cannot
+        satisfy an assertion about this one.
+    """
+    return f"kbr31-{uuid.uuid4().hex}"
+
+
+def redirected(adapter: ProviderAdapter, origin: str, provider_config: dict[str, Any] | None = None) -> ProviderAdapter:
+    """Return ``adapter`` re-hosted onto ``origin``, keeping path and query.
+
+    For the ~14 default-transport adapters that honour no configuration key,
+    :meth:`~kitty.providers.base.ProviderAdapter.build_base_url` is the only
+    seam: it is the single method the bridge calls for the destination.
+    Overriding ``default_base_url`` instead — the convention ``tests/bridge/``
+    established by hand — is **not** equivalent, because the six adapters that
+    override ``build_base_url`` ignore it.
+
+    **Scheme and authority are substituted; path, query and fragment survive.**
+    Replacing the whole URL is the obvious implementation and it is wrong:
+    Vertex builds ``/{version}/projects/{project_id}/locations/{location}`` into
+    its base URL, and §3.3.5 calls that "the account being billed". Deleting it
+    would make P21 report a routing mismatch against a request that went exactly
+    where the harness sent it. Azure survives a whole-URL replacement — its
+    routing is in ``get_upstream_path`` — so the check most people would run
+    passes while the row below it breaks. §3.3.5 specifies this same
+    substitution from the comparison side, so both sides are one rule.
+
+    Args:
+        adapter: The adapter to redirect. Its type, and any state its
+            constructor resolved, are preserved.
+        origin: Scheme and authority to re-host onto, e.g. a recorder's
+            ``base_url``. Anything it carries beyond those is ignored.
+        provider_config: Passed to the adapter's real ``build_base_url``.
+
+    Returns:
+        An instance of a subclass of ``type(adapter)`` whose ``build_base_url``
+        returns the re-hosted URL for any configuration.
+
+    Raises:
+        Exception: Whatever the adapter's own ``build_base_url`` raises — it is
+            called here, once. That method is also pre-flight's **validator**
+            (Vertex raises ``ProviderError`` for a missing ``project_id`` from
+            inside it), so a redirected adapter raises at redirect time and no
+            longer per request. A test exercising pre-flight validation must use
+            the adapter itself, not the redirected copy.
+    """
+    # Compute against the real implementation, so whatever the adapter derives
+    # from its configuration is kept rather than guessed at.
+    original = urlsplit(adapter.build_base_url(provider_config or {}))
+    target = urlsplit(origin)
+    rehosted = urlunsplit((target.scheme, target.netloc, original.path, original.query, original.fragment))
+
+    def _build_base_url(self: ProviderAdapter, provider_config: dict | None = None) -> str:
+        """Return the re-hosted base URL.
+
+        Args:
+            provider_config: Ignored; the URL was resolved at redirect time.
+
+        Returns:
+            The re-hosted URL.
+        """
+        return rehosted
+
+    subclass = type(
+        f"Redirected{type(adapter).__name__}",
+        (type(adapter),),
+        {"build_base_url": _build_base_url, "__doc__": f"{type(adapter).__name__} re-hosted onto {origin}."},
+    )
+
+    # Copy state rather than re-running `__init__`: `MiniMaxTokenAdapter`
+    # resolves a flag in its constructor, and a fresh no-arg instance would
+    # silently discard it. No adapter defines `__slots__`.
+    clone = object.__new__(subclass)
+    clone.__dict__.update(adapter.__dict__)
+    return clone
+
+
+@dataclass
+class AiohttpTransport:
+    """The default transport: T-W4's recorder, reached over plain HTTP.
+
+    The only transport this module registers. It binds ``custom_anthropic`` or
+    ``custom_openai`` — the two adapters that honour
+    ``provider_config["base_url"]`` — so the default path uses the product's own
+    redirection channel rather than a subclass.
+
+    Attributes:
+        format: The upstream wire format served.
+        responder: What to reply with; the recorder's minimal success when
+            omitted. A closure over mutable state is how a reply is scripted to
+            change between attempts.
+    """
+
+    #: A class attribute, not a field: every instance answers to one registry key.
+    name = "aiohttp"
+
+    format: WireFormat
+    responder: Responder | None = None
+    _recorder: RecordingUpstream = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        """Build the recorder eagerly, so an unserved format fails here.
+
+        Raises:
+            ValueError: When ``format`` is not one this recorder serves.
+                Constructing now rather than at :meth:`start` puts that check at
+                construction (R3.8) without this module keeping a second copy of
+                the served-format set.
+        """
+        self._recorder = RecordingUpstream(default_format=self.format, responder=self.responder)
+
+    @property
+    def recorder(self) -> RecordingUpstream:
+        """Return the underlying recorder.
+
+        Returns:
+            The :class:`~harness.recorder.RecordingUpstream`, for tests that
+            need the parts of it this interface does not expose.
+        """
+        return self._recorder
+
+    async def start(self) -> None:
+        """Bind an ephemeral loopback port and begin recording."""
+        await self._recorder.start()
+
+    async def stop(self) -> None:
+        """Release the port."""
+        await self._recorder.stop()
+
+    def bind(self) -> Binding:
+        """Return the adapter and config that reach this recorder.
+
+        Returns:
+            A fresh adapter for this transport's format, and the provider
+            configuration naming the recorder's base URL.
+
+        Raises:
+            RuntimeError: When the transport has not been started, because the
+                recorder has no port until then.
+        """
+        return _ADAPTER_FOR_FORMAT[self.format](), {"base_url": self._recorder.base_url}
+
+    @property
+    def captures(self) -> Sequence[CapturedRequest]:
+        """Return the completed captures, in arrival order.
+
+        Returns:
+            What the recorder holds. Spelled ``captures`` on a transport and
+            ``requests`` on the recorder; one list, §7.2's name unchanged.
+        """
+        return self._recorder.requests
+
+    @property
+    def connections(self) -> Sequence[ConnectionRecord]:
+        """Return every accepted connection.
+
+        Returns:
+            One record per connection, including any that carried no request.
+        """
+        return self._recorder.connections
+
+    def assert_teardown_clean(self) -> None:
+        """Assert every request was answered in the format this transport declares.
+
+        Raises:
+            UnmatchedPathError: When a request took the recorder's fallback.
+            MisdeclaredFormatError: When a request's path selected some *other*
+                format. That case leaves ``unmatched`` empty — the recorder
+                dispatches by suffix and found one — so nothing else reports it.
+        """
+        self._recorder.assert_all_paths_matched()
+
+        # The pure lookup, never `_format_for`: that one appends to `unmatched`,
+        # and an assertion must not mutate the evidence it judges.
+        wrong = [c.path for c in self.captures if format_for_path(c.path) is not self.format]
+        if wrong:
+            raise MisdeclaredFormatError(
+                f"transport {self.name!r} declares {self.format.value} but "
+                f"{wrong} select another format; the reply was chosen by the path, "
+                f"so the declared format was never under test"
+            )
+
+
+register_transport(AiohttpTransport.name, AiohttpTransport)
+
+
+def protocol_for(fmt: WireFormat) -> InboundProtocol:
+    """Return the inbound route whose dialect matches ``fmt``.
+
+    A convenience for helpers that must pick one, **not** a claim that the axes
+    are the same (§7.5.1); a test asserting on translation names both itself.
+
+    Args:
+        fmt: An upstream wire format.
+
+    Returns:
+        The inbound protocol in the same dialect.
+
+    Raises:
+        KeyError: When no inbound route speaks ``fmt``. Exactly two: Bedrock
+            Converse and Ollama ``/api/chat``, which the bridge reaches upstream
+            but never serves inbound. A transport on either — T-B3's botocore,
+            half of T-B1's — must name its own inbound route, because the bridge
+            translates and nothing can derive it from the upstream format.
+    """
+    return _PROTOCOL_FOR_FORMAT[fmt]
+
+
+def inbound_path(protocol: InboundProtocol, *, model: str = MODEL, stream: bool = False) -> str:
+    """Return the bridge route that serves ``protocol``.
+
+    Args:
+        protocol: The inbound protocol.
+        model: The model name. Only Gemini puts it in the path.
+        stream: Whether the request streams. Only Gemini puts it in the path;
+            every other protocol carries it in the body — so a Gemini caller
+            must pass the same value here *and* to
+            :func:`minimal_inbound_body`, which ignores it. Nothing detects a
+            mismatch, because to the bridge neither spelling is malformed.
+
+    Returns:
+        The path to POST to.
+    """
+    if protocol is InboundProtocol.GEMINI:
+        verb = "streamGenerateContent" if stream else "generateContent"
+        return f"/v1beta/models/{model}:{verb}"
+
+    return {
+        InboundProtocol.CHAT_COMPLETIONS: "/v1/chat/completions",
+        InboundProtocol.MESSAGES: "/v1/messages",
+        InboundProtocol.RESPONSES: "/v1/responses",
+    }[protocol]
+
+
+def minimal_inbound_body(
+    protocol: InboundProtocol, text: str, *, model: str = MODEL, stream: bool = False
+) -> dict[str, Any]:
+    """Return the smallest request ``protocol`` accepts, carrying ``text``.
+
+    Args:
+        protocol: The inbound protocol.
+        text: The user's text — a :func:`marker` when the caller means to find
+            it again in the captured upstream body.
+        model: The model to ask for.
+        stream: Whether to ask for a stream.
+
+    Returns:
+        The request body.
+    """
+    if protocol is InboundProtocol.GEMINI:
+        # Gemini carries neither model nor stream in the body; both are in the path.
+        return {"contents": [{"role": "user", "parts": [{"text": text}]}]}
+
+    if protocol is InboundProtocol.RESPONSES:
+        return {
+            "model": model,
+            "input": [{"type": "message", "role": "user", "content": [{"type": "input_text", "text": text}]}],
+            "stream": stream,
+        }
+
+    body: dict[str, Any] = {
+        "model": model,
+        "messages": [{"role": "user", "content": text}],
+        "stream": stream,
+    }
+    if protocol is InboundProtocol.MESSAGES:
+        # `max_tokens` is required by the Messages API and by nothing else.
+        body["max_tokens"] = 16
+    return body
+
+
+def profile_for(
+    transport: UpstreamTransport,
+    *,
+    name: str = "harness",
+    model: str = MODEL,
+    backup: bool = False,
+    binding: Binding | None = None,
+) -> Profile:
+    """Return a valid profile pointed at ``transport``.
+
+    ``provider_config`` is the channel the bridge reads — ``profile`` in
+    balancing mode, the constructor keyword in single-backend mode.
+    ``Profile.base_url`` is neither: the resolver never reads it, and it is typed
+    ``HttpsUrl``, which a loopback recorder serving ``http://`` cannot satisfy.
+
+    Args:
+        transport: A **started** transport; its binding is read here.
+        name: The profile name.
+        model: The model the profile pins.
+        backup: Whether this is a reserve-tier member.
+        binding: A binding already obtained from ``transport``, so a caller
+            building several profiles does not pay for it repeatedly.
+
+    Returns:
+        A profile the shipped schema accepts — including a UUIDv4 ``auth_ref``,
+        which ``tests/conftest.py``'s `sample_profile_dict` is not (KBR-175).
+    """
+    adapter, provider_config = binding if binding is not None else transport.bind()
+    return Profile(
+        name=name,
+        provider=adapter.provider_type,  # type: ignore[arg-type]
+        model=model,
+        auth_ref=_AUTH_REF,
+        provider_config=provider_config,
+        backup=backup,
+    )
+
+
+def backend_for(
+    transport: UpstreamTransport,
+    *,
+    name: str = "harness",
+    model: str = MODEL,
+    key: str = _KEY,
+    backup: bool = False,
+    binding: Binding | None = None,
+) -> Backend:
+    """Return one balancing-pool member pointed at ``transport``.
+
+    Args:
+        transport: A **started** transport.
+        name: The profile name; distinct per member.
+        model: The model this member pins.
+        key: The resolved credential.
+        backup: Whether this member is reserve tier.
+        binding: A binding already obtained from ``transport``. Passed in when
+            building several members, because ``bind()`` is not guaranteed cheap
+            — §7.5.2 says it may be an OAuth leg (T-B1) or a TLS session (T-B2),
+            so re-deriving it per member would multiply real work.
+
+    Returns:
+        The ``(adapter, key, profile)`` triple ``BridgeServer(backends=…)`` takes.
+    """
+    resolved = binding if binding is not None else transport.bind()
+    return resolved[0], key, profile_for(transport, name=name, model=model, backup=backup, binding=resolved)
+
+
+def pin_backend_order(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make balancing selection round-robin instead of weighted-random.
+
+    ``_get_next_backend`` picks with ``random.choices(tier, weights=…)``, so a
+    two-backend test without this may never try the backend it is about to
+    assert on. That is measured, not supposed:
+    ``tests/bridge/test_opencode_responses_refusal.py`` records that its own
+    two-backend test "would pass with the refusal handler deleted, which is how
+    this was found". Shipped here so four Epic I tickets do not re-derive it.
+
+    Args:
+        monkeypatch: Pytest's monkeypatch fixture, which reverts the patch.
+    """
+    calls = itertools.count()
+
+    def _round_robin(tier: Sequence[Any], weights: Sequence[float] | None = None, k: int = 1) -> list[Any]:
+        """Return the next member of ``tier``, cycling.
+
+        Args:
+            tier: The candidates.
+            weights: Ignored; determinism is the point.
+            k: Ignored; the caller always takes one.
+
+        Returns:
+            A one-element list, as ``random.choices`` returns.
+        """
+        # A true cycle rather than "first unseen, then stick": the sticky form
+        # starves every backend but one once the pool has been walked.
+        return [tier[next(calls) % len(tier)]]
+
+    # `kitty.bridge.server.random` is the stdlib module object, so this patches
+    # `random.choices` PROCESS-WIDE for the duration — every caller in the
+    # interpreter gets round-robin, not only the bridge. `monkeypatch` reverting
+    # it is what keeps that contained, which is why this takes the fixture
+    # rather than patching by hand.
+    monkeypatch.setattr("kitty.bridge.server.random.choices", _round_robin)
+
+
+@dataclass
+class BridgeFixture:
+    """A real ``BridgeServer`` started against a transport, as a context manager.
+
+    Attributes:
+        transport: The upstream this bridge is pointed at. Started and stopped
+            by this fixture.
+        model: The profile's model, or ``None`` for a profile that sets none.
+            ``None`` is not speculative: register row **M1** ("replace `model`
+            with the profile's model") is *conditional* on the profile setting
+            one, so proving it needs the trigger **and** its complement, and the
+            complement is only reachable this way. `tests/bridge/` already builds
+            it by hand for the same reason.
+        backend_models: One model per balancing-pool member, or ``None`` for the
+            single-backend shape. Distinct models make it observable which
+            member served a request, since all members share this transport's
+            recorder; a test needing members on *separate* recorders builds its
+            own ``backends`` from :func:`backend_for`.
+    """
+
+    transport: UpstreamTransport
+    model: str | None = MODEL
+    backend_models: Sequence[str] | None = None
+    server: BridgeServer | None = field(init=False, default=None)
+    _port: int = field(init=False, default=0, repr=False)
+
+    async def start(self) -> None:
+        """Start the transport, then a real bridge pointed at it.
+
+        Raises:
+            BaseException: Whatever the binding or the bridge raised, after
+                releasing the transport. ``__aenter__`` propagates a failure here
+                and Python then never calls ``__aexit__``, so without this the
+                recorder stays bound and only the *next* test's ephemeral port
+                allocation would notice. Reachable: a profile validation error in
+                :func:`backend_for`, or a bind failure.
+        """
+        await self.transport.start()
+        try:
+            await self._start_bridge()
+        except BaseException:
+            await self.stop()
+            raise
+
+    async def _start_bridge(self) -> None:
+        """Build and start the bridge against the already-started transport."""
+        adapter, provider_config = self.transport.bind()
+
+        # The `None` launcher adapter and its ignore are encapsulated here
+        # rather than repeated in each of the 38 modules that need them.
+        if self.backend_models is None:
+            self.server = BridgeServer(
+                None,  # type: ignore[arg-type]
+                adapter,
+                _KEY,
+                model=self.model,
+                provider_config=provider_config,
+            )
+        else:
+            backends = [
+                backend_for(self.transport, name=f"harness{i}", model=m, binding=(adapter, provider_config))
+                for i, m in enumerate(self.backend_models)
+            ]
+            self.server = BridgeServer(
+                None,  # type: ignore[arg-type]
+                adapter,
+                _KEY,
+                model=self.model,
+                backends=backends,
+            )
+
+        self._port = await self.server.start_async()
+
+    async def stop(self) -> None:
+        """Stop the bridge, then the transport, releasing both ports.
+
+        The transport is stopped in a ``finally``: a bridge that fails to shut
+        down must not leave a recorder bound, because the next test's ephemeral
+        port allocation is the only thing that would notice.
+
+        **This waits for in-flight upstream handlers.** ``stop_async`` cleans up
+        the runner and closes the bridge's sessions; it does not abort live
+        connections. So a test that deliberately leaves a request hanging — to
+        observe a timeout, say — must release it before teardown, or it pays the
+        full hold time in the gate. Aborting here instead would mean reaching
+        into T-W4's recorder, and §7.3's proxy is the place that decision was
+        already made for the case that needs it.
+        """
+        try:
+            if self.server is not None:
+                await self.server.stop_async()
+                self.server = None
+        finally:
+            # Forget the port, so a post-teardown `port` or `post()` fails with
+            # this class's own "not running" error rather than a connection
+            # refusal from a port that now belongs to nobody.
+            self._port = 0
+            await self.transport.stop()
+
+    async def __aenter__(self) -> BridgeFixture:
+        """Start the transport and the bridge.
+
+        Returns:
+            The started fixture.
+        """
+        await self.start()
+        return self
+
+    async def __aexit__(self, exc_type: type[BaseException] | None, *_: object) -> None:
+        """Release both ports, and check the transport only on the clean path.
+
+        Args:
+            exc_type: The exception type escaping the block, if any.
+            *_: The value and traceback, unused.
+
+        An exception raised here would **supersede** one raised in the block, so
+        running the teardown check over a failing body would replace the
+        assertion the test was making — and the falsification cases assert on
+        message content.
+        """
+        await self.stop()
+        if exc_type is None:
+            self.transport.assert_teardown_clean()
+
+    @property
+    def port(self) -> int:
+        """Return the bridge's bound port.
+
+        Returns:
+            The ephemeral port chosen by the kernel.
+
+        Raises:
+            RuntimeError: When the fixture has not been started.
+        """
+        if not self._port:
+            raise RuntimeError("bridge fixture is not running; use it as a context manager")
+        return self._port
+
+    @property
+    def base_url(self) -> str:
+        """Return the URL an agent would post to.
+
+        Returns:
+            The bridge's loopback origin, with no trailing slash.
+        """
+        return f"http://127.0.0.1:{self.port}"
+
+    @property
+    def captures(self) -> Sequence[CapturedRequest]:
+        """Return what reached the upstream, in arrival order.
+
+        Returns:
+            The transport's captures.
+        """
+        return self.transport.captures
+
+    async def post(self, path: str, body: dict[str, Any], *, timeout: float = DEFAULT_TIMEOUT) -> tuple[int, str]:
+        """POST ``body`` to the bridge and return the reply.
+
+        Args:
+            path: The inbound route, e.g. from :func:`inbound_path`.
+            body: The JSON body, e.g. from :func:`minimal_inbound_body`.
+            timeout: Total client timeout in seconds.
+
+        Returns:
+            The status and the raw response text. Text, not JSON: three of the
+            inbound surfaces answer with SSE, which a JSON decode cannot read.
+
+        Raises:
+            TransportTimeout: When the reply did not arrive in ``timeout``.
+        """
+        started = time.monotonic()
+        client_timeout = aiohttp.ClientTimeout(total=timeout)
+        # A session per call, deliberately, not an optimisation waiting to be
+        # made: it is what guarantees every client session is closed before
+        # `stop_async` runs. Hoisting it to fixture level would invert that
+        # ordering, and nothing here would go red.
+        try:
+            async with (
+                aiohttp.ClientSession(timeout=client_timeout) as session,
+                session.post(f"{self.base_url}{path}", json=body) as response,
+            ):
+                return response.status, await response.text()
+        except (TimeoutError, asyncio.TimeoutError) as exc:
+            # A bare cancellation says only that something was slow, which the
+            # reader already knows. The two ladders are named so they can tell
+            # a mis-wired binding from a wrong-format reply without a rerun.
+            raise TransportTimeout(
+                f"no reply from the bridge on {path} within {timeout}s "
+                f"(elapsed {time.monotonic() - started:.1f}s); transport "
+                f"{self.transport.name!r} holds {len(self.captures)} capture(s). "
+                f"An unreachable upstream costs ~{_CONNECT_LADDER_SECONDS}s and a "
+                f"wrong-format reply ~{_EMPTY_LADDER_SECONDS}s; raise timeout= to observe either"
+            ) from exc
+
+
+async def assert_transport_reaches_its_recorder(
+    subject: UpstreamTransport, *, protocol: InboundProtocol | None = None
+) -> None:
+    """Assert a registered transport actually carries a bridge's request.
+
+    Drives **one** request through a real :class:`BridgeFixture` and makes four
+    assertions, each of which a defect the other three pass can break — which is
+    the only argument that establishes they are not redundant. The defects are
+    in ``test_bridge_falsification.py``, one per assertion.
+
+    T-B1–T-B3 call this against their own registration; the meta-test in
+    ``test_bridge.py`` calls it over every registered transport, so a new one
+    inherits the check by registering rather than by remembering.
+
+    It takes an **unstarted transport**, not a registry name, so that the
+    deliberate defects in ``test_bridge_falsification.py`` never have to be
+    registered: a shared registry carrying four things that are wrong on purpose
+    is a hazard, and it would also make the registry-completeness meta-test
+    assert over them. The meta-test resolves names to instances itself.
+
+    Args:
+        subject: An unstarted transport. Started and stopped by this function.
+        protocol: The inbound route to drive; the one matching the transport's
+            declared format by default.
+
+    Raises:
+        AssertionError: When the bridge did not reach *this* transport's
+            recorder, exactly once, with this request's content, successfully,
+            in the declared format.
+    """
+    name = subject.name
+    route = protocol if protocol is not None else protocol_for(subject.format)
+    sent = marker()
+
+    async with BridgeFixture(subject) as fixture:
+        status, text = await fixture.post(inbound_path(route), minimal_inbound_body(route, sent))
+        captures = list(subject.captures)
+
+        # 1. Reached *this* recorder, once. An empty list is the decoy — a
+        #    binding pointed at somebody else's live upstream, which answers 200.
+        assert len(captures) == 1, (
+            f"transport {name!r} holds {len(captures)} capture(s), expected exactly 1: "
+            f"0 means the bridge reached some other upstream and every assertion built "
+            f"on this fixture would be quantified over nothing; more than 1 means a retry "
+            f"ladder fired, so the binding cannot be told from a broken one"
+        )
+
+        # 2. Carried *this* request. A count alone passes for a recorder that
+        #    fabricates captures or stores no body.
+        assert sent.encode() in (captures[0].body or b""), (
+            f"transport {name!r} captured a request whose body does not carry the "
+            f"marker {sent!r}; the capture cannot see the content under test"
+        )
+
+        # 3. And the client was actually served. A correct capture with a failed
+        #    client is real — an upstream 400 produces exactly that.
+        assert status == 200, (
+            f"transport {name!r} captured the request correctly but the bridge answered {status}: {text[:200]!r}"
+        )
+
+    # 4. And in the format this transport declares — asserted by the fixture's
+    #    own teardown, above, on the clean path. It is deliberately *not*
+    #    repeated here: it would then be an assertion no defect could falsify,
+    #    since `__aexit__` raises first either way, and an assertion nothing can
+    #    kill is the thing plan section 1.4 objects to. `_MisdeclaredTransport`
+    #    falsifies the teardown call instead.

--- a/tests/harness/bridge.py
+++ b/tests/harness/bridge.py
@@ -461,6 +461,12 @@ class AiohttpTransport:
     def assert_teardown_clean(self) -> None:
         """Assert every request was answered in the format this transport declares.
 
+        Named ``assert_*`` and **not** ``check_*``: ``recorder_conformance.py``
+        owns the ``check_*`` family for "the contract every recorder is judged
+        against" (§7.2.1), which is a different subject. A transport author
+        adding a sibling here should keep the ``assert_`` prefix rather than
+        reach for symmetry with that module.
+
         Raises:
             UnmatchedPathError: When a request took the recorder's fallback.
             MisdeclaredFormatError: When a request's path selected some *other*
@@ -710,7 +716,16 @@ class BridgeFixture:
                 allocation would notice. Reachable: a profile validation error in
                 :func:`backend_for`, or a bind failure.
         """
-        await self.transport.start()
+        # Two guards, not one. `RecordingUpstream.start` assigns its runner,
+        # awaits `setup()`, and only then binds the site — so a failure in the
+        # bind leaves a runner that still needs `cleanup()`, and it happens
+        # before there is any bridge for the second guard to unwind.
+        try:
+            await self.transport.start()
+        except BaseException:
+            await self.transport.stop()
+            raise
+
         try:
             await self._start_bridge()
         except BaseException:

--- a/tests/harness/recorder.py
+++ b/tests/harness/recorder.py
@@ -30,6 +30,10 @@ recorder must do are unreachable from the high-level route:
 
 Routing is not needed — a recorder answers every path — so the low-level server
 costs nothing else.
+
+It also exports :func:`format_for_path`, the **pure** half of the reply-format
+lookup, split out for T-W8's bridge fixture: that fixture judges captured paths
+at teardown and must not use the method, which records a miss as a side effect.
 """
 
 from __future__ import annotations

--- a/tests/harness/recorder.py
+++ b/tests/harness/recorder.py
@@ -51,6 +51,7 @@ __all__ = [
     "Reply",
     "minimal_success_body",
     "minimal_success_stream",
+    "format_for_path",
     "UnmatchedPathError",
 ]
 
@@ -256,6 +257,34 @@ def minimal_success_stream(fmt: WireFormat) -> tuple[bytes, ...]:
         )
 
     raise ValueError(f"the primary recorder serves {sorted(f.value for f in _SERVED_FORMATS)}, not {fmt.value}")
+
+
+def format_for_path(path: str) -> WireFormat | None:
+    """Return the wire format a request at ``path`` selects, or ``None``.
+
+    The pure half of :meth:`RecordingUpstream._format_for`: it answers the
+    question and records nothing.  Split out for T-W8 (KBR-31), whose bridge
+    fixture asserts at teardown that every captured path selected the format its
+    transport declares.  That assertion cannot call the method — the method
+    *appends to* :attr:`RecordingUpstream.unmatched` on a miss, so judging the
+    captures with it would mutate the evidence being judged, on every fixture
+    exit, and would fight the tests that deliberately clear that list.  Copying
+    :data:`_FORMAT_SUFFIXES` into the fixture was the alternative and is worse:
+    a second source of truth that stays green when the table moves.
+
+    Args:
+        path: The request's raw path.
+
+    Returns:
+        The format whose suffix ``path`` ends with, or ``None`` when no suffix
+        matches.  ``None`` rather than a default, because "no rule applies" and
+        "the fallback applies" are different facts and only the caller knows
+        which it wants.
+    """
+    for suffix, fmt in _FORMAT_SUFFIXES:
+        if path.endswith(suffix):
+            return fmt
+    return None
 
 
 def _wants_stream(body: bytes) -> bool:
@@ -480,9 +509,12 @@ class RecordingUpstream:
         Returns:
             The matched format, or :attr:`default_format` — recording the miss.
         """
-        for suffix, fmt in _FORMAT_SUFFIXES:
-            if path.endswith(suffix):
-                return fmt
+        matched = format_for_path(path)
+        if matched is not None:
+            return matched
+
+        # The recording half, which is why this is a method and not the pure
+        # function above: a miss is what `assert_all_paths_matched` reports.
         self.unmatched.append(path)
         return self.default_format
 

--- a/tests/harness/test_bridge.py
+++ b/tests/harness/test_bridge.py
@@ -1,0 +1,1035 @@
+"""The bridge fixture core and its transport extension interface.
+
+`.system_design/TEST_SUITE.md` §7.5 · plan task **T-W8** (KBR-31) ·
+`.requirements/20260911T233557Z_bridge_fixture_core/REQUIREMENTS.md`.
+
+The deliberate defects this module's subject must catch live in
+``test_bridge_falsification.py``; what is here is the fixture's own behaviour.
+
+**Layer.** No ``pytestmark``, so these take the ``l1`` path default, following
+T-W4 and T-W5. The reason is §8.2's and only §8.2's: a test may not be moved to
+``l3`` before the Subsystem job exists, and CI runs ``-m "l1 or l2"``, so an
+``l3`` marker today would leave the fixture's own correctness checked by no job
+at all while fifteen tickets build on it. §8.2 lists this module so T-K6
+inherits a list rather than a search.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import json
+import uuid
+from pathlib import Path
+
+import aiohttp
+import pytest
+
+from harness.bridge import (
+    DEFAULT_TIMEOUT,
+    MODEL,
+    REGISTERED_HERE,
+    AiohttpTransport,
+    BridgeFixture,
+    InboundProtocol,
+    MisdeclaredFormatError,
+    TransportTimeout,
+    UpstreamTransport,
+    assert_transport_reaches_its_recorder,
+    backend_for,
+    inbound_path,
+    marker,
+    minimal_inbound_body,
+    pin_backend_order,
+    profile_for,
+    protocol_for,
+    redirected,
+    register_transport,
+    registered_transports,
+    transport,
+)
+from harness.contract import WireFormat
+from harness.recorder import Reply, UnmatchedPathError, minimal_success_body
+from kitty.bridge.server import BridgeServer
+from kitty.providers.anthropic import AnthropicAdapter
+from kitty.providers.base import ProviderAdapter
+from kitty.providers.minimax_token import MiniMaxTokenAnthropicAdapter
+from kitty.providers.vertex import VertexAIAdapter
+
+#: One row per registered transport: the module that registers it, its registry
+#: name, the upstream format to construct it with, and **the inbound route that
+#: exercises it**. Each of T-B1 (KBR-40), T-B2 (KBR-41) and T-B3 (KBR-42) adds
+#: one row, and inherits the conformance check by doing so.
+#:
+#: The inbound route is a separate field and not derived, because the bridge
+#: *translates*: `BEDROCK_CONVERSE` (T-B3) and `OLLAMA_CHAT` (half of T-B1) have
+#: no inbound route of their own, so nothing can infer one from the format. A
+#: single hardcoded format here — the first draft — would have raised
+#: ``ValueError`` at construction for all three, since none of them serves
+#: Anthropic Messages.
+#:
+#: This lives here and not in ``bridge.py`` on purpose: the structural guard
+#: forbids that module importing an Epic B one, and registry completeness is a
+#: property of the suite, not of the core.
+CONFORMANCE_CASES: tuple[tuple[str, str, WireFormat, InboundProtocol], ...] = (
+    ("harness.bridge", "aiohttp", WireFormat.ANTHROPIC_MESSAGES, InboundProtocol.MESSAGES),
+)
+
+#: What the modules above are expected to have registered between them. Derived
+#: from the rows, **not** from ``REGISTERED_HERE``: that tuple is the core's own
+#: registration and is pinned to one entry, so deriving from it would mean an
+#: Epic B author's single new row still failed the completeness check.
+EXPECTED_TRANSPORTS: frozenset[str] = frozenset(name for _module, name, _fmt, _route in CONFORMANCE_CASES)
+
+#: Both formats the primary recorder serves, with the inbound route that matches
+#: each — the pair every end-to-end case below is parametrised over.
+SERVED = [
+    pytest.param(WireFormat.ANTHROPIC_MESSAGES, id="anthropic_messages"),
+    pytest.param(WireFormat.CHAT_COMPLETIONS, id="chat_completions"),
+]
+
+
+def _fixture(fmt: WireFormat = WireFormat.ANTHROPIC_MESSAGES, **kwargs: object) -> BridgeFixture:
+    """Build an unstarted fixture over a fresh aiohttp transport.
+
+    Args:
+        fmt: The upstream wire format to serve.
+        **kwargs: Passed to :class:`~harness.bridge.BridgeFixture`.
+
+    Returns:
+        The unstarted fixture.
+    """
+    return BridgeFixture(transport("aiohttp", fmt), **kwargs)  # type: ignore[arg-type]
+
+
+async def _drive(fixture: BridgeFixture, fmt: WireFormat, text: str) -> tuple[int, str]:
+    """POST one minimal request in the dialect matching ``fmt``.
+
+    Args:
+        fixture: A started fixture.
+        fmt: The upstream format, which selects the inbound route.
+        text: The user's text.
+
+    Returns:
+        The status and raw reply text.
+    """
+    route = protocol_for(fmt)
+    return await fixture.post(inbound_path(route), minimal_inbound_body(route, text))
+
+
+def _closed(port: int) -> bool:
+    """Return whether nothing is listening on ``port``.
+
+    Args:
+        port: A loopback TCP port.
+
+    Returns:
+        ``True`` when a connection is refused.
+    """
+    import socket
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+        probe.settimeout(0.5)
+        return probe.connect_ex(("127.0.0.1", port)) != 0
+
+
+class _TeardownWasChecked(AssertionError):
+    """Raised by :class:`_CheckedTransport` to prove its check was reached."""
+
+
+class _CheckedTransport(AiohttpTransport):
+    """A transport whose teardown check is unmistakable when it runs."""
+
+    def assert_teardown_clean(self) -> None:
+        """Announce that the check ran.
+
+        Raises:
+            _TeardownWasChecked: Always.
+        """
+        raise _TeardownWasChecked("the fixture ran the transport's teardown check")
+
+
+async def _raw_post(base_url: str, path: str, body: bytes = b'{"probe": true}') -> None:
+    """POST straight to a recorder, bypassing the bridge.
+
+    Used where the subject is what the *upstream* received at a given path. The
+    bridge chooses the upstream path from its adapter, so it cannot be steered
+    by choosing an inbound route.
+
+    Args:
+        base_url: The recorder's origin.
+        path: The upstream path to hit.
+        body: The request body.
+    """
+    async with (
+        aiohttp.ClientSession() as session,
+        session.post(f"{base_url}{path}", data=body, headers={"content-type": "application/json"}) as response,
+    ):
+        await response.read()
+
+
+# ── R3.5, R3.7 — the registry ────────────────────────────────────────────────
+
+
+class TestTheRegistry:
+    """Registration, lookup, and the pin on what this module itself registers."""
+
+    def test_the_default_transport_is_registered(self) -> None:
+        """The one transport T-W8 ships is reachable by name."""
+        assert "aiohttp" in registered_transports()
+
+    def test_registering_a_name_twice_raises(self) -> None:
+        """Silently replacing would let the loser be whichever imported first.
+
+        Two Epic B modules disagreeing about what a name means is a conflict
+        that must be visible, not resolved by import order.
+        """
+        with pytest.raises(ValueError, match="already registered"):
+            register_transport("aiohttp", AiohttpTransport)
+
+    def test_an_unknown_name_raises_and_names_what_is_registered(self) -> None:
+        """The message has to be actionable: the likely cause is a missing import."""
+        with pytest.raises(LookupError, match="aiohttp") as excinfo:
+            transport("curl_cffi", WireFormat.CHAT_COMPLETIONS)
+        assert "curl_cffi" in str(excinfo.value)
+
+    def test_this_module_registers_exactly_one_transport(self) -> None:
+        """Pin ``bridge.py``'s own registration, not the process-wide registry.
+
+        Asserting ``registered_transports() == ("aiohttp",)`` would be the
+        obvious form and would break on the first Epic B registration — in a
+        module five streams are told not to edit. The claim that stays true is
+        about what *this* module registers.
+        """
+        assert REGISTERED_HERE == ("aiohttp",)
+
+    def test_the_core_imports_no_epic_b_module(self) -> None:
+        """Structurally, not by convention.
+
+        T-B1–T-B3 register into the core; the core must not reach back, or the
+        extension interface is decorative and the import graph is a cycle
+        waiting to happen.
+        """
+        source = Path(__import__("harness.bridge", fromlist=["__file__"]).__file__).read_text(encoding="utf-8")
+        assert len(source) > 1000, "read no meaningful source; the guard would pass vacuously"
+
+        imported = {node.module or "" for node in ast.walk(ast.parse(source)) if isinstance(node, ast.ImportFrom)} | {
+            alias.name for node in ast.walk(ast.parse(source)) if isinstance(node, ast.Import) for alias in node.names
+        }
+        epic_b = {name for name in imported if name.startswith("harness.") and name != "harness.contract"}
+
+        assert epic_b == {"harness.recorder"}, f"the core imports harness modules it should not: {epic_b}"
+
+
+# ── R3.1–R3.4, R3.8, R3.9 — the extension interface ──────────────────────────
+
+
+class TestTheExtensionInterface:
+    """What a transport must provide, exercised on the one that ships."""
+
+    def test_the_default_transport_satisfies_the_protocol(self) -> None:
+        """The shipped transport is an instance of the interface it defines.
+
+        A `Protocol` nobody is checked against is documentation; this is what
+        makes it a contract T-B1–T-B3 can be judged by.
+
+        **What it does not buy:** ``isinstance`` against a ``runtime_checkable``
+        Protocol checks attribute *presence* only, never signatures, and
+        ``mypy`` runs on ``src/kitty`` alone (plan §1.3) — so a transport whose
+        ``bind()`` takes the wrong arguments passes this. The conformance check
+        is what catches that, by calling it.
+        """
+        assert isinstance(transport("aiohttp", WireFormat.ANTHROPIC_MESSAGES), UpstreamTransport)
+
+    @pytest.mark.parametrize(
+        "fmt",
+        [WireFormat.OPENAI_RESPONSES, WireFormat.GEMINI, WireFormat.BEDROCK_CONVERSE, WireFormat.OLLAMA_CHAT],
+    )
+    def test_a_format_this_transport_does_not_serve_raises_at_construction(self, fmt: WireFormat) -> None:
+        """Not at request time.
+
+        A wrong-format reply is not a loud failure — the adapter parses nothing,
+        the reply reads as empty, and the test pays the retry ladder. The four
+        formats here belong to T-B1–T-B3, whose transports this one never is.
+
+        Args:
+            fmt: A format outside the two the primary recorder serves.
+        """
+        with pytest.raises(ValueError, match="primary recorder serves"):
+            transport("aiohttp", fmt)
+
+    def test_the_factory_takes_no_host_keyword(self) -> None:
+        """A seam is paid for by a named consumer, and this one had none.
+
+        §7.3 gives T-E1 non-loopback addressing by *resolution* — the proxy's
+        ``resolve`` map — not by a bind address, and a CI runner may have no
+        non-loopback address to bind. Pinned so it is not re-added absently.
+        """
+        with pytest.raises(TypeError):
+            transport("aiohttp", WireFormat.ANTHROPIC_MESSAGES, host="127.0.0.2")  # type: ignore[call-arg]
+
+    async def test_bind_points_an_adapter_at_this_transport_s_recorder(self) -> None:
+        """The seam returns a product adapter and the config that reaches it."""
+        subject = transport("aiohttp", WireFormat.ANTHROPIC_MESSAGES)
+        await subject.start()
+        try:
+            adapter, config = subject.bind()
+
+            assert isinstance(adapter, ProviderAdapter)
+            assert config["base_url"] == subject.recorder.base_url  # type: ignore[attr-defined]
+            # The product's own channel, not a subclass: this adapter reads it.
+            assert adapter.build_base_url(config) == subject.recorder.base_url  # type: ignore[attr-defined]
+        finally:
+            await subject.stop()
+
+    def test_binding_before_the_transport_starts_raises(self) -> None:
+        """A recorder has no port until it is bound, so neither has a binding.
+
+        Documented on ``bind`` and otherwise untested; the failure it prevents is
+        a bridge pointed at ``http://127.0.0.1:0``.
+        """
+        with pytest.raises(RuntimeError, match="not running"):
+            transport("aiohttp", WireFormat.ANTHROPIC_MESSAGES).bind()
+
+    async def test_a_stateful_responder_scripts_successive_replies(self) -> None:
+        """Scripted failures are closures over the hook, not a setter on the Protocol.
+
+        Every consumer named for ``responder`` — §6.3.1's four injection points,
+        T-I8's blip-then-success — needs the reply to change between attempts.
+        This pins that the hook is enough, so no one adds a setter to an
+        interface fifteen tickets consume.
+        """
+        replies = iter(
+            [
+                (400, {"type": "error", "error": {"type": "invalid_request_error", "message": "no"}}),
+                (200, minimal_success_body(WireFormat.ANTHROPIC_MESSAGES)),
+            ]
+        )
+
+        async def scripted(captured: object, reply: Reply) -> None:
+            """Answer with the next scripted status and body.
+
+            The body matters as much as the status: an empty or unparseable one
+            is not a loud failure but 80 seconds of retry ladder, which would
+            exhaust this script and report a ``StopIteration`` instead of the
+            reply sequence under test.
+
+            Args:
+                captured: The capture, unused.
+                reply: The unprepared response.
+            """
+            status, body = next(replies)
+            await reply.begin(status, {"content-type": "application/json"})
+            await reply.write(json.dumps(body).encode())
+
+        subject = transport("aiohttp", WireFormat.ANTHROPIC_MESSAGES, responder=scripted)
+        async with BridgeFixture(subject) as fixture:
+            first, _ = await _drive(fixture, WireFormat.ANTHROPIC_MESSAGES, marker())
+            second, _ = await _drive(fixture, WireFormat.ANTHROPIC_MESSAGES, marker())
+
+        assert (first, second) == (400, 200)
+
+    async def test_connections_are_reported_alongside_captures(self) -> None:
+        """§5.2.1's bypass is a connection carrying no request.
+
+        No capture list can express it, and ``unattributable_peer_ports`` joins
+        on exactly these ports — so the interface carries them, rather than
+        T-E1 and T-I9 each reaching past it.
+        """
+        async with _fixture() as fixture:
+            await _drive(fixture, WireFormat.ANTHROPIC_MESSAGES, marker())
+            records = list(fixture.transport.connections)
+
+        assert len(records) == 1
+        assert records[0].requests == 1
+        assert records[0].peer_port > 0
+
+
+# ── R2.4 — redirection ───────────────────────────────────────────────────────
+
+
+class TestRedirection:
+    """Pointing an adapter that honours no configuration key at a recorder."""
+
+    def test_it_re_hosts_and_keeps_the_path(self) -> None:
+        """Vertex builds the billed account into the base URL's path.
+
+        §3.3.5: for Vertex "the account being billed is a URL component" (P21).
+        A whole-URL replacement deletes ``/projects/{id}/locations/{loc}`` while
+        T-D2's independently-derived expectation still carries it, so P21 would
+        report a routing mismatch against a request that went exactly where the
+        harness sent it.
+        """
+        config = {"project_id": "p1", "location": "europe-west4"}
+        rehosted = redirected(VertexAIAdapter(), "http://127.0.0.1:9", config).build_base_url(config)
+
+        assert rehosted.startswith("http://127.0.0.1:9/")
+        assert rehosted.endswith("/projects/p1/locations/europe-west4")
+
+    def test_a_whole_url_replacement_would_have_lost_that_path(self) -> None:
+        """The difference asserted, so the re-host rule cannot be quietly undone.
+
+        Without this, a later simplification to "return the origin" passes every
+        other test here — the two adapters T-W8 binds have empty base-URL paths,
+        so nothing else in this file would notice.
+        """
+        config = {"project_id": "p1"}
+        original = VertexAIAdapter().build_base_url(config)
+        rehosted = redirected(VertexAIAdapter(), "http://127.0.0.1:9", config).build_base_url(config)
+
+        from urllib.parse import urlsplit
+
+        assert urlsplit(original).path == urlsplit(rehosted).path != ""
+
+    def test_it_redirects_an_adapter_that_honours_no_configuration_key(self) -> None:
+        """The ~14 adapters ``provider_config["base_url"]`` cannot reach.
+
+        ``AnthropicAdapter`` does not override ``build_base_url`` at all, so the
+        product's own channel is a no-op for it — which is the whole reason this
+        helper exists.
+        """
+        assert AnthropicAdapter().build_base_url({"base_url": "http://127.0.0.1:9"}) != "http://127.0.0.1:9"
+        assert redirected(AnthropicAdapter(), "http://127.0.0.1:9").build_base_url({}) == "http://127.0.0.1:9"
+
+    def test_the_redirected_adapter_keeps_its_type_and_behaviour(self) -> None:
+        """Everything but the destination is inherited, so the shipped code runs.
+
+        The upstream **path** is the one asserted because it is what the
+        destination is composed with: a helper that moved it as well as the
+        origin would send a correct body to the wrong endpoint, which on Azure
+        is a different request entirely (§3.3.5).
+        """
+        original = AnthropicAdapter()
+        redirect = redirected(original, "http://127.0.0.1:9")
+
+        assert isinstance(redirect, AnthropicAdapter)
+        assert redirect.upstream_path == original.upstream_path
+        assert redirect.build_upstream_headers("k") == original.build_upstream_headers("k")
+
+    def test_constructor_resolved_state_survives_the_redirect(self) -> None:
+        """``MiniMaxTokenAnthropicAdapter`` resolves a flag in ``__init__``.
+
+        Re-running the constructor with no arguments would discard it silently,
+        and the redirected adapter would translate differently from the one the
+        test built.
+        """
+        adapter = MiniMaxTokenAnthropicAdapter(native_messages=True)
+        redirect = redirected(adapter, "http://127.0.0.1:9", {})
+
+        assert redirect.use_native_messages == adapter.use_native_messages is True
+
+    def test_the_adapter_s_own_validation_still_runs_at_redirect_time(self) -> None:
+        """``build_base_url`` is also pre-flight's validator.
+
+        Documented rather than discovered: the redirected copy raises here and
+        no longer per request, so a test exercising pre-flight validation must
+        use the adapter itself.
+        """
+        with pytest.raises(Exception, match="project_id"):
+            redirected(VertexAIAdapter(), "http://127.0.0.1:9", {})
+
+    async def test_a_redirected_adapter_reaches_a_real_recorder(self) -> None:
+        """End to end, because the three tests above are all about a string."""
+        subject = transport("aiohttp", WireFormat.ANTHROPIC_MESSAGES)
+        await subject.start()
+        try:
+            adapter = redirected(AnthropicAdapter(), subject.recorder.base_url)
+            server = BridgeServer(None, adapter, "k", model=MODEL)  # type: ignore[arg-type]
+            port = await server.start_async()
+            sent = marker()
+            route = protocol_for(WireFormat.ANTHROPIC_MESSAGES)
+            try:
+                # A plain client rather than `BridgeFixture.post`: this bridge is
+                # built by hand to isolate `redirected`, and borrowing the
+                # fixture's helper would mean assigning its private port field.
+                timeout = aiohttp.ClientTimeout(total=DEFAULT_TIMEOUT)
+                async with (
+                    aiohttp.ClientSession(timeout=timeout) as session,
+                    session.post(
+                        f"http://127.0.0.1:{port}{inbound_path(route)}",
+                        json=minimal_inbound_body(route, sent),
+                    ) as response,
+                ):
+                    status = response.status
+                    await response.read()
+            finally:
+                await server.stop_async()
+
+            assert status == 200
+            assert len(subject.captures) == 1
+            assert sent.encode() in subject.captures[0].body
+        finally:
+            await subject.stop()
+
+
+# ── R2.1–R2.3, R2.5 — profiles and backends ──────────────────────────────────
+
+
+class TestTheProfileFactory:
+    """Valid profiles, and the balancing triple ``BridgeServer`` consumes."""
+
+    async def test_a_profile_carries_the_binding_and_is_schema_valid(self) -> None:
+        """Including a UUIDv4 ``auth_ref``, which `sample_profile_dict` is not.
+
+        KBR-175: the existing shared fixture carries a UUIDv7 and cannot build a
+        ``Profile`` at all, which is why this factory exists rather than reusing it.
+        """
+        subject = transport("aiohttp", WireFormat.ANTHROPIC_MESSAGES)
+        await subject.start()
+        try:
+            profile = profile_for(subject)
+
+            assert profile.provider_config["base_url"] == subject.recorder.base_url  # type: ignore[attr-defined]
+            assert uuid.UUID(profile.auth_ref).version == 4
+            assert profile.base_url is None, "the resolver never reads this, and it is HTTPS-only"
+        finally:
+            await subject.stop()
+
+    async def test_a_backend_is_the_triple_the_bridge_takes(self) -> None:
+        """Asserted by construction rather than by shape, so the pin is real."""
+        subject = transport("aiohttp", WireFormat.ANTHROPIC_MESSAGES)
+        await subject.start()
+        try:
+            adapter, key, profile = backend_for(subject, model="m0")
+
+            assert isinstance(adapter, ProviderAdapter)
+            assert isinstance(key, str)
+            assert profile.model == "m0"
+            BridgeServer(None, adapter, key, backends=[(adapter, key, profile)])  # type: ignore[arg-type]
+        finally:
+            await subject.stop()
+
+    async def test_a_reserve_member_is_marked_backup(self) -> None:
+        """Reserve-tier selection is unreachable otherwise."""
+        subject = transport("aiohttp", WireFormat.ANTHROPIC_MESSAGES)
+        await subject.start()
+        try:
+            assert backend_for(subject, backup=True)[2].backup is True
+        finally:
+            await subject.stop()
+
+
+# ── R1.6, R1.1–R1.3, R5 — the fixture itself ─────────────────────────────────
+
+
+class TestTheFixtureCore:
+    """Starting, addressing, posting and stopping."""
+
+    async def test_it_starts_the_shipped_bridge_class(self) -> None:
+        """The subject is the product, not a stand-in for it."""
+        async with _fixture() as fixture:
+            assert isinstance(fixture.server, BridgeServer)
+            assert fixture.port > 0
+            assert fixture.base_url == f"http://127.0.0.1:{fixture.port}"
+
+    @pytest.mark.parametrize("fmt", SERVED)
+    async def test_one_request_reaches_the_upstream_once(self, fmt: WireFormat) -> None:
+        """The whole point, for each format the primary recorder serves.
+
+        Args:
+            fmt: The upstream wire format.
+        """
+        sent = marker()
+        async with _fixture(fmt) as fixture:
+            status, _ = await _drive(fixture, fmt, sent)
+            captures = list(fixture.captures)
+
+        assert status == 200
+        assert len(captures) == 1
+        assert sent.encode() in captures[0].body
+
+    @pytest.mark.parametrize("route", list(InboundProtocol))
+    async def test_every_inbound_protocol_reaches_the_upstream(self, route: InboundProtocol) -> None:
+        """All four routes, driven through a real bridge.
+
+        ``inbound_path`` and ``minimal_inbound_body`` are otherwise asserted
+        only against string constants, which proves the helpers agree with
+        themselves and nothing about whether the bridge accepts what they
+        build. For a module whose whole subject is harnesses that pass while
+        proving nothing, that is the one gap not worth leaving — the Responses
+        and Gemini bodies are used by no other case here.
+
+        Args:
+            route: The inbound protocol to drive.
+        """
+        sent = marker()
+        async with _fixture() as fixture:
+            status, _ = await fixture.post(inbound_path(route), minimal_inbound_body(route, sent))
+            captures = list(fixture.captures)
+
+        assert status == 200
+        assert len(captures) == 1
+        assert sent.encode() in captures[0].body, "the user's text must survive translation to the upstream"
+
+    async def test_a_streamed_reply_comes_back_as_text(self) -> None:
+        """Three inbound surfaces answer with SSE, which a JSON decode cannot read."""
+        route = protocol_for(WireFormat.ANTHROPIC_MESSAGES)
+        async with _fixture() as fixture:
+            status, text = await fixture.post(inbound_path(route), minimal_inbound_body(route, marker(), stream=True))
+
+        assert status == 200
+        assert "event:" in text
+
+    async def test_the_port_is_refused_before_the_fixture_starts(self) -> None:
+        """Reading an address that does not exist yet is a mistake, not a zero."""
+        with pytest.raises(RuntimeError, match="not running"):
+            _ = _fixture().port
+
+    async def test_a_timeout_names_the_transport_and_the_two_ladders(self) -> None:
+        """A bare cancellation says only that something was slow.
+
+        The reader already knows that. What identifies the defect is which
+        ladder the elapsed time resembles, so the message carries both.
+
+        The responder is released explicitly rather than left sleeping, because
+        teardown waits for in-flight upstream handlers: ``stop_async`` cleans up
+        the runner but does not abort live connections, so a responder that
+        slept for 30 seconds would charge the fast gate all 30 of them. A test
+        that means to leave a request hanging must free it before teardown.
+        """
+        route = protocol_for(WireFormat.ANTHROPIC_MESSAGES)
+        released = asyncio.Event()
+
+        async def waits_to_be_released(captured: object, reply: Reply) -> None:
+            """Hold the request open until the test lets go.
+
+            Args:
+                captured: The capture, unused.
+                reply: The unprepared response, never prepared.
+            """
+            await released.wait()
+
+        subject = transport("aiohttp", WireFormat.ANTHROPIC_MESSAGES, responder=waits_to_be_released)
+        fixture = BridgeFixture(subject)
+        await fixture.start()
+        try:
+            with pytest.raises(TransportTimeout) as excinfo:
+                await fixture.post(inbound_path(route), minimal_inbound_body(route, marker()), timeout=0.3)
+        finally:
+            released.set()
+            await fixture.stop()
+
+        message = str(excinfo.value)
+        assert "aiohttp" in message
+        assert "30" in message and "80" in message, "the message must name both ladders"
+        # Deterministically one, not zero: the recorder stores its capture after
+        # reading the body and *before* calling the responder, so a reply held
+        # open still leaves a complete capture. Pinning the value is what makes
+        # the count in the message worth carrying at all.
+        assert "1 capture" in message
+
+    def test_the_default_timeout_is_asserted_as_a_value(self) -> None:
+        """Not by waiting for it. aiohttp's own default is ``total=300``."""
+        from harness.bridge import DEFAULT_TIMEOUT
+
+        assert DEFAULT_TIMEOUT == 10.0
+
+
+class TestTeardown:
+    """Releasing both ports, and never substituting an exception."""
+
+    async def test_both_ports_are_released_on_the_clean_path(self) -> None:
+        """A leaked recorder is noticed only by the next test's port allocation."""
+        async with _fixture() as fixture:
+            bridge_port = fixture.port
+            upstream_port = fixture.transport.recorder.port  # type: ignore[attr-defined]
+            await _drive(fixture, WireFormat.ANTHROPIC_MESSAGES, marker())
+
+        assert _closed(bridge_port)
+        assert _closed(upstream_port)
+
+    async def test_a_bridge_that_fails_to_start_still_releases_the_recorder(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The failure path ``__aexit__`` never sees.
+
+        When ``start()`` raises, ``__aenter__`` propagates and Python does not
+        call ``__aexit__`` — so nothing else would release the recorder, and the
+        leak would surface as an unrelated test failing to bind much later.
+        Reachable in earnest: a profile validation error while building
+        backends, or a bind failure.
+
+        Args:
+            monkeypatch: Used to make the bridge's own start fail.
+        """
+        fixture = _fixture()
+        boom = RuntimeError("the bridge could not bind")
+        ports: list[int] = []
+
+        async def explode(_self: BridgeServer) -> int:
+            """Fail the way a bind failure would, once the recorder is up.
+
+            Args:
+                _self: The bridge, unused.
+
+            Returns:
+                Never; always raises.
+
+            Raises:
+                RuntimeError: Always.
+            """
+            ports.append(fixture.transport.recorder.port)
+            raise boom
+
+        monkeypatch.setattr(BridgeServer, "start_async", explode)
+
+        with pytest.raises(RuntimeError) as excinfo:
+            await fixture.start()
+
+        assert excinfo.value is boom
+        assert _closed(ports[0]), "the recorder outlived a bridge that never started"
+
+    async def test_a_stopped_fixture_forgets_its_port(self) -> None:
+        """A dead port is worse than no port.
+
+        Left in place, a post-teardown ``post()`` fails with a connection
+        refusal from a port that now belongs to nobody — or, worse, to whatever
+        bound it next.
+        """
+        fixture = _fixture()
+        async with fixture:
+            assert fixture.port > 0
+
+        with pytest.raises(RuntimeError, match="not running"):
+            _ = fixture.port
+
+    async def test_a_raising_body_still_releases_both_ports(self) -> None:
+        """Teardown that only runs on success is teardown that does not run."""
+        fixture = _fixture()
+        sentinel = RuntimeError("the test's own failure")
+
+        with pytest.raises(RuntimeError) as excinfo:
+            async with fixture:
+                bridge_port = fixture.port
+                upstream_port = fixture.transport.recorder.port  # type: ignore[attr-defined]
+                raise sentinel
+
+        assert excinfo.value is sentinel, "the original failure must reach the reporter"
+        assert _closed(bridge_port)
+        assert _closed(upstream_port)
+
+    async def test_the_teardown_check_does_not_replace_the_body_s_failure(self) -> None:
+        """An exception from ``__aexit__`` supersedes one from the block.
+
+        So a teardown check run over a failing body would report the wrong
+        thing, and the falsification cases — which assert on message content —
+        would fail for the wrong reason. Here the body fails *and* leaves an
+        unmatched path, which the teardown check would otherwise raise on.
+        """
+        fixture = _fixture()
+        sentinel = RuntimeError("the test's own failure")
+
+        with pytest.raises(RuntimeError) as excinfo:
+            async with fixture:
+                await fixture.post("/not/an/api", {"model": MODEL})
+                raise sentinel
+
+        assert excinfo.value is sentinel
+
+
+class TestTeardownChecks:
+    """What ``assert_teardown_clean`` catches, who calls it, and what it must not disturb.
+
+    These drive the **recorder** directly rather than through the bridge. The
+    subject is what the *upstream* received, and the bridge decides the upstream
+    path from its adapter — an inbound route of ``/not/an/api`` is a bridge 404
+    and produces no upstream request at all. That is §7.5.1's two axes, and
+    getting it wrong here would have made every case below vacuous.
+    """
+
+    async def test_an_unmatched_path_fails_the_transport(self) -> None:
+        """A fallback-format reply is silent and costs the retry ladder.
+
+        Inherited from T-W4's recorder and routed through the transport, so
+        every consumer of the fixture gets it.
+        """
+        subject = transport("aiohttp", WireFormat.ANTHROPIC_MESSAGES)
+        await subject.start()
+        try:
+            await _raw_post(subject.recorder.base_url, "/not/an/api")
+            with pytest.raises(UnmatchedPathError):
+                subject.assert_teardown_clean()
+        finally:
+            await subject.stop()
+
+    async def test_a_path_selecting_another_format_fails_and_names_the_declaration(self) -> None:
+        """The case ``unmatched`` cannot report.
+
+        The recorder dispatches by path **suffix**, so a request to the *other*
+        format's path is answered in that format, the adapter parses it happily,
+        and nothing is recorded as unmatched. The transport's declared format was
+        simply never under test — this is the only signal that says so.
+        """
+        subject = transport("aiohttp", WireFormat.ANTHROPIC_MESSAGES)
+        await subject.start()
+        try:
+            await _raw_post(subject.recorder.base_url, "/chat/completions")
+
+            assert subject.recorder.unmatched == [], "the suffix matched, so nothing is unmatched"
+            with pytest.raises(MisdeclaredFormatError, match="anthropic_messages"):
+                subject.assert_teardown_clean()
+        finally:
+            await subject.stop()
+
+    async def test_the_check_leaves_the_recorder_s_unmatched_list_alone(self) -> None:
+        """An assertion must not mutate the evidence it judges.
+
+        ``RecordingUpstream._format_for`` appends to ``unmatched`` on a miss, so
+        judging captures with it would grow that list on every fixture exit and
+        fight the tests that deliberately clear it. This is why T-W4's pure
+        ``format_for_path`` was split out, and this is what would notice if the
+        split were undone.
+        """
+        subject = transport("aiohttp", WireFormat.ANTHROPIC_MESSAGES)
+        await subject.start()
+        try:
+            await _raw_post(subject.recorder.base_url, "/not/an/api")
+            subject.recorder.unmatched.clear()
+
+            with pytest.raises(MisdeclaredFormatError):
+                subject.assert_teardown_clean()
+
+            assert subject.recorder.unmatched == []
+        finally:
+            await subject.stop()
+
+    async def test_the_fixture_runs_the_check_on_the_clean_path(self) -> None:
+        """Otherwise the guard is enforced by nothing.
+
+        A unit test on ``assert_teardown_clean`` proves that function raises; it
+        does not prove anything **calls** it. Plan §1.4's own list of past
+        harness failures includes "a guard proving a function was called when
+        the enforcement was the branch after it", and this is its mirror.
+        """
+        with pytest.raises(_TeardownWasChecked):
+            async with BridgeFixture(_CheckedTransport(WireFormat.ANTHROPIC_MESSAGES)):
+                pass
+
+    async def test_the_fixture_skips_the_check_when_the_body_raised(self) -> None:
+        """An exception from ``__aexit__`` supersedes one from the block.
+
+        So a teardown check run over a failing body would report the wrong
+        thing, and the falsification cases — which assert on message content —
+        would fail for the wrong reason. The transport here raises a distinctive
+        error from its check, so a regression is unmistakable rather than
+        inferred from an absence.
+        """
+        sentinel = RuntimeError("the test's own failure")
+
+        with pytest.raises(RuntimeError) as excinfo:
+            async with BridgeFixture(_CheckedTransport(WireFormat.ANTHROPIC_MESSAGES)):
+                raise sentinel
+
+        assert excinfo.value is sentinel
+
+
+# ── R1.4, R1.5 — both bridge shapes ──────────────────────────────────────────
+
+
+class TestBothBridgeShapes:
+    """Single-backend and balancing, which share no selection code."""
+
+    async def test_a_balancing_pool_serves_a_request(self) -> None:
+        """``_select_backend`` is unreachable through the single-backend constructor."""
+        sent = marker()
+        async with _fixture(backend_models=["m0", "m1"]) as fixture:
+            status, _ = await _drive(fixture, WireFormat.ANTHROPIC_MESSAGES, sent)
+            captures = list(fixture.captures)
+
+        assert status == 200
+        assert len(captures) == 1
+        assert sent.encode() in captures[0].body
+
+    def test_the_product_really_selects_at_random(self) -> None:
+        """The half of R1.5 the round-robin test cannot assert.
+
+        ``pin_backend_order`` is worth shipping only because the shipped
+        selection is weighted-random. If the product ever became deterministic,
+        the seam would be dead weight and every balancing test would be pinning
+        something that no longer moves — visibly, here, rather than never.
+        """
+        source = (Path(__file__).resolve().parents[2] / "src" / "kitty" / "bridge" / "server.py").read_text(
+            encoding="utf-8"
+        )
+
+        assert "random.choices(tier, weights=weights, k=1)" in source
+
+    async def test_pinning_makes_selection_round_robin(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Weighted-random selection makes an undisciplined balancing test vacuous.
+
+        Measured, not supposed: ``test_opencode_responses_refusal.py`` records a
+        two-backend test that "would pass with the refusal handler deleted".
+        Distinct models per member are what make the choice observable, since
+        both members share this transport's recorder.
+
+        Args:
+            monkeypatch: Reverts the patch on the ambient random source.
+        """
+        pin_backend_order(monkeypatch)
+
+        async with _fixture(backend_models=["m0", "m1"]) as fixture:
+            await _drive(fixture, WireFormat.ANTHROPIC_MESSAGES, marker())
+            await _drive(fixture, WireFormat.ANTHROPIC_MESSAGES, marker())
+            models = [c.body.decode() for c in fixture.captures]
+
+        assert len(models) == 2
+        assert '"model": "m0"' in models[0]
+        assert '"model": "m1"' in models[1]
+
+
+# ── R1.6 — the inbound vocabulary ────────────────────────────────────────────
+
+
+class TestTheInboundHelpers:
+    """Routes and bodies per inbound protocol — the axis that is not ``WireFormat``."""
+
+    @pytest.mark.parametrize(
+        ("protocol", "expected"),
+        [
+            (InboundProtocol.CHAT_COMPLETIONS, "/v1/chat/completions"),
+            (InboundProtocol.MESSAGES, "/v1/messages"),
+            (InboundProtocol.RESPONSES, "/v1/responses"),
+        ],
+    )
+    def test_each_protocol_has_its_own_route(self, protocol: InboundProtocol, expected: str) -> None:
+        """Pinned, because a wrong route is a 404 rather than a translation bug.
+
+        Args:
+            protocol: The inbound protocol.
+            expected: Its route.
+        """
+        assert inbound_path(protocol) == expected
+
+    @pytest.mark.parametrize("stream", [False, True], ids=["unary", "stream"])
+    def test_gemini_carries_the_model_and_the_verb_in_the_path(self, stream: bool) -> None:
+        """The one protocol whose route is not a constant.
+
+        Args:
+            stream: Whether the request streams.
+        """
+        path = inbound_path(InboundProtocol.GEMINI, model="m", stream=stream)
+        assert path.startswith("/v1beta/models/m:")
+        assert path.endswith("streamGenerateContent" if stream else "generateContent")
+
+    @pytest.mark.parametrize("protocol", list(InboundProtocol))
+    def test_every_body_carries_the_marker(self, protocol: InboundProtocol) -> None:
+        """The marker is how a capture is tied to the request that produced it.
+
+        Args:
+            protocol: The inbound protocol.
+        """
+        assert "MARK" in str(minimal_inbound_body(protocol, "MARK"))
+
+    def test_the_messages_body_carries_the_field_only_it_requires(self) -> None:
+        """``max_tokens`` is required by the Messages API and by nothing else."""
+        assert "max_tokens" in minimal_inbound_body(InboundProtocol.MESSAGES, "x")
+        assert "max_tokens" not in minimal_inbound_body(InboundProtocol.CHAT_COMPLETIONS, "x")
+
+    @pytest.mark.parametrize("fmt", SERVED)
+    def test_the_matching_route_is_a_convenience_not_an_equivalence(self, fmt: WireFormat) -> None:
+        """Two axes, and only the pass-through pairs coincide.
+
+        The formats with no inbound route at all are what make the point:
+        ``protocol_for`` must refuse them rather than invent one.
+
+        Args:
+            fmt: A format the primary recorder serves.
+        """
+        assert isinstance(protocol_for(fmt), InboundProtocol)
+
+    @pytest.mark.parametrize(
+        ("fmt", "expected"),
+        [
+            (WireFormat.ANTHROPIC_MESSAGES, InboundProtocol.MESSAGES),
+            (WireFormat.CHAT_COMPLETIONS, InboundProtocol.CHAT_COMPLETIONS),
+            (WireFormat.OPENAI_RESPONSES, InboundProtocol.RESPONSES),
+            (WireFormat.GEMINI, InboundProtocol.GEMINI),
+        ],
+    )
+    def test_every_format_with_an_inbound_route_resolves(self, fmt: WireFormat, expected: InboundProtocol) -> None:
+        """All four, not just the two the primary recorder serves.
+
+        Parametrising over ``SERVED`` cannot see a missing entry for a format
+        some *other* transport declares — and T-B2's is ``OPENAI_RESPONSES``,
+        which has a route of its own and was missing from the map.
+
+        Args:
+            fmt: A format with an inbound route.
+            expected: That route.
+        """
+        assert protocol_for(fmt) is expected
+
+    @pytest.mark.parametrize("fmt", [WireFormat.BEDROCK_CONVERSE, WireFormat.OLLAMA_CHAT])
+    def test_the_two_formats_with_no_inbound_route_refuse(self, fmt: WireFormat) -> None:
+        """Exactly two, and they must refuse rather than invent one.
+
+        The bridge reaches both upstream and serves neither inbound, so a
+        transport on either names its own route. Guessing would drive a request
+        the product never receives.
+
+        Args:
+            fmt: A format with no inbound route.
+        """
+        with pytest.raises(KeyError):
+            protocol_for(fmt)
+
+
+# ── R4 — the conformance check ───────────────────────────────────────────────
+
+
+class TestTheConformanceCheck:
+    """The claim every transport, present and future, is judged by."""
+
+    @pytest.mark.parametrize("fmt", SERVED)
+    async def test_the_registered_transport_passes(self, fmt: WireFormat) -> None:
+        """The positive control.
+
+        Args:
+            fmt: A format the primary recorder serves.
+        """
+        await assert_transport_reaches_its_recorder(transport("aiohttp", fmt))
+
+    @pytest.mark.parametrize(
+        ("name", "fmt", "route"),
+        [(name, fmt, route) for _module, name, fmt, route in CONFORMANCE_CASES],
+        ids=[name for _module, name, _fmt, _route in CONFORMANCE_CASES],
+    )
+    async def test_every_registered_transport_passes(self, name: str, fmt: WireFormat, route: InboundProtocol) -> None:
+        """The meta-test: a transport inherits the check by registering.
+
+        Each row carries its own format and inbound route, so an Epic B author
+        adds a row and is done. A single hardcoded format here would raise
+        ``ValueError`` at construction for every one of T-B1, T-B2 and T-B3 —
+        none of them serves Anthropic Messages — which would make "inherits by
+        registering" false for all three transports it was written for.
+
+        Args:
+            name: A registered transport name.
+            fmt: The upstream format to construct it with.
+            route: The inbound route that exercises it.
+        """
+        await assert_transport_reaches_its_recorder(transport(name, fmt), protocol=route)
+
+    def test_the_meta_test_iterates_a_complete_set_not_whatever_was_imported(self) -> None:
+        """ "Non-empty" would report success for a category it never ran.
+
+        A name enters the registry only when something imports the registering
+        module, so under a selective run the meta-test above could iterate a set
+        of one and pass. Every row's module is imported explicitly and the
+        registered set is asserted **equal** — the principle `tests/conftest.py`
+        states: "a job that reports success without running a category it claims
+        is worse than one that fails".
+        """
+        import importlib
+
+        for module, _name, _fmt, _route in CONFORMANCE_CASES:
+            importlib.import_module(module)
+
+        assert set(registered_transports()) == EXPECTED_TRANSPORTS, (
+            "a transport is registered that no CONFORMANCE_CASES row covers, or a row "
+            "names a transport nothing registered; add the row beside the registration"
+        )
+
+    def test_two_markers_differ(self) -> None:
+        """A capture left by an earlier fixture must not satisfy a later assertion."""
+        assert marker() != marker()

--- a/tests/harness/test_bridge.py
+++ b/tests/harness/test_bridge.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import ast
 import asyncio
 import json
+import socket
 import uuid
 from pathlib import Path
 
@@ -126,8 +127,6 @@ def _closed(port: int) -> bool:
     Returns:
         ``True`` when a connection is refused.
     """
-    import socket
-
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
         probe.settimeout(0.5)
         return probe.connect_ex(("127.0.0.1", port)) != 0
@@ -213,8 +212,18 @@ class TestTheRegistry:
         source = Path(__import__("harness.bridge", fromlist=["__file__"]).__file__).read_text(encoding="utf-8")
         assert len(source) > 1000, "read no meaningful source; the guard would pass vacuously"
 
-        imported = {node.module or "" for node in ast.walk(ast.parse(source)) if isinstance(node, ast.ImportFrom)} | {
-            alias.name for node in ast.walk(ast.parse(source)) if isinstance(node, ast.Import) for alias in node.names
+        tree = ast.parse(source)
+        from_imports = [node for node in ast.walk(tree) if isinstance(node, ast.ImportFrom)]
+
+        # A *relative* import would slip past the name check entirely: its target
+        # lives in `node.level`, and `node.module` is the tail or None — so
+        # `from .epic_b import X` presents as "epic_b" and matches no prefix.
+        # This package has an `__init__.py`, so the form is available.
+        relative = [f".{node.module or ''}" for node in from_imports if node.level]
+        assert relative == [], f"the core uses relative imports, which the name check cannot see: {relative}"
+
+        imported = {node.module or "" for node in from_imports} | {
+            alias.name for node in ast.walk(tree) if isinstance(node, ast.Import) for alias in node.names
         }
         epic_b = {name for name in imported if name.startswith("harness.") and name != "harness.contract"}
 
@@ -678,6 +687,52 @@ class TestTeardown:
 
         assert excinfo.value is boom
         assert _closed(ports[0]), "the recorder outlived a bridge that never started"
+
+    async def test_a_transport_that_fails_to_start_is_released_too(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The other half of the failure ``__aexit__`` never sees.
+
+        ``RecordingUpstream.start`` assigns its runner, awaits ``setup()`` and
+        only then binds the site — so a failure in the bind leaves a runner that
+        still needs ``cleanup()``, and it happens before there is any bridge for
+        the second guard to unwind. Two guards, because one cannot cover both.
+
+        Args:
+            monkeypatch: Used to fail the transport's own start.
+        """
+        fixture = _fixture()
+        boom = RuntimeError("the recorder could not bind")
+        stopped: list[bool] = []
+
+        original_stop = type(fixture.transport).stop
+
+        async def spy_stop(transport_self: AiohttpTransport) -> None:
+            """Record that the transport was released, then release it.
+
+            Args:
+                transport_self: The transport being stopped.
+            """
+            stopped.append(True)
+            await original_stop(transport_self)
+
+        async def explode(_self: AiohttpTransport) -> None:
+            """Fail the way a bind failure inside the recorder would.
+
+            Args:
+                _self: The transport, unused.
+
+            Raises:
+                RuntimeError: Always.
+            """
+            raise boom
+
+        monkeypatch.setattr(AiohttpTransport, "stop", spy_stop)
+        monkeypatch.setattr(AiohttpTransport, "start", explode)
+
+        with pytest.raises(RuntimeError) as excinfo:
+            await fixture.start()
+
+        assert excinfo.value is boom
+        assert stopped == [True], "a transport that failed part-way through start was never released"
 
     async def test_a_stopped_fixture_forgets_its_port(self) -> None:
         """A dead port is worse than no port.

--- a/tests/harness/test_bridge_falsification.py
+++ b/tests/harness/test_bridge_falsification.py
@@ -1,0 +1,302 @@
+"""Four deliberate defects the bridge fixture's conformance check must catch.
+
+`.system_design/TEST_SUITE.md` §7.5.4 · plan task **T-W8** (KBR-31), plan §1.4 ·
+`.requirements/20260911T233557Z_bridge_fixture_core/REQUIREMENTS.md` R6.
+
+Plan §1.4: *"the first working version of every harness ships with at least one
+falsification case — a deliberate defect it must detect, running in the suite."*
+Four review rounds on the design produced four harnesses that would have passed
+while proving nothing, and a bridge fixture's own version of that failure is
+**silent**: a bridge pointed at the wrong live upstream answers 200, and the
+recording is empty.
+
+**One defect per assertion, and each passes the other three.** That is the only
+argument that establishes the four assertions are not redundant — "each is
+insufficient alone" is a different and weaker claim. The defects are:
+
+=========================  ==========================  ==================================
+Defect                     Assertion it breaks         What the other three see
+=========================  ==========================  ==================================
+:class:`_DecoyTransport`   exactly one capture         200, clean teardown, no marker to
+                                                       look for because the list is empty
+:class:`_BlindTransport`   the marker is in the body   one capture, 200, clean teardown
+:class:`_RefusingTransport` the status is 200          one capture, marker present, clean
+:class:`_MisdeclaredTransport` teardown is clean       one capture, marker present, 200
+=========================  ==========================  ==================================
+
+The last is why it is a transport and not a unit test on
+``assert_teardown_clean``. A unit test proves that function raises; it does not
+prove the conformance check **calls** it — and plan §1.4's own list includes "a
+guard proving a function was *called* when the enforcement was the branch after
+it".
+
+**None of these is registered.** They are passed to the check as instances. A
+shared registry holding four things that are wrong on purpose is a hazard, and
+it would also make the registry-completeness meta-test assert over them.
+
+**Layer.** No ``pytestmark``: the ``l1`` path default, for the reason
+``test_bridge.py`` records.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field, replace
+
+import pytest
+
+from harness.bridge import (
+    AiohttpTransport,
+    Binding,
+    MisdeclaredFormatError,
+    assert_transport_reaches_its_recorder,
+)
+from harness.contract import CapturedRequest, WireFormat
+from harness.recorder import RecordingUpstream, Reply
+
+#: The format every defect below declares, so the one thing that differs between
+#: them is the defect itself.
+FORMAT = WireFormat.ANTHROPIC_MESSAGES
+
+
+class _BlindRecorder(RecordingUpstream):
+    """A recorder that counts a request and keeps none of its content."""
+
+    def store(self, index: int, captured: CapturedRequest) -> None:
+        """Store the capture with its body removed.
+
+        ``store`` is T-W4's seam for exactly this: a defect that disturbs one
+        thing and leaves the connection log and the ordering intact.
+
+        Args:
+            index: The reserved slot.
+            captured: The capture, stored without its body.
+        """
+        super().store(index, replace(captured, body=b""))
+
+
+@dataclass
+class _DecoyTransport(AiohttpTransport):
+    """Points the bridge at a *different* live recorder than the one it reports.
+
+    §7.5.4's measured row 3, and the expensive failure: the request succeeds, the
+    bridge is satisfied, the client gets 200, and this transport's capture list
+    is empty. Every oracle built on the fixture would then be quantified over
+    nothing and would pass for free.
+    """
+
+    name = "falsify-decoy"
+
+    _decoy: RecordingUpstream = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        """Build both recorders: the one reported, and the one actually reached."""
+        super().__post_init__()
+        self._decoy = RecordingUpstream(default_format=self.format)
+
+    async def start(self) -> None:
+        """Start both, so the decoy really answers rather than timing out."""
+        await super().start()
+        await self._decoy.start()
+
+    async def stop(self) -> None:
+        """Stop both, in a ``finally`` so neither leaks if the other raises."""
+        try:
+            await super().stop()
+        finally:
+            await self._decoy.stop()
+
+    def bind(self) -> Binding:
+        """Return a binding that reaches the decoy.
+
+        Returns:
+            The adapter this transport's format calls for, pointed elsewhere.
+        """
+        adapter, _config = super().bind()
+        return adapter, {"base_url": self._decoy.base_url}
+
+
+@dataclass
+class _BlindTransport(AiohttpTransport):
+    """Counts the request and records nothing about it.
+
+    Plan §1.4's fourth named harness failure: "a projection that could not see
+    the model name, in a product whose purpose is changing the model name".
+    """
+
+    name = "falsify-blind"
+
+    def __post_init__(self) -> None:
+        """Use the body-dropping recorder instead of the real one."""
+        self._recorder = _BlindRecorder(default_format=self.format, responder=self.responder)
+
+
+@dataclass
+class _RefusingTransport(AiohttpTransport):
+    """Receives the request correctly and refuses it.
+
+    Measured at one capture, marker present, clean teardown, downstream 400, in
+    0.00 s. An upstream **500** would have been the obvious choice and is wrong:
+    measured at four captures over seven seconds, it trips the capture-count
+    assertion too and so is not orthogonal.
+    """
+
+    name = "falsify-refusing"
+
+    def __post_init__(self) -> None:
+        """Install a responder that answers 400 with a well-formed error body."""
+        self.responder = _refuse
+        super().__post_init__()
+
+
+@dataclass
+class _MisdeclaredTransport(AiohttpTransport):
+    """Declares one format and binds an adapter that posts to the other.
+
+    The recorder dispatches its reply by path **suffix**, so the request is
+    answered in the format the *path* named and the adapter parses it happily.
+    Nothing is recorded as unmatched, the capture is complete and correct, and
+    the declared format was simply never under test.
+    """
+
+    name = "falsify-misdeclared"
+
+    def bind(self) -> Binding:
+        """Return an adapter for the format this transport does **not** declare.
+
+        Returns:
+            A Chat Completions adapter, while :attr:`format` says Anthropic
+            Messages.
+        """
+        from kitty.providers.custom_openai import CustomOpenAIAdapter
+
+        _adapter, config = super().bind()
+        return CustomOpenAIAdapter(), config
+
+
+async def _refuse(captured: CapturedRequest, reply: Reply) -> None:
+    """Answer 400 with a well-formed, non-empty error body.
+
+    The body is load-bearing. An empty or unparseable one is not a loud failure
+    but the 80-second empty-response ladder (§7.2.1), which would break the
+    capture-count assertion as well and cost this case its orthogonality.
+
+    Args:
+        captured: The capture, unused.
+        reply: The unprepared response.
+    """
+    await reply.begin(400, {"content-type": "application/json"})
+    body = {"type": "error", "error": {"type": "invalid_request_error", "message": "no"}}
+    await reply.write(json.dumps(body).encode())
+
+
+async def _failure_message(transport: AiohttpTransport) -> str:
+    """Run the conformance check against a defect and return why it failed.
+
+    Args:
+        transport: An unstarted defective transport.
+
+    Returns:
+        The failure message.
+
+    Raises:
+        Failed: When the check passed, which is the whole point of this module.
+    """
+    with pytest.raises(AssertionError) as excinfo:
+        await assert_transport_reaches_its_recorder(transport)
+    return str(excinfo.value)
+
+
+class TestEachDefectIsCaught:
+    """One case per conformance assertion."""
+
+    async def test_a_binding_that_reaches_another_upstream_is_caught(self) -> None:
+        """The decoy — the failure no status check can see.
+
+        The inbound request returns 200 and the recording is empty, so this is
+        the one defect that makes every downstream assertion pass vacuously.
+        """
+        message = await _failure_message(_DecoyTransport(FORMAT))
+
+        assert "0 capture" in message
+        assert "quantified over nothing" in message
+
+    async def test_a_capture_that_cannot_see_the_content_is_caught(self) -> None:
+        """The blind capture — right count, right status, no evidence."""
+        message = await _failure_message(_BlindTransport(FORMAT))
+
+        assert "marker" in message
+
+    async def test_a_correct_request_that_still_fails_the_client_is_caught(self) -> None:
+        """The refusal — the upstream got exactly the right request.
+
+        A count and a marker both pass here. Only the inbound status says the
+        client was not served.
+        """
+        message = await _failure_message(_RefusingTransport(FORMAT))
+
+        assert "400" in message
+
+    async def test_a_format_that_was_never_under_test_is_caught(self) -> None:
+        """The mis-declared format — a complete, correct capture list.
+
+        This is the opposite of the decoy, not a variant of it, and it is the
+        only case that proves the conformance check *calls* the teardown check
+        rather than merely that the teardown check works.
+        """
+        with pytest.raises(MisdeclaredFormatError) as excinfo:
+            await assert_transport_reaches_its_recorder(_MisdeclaredTransport(FORMAT))
+
+        assert "anthropic_messages" in str(excinfo.value)
+
+
+class TestTheDefectsAreOrthogonal:
+    """Each defect must break its own assertion and no other.
+
+    Without this, a later tidy-up that collapsed two checks into one would leave
+    every case above still green, and the suite would have quietly halved its
+    evidence. ``recorder_conformance.py``'s orthogonality tests exist for the
+    same reason and will look equally redundant to a reader in a hurry.
+    """
+
+    async def test_the_four_messages_are_mutually_distinguishable(self) -> None:
+        """Pairwise, on the words that identify which assertion fired."""
+        messages = {
+            "decoy": await _failure_message(_DecoyTransport(FORMAT)),
+            "blind": await _failure_message(_BlindTransport(FORMAT)),
+            "refusing": await _failure_message(_RefusingTransport(FORMAT)),
+            "misdeclared": await _failure_message(_MisdeclaredTransport(FORMAT)),
+        }
+
+        assert len(set(messages.values())) == 4, f"two defects report the same failure: {messages}"
+
+        # The specific confusion worth naming: the decoy and the mis-declared
+        # format differ by whether the capture list is empty or complete, so a
+        # count-shaped message from the latter would mean the two had merged.
+        assert "capture" in messages["decoy"] and "marker" not in messages["decoy"]
+        assert "marker" in messages["blind"]
+        assert "400" in messages["refusing"]
+        assert "anthropic_messages" in messages["misdeclared"]
+
+    async def test_the_three_survivable_defects_still_deliver_a_complete_capture(self) -> None:
+        """The blind, refusing and mis-declared cases all reach their own recorder.
+
+        Stated positively so the decoy's emptiness stays a property of the decoy
+        alone. If a change made every defect produce an empty recording, all four
+        cases above would still pass and all four would be testing one thing.
+        """
+        for defect, expected_body in (
+            (_RefusingTransport(FORMAT), True),
+            (_MisdeclaredTransport(FORMAT), True),
+            (_BlindTransport(FORMAT), False),
+        ):
+            with pytest.raises(AssertionError):
+                await assert_transport_reaches_its_recorder(defect)
+
+            assert len(defect.captures) == 1, f"{defect.name} should still have reached its own recorder"
+            assert bool(defect.captures[0].body) is expected_body
+
+        decoy = _DecoyTransport(FORMAT)
+        with pytest.raises(AssertionError):
+            await assert_transport_reaches_its_recorder(decoy)
+        assert list(decoy.captures) == []

--- a/tests/harness/test_bridge_falsification.py
+++ b/tests/harness/test_bridge_falsification.py
@@ -53,6 +53,7 @@ from harness.bridge import (
 )
 from harness.contract import CapturedRequest, WireFormat
 from harness.recorder import RecordingUpstream, Reply
+from kitty.providers.custom_openai import CustomOpenAIAdapter
 
 #: The format every defect below declares, so the one thing that differs between
 #: them is the defect itself.
@@ -168,8 +169,6 @@ class _MisdeclaredTransport(AiohttpTransport):
             A Chat Completions adapter, while :attr:`format` says Anthropic
             Messages.
         """
-        from kitty.providers.custom_openai import CustomOpenAIAdapter
-
         _adapter, config = super().bind()
         return CustomOpenAIAdapter(), config
 

--- a/tests/harness/test_recorder.py
+++ b/tests/harness/test_recorder.py
@@ -33,6 +33,7 @@ from harness.recorder import (
     RecordingUpstream,
     Reply,
     UnmatchedPathError,
+    format_for_path,
     minimal_success_body,
     minimal_success_stream,
 )
@@ -607,6 +608,30 @@ class TestFormatDispatch:
         # Opt out of the fixture's own teardown guard: this test *meant* to take
         # the fallback, and the guard would otherwise fail it for succeeding.
         recorder.unmatched.clear()
+
+    async def test_the_pure_lookup_agrees_with_the_recording_one_and_records_nothing(
+        self, recorder: RecordingUpstream
+    ) -> None:
+        """Assert ``format_for_path`` answers the same question without the side effect.
+
+        T-W8's bridge fixture judges its captured paths against the format its
+        transport declares, at teardown, on every fixture exit. It must not do
+        that with :meth:`RecordingUpstream._format_for`, which *appends to*
+        ``unmatched`` on a miss — an assertion that mutates the evidence it is
+        judging. Both halves are asserted here because a lookup that silently
+        stopped agreeing with the recording one would be a second source of
+        truth, which is the thing splitting it was meant to avoid.
+
+        Args:
+            recorder: The running recorder.
+        """
+        assert format_for_path("/v1/messages") is WireFormat.ANTHROPIC_MESSAGES
+        assert format_for_path("/openai/deployments/d/chat/completions") is WireFormat.CHAT_COMPLETIONS
+
+        # `None` for a miss, not the fallback: "no rule applies" and "the
+        # fallback applies" are different facts, and only a caller knows which.
+        assert format_for_path("/not/an/api") is None
+        assert recorder.unmatched == []
 
     async def test_a_malformed_body_still_gets_a_success(
         self, recorder: RecordingUpstream


### PR DESCRIPTION
Closes [KBR-31](https://shelpuk.atlassian.net/browse/KBR-31) — plan task **T-W8**, Milestone 0.

## Context for the Product Owner

Kitty Bridge sits on the wire between a coding agent and an LLM provider. Three of its promises are commercial, not cosmetic: the user's message reaches the provider unchanged except where we say otherwise, the bridge is indistinguishable from the agent talking to the provider directly, and nothing escapes the configured network path. **Every test that proves any of those needs a real bridge running in front of a fake provider that records exactly what was sent.**

Today no such thing exists. Of the 62 test files covering the bridge, **38 build their own** — their own fake provider, their own start/stop plumbing, their own request helper. Around **fifteen** planned pieces of work need one shared version, and three more need to plug in *different* provider transports (the ChatGPT subscription path, Amazon Bedrock, Ollama Cloud). This ships that shared version, plus the socket those three plug into without editing shared code.

**Why it took four review rounds rather than one.** A test harness of this kind fails *silently*. Measured on this branch: a bridge pointed at the **wrong live provider** returns a clean **200** — the test passes, and the recording is simply empty. Every later check built on it ("did the user's message survive?", "did anything leak?") would then be measuring nothing and passing for free. You would have a green suite proving nothing about the product's core promises. So the fixture ships with a check that a request genuinely landed in *its* recorder carrying a fingerprint unique to that request, plus four deliberately broken versions it must catch.

**What the reviews caught that would have shipped broken:**

| Found | Consequence if shipped |
|---|---|
| Pointing an adapter at the test provider by replacing its whole URL | Works for Azure, silently destroys **Vertex's routing — where the billed Google Cloud account lives**. The obvious test would have passed |
| The "any new transport inherits the check automatically" promise | Was false for **all three** transports it was written for — each would have crashed on the day it registered |
| One of the four checks | Could be deleted with nothing going red. Removed; the project's own rules forbid an assertion nothing can kill |
| The shared `sample_profile_dict` test fixture | Cannot build the object it describes (wrong ID version) and nothing reads it — filed as **KBR-175**, left for you to decide: delete or repair |

No product code changed. This is test infrastructure plus the design document that was missing for it.

## What is in the diff

- **`tests/harness/bridge.py`** — the fixture, the transport extension interface and registry, the profile/backend factory, the balancing determinism seam, the inbound-request vocabulary, and the conformance check.
- **`tests/harness/test_bridge.py`** — 66 cases covering the core.
- **`tests/harness/test_bridge_falsification.py`** — the four deliberate defects (plan §1.4).
- **`tests/harness/recorder.py`** — `format_for_path` extracted from `_format_for`; the fixture must judge captured paths at teardown, and the original *appends to* the list it would be judging.
- **`.system_design/TEST_SUITE.md` §7.5** — new. §7 had a section for every shared harness and none for this one.

## Evidence

| Check | Result |
|---|---|
| Full suite | **4361 passed, 2 skipped** (19m41s) |
| `ruff`, `mypy src/kitty`, `lint-imports` | clean · clean · 4 contracts kept |
| Layer guards | 68 passed |
| New modules' runtime | **1.6 s** combined, registered in §8.2 with the measurement |
| Falsification | Each conformance assertion deleted in turn; **exactly** its own case went red |
| Assertion liveness | All **80** assertions in the new tests negated one at a time — **0 survivors** |

## Decisions worth a reviewer's eye

- **`redirected()` re-hosts, never replaces** — scheme and authority only, path and query verbatim. §3.3.5 already specifies that substitution from the comparison side, so both sides are now one rule.
- **Two vocabularies, not one.** `WireFormat` is what a recorder serves; `InboundProtocol` is the route an agent posts to. Translating between them is what the bridge *is*, and two of the six formats have no inbound route at all.
- **No `host=` seam, no pytest plugin.** Neither had a named consumer; the plugin measured 0.72 s charged to every pytest run in the repo.
- **`l1`, not `l3`** — §8.2's rule: a test may not move to `l3` before the Subsystem job exists, or it runs in no job at all.

Requirements, acceptance criteria and all 40 review findings with their dispositions are in `.requirements/20260911T233557Z_bridge_fixture_core/REQUIREMENTS.md` (gitignored, local).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016GTtJS1VSesqdAsp66n6fz


[KBR-31]: https://shelpuk.atlassian.net/browse/KBR-31?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ