### PR TITLE
KBR-154: report the bridge child's failure instead of dying decoding it

### DIFF
--- a/src/kitty/bridge/manage.py
+++ b/src/kitty/bridge/manage.py
@@ -439,7 +439,12 @@ def start_bridge(
                 # Process already exited — read error
                 print(f"Error: Bridge failed to start (exit code {proc.returncode})", file=sys.stderr)
                 if proc.stderr:
-                    print(proc.stderr.read().decode(), file=sys.stderr)
+                    # A child that died before `kitty.bridge_runner:main` never ran
+                    # harden_output_streams, so its traceback carries the locale
+                    # codepage, not UTF-8. A strict decode killed this diagnostic
+                    # instead of printing it (KBR-154); backslashreplace keeps the
+                    # undecodable bytes readable rather than collapsing them to U+FFFD.
+                    print(proc.stderr.read().decode(errors="backslashreplace"), file=sys.stderr)
             else:
                 # Process is running but state file never appeared
                 print("Error: Bridge started but state file not found", file=sys.stderr)

--- a/tests/bridge/test_bridge_management.py
+++ b/tests/bridge/test_bridge_management.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import io
 import ipaddress
 import json
 import os
@@ -946,3 +947,91 @@ class TestStopBridgeForceKillIsCrossPlatform:
             manage.stop_bridge(state_path)
 
         assert not state_path.exists()
+
+
+class TestStartBridgeReportingAChildThatDiedAtImport:
+    """Reporting a bridge child that exited before it wrote its state file.
+
+    The parent explains the failure by reading the dead child's stderr back. A child
+    that never reached :func:`kitty.bridge_runner.main` never ran
+    :func:`kitty.io_encoding.harden_output_streams`, so those bytes carry the machine's
+    locale codepage rather than UTF-8, and a strict decode of them killed the parent
+    mid-diagnostic (KBR-154). Every case here supplies the child's bytes as a literal,
+    never from the host locale, so the claim is proven on any runner.
+    """
+
+    # cp1251 for 'File "C:/Users/Пётр/boot.py", line 1', in the form CPython's default
+    # stderr emits it: `backslashreplace` escapes only what the codepage cannot encode,
+    # so an encodable non-ASCII name goes out as raw single bytes.
+    _CP1251_TRACEBACK = b'File "C:/Users/\xcf\xb8\xf2\xf0/boot.py", line 1'
+
+    @staticmethod
+    def _dead_child(stderr_bytes: bytes) -> SimpleNamespace:
+        """Build a stand-in for a child that exited before writing its state file.
+
+        Args:
+            stderr_bytes: The bytes the child is to have written to its stderr.
+
+        Returns:
+            An object exposing the three attributes ``start_bridge`` reads from a
+            :class:`subprocess.Popen`: ``poll``, ``returncode`` and ``stderr``.
+        """
+        return SimpleNamespace(poll=lambda: 1, returncode=1, stderr=io.BytesIO(stderr_bytes))
+
+    def _report(self, tmp_path: Path, stderr_bytes: bytes) -> SystemExit:
+        """Run ``start_bridge`` against a dead child and return the exit it raised.
+
+        Args:
+            tmp_path: Directory for the state file, which is never written, so
+                ``start_bridge`` takes its failure branch.
+            stderr_bytes: The bytes the stand-in child is to have written to stderr.
+
+        Returns:
+            The :exc:`SystemExit` raised by :func:`kitty.bridge.manage.start_bridge`.
+        """
+        from kitty.bridge.manage import start_bridge
+
+        with (
+            patch(
+                "kitty.bridge.manage.subprocess.Popen",
+                return_value=self._dead_child(stderr_bytes),
+            ),
+            pytest.raises(SystemExit) as excinfo,
+        ):
+            start_bridge(state_path=tmp_path / "state.json", host="127.0.0.1", port=0)
+
+        return excinfo.value
+
+    def test_a_child_whose_stderr_is_not_utf8_does_not_kill_the_parent(self, tmp_path: Path, capsys):
+        """Exit 1 rather than dying on the decode of the child's stderr.
+
+        That the child's own text survives is
+        :meth:`test_the_undecodable_bytes_are_rendered_beside_the_ascii`'s claim; this one
+        pins only that the parent reaches its exit instead of raising.
+        """
+        exit_exc = self._report(tmp_path, self._CP1251_TRACEBACK)
+
+        assert exit_exc.code == 1
+        assert "Bridge failed to start (exit code 1)" in capsys.readouterr().err
+
+    def test_the_undecodable_bytes_are_rendered_beside_the_ascii(self, tmp_path: Path, capsys):
+        """Render the bytes UTF-8 cannot decode instead of dropping them."""
+        self._report(tmp_path, self._CP1251_TRACEBACK)
+        err = capsys.readouterr().err
+
+        # The ASCII either side of the operator's account name is what makes the
+        # child's traceback readable at all, so it must survive untouched.
+        assert 'File "C:/Users/' in err
+        assert '/boot.py", line 1' in err
+
+        # Escapes, not U+FFFD: the byte values stay on screen, which is how a support
+        # engineer works out which codepage — and so which install — broke.
+        assert r"\xf2" in err
+        assert r"\xf0" in err
+        assert "\ufffd" not in err, "errors='replace' would satisfy neither KBR-154 AC2 nor this"
+
+    def test_a_child_whose_stderr_is_valid_utf8_is_reported_verbatim(self, tmp_path: Path, capsys):
+        """Leave a decodable diagnostic exactly as the child wrote it."""
+        self._report(tmp_path, "Ошибка импорта".encode())
+
+        assert "Ошибка импорта" in capsys.readouterr().err


### PR DESCRIPTION
## Context for the Product Owner

**What a user hits today.** `kitty bridge start` runs the bridge as a background child process. When that child cannot start — a missing dependency, a broken virtualenv, a corrupt install — the parent is supposed to print the child's error so the user can see *why*. On any machine whose locale is not UTF-8, it doesn't: the parent crashes with its own unrelated traceback while trying to read that message. The user is left with a broken install **and** no explanation, because the one diagnostic that would have explained it is what killed the command.

This is the same population as KBR-10, shipped yesterday: Windows users whose account name is not ASCII — Russian, Japanese, Chinese, and anyone in Western Europe with an accent in their name. KBR-10 fixed the *writing* side of this problem. This is the *reading* side, on a code path KBR-10 structurally could not reach: it hardened the child, and this is about a child that dies before the hardening runs.

**What the user gets after this change.** The same failure now prints:

```
Error: Bridge failed to start (exit code 1)
File "C:/Users/ϸ\xf2\xf0/boot.py", line 1
```

The account name is mangled — those bytes genuinely are not UTF-8 and nothing can un-mangle them — but everything that matters is legible: which file, which line, the whole traceback around it. The command exits 1 exactly as before. Nothing else in the product changes; no configuration, no interface, no behaviour on a working install.

**Severity.** Medium. It needs two things to coincide: a non-UTF-8 locale and a bridge that is already broken. The cost is that our error message is replaced by noise at precisely the moment the user most needs it — the same "a misleading error costs more than the bug" failure recorded for KBR-134.

---

## The change

One keyword in `src/kitty/bridge/manage.py`, plus the tests that prove it:

```python
print(proc.stderr.read().decode(errors="backslashreplace"), file=sys.stderr)
```

### Why `backslashreplace`, when the ticket suggested `replace`

The ticket offered `errors="replace"` and said explicitly it was not prescriptive. `replace` collapses every undecodable byte to `U+FFFD` — `File "C:/Users/ϸ��/boot.py"` — throwing away the evidence. `backslashreplace` leaves the byte values on screen, which is usually the fastest route to working out *which* codepage, and therefore which install, is broken. Acceptance criterion 2 asks for the bytes "rendered rather than dropped", and only one of the two handlers satisfies that reading.

It is also the handler KBR-10 chose on the encode side, so both halves of "kitty cannot die handling its own text" now behave alike.

Stated precisely, because an earlier draft of the spec overstated it and was measured wrong: recovery here is **by eye, not mechanical**. `decoded.encode("utf-8", "backslashreplace")` does *not* invert the decode (UTF-8 encodes everything, so the handler never fires), and no mechanical inverse exists in general — a child that printed the literal text `\xf2` is indistinguishable from one that emitted byte `0xf2`. Having the byte values still beats not having them; the mechanism just must not be oversold.

### Tests

Three, at **L1** — the lowest layer that can prove the claim, per `TEST_SUITE.md` §2.2. They stand the child in with `SimpleNamespace(poll, returncode, stderr=io.BytesIO(...))` behind the existing `Popen`-patching pattern already used three times in this file, and construct the child's bytes as **literals**, so they never read the host locale and fail on the Linux runner before the fix.

| Test | Proves | Pre-fix |
|---|---|---|
| `..._does_not_kill_the_parent` | decode never raises; exit code is still 1 | fails — `UnicodeDecodeError` |
| `..._rendered_beside_the_ascii` | the bytes are escaped, the ASCII survives | fails — same |
| `..._reported_verbatim` | a valid-UTF-8 diagnostic is unchanged | passes (control) |

**The handler choice is pinned by a standing test, not by a comment.** `kitty.bridge.manage` is outside the `mutmut` scope in `TEST_SUITE.md` §6.1, so nothing else defends it. Measured: test 2 goes red under `errors="replace"` and under `errors="ignore"`, green only under `backslashreplace`. Test 3 is the control that catches a "fix" which drops the child's output entirely.

## Verification

- `ruff check .` · `ruff format --check` · `lint-imports` (5/5 contracts) · `mypy src/kitty` (90 files) — all clean.
- `pytest tests/bridge/test_bridge_management.py` → 69 passed.
- Watched the new tests fail first, for the right reason: `UnicodeDecodeError` at `manage.py:442`, not something incidental.
- Full `l1 or l2` gate: deferred to CI on this PR, which is the authority for it.

## Scope notes

- **The rest of the tree was surveyed**, as the ticket asks. The predicate has to be "no non-strict `errors=` handler" rather than "no argument list" — an explicit codec is not a safety property, and `.decode("utf-8")` is still strict. Five hits; none needs changing.
- **Found here and filed, deliberately not folded in: KBR-176.** The parent opens pipes to the child and never drains them. Measured: a child writing past one pipe buffer (~64 KB) blocks forever, and Kitty then reports *"Bridge started but state file not found"* — which is false — and walks away leaving a wedged process. Fixing it means moving to `proc.communicate()`, which would **supersede** this change rather than extend it, and that alters the process-management contract this ticket's acceptance criteria pin. It deserves its own review.

Jira: https://shelpuk.atlassian.net/browse/KBR-154

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VMeBsTCWi33JzGFU8RLB1k
