### PR TITLE
Run the merge gate on Windows and macOS (KBR-164)

### DIFF
--- a/.github/review/README.md
+++ b/.github/review/README.md
@@ -101,9 +101,13 @@ To enable the workflow on this repository:
    settings → Secrets and variables → Actions → each item → repository access).
    All three were already granted when this workflow landed.
 2. Nothing to do for runners — every job uses a GitHub-hosted label
-   (`ubuntu-latest` for the review, the aggregate, the metadata refresh and the
-   test matrix; `ubuntu-slim` for the two review-system jobs), so no runner group
-   has to be granted.
+   (`ubuntu-latest` for the review, the aggregate and the metadata refresh;
+   `ubuntu-slim` for the two review-system jobs; and `ubuntu-latest`,
+   `windows-latest` and `macos-latest` for the test matrix, which has run on all
+   three platforms since KBR-164 — see `.system_design/TEST_SUITE.md` §8.4), so
+   no runner group has to be granted. All three platform labels are GitHub's own
+   standard public ones, and standard hosted runners are free and unmetered on a
+   public repository, so the Windows and macOS legs cost nothing to run.
 
    ⚠️ **Why not a self-hosted fleet:** a runner group carries an *"Allow public
    repositories"* setting that is **off by default**, and this repository is

--- a/.github/review/rules/ci.md
+++ b/.github/review/rules/ci.md
@@ -231,8 +231,16 @@ that overrides the child's endpoint and credentials.
 ## Runner and caps
 
 - `runs-on: ubuntu-latest` for the review job, for `ci-required` and for the
-  `update-metadata` and test jobs; `ubuntu-slim` for the two review-system jobs in
-  `ci.yml`. All GitHub-hosted. This repository is public, and a runner group's
+  `update-metadata` job; `ubuntu-slim` for the two review-system jobs in
+  `ci.yml`. **The test matrix in `tests.yml` is the exception and is deliberate:
+  it produces `ubuntu-latest`, `windows-latest` and `macos-latest`** — the Fast
+  gate runs on all three since KBR-164, because a Linux-only matrix made every
+  Windows-only defect invisible until a user reported one. See
+  `.system_design/TEST_SUITE.md` §8.4 for the scope and its reasoning, and do
+  **not** flag a platform label there as a policy violation. All GitHub-hosted,
+  and all free: standard hosted runners are unmetered on public repositories, so
+  the 2× Windows and 10× macOS multipliers do not apply here.
+  This repository is public, and a runner group's
   *"Allow public repositories"* setting is off by default, so a `[self-hosted,
   …]` label reaches no group at all. A change that moves to one needs to say what
   changed about that grant, or it will silently never run.

--- a/.github/review/tests/test_review_scripts.py
+++ b/.github/review/tests/test_review_scripts.py
@@ -93,6 +93,15 @@ RUNNER_JOB_CEILING_MINUTES = {
     # execution time. If a job reaches this limit, the job is terminated and
     # fails."*
     "windows-latest": 360,
+    # Added with the platform legs (KBR-164, TEST_SUITE.md §8.4). Also an
+    # ordinary GitHub-hosted runner -- 3 CPUs on the arm64 tier rather than 4,
+    # which changes its speed and not its ceiling: the 6-hour rule is stated per
+    # job, not per core, and only the single-CPU tier carries a special one.
+    # ⚠️ A missing row here is not a soft failure. `_lowest_ceiling` takes the
+    # minimum over a job's producible labels, so an unrecorded label fails the
+    # review-scripts job outright rather than being skipped -- which is the
+    # point, since the alternative is a cap nothing can honour.
+    "macos-latest": 360,
     "ubuntu-24.04": 360,
     "ubuntu-22.04": 360,
     "[self-hosted, cap-main, noble]": 7200,
@@ -13452,9 +13461,18 @@ class MatrixRunnerResolutionTests(unittest.TestCase):
         job that also runs somewhere nobody recorded. The unrecorded label
         already fails its own check; this returns ``None`` so the cap check does
         not additionally report a verdict it cannot support.
+
+        🔴 **The example label must be one the table will never record**, and
+        this test is the reason that matters. It used to pass ``macos-latest``,
+        which was unrecorded only until somebody needed a macOS runner --
+        KBR-164 added that row and this test went green while proving nothing
+        about unrecorded labels, because both of its labels had ceilings. A
+        fabricated label cannot be adopted by a future ticket, so the case stays
+        a case. Adding a real runner row must never be what disarms it.
         """
 
-        self.assertIsNone(_lowest_ceiling(("ubuntu-latest", "macos-latest")))
+        self.assertNotIn("plan9-latest", RUNNER_JOB_CEILING_MINUTES)
+        self.assertIsNone(_lowest_ceiling(("ubuntu-latest", "plan9-latest")))
 
     def test_a_trailing_comment_is_not_part_of_a_matrix_value(self):
         """The tolerance `runs-on:` and `timeout-minutes:` already carry.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -92,15 +92,21 @@ jobs:
       # silently ignores it there and 9.1 does not, so a config-file placement
       # would mean the gate behaves differently on two contributors' machines.
       # `pyproject.toml` carries the reasoning in full.
-      # 🔴 `-rs` lists every skipped test WITH its reason. §8 makes a skip a
-      # failure in a gating job and permits exactly one exception — a platform or
-      # interpreter skip — which is precisely what the Windows and macOS legs
-      # produce. A silent skip count is how such a leg goes green by running
-      # nothing, so the reasons are printed on every leg. One invocation, shared
-      # by all six: a second one here would be the "second, weaker definition"
-      # this file's header exists to rule out.
+      # 🔴 `-rsfE`, and the `fE` half is NOT decoration. `-r` STORES reportchars,
+      # it does not append to them: a bare `-rs` REPLACES pytest's default `fE`
+      # and deletes the `FAILED …` summary from the end of the log. Measured on
+      # pytest 9.1.1 with this exact command — `-q -rs` printed the skip list and
+      # no FAILED line at all. On a ~3,600-item suite that summary is how a red
+      # leg is read, and the first red Windows leg is exactly when it is needed.
+      #
+      # `s` is what this change added. §8 makes a skip a failure in a gating job
+      # and permits one exception — a platform or interpreter skip — which is
+      # precisely what the Windows and macOS legs produce. A silent skip count is
+      # how such a leg goes green by running nothing, so every skip is printed
+      # with its reason. One invocation shared by all six legs: a second one here
+      # would be the "second, weaker definition" this file's header rules out.
       - name: Test
         run: >-
-          pytest -m "l1 or l2" -q -rs --strict-markers
+          pytest -m "l1 or l2" -q -rsfE --strict-markers
           --require-category=l1 --require-category=l2
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,18 +12,51 @@ permissions:
 
 jobs:
   test:
-    name: Python ${{ matrix.python-version }}
-    runs-on: ubuntu-latest
-    # A backstop, not a budget: the suite runs in a couple of minutes. Sized to
-    # notice a hang. ⚠️ A matrix job is held to the LOWEST platform ceiling among
-    # the labels its matrix can produce, so adding an `ubuntu-slim` entry here
-    # would make this cap a fiction — see `.github/review/rules/ci.md`.
-    timeout-minutes: 30
+    name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    # A backstop, not a budget. ⚠️ The number below used to be 30 beside a comment
+    # claiming "the suite runs in a couple of minutes" — stale by an order of
+    # magnitude: the Linux legs measure 19–20 minutes on GitHub-hosted runners,
+    # so that cap had ~50% headroom on a leg nobody had timed. 60 clears the
+    # slowest platform leg. The cost, stated rather than hidden: a hung Linux leg
+    # is noticed 30 minutes later than before — cheap on a free runner, and far
+    # cheaper than a cap that kills a healthy Windows leg and reads as a product
+    # failure.
+    #
+    # ⚠️ A matrix job is held to the LOWEST platform ceiling among the labels its
+    # matrix can produce. All three labels here are ordinary GitHub-hosted
+    # runners at 360 minutes; an `ubuntu-slim` entry would drop that to 15 and
+    # make this cap a fiction — see `.github/review/rules/ci.md`. It must stay an
+    # integer: `DeclaredJobCapIsEnforceableTests` parses it with `(\d+)`, so an
+    # `${{ }}` expression reads as ABSENT and the guard reports a missing cap
+    # about a line that is plainly here.
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest]
         # Must track requires-python and the classifiers in pyproject.toml.
         python-version: ["3.10", "3.11", "3.12", "3.13"]
+        # 🔴 These two entries are what produce the Windows and macOS legs, and
+        # the rule that makes them work is the one this construct is misread
+        # over: an `include:` object is merged into an existing combination ONLY
+        # if it overwrites none of the base matrix values. `os` here would
+        # overwrite `ubuntu-latest`, so neither object can be merged and GitHub
+        # creates a NEW combination from each — six jobs, not four.
+        #
+        # Written as `include:` rather than a full os × python-version product
+        # with `exclude:` because the product form needs six excludes to remove
+        # six of twelve combinations, and `_matrix_values` in the review-scripts
+        # guard deliberately does not honour `exclude:` — it over-approximates on
+        # purpose, which is safe for a ceiling check and wrong for a matrix that
+        # would then be mostly holes.
+        #
+        # One Python version per platform, and why, in `TEST_SUITE.md` §8.4.
+        include:
+          - os: windows-latest
+            python-version: "3.12"
+          - os: macos-latest
+            python-version: "3.12"
     steps:
       - uses: actions/checkout@v4
 
@@ -59,8 +92,15 @@ jobs:
       # silently ignores it there and 9.1 does not, so a config-file placement
       # would mean the gate behaves differently on two contributors' machines.
       # `pyproject.toml` carries the reasoning in full.
+      # 🔴 `-rs` lists every skipped test WITH its reason. §8 makes a skip a
+      # failure in a gating job and permits exactly one exception — a platform or
+      # interpreter skip — which is precisely what the Windows and macOS legs
+      # produce. A silent skip count is how such a leg goes green by running
+      # nothing, so the reasons are printed on every leg. One invocation, shared
+      # by all six: a second one here would be the "second, weaker definition"
+      # this file's header exists to rule out.
       - name: Test
         run: >-
-          pytest -m "l1 or l2" -q --strict-markers
+          pytest -m "l1 or l2" -q -rs --strict-markers
           --require-category=l1 --require-category=l2
 

--- a/.system_design/TEST_SUITE.md
+++ b/.system_design/TEST_SUITE.md
@@ -3018,21 +3018,90 @@ matrix job is held to the **lowest** platform ceiling among the labels its matri
 all three labels here are ordinary GitHub-hosted 4-CPU runners at **360 minutes**, so the cap is
 bounded by measurement rather than by the platform.
 
-**The measurement, because the number beside it used to be fiction.** The Linux legs take
-**19–20 minutes** (six successful jobs on 2026-09-12, e.g. 01:17:37Z → 01:36:34Z) — the comment
-that stood beside `timeout-minutes: 30` claimed *"the suite runs in a couple of minutes"* and was
-stale by an order of magnitude, leaving the backstop only ~50% headroom on a leg nobody had
-timed. The cap is **60**, sized to clear the slowest platform leg with headroom. The cost of that
-choice, stated rather than hidden: a **hung Linux leg is now noticed 30 minutes later than it
-was**. On a free runner that is cheap, and a cap too low is worse — it kills a healthy Windows
-leg and reads as a product failure.
+**`openssl` is an environment prerequisite on all three images, and §8 already said so.** The
+paragraph above on the resource-availability rule states the duty in advance of this change: *"a
+non-Ubuntu matrix entry has to keep it, and the fix for a red gate is to install `openssl`, never
+to reinstate the skip."* `tests/bridge/tls_certs.py` calls `pytest.fail` — not `skip` — when the
+binary is absent, so a missing `openssl` is a red gating leg with no sanctioned recovery.
+Discharged, and recorded rather than assumed: **confirmed 2026-09-12** against the
+`actions/runner-images` image manifests — Windows Server 2025 ships **OpenSSL 3.6.4**, macOS 15
+arm64 ships **OpenSSL 1.1.1w**, Ubuntu 24.04 ships **3.0.13**. A future image bump inherits that
+duty. ⚠️ If the Windows TLS tests go red, check `-subj "/CN=localhost"` first: a leading-slash
+argument is mangled by MSYS2 path conversion if the resolved `openssl.exe` is the Git-for-Windows
+build rather than the native one.
+
+**`fail-fast: false` is load-bearing now, and was merely tidy before.** With six legs it is the
+only reason a Windows failure does not cancel the four Linux legs mid-run. Cancelling them would
+destroy the evidence needed to tell "Windows is broken" from "this change is broken" — which is
+the first question asked of every red platform leg. It predates this subsection; its importance
+does not.
+
+**A red platform leg blocks a release, deliberately.** `publish.yml` calls this same reusable
+workflow, so macOS and Windows have just joined the release gate — which is not free, and the
+cost is named rather than discovered later. `rules/ci.md` already notes that the release path
+carries blast radius beyond itself; after this change a red or flaky platform leg stops a PyPI
+release of a product whose platform behaviour was, until now, never exercised at all. That is the
+correct trade — shipping a release known to be broken on Windows is the worse outcome — and the
+break-glass is the same admin path `review/README.md` documents.
+
+**The measurement, because the number beside it used to be fiction.** The comment that stood
+beside `timeout-minutes: 30` claimed *"the suite runs in a couple of minutes"* — stale by an
+order of magnitude, leaving the backstop only ~50% headroom on a leg nobody had timed. Measured
+on the first six-leg run (2026-09-12, run 34689734864):
+
+| Leg | Wall clock | Outcome |
+|---|---|---|
+| Linux × 4 | 19.5 – 19.7 min | passed |
+| **macOS** | **20.6 min** | **passed, whole suite, first run** |
+| Windows | 2.3 min | **not a measurement** — aborted early on KBR-180 |
+
+The cap is **60**, which clears the slowest *completed* leg (macOS, 20.6) by ~3×. ⚠️ Windows is
+**not yet timed**: its first run aborted 227 tests in, so the figure above measures a failure, not
+the suite. Whoever next reads a green Windows leg should set this number from it. The cost of 60,
+stated rather than hidden: a **hung Linux leg is noticed 30 minutes later than it was**. On a free
+runner that is cheap, and a cap too low is worse — it kills a healthy leg and reads as a product
+failure. **A platform leg killed at the cap is a cap problem until proven otherwise**, never
+triaged as a hang; the platform ceiling is 360, so there is room to raise it.
+
+**What the legs found on their first run, recorded because it is the argument for the whole
+subsection.** macOS passed the entire suite immediately. Windows did not, and the failure was not
+a latent POSIX assumption in a test — it was a **user-facing product defect**
+([KBR-180](https://shelpuk.atlassian.net/browse/KBR-180)): `probe_pid` in `bridge/manage.py`
+probes liveness with `os.kill(pid, 0)`, and `signal.CTRL_C_EVENT` **is** `0` on Windows, so that
+call broadcasts a Ctrl+C to every process sharing the console instead of probing. It is reached by
+`kitty bridge status`, `stop`, `start` and `restart`, so each of those interrupted the user's own
+shell. Its docstring asserted the opposite — *"on Windows as well as POSIX — it does not terminate
+the target"* — and the `except OSError` branch beneath it explained a Windows code path that call
+never reaches. Both were written by reasoning about Windows rather than running there. **That is
+the failure mode a platform leg exists to end**, and it was caught within two minutes of the leg
+first existing.
 
 **Skips are named, not counted in silence.** §8's rule — a gating job that goes green because it
 ran nothing is the most expensive false confidence — is what a new platform leg is most likely to
 breach, because a **platform** skip is the one kind §8 permits. So the gate's pytest invocation
-carries **`-rs`**: every skipped test is listed in the log *with its reason*, on all six legs. The
-flag is on the one shared invocation rather than on the platform legs alone, because a second
+carries **`-rsfE`**: every skipped test is listed in the log *with its reason*, on all six legs.
+The flag is on the one shared invocation rather than on the platform legs alone, because a second
 invocation in the file is exactly the second definition this subsection's first decision rejects.
+
+🔴 **`fE` is not decoration, and the obvious spelling is a trap this section fell into before it
+was corrected.** `-r` **stores** reportchars; it does not append to them. A bare `-rs` therefore
+*replaces* pytest's default `fE` and **deletes the `FAILED …` summary** from the end of the run —
+measured on pytest 9.1.1 with this exact command. On a suite of this size that summary is how a
+red leg is read, and the first red platform leg is precisely when it is needed. The skip letter
+must be **added** to the defaults, never substituted for them. An earlier draft of this paragraph
+claimed the visibility "costs one flag"; it costs one flag *only* when the defaults are restated
+alongside it. `tests/test_github_actions.py::…::test_the_gate_keeps_its_failure_summary_while_reporting_skips`
+is the check, because a claim about a flag that nothing verifies is how the first spelling
+survived review.
+
+⚠️ **A platform skip is not a licence to skip a platform's defects.** §8 permits a skip for
+behaviour that *does not exist* on a platform — no `SIGKILL`, no POSIX path semantics — and the
+distinction matters most here, where a leg is new and red. A test that fails because a tool is
+missing or behaves differently is a **resource-availability** skip in platform clothing: the
+shape §8 forbids and KBR-132 closed. The fix for that is to provision the runner or make the test
+platform-agnostic, never `skipif`. And a test that fails because the **product is broken on that
+platform** is neither: it is a defect, it gets a ticket, and the leg stays red until the defect is
+fixed. `tests/bridge/tls_certs.py` is the template for stating the difference in code.
 
 **A consequence that is a product win, not a side effect.** Two things in the repository have
 never executed even once:

--- a/.system_design/TEST_SUITE.md
+++ b/.system_design/TEST_SUITE.md
@@ -2606,7 +2606,7 @@ defined by its marker expression and no test can fall between two jobs or into b
 
 | Job | Selection | Trigger | Gates a PR? | Gates a release? |
 |---|---|---|---|---|
-| **Fast** | `ruff`, `lint-imports`, `mypy src/kitty`, then `pytest -m "l1 or l2" -q` on Python 3.10–3.13 | push, PR | **Yes** | **Yes** |
+| **Fast** | `ruff`, `lint-imports`, `mypy src/kitty`, then `pytest -m "l1 or l2" -q` on Python 3.10–3.13 on Linux, and on one pinned version on Windows and macOS (§8.4) | push, PR | **Yes** | **Yes** |
 | **Subsystem** | `pytest -m l3 -q` | PR | **Yes** | **Yes** |
 | **Acceptance** | `pytest -m "acceptance or agent_smoke" -q` | PR | **Yes** | **Yes** |
 | **Deep** | mutation testing (§6.1), schemathesis at high `--max-examples`, extended property runs | nightly | No | No |
@@ -2950,6 +2950,103 @@ That makes the registry-shape check itself vulnerable to §8's own "green becaus
 looking": a validator run over zero rows passes perfectly. So `registry_violations` is proved
 against a **fabricated malformed registry** rather than against the production one, and the
 production registry is asserted clean as a separate, weaker claim.
+
+### 8.4 The platform matrix
+
+Delivered by [KBR-164](https://shelpuk.atlassian.net/browse/KBR-164). Until it landed, every
+job in the repository ran on Linux, so **every Windows-only and macOS-only defect in the product
+was reachable only by a user reporting it** — which is how all three platform bugs on epic
+KBR-123 (KBR-1, KBR-4, KBR-10) were in fact found.
+
+The Fast gate therefore runs on three platforms:
+
+| Leg | Runner label | Python | Selection |
+|---|---|---|---|
+| Linux | `ubuntu-latest` | 3.10, 3.11, 3.12, 3.13 | the whole Fast gate |
+| Windows | `windows-latest` | 3.12 | **identical** |
+| macOS | `macos-latest` | 3.12 | **identical** |
+
+**One job with an `os` matrix dimension, not a second job.** A separate platform job would
+duplicate the five-step list, and the day the two copies differ the platform leg stops being
+evidence about the gate and becomes evidence about a *similar* gate. This is the same argument
+`tests.yml`'s header already makes for the release path — *"there is no second, weaker
+definition to drift out of sync"* — applied across platforms instead of across events. It also
+means the legs gate a pull request through `ci-required`'s existing `needs: [test, …]` with **no
+change to `ci.yml`**, and gate a release through `publish.yml`, for free.
+
+**The same tests, not a platform-dependent subset.** The ticket floated scoping the leg "to the
+tests whose behaviour is actually platform-dependent". Rejected: that set is precisely what
+nobody knows — a latent POSIX assumption is invisible until the test runs somewhere else — and
+naming it would need a second marker axis, which collides with §8.1's exactly-one-layer-marker
+rule. The whole `l1 or l2` expression runs on every leg.
+
+**GitHub-hosted, and this is not a new decision.** `.github/review/rules/ci.md` § "Runner and
+caps" already fixed it for every job in the repository: a self-hosted runner group carries an
+*"Allow public repositories"* setting that is **off by default**, and this repository is public,
+so a `[self-hosted, …]` label reaches no group at all and the job **queues for ever — no error,
+no annotation, no timeout**. The platform legs inherit that unchanged.
+
+**The cost objection in the ticket does not apply here, and the reason is worth recording
+because it is the whole reason this was cheap.** KBR-164 was written expecting a large bill
+("`windows-latest` minutes bill at 2×"). That multiplier is a **private**-repository rule.
+`kitty-bridge` is public, and GitHub's runner reference states the case in one sentence: *"Use of
+the standard GitHub-hosted runners is free and unlimited on public repositories."* `windows-latest`
+and `macos-latest` are both in that table. **Confirmed 2026-09-12.** If this repository is ever
+made private, this subsection is the one to revisit first — the legs keep working and start
+billing at 2× and 10× respectively.
+
+**One Python version per platform, and it is 3.12.** The suite is mostly platform-independent, so
+a four-version Windows matrix would quadruple wall-clock and quadruple the first-run triage
+surface to re-prove interpreter-version facts the Linux legs already prove. 3.12 rather than the
+newest because `ci.yml`'s two review-system jobs already pin 3.12, so the repository names one
+version in one place; and because a Windows-only defect is likelier to reach a user on a
+mainstream version than on the newest. Interpreter-version questions stay the Linux matrix's job.
+
+**`include:` entries, not an `os` × `python-version` product with `exclude:`.** The product form
+needs six `exclude:` entries to remove six of twelve combinations, and `_matrix_values` in
+`.github/review/tests/test_review_scripts.py` deliberately does **not** honour `exclude:` — it
+over-approximates on purpose, which is the safe direction for a ceiling check but the wrong one
+for a matrix that would then be mostly holes. ⚠️ The `include:` form carries its own subtlety and
+it is where this construct is misread: an include object whose keys would **overwrite** a base
+matrix value is not merged into the existing combinations — it becomes a **new** combination.
+That is what produces the two platform legs, and a comment in `tests.yml` says so beside them.
+
+**One integer `timeout-minutes` for the whole matrix job.** `DeclaredJobCapIsEnforceableTests`
+parses the cap with `(\d+)`, so a `${{ matrix.… }}` expression there reads as **absent** and the
+guard reports "declares no job-level `timeout-minutes:`" about a line that is plainly present. A
+matrix job is held to the **lowest** platform ceiling among the labels its matrix can produce;
+all three labels here are ordinary GitHub-hosted 4-CPU runners at **360 minutes**, so the cap is
+bounded by measurement rather than by the platform.
+
+**The measurement, because the number beside it used to be fiction.** The Linux legs take
+**19–20 minutes** (six successful jobs on 2026-09-12, e.g. 01:17:37Z → 01:36:34Z) — the comment
+that stood beside `timeout-minutes: 30` claimed *"the suite runs in a couple of minutes"* and was
+stale by an order of magnitude, leaving the backstop only ~50% headroom on a leg nobody had
+timed. The cap is **60**, sized to clear the slowest platform leg with headroom. The cost of that
+choice, stated rather than hidden: a **hung Linux leg is now noticed 30 minutes later than it
+was**. On a free runner that is cheap, and a cap too low is worse — it kills a healthy Windows
+leg and reads as a product failure.
+
+**Skips are named, not counted in silence.** §8's rule — a gating job that goes green because it
+ran nothing is the most expensive false confidence — is what a new platform leg is most likely to
+breach, because a **platform** skip is the one kind §8 permits. So the gate's pytest invocation
+carries **`-rs`**: every skipped test is listed in the log *with its reason*, on all six legs. The
+flag is on the one shared invocation rather than on the platform legs alone, because a second
+invocation in the file is exactly the second definition this subsection's first decision rejects.
+
+**A consequence that is a product win, not a side effect.** Two things in the repository have
+never executed even once:
+
+- `tests/test_launcher_discovery.py`'s two `skipif(sys.platform != "win32")` cases — written for
+  a leg that did not exist, skipped in every run that has ever happened;
+- **every `if sys.platform == "win32"` branch in `src/kitty`, as far as `mypy` is concerned.**
+  mypy resolves `sys.platform` against the platform it runs on, so the Windows bodies were
+  invisible to the only type check we run — and §8's table credits mypy with four user-visible
+  defects the suite could not find, one of them explicitly *"on a non-Linux OS"*.
+
+Running `mypy src/kitty` on the Windows leg is therefore not redundant with the Linux legs; it is
+a **new detector over code no check has ever read**. That is also why the platform legs run the
+whole step list rather than pytest alone.
 
 ## 9. Gap register
 

--- a/.system_design/TEST_SUITE.md
+++ b/.system_design/TEST_SUITE.md
@@ -2938,13 +2938,21 @@ T-G5 and T-J2 land — is unchecked until that job is activated, so there the ex
 outlive its defect. The task that activates the job owns re-checking the rows on its layer, in
 the same way §8.2 makes each pending layer someone's named handoff.
 
-**The registry ships empty, today.** The row this section names — TR-1c's header-subset
-assertion, KBR-8 — belongs to an acceptance scenario that does not exist yet (§6.4.1, delivered
-by T-J2 downstream of T-J1). A registry row for an assertion no test contains documents a
-fiction, and the guard against a fiction cannot be the unexpected-pass rule, because nothing ever
-runs it. Whichever of T-G1, T-G4, T-G5, T-G9 or T-J2 lands first adds the first row. §6.4.1 and
-§6.2.3 are not amended to say so: this document states the To-Be state, in which those rows
-exist, and §8's row-count parenthetical now says which state it is counting.
+**The registry no longer ships empty — KBR-164 added the first five rows**, and they are not the
+row this section anticipated. TR-1c's header-subset assertion (KBR-8) still belongs to an
+acceptance scenario that does not exist yet (§6.4.1, delivered by T-J2 downstream of T-J1), and a
+registry row for an assertion no test contains documents a fiction — so it is still unwritten.
+What arrived first instead were the **Windows cells** of five assertions that the platform legs
+(§8.4) found to be false on Windows and true everywhere else: four over KBR-188 and one over
+KBR-189.
+
+They are the parametrised-cell shape above rather than whole-test exemptions, and the reason is
+the rule this section opens with. A `skipif` would have been the obvious move and is the wrong
+one: §8 permits a platform skip for behaviour that **does not exist** on a platform, and these
+assertions are not inapplicable on Windows — they are **false** there, which is a defect with a
+ticket. Exempting the cell keeps the assertion gating on the four Linux legs and on macOS, keeps
+the count of outstanding Windows defects readable in one file, and fails the job the day Windows
+starts passing. Skipping would have bought a green leg by not looking.
 
 That makes the registry-shape check itself vulnerable to §8's own "green because it stopped
 looking": a validator run over zero rows passes perfectly. So `registry_violations` is proved

--- a/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
+++ b/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
@@ -35,7 +35,9 @@ Give each shared file a named integration owner. Give each stream its own module
 ### 1.3 Definition of done
 
 1. The deliverable satisfies the acceptance criteria in its row.
-2. `ruff`, `lint-imports`, `mypy src/kitty` and the full suite pass on Python 3.10–3.13.
+2. `ruff`, `lint-imports`, `mypy src/kitty` and the full suite pass on Python 3.10–3.13 on Linux,
+   **and on the Windows and macOS legs** the Fast gate has run since KBR-164 (TEST_SUITE.md §8.4).
+   A change that is green only on Linux is not done.
 3. Every new test carries exactly one layer marker (**T-W1**).
 4. Google-style docstrings throughout; block comments explaining *why*. Test code is code.
 5. **It lands on `main` alone**, without leaving the suite red waiting for a sibling.

--- a/README.md
+++ b/README.md
@@ -86,6 +86,11 @@ pip install kitty-bridge
 
 Requires Python 3.10+.
 
+**Supported platforms.** Linux, Windows and macOS. Every change is tested on all three before it
+can be merged or released: Linux on Python 3.10–3.13, Windows and macOS on Python 3.12. What that
+covers is the full unit and contract suite plus type checking on each platform — not an
+end-to-end run against a live provider, which is exercised on Linux only.
+
 **2. Set up a profile**
 
 ```bash

--- a/src/kitty/bridge/manage.py
+++ b/src/kitty/bridge/manage.py
@@ -45,6 +45,59 @@ class ProcessLiveness(enum.Enum):
     UNKNOWN = "unknown"
 
 
+#: Windows constants, named here rather than inline so the pure decisions below
+#: can be handed each value without a live handle. ``ERROR_ACCESS_DENIED`` proves
+#: a process exists; ``WAIT_TIMEOUT`` is the answer a zero-timeout wait gives for
+#: a handle that is NOT yet signalled, which is what "still running" looks like.
+_ERROR_ACCESS_DENIED = 5
+_WAIT_TIMEOUT = 0x102
+_SYNCHRONIZE = 0x00100000
+_PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+
+
+def liveness_from_open_failure(last_error: int) -> ProcessLiveness:
+    """Classify a failed ``OpenProcess`` by the error it set.
+
+    Pure, and separated from the ``ctypes`` call for the reason
+    ``TEST_SUITE.md`` §8.1 gives for every decision in this codebase: a decision
+    entangled with a system call cannot be handed a deliberate defect. This one
+    can be checked on any platform, which matters because the caller only ever
+    runs on one.
+
+    Args:
+        last_error: The Win32 error code ``GetLastError`` reported.
+
+    Returns:
+        :attr:`ProcessLiveness.UNKNOWN` for ``ERROR_ACCESS_DENIED``, which proves
+        the process **exists** and is not ours to signal;
+        :attr:`ProcessLiveness.DEAD` otherwise — ``ERROR_INVALID_PARAMETER``
+        (87) is what a PID nothing holds produces.
+    """
+    # Access denied is the opposite conclusion from a missing process, and
+    # collapsing the two is the defect issue #3 was about on POSIX.
+    if last_error == _ERROR_ACCESS_DENIED:
+        return ProcessLiveness.UNKNOWN
+    return ProcessLiveness.DEAD
+
+
+def liveness_from_wait(wait_result: int) -> ProcessLiveness:
+    """Classify a zero-timeout wait on a process handle.
+
+    Args:
+        wait_result: The value ``WaitForSingleObject`` returned.
+
+    Returns:
+        :attr:`ProcessLiveness.ALIVE` when the wait timed out, meaning the handle
+        is not signalled and the process is still running;
+        :attr:`ProcessLiveness.DEAD` otherwise.
+
+    Reading a **timeout** as "alive" is the inversion worth stating: a process
+    handle becomes signalled when the process *exits*, so the wait succeeding is
+    the death certificate and the wait timing out is the sign of life.
+    """
+    return ProcessLiveness.ALIVE if wait_result == _WAIT_TIMEOUT else ProcessLiveness.DEAD
+
+
 def _probe_pid_windows(pid: int) -> ProcessLiveness:
     """Probe a PID on Windows without signalling anything.
 
@@ -81,29 +134,14 @@ def _probe_pid_windows(pid: int) -> ProcessLiveness:
     kernel32.CloseHandle.argtypes = (wintypes.HANDLE,)
     kernel32.CloseHandle.restype = wintypes.BOOL
 
-    synchronize = 0x00100000
-    query_limited_information = 0x1000
-    error_access_denied = 5
-    wait_timeout = 0x102
-
-    handle = kernel32.OpenProcess(synchronize | query_limited_information, False, pid)
+    handle = kernel32.OpenProcess(_SYNCHRONIZE | _PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
     if not handle:
-        # ERROR_ACCESS_DENIED proves the process EXISTS and is not ours, which is
-        # the opposite conclusion from a missing PID; every other failure
-        # (ERROR_INVALID_PARAMETER 87 for a PID nothing holds) means dead.
-        if ctypes.get_last_error() == error_access_denied:
-            return ProcessLiveness.UNKNOWN
-        return ProcessLiveness.DEAD
+        return liveness_from_open_failure(ctypes.get_last_error())
     try:
-        # A process handle is signalled once the process exits, so a zero-timeout
-        # wait that TIMES OUT is the liveness answer. Deliberately not
-        # GetExitCodeProcess, whose STILL_ACTIVE is the value 259 -- a process
-        # that genuinely exited with code 259 would read as running.
-        return (
-            ProcessLiveness.ALIVE
-            if kernel32.WaitForSingleObject(handle, 0) == wait_timeout
-            else ProcessLiveness.DEAD
-        )
+        # Deliberately not GetExitCodeProcess, whose STILL_ACTIVE is the value
+        # 259 -- a process that genuinely exited with code 259 would read as
+        # running. :func:`liveness_from_wait` carries the rest of the reasoning.
+        return liveness_from_wait(kernel32.WaitForSingleObject(handle, 0))
     finally:
         kernel32.CloseHandle(handle)
 

--- a/src/kitty/bridge/manage.py
+++ b/src/kitty/bridge/manage.py
@@ -45,15 +45,85 @@ class ProcessLiveness(enum.Enum):
     UNKNOWN = "unknown"
 
 
+def _probe_pid_windows(pid: int) -> ProcessLiveness:
+    """Probe a PID on Windows without signalling anything.
+
+    Windows has no "signal 0" probe, so liveness is asked of the process object
+    directly: open a handle, then ask whether that handle is signalled.
+    ``WaitForSingleObject`` with a zero timeout answers immediately and never
+    touches the target.
+
+    Args:
+        pid: Process ID to probe. Assumed positive; :func:`probe_pid` screens it.
+
+    Returns:
+        :attr:`ProcessLiveness.ALIVE`, :attr:`ProcessLiveness.DEAD`, or
+        :attr:`ProcessLiveness.UNKNOWN`.
+    """
+    # Narrows the platform for mypy as well as for the reader: every name below
+    # exists only on Windows, and on a POSIX type-check run this makes the rest
+    # of the function unreachable rather than an error.
+    if sys.platform != "win32":  # pragma: no cover - guarded by probe_pid
+        raise RuntimeError("_probe_pid_windows is Windows-only")
+
+    import ctypes
+    from ctypes import wintypes
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+
+    # 🔴 restype MUST be declared. ctypes defaults a return value to C `int`,
+    # which truncates a 64-bit HANDLE to 32 bits -- the handle then fails to
+    # close and, worse, a valid handle can truncate to zero and read as failure.
+    kernel32.OpenProcess.argtypes = (wintypes.DWORD, wintypes.BOOL, wintypes.DWORD)
+    kernel32.OpenProcess.restype = wintypes.HANDLE
+    kernel32.WaitForSingleObject.argtypes = (wintypes.HANDLE, wintypes.DWORD)
+    kernel32.WaitForSingleObject.restype = wintypes.DWORD
+    kernel32.CloseHandle.argtypes = (wintypes.HANDLE,)
+    kernel32.CloseHandle.restype = wintypes.BOOL
+
+    synchronize = 0x00100000
+    query_limited_information = 0x1000
+    error_access_denied = 5
+    wait_timeout = 0x102
+
+    handle = kernel32.OpenProcess(synchronize | query_limited_information, False, pid)
+    if not handle:
+        # ERROR_ACCESS_DENIED proves the process EXISTS and is not ours, which is
+        # the opposite conclusion from a missing PID; every other failure
+        # (ERROR_INVALID_PARAMETER 87 for a PID nothing holds) means dead.
+        if ctypes.get_last_error() == error_access_denied:
+            return ProcessLiveness.UNKNOWN
+        return ProcessLiveness.DEAD
+    try:
+        # A process handle is signalled once the process exits, so a zero-timeout
+        # wait that TIMES OUT is the liveness answer. Deliberately not
+        # GetExitCodeProcess, whose STILL_ACTIVE is the value 259 -- a process
+        # that genuinely exited with code 259 would read as running.
+        return (
+            ProcessLiveness.ALIVE
+            if kernel32.WaitForSingleObject(handle, 0) == wait_timeout
+            else ProcessLiveness.DEAD
+        )
+    finally:
+        kernel32.CloseHandle(handle)
+
+
 def probe_pid(pid: int) -> ProcessLiveness:
     """Probe whether a process exists and whether this user may signal it.
 
-    Signal ``0`` performs no action and only probes for the process, on Windows
-    as well as POSIX — it does not terminate the target. The three outcomes are
-    kept apart because they call for different handling: a permission-denied
-    probe proves the process is *running* under another account, which is the
-    opposite conclusion from a missing process, yet both raise from
-    :func:`os.kill`.
+    The three outcomes are kept apart because they call for different handling:
+    a permission-denied probe proves the process is *running* under another
+    account, which is the opposite conclusion from a missing process.
+
+    🔴 **The POSIX ``os.kill(pid, 0)`` idiom must never run on Windows.**
+    ``signal.CTRL_C_EVENT`` **is** ``0`` there, so that call does not probe — it
+    raises a **Ctrl+C console event** delivered to every process sharing the
+    console window, including the caller's own shell and whatever agent is
+    running in it. See KBR-180: this function is reached by ``kitty bridge
+    status``, ``stop``, ``start`` and ``restart``, so on Windows each of those
+    interrupted the session it was reporting on. The defect survived because
+    nothing had ever executed this line on Windows; the platform legs added by
+    KBR-164 found it on their first run.
 
     Args:
         pid: Process ID to probe.
@@ -68,22 +138,30 @@ def probe_pid(pid: int) -> ProcessLiveness:
     # SIGTERM/SIGKILL against the user's own shell session.
     if pid <= 0:
         return ProcessLiveness.DEAD
+    # Branch before the try, not inside it: the Windows path must be
+    # unreachable-by-construction rather than a fallback something could fall
+    # through to.
+    if sys.platform == "win32":
+        return _probe_pid_windows(pid)
     try:
         os.kill(pid, 0)
         return ProcessLiveness.ALIVE
     except ProcessLookupError:
         return ProcessLiveness.DEAD
     except PermissionError:
-        # EPERM (POSIX) / ERROR_ACCESS_DENIED (Windows) proves the process
-        # exists — we simply may not signal it. Reporting it as dead is what
-        # issue #3 is about; reporting it as alive would let stop_bridge()
-        # signal a stranger's process after PID recycling.
+        # EPERM proves the process exists — we simply may not signal it.
+        # Reporting it as dead is what issue #3 is about; reporting it as alive
+        # would let stop_bridge() signal a stranger's process after PID
+        # recycling.
         return ProcessLiveness.UNKNOWN
     except OSError:
-        # Windows has no ProcessLookupError for this: OpenProcess fails with
-        # ERROR_INVALID_PARAMETER (87) for a PID that does not exist, which
-        # surfaces as a plain OSError. Without this branch every stale-state
-        # code path (bridge status/stop/start/restart) crashes on Windows.
+        # Kept as a backstop, with its justification corrected. It used to read
+        # "Windows has no ProcessLookupError for this: OpenProcess fails with
+        # ERROR_INVALID_PARAMETER (87)" -- which was wrong twice over, since
+        # `os.kill(pid, 0)` never reaches OpenProcess on Windows and this line
+        # is now POSIX-only. It stays because removing it would change POSIX
+        # behaviour for an errno neither branch above names, which is not this
+        # fix's business.
         return ProcessLiveness.DEAD
 
 

--- a/src/kitty/tui/menu.py
+++ b/src/kitty/tui/menu.py
@@ -11,6 +11,30 @@ import questionary
 __all__ = ["CheckboxMenu", "SelectionMenu"]
 
 
+def _can_host_a_menu() -> bool:
+    """Report whether this process can host an interactive menu.
+
+    Both streams are checked, not just stdin, and the second one is the point:
+    a menu must **read keys and draw**, so a console on one side is not enough.
+
+    🔴 KBR-187. This guard read ``sys.stdin.isatty()`` alone, which is a POSIX
+    reading of the question. On Windows ``isatty()`` is true for any *character
+    device*, and that includes ``NUL`` -- so a child spawned with stdin
+    redirected to ``NUL`` reported an interactive stdin, passed this guard, and
+    died inside ``prompt_toolkit`` with ``NoConsoleScreenBufferError`` when it
+    tried to build a Win32 screen buffer over a **piped stdout**. On POSIX the
+    same child reads ``/dev/null`` as not-a-tty and returns here, which is why
+    no Linux run ever saw it.
+
+    That is the same user-facing failure as KBR-10 -- kitty crashing because its
+    output is redirected -- reached by a different route.
+
+    Returns:
+        ``True`` when both standard input and standard output are terminals.
+    """
+    return sys.stdin.isatty() and sys.stdout.isatty()
+
+
 class SelectionMenu:
     """Single-item arrow-key menu.
 
@@ -28,7 +52,7 @@ class SelectionMenu:
         Returns:
             The selected option string, or None if cancelled or non-interactive.
         """
-        if not sys.stdin.isatty():
+        if not _can_host_a_menu():
             return None
         if not self._options:
             return None
@@ -66,7 +90,7 @@ class CheckboxMenu:
             List of selected option strings (may be empty), or None if cancelled
             or non-interactive.
         """
-        if not sys.stdin.isatty():
+        if not _can_host_a_menu():
             return None
 
         choices: list[Any] = [

--- a/tests/bridge/test_bridge_management.py
+++ b/tests/bridge/test_bridge_management.py
@@ -7,6 +7,7 @@ import json
 import os
 import signal
 import socket
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -798,12 +799,30 @@ class TestBridgeReachable:
         assert bridge_reachable("kitty-bridge.invalid", 9, timeout=0.2) is False
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="the POSIX errno mapping of os.kill(pid, 0); Windows never calls it (KBR-180)",
+)
 class TestProbePidErrorMapping:
-    """Cross-platform mapping of os.kill(pid, 0) outcomes to liveness.
+    """Mapping of ``os.kill(pid, 0)`` errno outcomes to liveness, on POSIX.
 
-    Signal 0 performs no action and only probes the process — on Windows as
-    well as POSIX. The platforms differ in how they report a missing PID, and
-    that difference previously crashed every stale-state code path on Windows.
+    🔴 This class used to call itself *cross-platform* and open with "Signal 0
+    performs no action and only probes the process — on Windows as well as
+    POSIX". That claim was false, and it is the one KBR-180 was filed against:
+    ``signal.CTRL_C_EVENT`` **is** ``0`` on Windows, so the call broadcasts a
+    Ctrl+C to the console instead of probing. The tests below patch
+    ``manage.os.kill`` and assert the errno mapping around it, which is a POSIX
+    claim about a POSIX call.
+
+    Skipped on Windows because the behaviour under test **does not exist**
+    there — §8's one permitted kind of skip — not because the product is
+    broken there. :func:`probe_pid` dispatches to ``_probe_pid_windows``
+    before reaching ``os.kill``, and that path is covered by
+    :meth:`TestBridgeManagementHelpers.test_probe_pid_for_current_process` and
+    ``test_probe_pid_for_dead_pid``, which exercise the real implementation on
+    the Windows leg, plus
+    ``test_probe_pid_never_signals_zero_on_windows``, which holds the dispatch
+    itself on every platform.
     """
 
     def test_signallable_process_is_alive(self):

--- a/tests/bridge/test_bridge_management.py
+++ b/tests/bridge/test_bridge_management.py
@@ -34,6 +34,49 @@ class TestBridgeManagementHelpers:
         # Use a very high PID that's extremely unlikely to exist
         assert probe_pid(999999999) is ProcessLiveness.DEAD
 
+    def test_probe_pid_never_signals_zero_on_windows(self, monkeypatch):
+        """KBR-180: ``os.kill(pid, 0)`` is a Ctrl+C broadcast on Windows.
+
+        🔴 ``signal.CTRL_C_EVENT`` **is** ``0``, so on Windows that call does
+        not probe -- it raises a console Ctrl+C delivered to every process
+        sharing the console window, including the user's own shell. The
+        Windows CI leg caught it as a ``KeyboardInterrupt`` that aborted the
+        run 227 tests in.
+
+        This runs on **every** platform, deliberately: the defect is invisible
+        on the Linux legs that make up four of the six, so a Windows-only
+        regression test would be checked by one leg and could rot unnoticed
+        in between. Faking the platform is what makes the claim checkable
+        everywhere.
+        """
+        from kitty.bridge import manage
+
+        # Fails loudly rather than silently passing if the dispatch is ever
+        # removed: a test that asserts `os.kill` was not called would also
+        # pass if `probe_pid` did nothing at all.
+        def _explode(*args: object, **kwargs: object) -> None:
+            raise AssertionError(f"probe_pid reached os.kill{args!r} on Windows")
+
+        monkeypatch.setattr(manage.sys, "platform", "win32")
+        monkeypatch.setattr(manage.os, "kill", _explode)
+        monkeypatch.setattr(
+            manage, "_probe_pid_windows", lambda pid: manage.ProcessLiveness.ALIVE
+        )
+
+        assert manage.probe_pid(4321) is manage.ProcessLiveness.ALIVE
+
+    def test_probe_pid_screens_non_positive_pids_before_any_dispatch(self):
+        """A corrupt state file must not reach either platform path.
+
+        On POSIX a pid of 0 addresses the caller's whole process group; on
+        Windows it is CTRL_C_EVENT's own group broadcast. The screen is what
+        stops a corrupt ``bridge_state.json`` from reaching either.
+        """
+        from kitty.bridge.manage import ProcessLiveness, probe_pid
+
+        assert probe_pid(0) is ProcessLiveness.DEAD
+        assert probe_pid(-1) is ProcessLiveness.DEAD
+
     def test_stop_bridge_removes_state_file(self, tmp_path: Path):
         from kitty.bridge.manage import stop_bridge
 

--- a/tests/bridge/test_bridge_management.py
+++ b/tests/bridge/test_bridge_management.py
@@ -73,10 +73,21 @@ class TestBridgeManagementHelpers:
         Windows it is CTRL_C_EVENT's own group broadcast. The screen is what
         stops a corrupt ``bridge_state.json`` from reaching either.
         """
-        from kitty.bridge.manage import ProcessLiveness, probe_pid
+        from kitty.bridge import manage
 
-        assert probe_pid(0) is ProcessLiveness.DEAD
-        assert probe_pid(-1) is ProcessLiveness.DEAD
+        # Asserts the SCREEN, not just the answer. `probe_pid(0) is DEAD` would
+        # also hold if the pid reached a probe that happened to report dead --
+        # so the claim 'before any dispatch' would go unchecked. Both platform
+        # paths are blocked, because the screen protects both.
+        def _explode(*args: object, **kwargs: object) -> None:
+            raise AssertionError(f"a non-positive pid reached a probe: {args!r}")
+
+        with (
+            patch.object(manage.os, "kill", _explode),
+            patch.object(manage, "_probe_pid_windows", _explode),
+        ):
+            assert manage.probe_pid(0) is manage.ProcessLiveness.DEAD
+            assert manage.probe_pid(-1) is manage.ProcessLiveness.DEAD
 
     def test_stop_bridge_removes_state_file(self, tmp_path: Path):
         from kitty.bridge.manage import stop_bridge
@@ -797,6 +808,51 @@ class TestBridgeReachable:
         from kitty.bridge.manage import bridge_reachable
 
         assert bridge_reachable("kitty-bridge.invalid", 9, timeout=0.2) is False
+
+
+class TestTheWindowsLivenessDecisions:
+    """The Windows probe's decisions, checked on every platform.
+
+    🔴 Raised in PR review: the ``ctypes`` body of ``_probe_pid_windows`` runs
+    on one leg of six, so the mapping it implements was proved only where it
+    is hardest to run and impossible to provoke -- nothing can produce an
+    ``ERROR_ACCESS_DENIED`` process on demand in CI.
+
+    The decisions are therefore pure functions, the shape TEST_SUITE.md §8.1
+    requires of every decision in this codebase, and these cases hand each one
+    the values Windows would. What stays Windows-only is the ``ctypes`` call
+    itself, which is plumbing rather than a decision.
+    """
+
+    def test_access_denied_means_the_process_exists(self):
+        """ERROR_ACCESS_DENIED is the opposite conclusion from a missing PID."""
+        from kitty.bridge.manage import ProcessLiveness, liveness_from_open_failure
+
+        assert liveness_from_open_failure(5) is ProcessLiveness.UNKNOWN
+
+    def test_any_other_open_failure_means_dead(self):
+        """ERROR_INVALID_PARAMETER (87) is what a PID nothing holds produces."""
+        from kitty.bridge.manage import ProcessLiveness, liveness_from_open_failure
+
+        assert liveness_from_open_failure(87) is ProcessLiveness.DEAD
+        assert liveness_from_open_failure(0) is ProcessLiveness.DEAD
+
+    def test_a_wait_that_times_out_means_alive(self):
+        """🔴 The inversion: a process handle is signalled once it EXITS.
+
+        So the wait timing out (``WAIT_TIMEOUT``, 0x102) is the sign of life,
+        and the wait succeeding is the death certificate. Reading this the
+        natural way round is the mistake this case exists to catch.
+        """
+        from kitty.bridge.manage import ProcessLiveness, liveness_from_wait
+
+        assert liveness_from_wait(0x102) is ProcessLiveness.ALIVE
+
+    def test_a_wait_that_completes_means_dead(self):
+        """WAIT_OBJECT_0 (0) means the handle is signalled: the process exited."""
+        from kitty.bridge.manage import ProcessLiveness, liveness_from_wait
+
+        assert liveness_from_wait(0) is ProcessLiveness.DEAD
 
 
 @pytest.mark.skipif(

--- a/tests/bridge/tls_certs.py
+++ b/tests/bridge/tls_certs.py
@@ -39,7 +39,9 @@ import pytest
 
 # Generous enough that a loaded CI runner never trips it, short enough that a
 # genuinely wedged `openssl` is reported as a failure rather than eating the
-# job's 30-minute ceiling. RSA-2048 keygen is milliseconds when it works at all.
+# job's cap (60 minutes since KBR-164 widened it for the platform legs; the
+# argument is unchanged by the number, which is why this reads "the cap" and
+# names it only in passing). RSA-2048 keygen is milliseconds when it works.
 _OPENSSL_TIMEOUT_SECONDS = 60
 
 # Repeated in every failure message so a CI log says why the run did not simply

--- a/tests/exemptions.py
+++ b/tests/exemptions.py
@@ -87,20 +87,67 @@ class Exemption:
 # 🔴 The registry of ACKNOWLEDGED DEBT. One row per exempt assertion, and the
 # list is supposed to trend towards zero.
 #
-# It ships EMPTY, deliberately. TEST_SUITE.md §8 names one row -- TR-1c's
-# header-subset assertion, pending G3's policy half (Q1); it was keyed to KBR-8
-# until that shipped without closing parity -- but TR-1c is an acceptance scenario that
-# does not exist yet (§6.4.1, plan task T-J2). A row for an assertion no test
-# contains documents a fiction, and the unexpected-pass rule cannot catch that
-# one, because nothing ever runs it. Whichever of T-G1, T-G4, T-G5, T-G9 or
-# T-J2 lands first adds the first row.
+# It shipped EMPTY until KBR-164, which added the five rows below -- the Windows
+# cells of assertions the platform legs found false on Windows and true on the
+# other five legs (TEST_SUITE.md §8.3, §8.4).
+#
+# Still unwritten, and still for the stated reason: TEST_SUITE.md §8 names
+# TR-1c's header-subset assertion, pending G3's policy half (Q1) and keyed to
+# KBR-8 until that shipped without closing parity -- but TR-1c is an acceptance
+# scenario that does not exist yet (§6.4.1, plan task T-J2). A row for an
+# assertion no test contains documents a fiction, and the unexpected-pass rule
+# cannot catch that one, because nothing ever runs it.
 #
 # A `MappingProxyType`, not a bare dict, so the value matches the read-only
 # annotation at runtime as well as to a type checker. `EXEMPTIONS[...] = ...`
 # from a guard would otherwise pass `mypy` and register a row nobody can find by
 # reading this file -- the one-registry invariant defeated by one line. Rows are
 # added by editing the literal below.
-EXEMPTIONS: Mapping[str, Exemption] = MappingProxyType({})
+#: 🔴 The first rows this registry has ever carried, added by KBR-164 when the
+#: Windows leg went in. Every one of them is a **Windows cell** of an assertion
+#: that gates normally on the four Linux legs and on macOS — the parametrised
+#: shape §8.3 describes, not a blanket amnesty — so each fails the job the day
+#: its own platform starts passing.
+#:
+#: They are exemptions rather than skips on purpose. A `skipif` here would hide
+#: two real defects behind a green leg, and §8 permits a platform skip only for
+#: behaviour that *does not exist* on the platform. These assertions are not
+#: inapplicable on Windows; they are **false** there, and that is a debt with a
+#: ticket, not a platform difference.
+EXEMPTIONS: Mapping[str, Exemption] = MappingProxyType(
+    {
+        "recorder-arrival-increases-per-session": Exemption(
+            assertion="request arrival times increase across a recorded session",
+            condition="on Windows the clock is too coarse to separate two adjacent "
+            "requests, so two sends share one timestamp and strict increase fails",
+            issue="KBR-188",
+        ),
+        "recorder-falsification-reordering-only-order-check": Exemption(
+            assertion="a reordering recorder is rejected by the order check alone",
+            condition="on Windows the coarse clock also trips check_arrival_increases, "
+            "so a second check fires and the defect is caught by two, not one",
+            issue="KBR-188",
+        ),
+        "recorder-falsification-miscount-only-connection-check": Exemption(
+            assertion="a miscounting connection log is rejected by the connection check alone",
+            condition="on Windows the coarse clock also trips check_arrival_increases, "
+            "so a second check fires and the defect is caught by two, not one",
+            issue="KBR-188",
+        ),
+        "recorder-falsification-probe-passes-real-recorder": Exemption(
+            assertion="the falsification probe passes cleanly against the real recorder",
+            condition="on Windows the coarse clock trips check_arrival_increases against "
+            "a recorder that has no defect at all",
+            issue="KBR-188",
+        ),
+        "recorder-responder-abort-emits-before-dropping": Exemption(
+            assertion="a responder that aborts mid-stream still delivers a data frame first",
+            condition="on Windows the abort wins the race against the first chunk, so the "
+            "client sees response headers and no body",
+            issue="KBR-189",
+        ),
+    }
+)
 
 
 class UnknownExemption(Exception):

--- a/tests/exemptions.py
+++ b/tests/exemptions.py
@@ -87,9 +87,12 @@ class Exemption:
 # 🔴 The registry of ACKNOWLEDGED DEBT. One row per exempt assertion, and the
 # list is supposed to trend towards zero.
 #
-# It shipped EMPTY until KBR-164, which added the five rows below -- the Windows
-# cells of assertions the platform legs found false on Windows and true on the
-# other five legs (TEST_SUITE.md §8.3, §8.4).
+# It shipped EMPTY until KBR-164. Every row below is the WINDOWS CELL of an
+# assertion the platform legs found false on Windows and true on the other
+# legs (TEST_SUITE.md §8.3, §8.4). Deliberately not counted in this comment:
+# a count in prose is wrong the moment the next row lands, and nothing checks
+# it -- the rule §8's own header states about naming things rather than
+# counting them.
 #
 # Still unwritten, and still for the stated reason: TEST_SUITE.md §8 names
 # TR-1c's header-subset assertion, pending G3's policy half (Q1) and keyed to
@@ -103,14 +106,12 @@ class Exemption:
 # from a guard would otherwise pass `mypy` and register a row nobody can find by
 # reading this file -- the one-registry invariant defeated by one line. Rows are
 # added by editing the literal below.
-#: 🔴 The first rows this registry has ever carried, added by KBR-164 when the
-#: Windows leg went in. Every one of them is a **Windows cell** of an assertion
-#: that gates normally on the four Linux legs and on macOS — the parametrised
+#: Each row gates normally on the Linux and macOS legs — the parametrised-cell
 #: shape §8.3 describes, not a blanket amnesty — so each fails the job the day
 #: its own platform starts passing.
 #:
 #: They are exemptions rather than skips on purpose. A `skipif` here would hide
-#: two real defects behind a green leg, and §8 permits a platform skip only for
+#: real defects behind a green leg, and §8 permits a platform skip only for
 #: behaviour that *does not exist* on the platform. These assertions are not
 #: inapplicable on Windows; they are **false** there, and that is a debt with a
 #: ticket, not a platform difference.
@@ -120,6 +121,12 @@ EXEMPTIONS: Mapping[str, Exemption] = MappingProxyType(
             assertion="request arrival times increase across a recorded session",
             condition="on Windows the clock is too coarse to separate two adjacent "
             "requests, so two sends share one timestamp and strict increase fails",
+            issue="KBR-188",
+        ),
+        "recorder-arrival-increases-across-requests": Exemption(
+            assertion="arrival moves forward from one request to the next",
+            condition="on Windows the clock is too coarse to separate two sequential "
+            "requests, so both are stamped with the same instant",
             issue="KBR-188",
         ),
         "recorder-falsification-reordering-only-order-check": Exemption(

--- a/tests/harness/test_recorder.py
+++ b/tests/harness/test_recorder.py
@@ -21,10 +21,13 @@ import asyncio
 import gzip
 import json
 import socket
+import sys
 from collections.abc import Callable
+from contextlib import nullcontext
 from pathlib import Path
 
 import pytest
+from exemptions import ratchet
 
 import harness.recorder as recorder_module
 import harness.recorder_conformance as conformance_module
@@ -111,7 +114,12 @@ class TestTheRecorderPassesEveryConformanceCheck:
             await send(recorder.host, recorder.port, probe(marker), marker=marker)
             for marker in ("first", "second")
         ]
-        check(recording_of(recorder), sent, [s.source_port for s in sent])
+        # KBR-188/189: exempt the WINDOWS CELL only -- this assertion gates
+        # normally on the Linux and macOS legs, and fails the job the day
+        # Windows starts passing. §8.3's parametrised-cell shape.
+        exempt = sys.platform == "win32" and check.__name__ == "check_arrival_increases"
+        with ratchet("recorder-arrival-increases-per-session") if exempt else nullcontext():
+            check(recording_of(recorder), sent, [s.source_port for s in sent])
 
 
 class TestCaptureFidelity:
@@ -725,7 +733,13 @@ class TestTheResponderSeam:
         recorder.responder = truncate
         reply = await _exchange(recorder, probe("t", body=b'{"stream": true}'))
 
-        assert b"data: " in reply
+        # KBR-188/189: exempt the WINDOWS CELL only -- this assertion gates
+        # normally on the Linux and macOS legs, and fails the job the day
+        # Windows starts passing. §8.3's parametrised-cell shape.
+        exempt = sys.platform == "win32"
+        with ratchet("recorder-responder-abort-emits-before-dropping") if exempt else nullcontext():
+            assert b"data: " in reply
+
         assert b"[DONE]" not in reply, "the stream must have been cut before its terminator"
 
 

--- a/tests/harness/test_recorder.py
+++ b/tests/harness/test_recorder.py
@@ -310,7 +310,13 @@ class TestCaptureFidelity:
 
         first, second = recorder.requests
         assert first.arrival is not None and second.arrival is not None
-        assert second.arrival > first.arrival
+
+        # KBR-188: the Windows cell only. Gates normally on the four Linux legs
+        # and on macOS, and fails the job the day Windows starts passing. The
+        # block holds this one assertion and nothing else, per §8.3.
+        exempt = sys.platform == "win32"
+        with ratchet("recorder-arrival-increases-across-requests") if exempt else nullcontext():
+            assert second.arrival > first.arrival
 
     async def test_a_request_that_never_completes_is_not_published(
         self, recorder: RecordingUpstream

--- a/tests/harness/test_recorder_falsification.py
+++ b/tests/harness/test_recorder_falsification.py
@@ -31,13 +31,16 @@ from __future__ import annotations
 
 import asyncio
 import socket
+import sys
 import time
 from collections.abc import Sequence
+from contextlib import nullcontext
 from dataclasses import replace
 from typing import Any
 
 import pytest
 from aiohttp import web
+from exemptions import ratchet
 
 from harness.contract import CapturedRequest, WireFormat
 from harness.recorder import ConnectionRecord, RecordingUpstream, _ConnectionLoggingServer
@@ -639,7 +642,12 @@ class TestSessionDefectsAreCaughtByExactlyTheirOwnCheck:
         """Assert misordering is attributable to the ordering check alone."""
         failing = next(c for c in PER_SESSION_CHECKS if c.__name__ == "check_request_order")
         recording, sent, opened = await self._run_pair(ReorderingRecorder)
-        self._assert_only(failing, recording, sent, opened, "request order")
+        # KBR-188/189: exempt the WINDOWS CELL only -- this assertion gates
+        # normally on the Linux and macOS legs, and fails the job the day
+        # Windows starts passing. §8.3's parametrised-cell shape.
+        exempt = sys.platform == "win32"
+        with ratchet("recorder-falsification-reordering-only-order-check") if exempt else nullcontext():
+            self._assert_only(failing, recording, sent, opened, "request order")
 
     async def test_a_dropping_recorder_fails_only_the_coverage_check(self) -> None:
         """Assert a lost request is attributable to the coverage check alone."""
@@ -657,7 +665,12 @@ class TestSessionDefectsAreCaughtByExactlyTheirOwnCheck:
         """
         failing = next(c for c in PER_SESSION_CHECKS if c.__name__ == "check_connection_logged")
         recording, sent, opened = await self._run_pair(MiscountingConnectionRecorder)
-        self._assert_only(failing, recording, sent, opened, "accounts for 0 requests")
+        # KBR-188/189: exempt the WINDOWS CELL only -- this assertion gates
+        # normally on the Linux and macOS legs, and fails the job the day
+        # Windows starts passing. §8.3's parametrised-cell shape.
+        exempt = sys.platform == "win32"
+        with ratchet("recorder-falsification-miscount-only-connection-check") if exempt else nullcontext():
+            self._assert_only(failing, recording, sent, opened, "accounts for 0 requests")
 
     async def test_a_frozen_clock_fails_only_the_arrival_check(self) -> None:
         """Assert a constant clock is attributable to the arrival check alone."""
@@ -699,8 +712,13 @@ class TestSessionDefectsAreCaughtByExactlyTheirOwnCheck:
         finally:
             await upstream.stop()
 
-        for check in PER_SESSION_CHECKS:
-            check(recording, sent, opened)
+        # KBR-188/189: exempt the WINDOWS CELL only -- this assertion gates
+        # normally on the Linux and macOS legs, and fails the job the day
+        # Windows starts passing. §8.3's parametrised-cell shape.
+        exempt = sys.platform == "win32"
+        with ratchet("recorder-falsification-probe-passes-real-recorder") if exempt else nullcontext():
+            for check in PER_SESSION_CHECKS:
+                check(recording, sent, opened)
 
     async def test_a_lazily_logged_connection_log_fails_the_connection_check(self) -> None:
         """Assert a log that only sees request-bearing connections is caught.

--- a/tests/harness/test_recorder_falsification.py
+++ b/tests/harness/test_recorder_falsification.py
@@ -712,12 +712,20 @@ class TestSessionDefectsAreCaughtByExactlyTheirOwnCheck:
         finally:
             await upstream.stop()
 
-        # KBR-188/189: exempt the WINDOWS CELL only -- this assertion gates
-        # normally on the Linux and macOS legs, and fails the job the day
-        # Windows starts passing. §8.3's parametrised-cell shape.
-        exempt = sys.platform == "win32"
-        with ratchet("recorder-falsification-probe-passes-real-recorder") if exempt else nullcontext():
-            for check in PER_SESSION_CHECKS:
+        # 🔴 The ratchet goes INSIDE the loop and names one check, not around it.
+        # Wrapping the loop would amnesty all four checks on Windows, so a check
+        # failing there for an unrelated reason would be suppressed by a row that
+        # names `check_arrival_increases` -- the blanket amnesty §8 rejects,
+        # rebuilt inside the mechanism meant to prevent it. §8.3 says the block
+        # holds exactly one assertion and that nothing detects a second; this is
+        # what heeding that looks like. Raised in PR review.
+        for check in PER_SESSION_CHECKS:
+            exempt = sys.platform == "win32" and check.__name__ == "check_arrival_increases"
+            with (
+                ratchet("recorder-falsification-probe-passes-real-recorder")
+                if exempt
+                else nullcontext()
+            ):
                 check(recording, sent, opened)
 
     async def test_a_lazily_logged_connection_log_fails_the_connection_check(self) -> None:

--- a/tests/test_github_actions.py
+++ b/tests/test_github_actions.py
@@ -116,11 +116,21 @@ class TestCIWorkflow:
         branches = trigger.get("pull_request", {}).get("branches", [])
         assert "main" in branches, "CI must trigger on PRs targeting main"
 
-    def test_runs_on_ubuntu(self, workflow: dict):
-        jobs = _resolve_jobs(workflow)
-        for job_name, job in jobs.items():
-            runs_on = job.get("runs-on", "")
-            assert "ubuntu" in str(runs_on), f"Job '{job_name}' must run on ubuntu"
+    def test_the_workflows_own_jobs_run_on_linux(self, workflow: dict):
+        """Every job `ci.yml` declares itself runs on Linux.
+
+        ⚠️ Narrowed from an assertion over every *resolved* job, which swept in
+        the delegated test matrix and so forbade the Windows and macOS legs
+        `.system_design/TEST_SUITE.md` §8.4 requires. A job whose `runs-on:`
+        defers to a matrix is left to :class:`TestThePlatformLegsExist`, which
+        reads the matrix the expression points at; the exact labels are held by
+        `RUNNER_JOB_CEILING_MINUTES` in the review-scripts suite.
+        """
+        for job_name, job in _resolve_jobs(workflow).items():
+            runs_on = str(job.get("runs-on", ""))
+            if runs_on.startswith("${{"):
+                continue
+            assert "ubuntu" in runs_on, f"Job '{job_name}' must run on ubuntu"
 
     def test_checks_out_code(self, workflow: dict):
         steps = _get_all_steps(workflow)
@@ -371,6 +381,145 @@ class TestReleaseIsGatedOnTests:
 
         assert claimed, "expected Python version classifiers in pyproject.toml"
         assert claimed <= tested, f"classifiers claim {sorted(claimed - tested)} but CI never tests them"
+
+
+# ── R5b: the gate runs on every platform the product ships to ─────────────
+
+
+#: The platform families the Fast gate must cover, as substrings of a runner
+#: label. Substrings rather than exact labels deliberately: `ubuntu-latest` and
+#: `ubuntu-24.04` are the same platform for this file's question, and pinning
+#: exact labels here would make a routine runner-image bump read as a lost leg.
+#: The exact labels are pinned elsewhere and for a different reason, by
+#: `RUNNER_JOB_CEILING_MINUTES` in `.github/review/tests/test_review_scripts.py`.
+REQUIRED_PLATFORMS = ("ubuntu", "windows", "macos")
+
+
+def _matrix_platforms(job: dict) -> set[str]:
+    """Collect every ``os`` value a job's matrix can produce.
+
+    Reads the top-level ``os`` list **and** every ``include:`` entry's ``os``.
+    An include entry whose value would overwrite a base matrix value does not
+    modify an existing combination -- GitHub creates a **new** one from it, and
+    that is precisely how the Windows and macOS legs come to exist. An include
+    entry read as a mere annotation would leave both legs invisible here.
+
+    ``exclude:`` is deliberately not honoured: it only removes combinations, so
+    ignoring it over-approximates, which is the safe direction for a question
+    about whether a platform is *present*.
+
+    Args:
+        job: A parsed job mapping, as `tests.yml` declares it.
+
+    Returns:
+        The ``os`` values the matrix can produce. Empty when the job declares no
+        matrix, or none this function can read -- see
+        :meth:`TestThePlatformLegsExist.test_the_reader_reports_an_unreadable_matrix_as_empty`.
+    """
+    matrix = job.get("strategy", {}).get("matrix", {})
+    platforms = {str(value) for value in matrix.get("os", [])}
+    # An include entry without an `os` key annotates a combination rather than
+    # naming a runner, so it contributes no platform.
+    for entry in matrix.get("include", []):
+        if "os" in entry:
+            platforms.add(str(entry["os"]))
+    return platforms
+
+
+class TestThePlatformLegsExist:
+    """The Fast gate must run on Linux, Windows and macOS.
+
+    Until KBR-164 every job in the repository ran on Linux, so a Windows-only or
+    macOS-only defect was reachable only by a user reporting one -- which is how
+    all three platform bugs on epic KBR-123 were in fact found.
+    ``.system_design/TEST_SUITE.md`` §8.4 records the matrix and its reasoning;
+    this class is what stops a later edit quietly removing a leg.
+    """
+
+    @pytest.fixture()
+    def test_job(self) -> dict:
+        jobs = _load_workflow("tests.yml").get("jobs", {})
+        assert "test" in jobs, "tests.yml must declare the `test` job"
+        return jobs["test"]
+
+    def test_the_reader_reports_an_unreadable_matrix_as_empty(self):
+        """A matrix this reader cannot understand must read as no platforms.
+
+        🔴 Fabricated input, not the production workflow, for the reason
+        TEST_SUITE.md §8.3 gives about its own registry validator: a reader
+        proved only against a matrix that works cannot show it fails *safe*. If
+        an unreadable matrix returned something non-empty, the coverage
+        assertions below would report on platforms nobody declared.
+        """
+        assert _matrix_platforms({}) == set()
+        assert _matrix_platforms({"strategy": {"matrix": {"python-version": ["3.12"]}}}) == set()
+
+    def test_the_reader_sees_a_leg_that_exists_only_as_an_include_entry(self):
+        """The `include:` path is the one that produces both platform legs.
+
+        Fabricated for the same reason as above, and pointed at the specific
+        shape `tests.yml` uses: a reader that returned only the top-level `os`
+        list would report a Linux-only matrix while two platform legs ran.
+        """
+        fabricated = {
+            "strategy": {
+                "matrix": {
+                    "os": ["ubuntu-latest"],
+                    "include": [{"os": "windows-latest", "python-version": "3.12"}],
+                }
+            }
+        }
+        assert _matrix_platforms(fabricated) == {"ubuntu-latest", "windows-latest"}
+
+    def test_the_matrix_names_a_platform_at_all(self, test_job: dict):
+        """Guard the guard: an empty read makes every assertion below vacuous."""
+        assert _matrix_platforms(test_job), (
+            "no `os` value could be read from the test matrix, so every platform "
+            "assertion in this class would pass by asking nothing"
+        )
+
+    @pytest.mark.parametrize("platform", REQUIRED_PLATFORMS)
+    def test_the_gate_runs_on_every_supported_platform(self, test_job: dict, platform: str):
+        produced = _matrix_platforms(test_job)
+        assert any(platform in label for label in produced), (
+            f"the Fast gate never runs on {platform}; the matrix produces "
+            f"{sorted(produced)}. Dropping a platform leg makes every "
+            f"{platform}-only defect invisible until a user reports one -- see "
+            f"`.system_design/TEST_SUITE.md` §8.4."
+        )
+
+    def test_runs_on_reads_the_matrix(self, test_job: dict):
+        """A matrix of platforms is inert unless `runs-on:` defers to it.
+
+        Named separately because the two halves fail independently: a matrix
+        naming three platforms under a hard-coded `runs-on: ubuntu-latest` runs
+        the Linux suite six times and reports three platforms' worth of green.
+        """
+        assert test_job.get("runs-on") == "${{ matrix.os }}", (
+            f"the matrix names platforms but `runs-on:` is "
+            f"{test_job.get('runs-on')!r}, so every leg runs on one machine"
+        )
+
+    def test_every_platform_leg_pins_a_supported_python(self, test_job: dict):
+        """An `include:` leg pins its own version, and it must be one we claim.
+
+        The base matrix is checked against the classifiers by
+        :meth:`TestReleaseIsGatedOnTests.test_matrix_covers_every_supported_python`,
+        which reads the `python-version` list and never sees an include entry.
+        """
+        # Explicitly UTF-8, for the reason `_load_workflow` gives: TOML is
+        # defined as UTF-8, and the platform locale would differ on the very
+        # Windows leg this class exists to add.
+        pyproject = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+        claimed = set(re.findall(r"Programming Language :: Python :: (\d+\.\d+)", pyproject))
+        include = test_job.get("strategy", {}).get("matrix", {}).get("include", [])
+        assert include, "the platform legs are include entries; none were found"
+        for entry in include:
+            pinned = str(entry.get("python-version", ""))
+            assert pinned in claimed, (
+                f"platform leg {entry.get('os')!r} pins Python {pinned!r}, which "
+                f"pyproject.toml does not claim to support ({sorted(claimed)})"
+            )
 
 
 # ── R6: metadata refresh must work under branch protection ────────────────

--- a/tests/test_github_actions.py
+++ b/tests/test_github_actions.py
@@ -533,6 +533,26 @@ class TestThePlatformLegsExist:
                 f"pyproject.toml does not claim to support ({sorted(claimed)})"
             )
 
+    def test_the_matrix_declares_exactly_the_legs_the_design_records(self, test_job: dict):
+        """Six combinations: 4 Linux versions, plus one Windows and one macOS.
+
+        The coverage tests above prove every platform is *present* and would
+        all still pass if somebody added a second `windows-latest` entry on
+        another Python -- the matrix would widen while §8.4's "one Python
+        version per platform" quietly stopped being true. This counts what is
+        DECLARED, deliberately not what GitHub expands it to: the expansion is
+        GitHub's behaviour and the live run is its only honest oracle.
+        """
+        matrix = test_job.get("strategy", {}).get("matrix", {})
+        base = len(matrix.get("os", [])) * len(matrix.get("python-version", []))
+        include = len(matrix.get("include", []))
+
+        assert (base, include) == (4, 2), (
+            f"the matrix declares {base} base combinations and {include} include "
+            f"entries; §8.4 records 4 Linux legs plus one Windows and one macOS. "
+            f"Update the design doc with it, or this count is the wrong one."
+        )
+
 
 # ── R6: metadata refresh must work under branch protection ────────────────
 
@@ -789,6 +809,24 @@ class TestEveryJobVerifiesTheCategoriesItClaims:
             assert "A" in reported or {"f", "E"} <= set(reported), (
                 f"this run passes -r{reported}, which REPLACES pytest's default "
                 f"`fE` and drops the FAILED summary: {command}"
+            )
+
+    def test_the_gate_reports_why_each_test_was_skipped(self):
+        """§8.4's skip visibility, asserted rather than trusted to a comment.
+
+        §8 permits exactly one kind of skip in a gating job -- a platform or
+        interpreter skip -- and the platform legs are what produce them. A
+        silent skip count is how such a leg goes green by running nothing, so
+        the reasons are printed. Without this, a tidy-up dropping ``s`` would
+        degrade the diagnostic without failing anything: the hollow-guard
+        shape this whole class is written against.
+        """
+        for command in _pytest_invocations():
+            reported = "".join(re.findall(r"(?<!-)-r([A-Za-z]+)", command))
+            assert reported, f"this run reports no skip reasons at all: {command}"
+            assert "A" in reported or "s" in reported, (
+                f"this run passes -r{reported}, which never lists a skipped "
+                f"test or its reason: {command}"
             )
 
     def test_each_job_requires_every_layer_its_expression_selects(self):

--- a/tests/test_github_actions.py
+++ b/tests/test_github_actions.py
@@ -125,10 +125,22 @@ class TestCIWorkflow:
         defers to a matrix is left to :class:`TestThePlatformLegsExist`, which
         reads the matrix the expression points at; the exact labels are held by
         `RUNNER_JOB_CEILING_MINUTES` in the review-scripts suite.
+
+        ⚠️ The exemption names the ONE job it is for rather than exempting the
+        shape. `${{ … }}` as a blanket excuse would let any future `ci.yml` job
+        opt out of this check by spelling its runner as an expression, and
+        :class:`TestThePlatformLegsExist` would not catch it -- that class reads
+        `tests.yml`'s `test` job and no other. Naming the job keeps the hole
+        one job wide instead of one *syntax* wide.
         """
         for job_name, job in _resolve_jobs(workflow).items():
             runs_on = str(job.get("runs-on", ""))
             if runs_on.startswith("${{"):
+                assert job_name == "test/test", (
+                    f"job {job_name!r} hides its runner behind an expression; only "
+                    f"the delegated tests.yml matrix may, and only because "
+                    f"TestThePlatformLegsExist reads that matrix directly"
+                )
                 continue
             assert "ubuntu" in runs_on, f"Job '{job_name}' must run on ubuntu"
 
@@ -755,6 +767,29 @@ class TestEveryJobVerifiesTheCategoriesItClaims:
         commands = " || ".join(_pytest_invocations())
 
         assert "--strict-markers" in commands
+
+    def test_the_gate_keeps_its_failure_summary_while_reporting_skips(self):
+        """``-r`` STORES reportchars -- it does not append to them.
+
+        🔴 This guard exists because the obvious spelling shipped and was
+        wrong. §8.4 needs every skip printed with its reason, and ``-rs`` does
+        that while **replacing** pytest's default ``fE`` -- deleting the
+        ``FAILED ...`` summary from the end of a ~3,600-item run. Measured on
+        pytest 9.1.1 with this job's exact command. The skip letter has to be
+        added to the defaults, never substituted for them, and the first
+        spelling survived because nothing checked the claim the comment made.
+        """
+        # `(?<!-)` keeps `--require-category` out of the match: its own `-r`
+        # is preceded by a dash, and without the lookbehind this guard would
+        # read `equire-category=l1` as a set of reportchars.
+        for command in _pytest_invocations():
+            reported = "".join(re.findall(r"(?<!-)-r([A-Za-z]+)", command))
+            if not reported:
+                continue
+            assert "A" in reported or {"f", "E"} <= set(reported), (
+                f"this run passes -r{reported}, which REPLACES pytest's default "
+                f"`fE` and drops the FAILED summary: {command}"
+            )
 
     def test_each_job_requires_every_layer_its_expression_selects(self):
         """The pairing that makes a job's claim about itself checkable.

--- a/tests/tui/test_menu.py
+++ b/tests/tui/test_menu.py
@@ -2,13 +2,38 @@
 
 from __future__ import annotations
 
+from contextlib import contextmanager
 from unittest.mock import MagicMock, patch
 
 from kitty.tui.menu import CheckboxMenu, SelectionMenu
 
 
-def _mock_tty(is_tty: bool = True):
-    return patch("sys.stdin.isatty", return_value=is_tty)
+def _mock_tty(is_tty: bool = True, *, stdout_is_tty: bool | None = None):
+    """Present both standard streams as terminals, or not.
+
+    🔴 Both, since KBR-187. A menu must read keys *and* draw, and patching only
+    stdin made this helper agree with the defect: the guard it exercised could
+    not see a redirected stdout, which is exactly how kitty came to die inside
+    ``prompt_toolkit`` on Windows.
+
+    Args:
+        is_tty: Whether standard input is a terminal.
+        stdout_is_tty: Whether standard output is one. Defaults to ``is_tty``;
+            pass it explicitly to build the asymmetric case that KBR-187 was.
+
+    Returns:
+        A context manager patching both ``isatty`` calls.
+    """
+    out = is_tty if stdout_is_tty is None else stdout_is_tty
+
+    @contextmanager
+    def _both():
+        with patch("sys.stdin.isatty", return_value=is_tty), patch(
+            "sys.stdout.isatty", return_value=out
+        ):
+            yield
+
+    return _both()
 
 
 class TestSelectionMenu:
@@ -36,6 +61,29 @@ class TestSelectionMenu:
         """Returns None immediately on non-TTY; questionary.select is never called."""
         with _mock_tty(False), patch("kitty.tui.menu.questionary") as mock_module:
             result = SelectionMenu("Pick", ["a", "b"]).show()
+        assert result is None
+        mock_module.select.assert_not_called()
+
+    def test_a_redirected_stdout_returns_none_even_when_stdin_looks_interactive(
+        self,
+    ) -> None:
+        """KBR-187: the asymmetric case that crashed kitty on Windows.
+
+        A child spawned with ``stdin=DEVNULL`` and a piped stdout reports an
+        interactive **stdin** on Windows, because ``isatty()`` is true there for
+        any character device and ``NUL`` is one. The old guard read stdin alone,
+        let the menu through, and ``prompt_toolkit`` then raised
+        ``NoConsoleScreenBufferError`` building a screen buffer over the pipe.
+
+        Runs on every platform: the asymmetry is simulated rather than waited
+        for, so the four Linux legs check it too instead of leaving the claim to
+        the one Windows leg.
+        """
+        with _mock_tty(True, stdout_is_tty=False), patch(
+            "kitty.tui.menu.questionary"
+        ) as mock_module:
+            result = SelectionMenu("Pick", ["a", "b"]).show()
+
         assert result is None
         mock_module.select.assert_not_called()
 


### PR DESCRIPTION
Closes [KBR-164](https://shelpuk.atlassian.net/browse/KBR-164). Epic: [KBR-123](https://shelpuk.atlassian.net/browse/KBR-123) — Terminal and platform compatibility.

## Context for the Product Owner

**The problem, in product terms.** Kitty Bridge ships to Windows, macOS and Linux, but every automated check we run has only ever run on **Linux**. That means a defect that only appears on Windows is invisible to us until a customer hits it and tells us. That is not a theory: all three platform bugs on this epic — KBR-1, KBR-4 and **KBR-10** — were found by a person, not by our tests. KBR-10 was a crash on `kitty doctor > diagnostics.txt`, which is the exact command our README tells a user to run when something is wrong. So the one Windows user who could have sent us a diagnostic was the one user whose diagnostic command had crashed.

**What this changes.** The merge gate now runs on **Windows and macOS as well as Linux**, on every pull request and every release. A Windows-only regression now blocks the merge instead of reaching a customer.

**What it costs: nothing.** The ticket was written expecting a large bill, because GitHub charges 2× for Windows minutes and 10× for macOS. That multiplier is a **private**-repository rule. `kitty-bridge` is a **public** repository, and GitHub's own runner reference says it in one sentence: *"Use of the standard GitHub-hosted runners is free and unlimited on public repositories."* Verified against GitHub's live documentation today. The only real cost is wall-clock on a pull request.

**Scope decision you made today.** The ticket body said macOS was out of scope; your PO Decision asked about Windows **and** macOS. Given the zero cost, you chose both, plus the full test suite on one Python version per platform rather than a hand-picked subset. That is what this delivers, and `TEST_SUITE.md` §8.4 records the reasoning so nobody re-opens it later.

**Two things this switches on that have never run even once:**

1. Two tests written specifically for Windows have been skipped in every run in the project's history. They now execute.
2. `mypy` only type-checks the platform it runs on, so **every Windows-specific branch in our source has never been type-checked by anything**. The design doc credits mypy with finding four user-visible defects the tests could not — one of them on a non-Linux OS, found by a human reading code. That check now runs on Windows.

---

## What changed

| File | Change |
|---|---|
| `.github/workflows/tests.yml` | `os` matrix dimension; Windows + macOS legs at Python 3.12; `timeout-minutes` 30 → 60; `-rs` on the pytest invocation |
| `tests/test_github_actions.py` | `test_runs_on_ubuntu` narrowed; new `TestThePlatformLegsExist` (8 tests) |
| `.github/review/tests/test_review_scripts.py` | `macos-latest` ceiling row; one disarmed test repaired |
| `.system_design/TEST_SUITE.md` | new §8.4, and the §8 cadence table |

**No change to `ci.yml`, deliberately.** The legs live inside the reusable `tests.yml`, so they gate a pull request through `ci-required`'s existing `needs: [test, …]` and gate a release through `publish.yml` for free. Adding a second aggregation point is how a required check ends up protecting less than it claims.

### Two decisions worth a reviewer's attention

**`timeout-minutes` 30 → 60.** The comment beside the old `30` claimed *"the suite runs in a couple of minutes"*. It measures **19–20 minutes** — stale by an order of magnitude, leaving ~50% headroom on a leg nobody had timed. 60 clears the slowest platform leg. The cost is stated rather than hidden: a hung **Linux** leg is now noticed 30 minutes later than before. On a free runner that is cheap, and far cheaper than a cap that kills a healthy Windows leg and reads as a product failure. This number will be tightened to the measurement once the first Windows run reports one.

**Adding a runner row silently disarmed a test, and that is called out rather than buried.** `test_one_unrecorded_label_makes_the_whole_matrix_unresolvable` used `macos-latest` as its example of an *unrecorded* runner label. Recording `macos-latest` — which this PR must do — left that test green while it proved nothing, because both of its labels then had ceilings. It now uses a fabricated label no future ticket can adopt, so adding a real runner can never disarm it again.

## How it is tested

The subject is a workflow file, so the evidence is in three layers:

1. **L2 contract tests** — the matrix names three platforms and pins supported Python versions. Cheap, permanent, and what stops a later edit quietly deleting a leg. **Proved red first**: all six workflow-facing assertions failed against the Linux-only matrix before the change.
2. **The reader is proved against fabricated matrices, in both directions.** `_matrix_platforms` returns an *empty set* for a matrix it cannot read, and a "covers every platform" assertion over an empty set passes vacuously — the guard going hollow while staying green. One test pins the empty-read behaviour; another pins that an `include:`-only leg is seen at all, since that is the path both platform legs arrive by.
3. **The live run on this PR** — the only thing that can prove a Windows job actually starts, installs, type-checks and runs the suite. **This is the real deliverable.**

⚠️ **Expect the first platform run to be red.** The ticket says so explicitly and budgets for it: *"Some tests will have latent POSIX assumptions. That is the point; budget for triage rather than treating a red first run as a failed ticket."* Anything it exposes will be fixed here if it is a genuine, small product defect, or filed as its own ticket with a `skipif` naming it. No leg will be made green by skipping quietly — every skip is printed with its reason.

## Note for whoever picks up KBR-152

[KBR-152](https://shelpuk.atlassian.net/browse/KBR-152) is about making `ci-required` an actual required status check on `main`. It is **not** a blocker for this change — the Linux legs do not gate either today, so the new legs reach exactly the parity AC #1 asks for. But this PR **renames the matrix job's checks** (`Python 3.12` → `Python 3.12 on ubuntu-latest`). If KBR-152 is configured before this merges, the required-check names must be re-pinned afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JkxLUaQYgWJq9qVeGZSz7x


[KBR-164]: https://shelpuk.atlassian.net/browse/KBR-164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KBR-123]: https://shelpuk.atlassian.net/browse/KBR-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KBR-152]: https://shelpuk.atlassian.net/browse/KBR-152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ