### PR TITLE
Release 1.10.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kitty-bridge"
-version = "1.9.2"
+version = "1.10.0"
 description = "Kitty Bridge — launch coding agents through a local API bridge"
 readme = "README.md"
 license = "MIT"

--- a/src/kitty/__init__.py
+++ b/src/kitty/__init__.py
@@ -4,5 +4,5 @@ import logging
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
-__version__ = "1.9.2"
+__version__ = "1.10.0"
 __all__ = ["__version__"]


### PR DESCRIPTION
Bumps `pyproject.toml` and `src/kitty/__init__.py` to **1.10.0**. Two lines; no other change.

## Context for the Product Owner

**A minor, not a patch — and the reason is not just "lots of fixes".** Under this project's rule the patch digit is for fixes only. Three things in this release do not fit that:

1. **Azure OpenAI could not be configured at all. Now it can** (#64).
2. **Six OpenCode Go models were unreachable. Now they work** (#61).
3. **`/model` inside a Codex session stops taking effect** on the ChatGPT-subscription provider (#71) — a capability users had, removed on purpose.

That third one is the clearest reason the digit moves: it is a deliberate behaviour change, not a repair. **It belongs in the customer-facing release notes.**

---

### New configurations that work

**Azure OpenAI, pasted verbatim — #64 ([KBR-143](https://shelpuk.atlassian.net/browse/KBR-143))**

Kitty's promise for `custom_openai` is "any service with a `/v1/chat/completions` endpoint". Azure OpenAI is the largest enterprise OpenAI-compatible service and it was silently excluded — not by a missing feature, but because Kitty built the upstream address by gluing two strings together. Azure's documented endpoint carries a query string, so the endpoint path landed *after* it and `api-version` silently became `2024-02-01/chat/completions`. The request reached nothing.

Kitty now composes the URL properly. A customer pastes Microsoft's documented endpoint verbatim, the query is preserved and sent with every request, and the README documents the form. Two side benefits: a bad base URL now reports itself as a bad base URL instead of *"your API key contains invalid characters"*, and it no longer kills the launch with a raw Python traceback when an egress proxy is configured.

**Ten OpenCode Go models stop lying about why they fail — #61 ([KBR-126](https://shelpuk.atlassian.net/browse/KBR-126))**

OpenCode Go is a $10/month subscription serving ~28 models across three API dialects. Ten of them were broken, and the breakage did not look like a routing problem: the provider answers an unsupported model with `401`, Kitty classified that as an authentication failure with a 15-minute cooldown, and the customer was told **"Authentication failed — please re-login"**. They re-entered a perfectly good API key and got the same message again.

- **Six models start working**: `minimax-m3` and the five `qwen3.*` models, served on the Anthropic Messages endpoint.
- **Four fail honestly**: `grok-4.6`, `gpt-5.6-luna` and the two Muse Spark models are served on the OpenAI Responses API, which Kitty does not speak yet. They now say so, naming the model. They did not work before either — the failure is legible, not new. Making them work is [KBR-137](https://shelpuk.atlassian.net/browse/KBR-137).
- `kitty auth` stops risking a false failure on this provider; its validation model had quietly left the catalogue.

### The behaviour change to announce

**The profile's model wins on the subscription path — #71 ([KBR-160](https://shelpuk.atlassian.net/browse/KBR-160))**

Kitty's core promise is that *your profile decides which model runs*. On one route it did not: an `openai_subscription` profile driven by a Codex-family client shipped whatever model the agent asked for, and the configured model was computed then discarded with no warning. Kitty's own setup wizard asks for a model on this provider — on this route, that question had no effect.

The profile now wins everywhere. Two consequences for users:

- **`/model` inside a Codex session no longer takes effect on this provider.** This is exactly what the product says it does, but it is visible and users will notice.
- A model the ChatGPT backend does not accept now produces an error instead of silently falling back to the agent's model. On the streaming route it surfaces as an in-stream `upstream_error` event, not an HTTP status.

### Fixes

- **Route, body and auth header now read one model name** — #55 ([KBR-127](https://shelpuk.atlassian.net/browse/KBR-127)). They were built from two different values, so a prefixed name like `opencode/minimax-m2.5` sent a correct body to the wrong endpoint under the wrong auth scheme. Profiles that worked keep working; silently broken ones start working.
- **Context window resolves however the model is spelled** — #68 ([KBR-151](https://shelpuk.atlassian.net/browse/KBR-151)). A prefixed name missed the lookup and fell back to a generic 200,000 tokens; on Azure that is 56% more room than exists, so Kitty under-compacted and the provider rejected the oversized request. Measured across the catalog and all 23 providers: **9,130 lookups fixed, none broken**.
- **`/v1/responses` accepts a string `input`** — #67 ([KBR-144](https://shelpuk.atlassian.net/browse/KBR-144)). OpenAI documents the plain string and the structured array as equivalent; Kitty took only the array. 20 of 21 providers answered HTTP 500. The subscription provider did something worse: it shredded `"hi"` into `["h", "i"]` and forwarded that as the customer's words — successfully, and silently.
- **The hourly token refresh presents the Codex identity** — #72 ([KBR-161](https://shelpuk.atlassian.net/browse/KBR-161)). Prompt traffic impersonated Codex CLI correctly; the token renewal dropped the disguise entirely — no user-agent, different TLS fingerprint, same vendor, same account. Two clients for one account is a shape no genuine install produces. All four recurring auth requests now present one identity. A pre-existing credential leak in the redaction path was found and closed here too.
- **One client version, from one source** — #62 ([KBR-8](https://shelpuk.atlassian.net/browse/KBR-8)). The subscription path announced its version twice with two different answers in the same request, and one was Kitty's own release number — a version oracle for the bridge itself.
- **Output is UTF-8 whatever the locale says** — #65 ([KBR-10](https://shelpuk.atlassian.net/browse/KBR-10)). On a Windows machine not set to a UTF-8 locale, `kitty doctor > diagnostics.txt` — the command our README prescribes when something goes wrong — died with a traceback and left an empty file. `kitty --version` and the background bridge service had the same bug, as did non-English account paths.
- **The liveness probe answers the same on every supported Python** — #66 ([KBR-146](https://shelpuk.atlassian.net/browse/KBR-146)). `kitty status`, `stop` and `restart` rewrite a wildcard listen address to loopback before dialling; for the IPv4-mapped spelling that rewrite did not happen and a healthy bridge was reported as dead. Filed five separate times because the standard-library property it depended on changed answers partway through every Python version we support.

### Everything else ships no product code

The shared CONNECT proxy fixture (#56), the OpenAI Responses reader (#74), the bridge fixture core and transport extension interface (#76), a header guard that was never reaching the wire it claimed to watch (#70), and CI review tooling that had been reporting a spent provider balance as a broken workflow (#69).

## Release mechanics

Merging this does **not** publish. The `v1.10.0` tag does, and `publish.yml` gates the upload on the same full suite a pull request must pass — a tag whose tests fail never reaches PyPI, where a version number can never be reused.

Verified before opening: `tests/test_pypi_packaging.py` passes with the bump (26 tests), and no stale `1.9.2` string remains anywhere in the repo except a deliberate bait literal in `tests/bridge/test_compaction_failure_response.py`, which is an arbitrary value and not tied to the release version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HdkFBQQRUhxJaL2Sj1Ep4t


[KBR-143]: https://shelpuk.atlassian.net/browse/KBR-143?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KBR-126]: https://shelpuk.atlassian.net/browse/KBR-126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ