### PR TITLE
Prove the Milestone 0 contracts compose, not merely exist (KBR-32 / T-W9)

### DIFF
--- a/.system_design/TEST_SUITE.md
+++ b/.system_design/TEST_SUITE.md
@@ -3125,8 +3125,9 @@ business, together with the job that runs them; doing it earlier would remove th
 gate. T-H1 must take that reclassification into account before it measures a mutation
 baseline, because it selects on `l1`.
 
-**Seven modules are bulleted below, and `tests/cli/test_stream_encoding.py` (KBR-10) is described
-after them — eight in all, named here so T-K6 inherits a list rather than a search** — the count
+**Seven modules are bulleted below — in five bullets, since the T-W4 and T-W8 rows name two
+modules each — and `tests/cli/test_stream_encoding.py` (KBR-10) is described after them, eight in
+all, named here so T-K6 inherits a list rather than a search** — the count
 is what T-K6 and T-H1 plan against. (The bullet count and the KBR-10 paragraph were already
 drifting apart before T-W8 added two; spelling out both is what stops the next addition
 guessing which set it joins. T-W9 joins the **bulleted** set, not the paragraph above it, which

--- a/.system_design/TEST_SUITE.md
+++ b/.system_design/TEST_SUITE.md
@@ -3310,6 +3310,20 @@ for the number, across every leg — 3.10–3.13 on Linux plus the pinned Window
 §8.4 added after this module was written — and a platform- or version-dependent failure means
 raising it, never skipping.
 
+**The coarse clock reached this module twice, and only one of them was foreseen.** The second was
+found by the Windows leg itself: `test_the_budget_is_enforced_on_every_driven_request` drove a
+request with an "impossible" budget of literal `0.0`, on the reasoning that zero is over-budget
+for any real request. On Windows `elapsed` measured **exactly** `0.0`, so `0.0 <= 0.0` held and
+the case failed with "DID NOT RAISE" while all five other legs were green. The impossible budget
+is **negative** now, which no measurement can satisfy at any resolution.
+
+Worth separating from the rule two paragraphs above, because the remedy was **not** that rule.
+"A platform-dependent failure means raising the budget, never skipping" governs the **4.0 s**
+budget, whose margin is a judgement about runner speed. This was a different defect: an assertion
+written so that it *could not fire* on a coarse clock. The fix was to make it
+resolution-independent, not to widen a margin — and no §8.3 row was added, because the platform
+dependence was removed rather than amnestied.
+
 **The slice needs no Windows exemption row, and must not acquire one.** §8.3's registry is all
 arrival *ordering*: Windows' clock cannot separate two adjacent requests, so every "arrival
 increases" assertion is false there (KBR-188). This module asserts only that `arrival` is

--- a/.system_design/TEST_SUITE.md
+++ b/.system_design/TEST_SUITE.md
@@ -2865,9 +2865,14 @@ What ships is `time.monotonic()` around each driven request, asserted against a 
 `_EMPTY_RETRY_DELAYS[0]`, so any ladder that sleeps trips it", and that is wrong twice over. Any
 ladder that fires leaves an **extra capture**, so the one-capture assertion sees it first and sees
 it deterministically, with no dependence on a runner's speed. And there are **two ladders, not
-one**: `_EMPTY_RETRY_DELAYS` is read at exactly one site, `_request_with_retry_single` — the
-*non-streaming* helper — while every streaming path sleeps `_BACKOFF_BASE * 2 ** (attempt % 4)`,
-i.e. 1, 2, 4, 8 s, reaching `_EMPTY_FINAL_DELAYS` only on its last two attempts. A streaming
+one**: `_request_with_retry_single` — the *non-streaming* helper — is the only site that
+**sleeps** `_EMPTY_RETRY_DELAYS`, while every streaming path sleeps
+`_BACKOFF_BASE * 2 ** (attempt % 4)`, i.e. 1, 2, 4, 8 s, reaching `_EMPTY_FINAL_DELAYS` only on
+its last two attempts. (Say *sleeps*, not *reads*: one other site reads the list's **length**, to
+report an attempt total. An earlier draft of this paragraph said "read at exactly one site",
+which is simply false about the source tree — and a docstring citing another module's internals
+as an invariant is a failure mode this repo has already been bitten by. It is also why T-W9's
+monkeypatch changes those values and leaves the lengths alone.) A streaming
 ladder can therefore fire **twice inside a 4-second budget**. That fact is recorded here because
 it is non-obvious and the next author will otherwise repeat the mistake.
 
@@ -2918,9 +2923,18 @@ three lines above it. Recorded so the divergence reads as a decision and not as 
 what is worth recording is its result. Each of the recorder's capture fields was mutated in turn
 and the module re-run:
 
-- Ten of eleven mutations were caught by **exactly one** case each — wrong method, scheme, host,
-  headers, body, arrival, a wrong or absent peer port, a dropped query, a percent-decoded query,
-  and a duplicate-collapsing query.
+- **Every** mutation is caught: wrong method, scheme, host, headers, body, arrival, a wrong or
+  absent peer port, and a dropped, percent-decoded or duplicate-collapsing query. Most red
+  exactly one case; a corrupted body reds three, and each query mutation reds two, because the
+  field-completeness case asserts the query alongside the six other fields and the dedicated
+  query case asserts it alone. That overlap is deliberate — one case is "the capture is
+  complete", the other is "routing survives" — but it means the sweep shows *caught*, not
+  *uniquely attributed*. An earlier draft of this paragraph claimed the stronger property, which
+  the sweep's own output contradicts.
+- Mutating `host` to aiohttp's `request.host` kills nothing, and that is an **equivalent
+  mutant** rather than a hole: aiohttp returns the Host header whenever one is present and the
+  bridge always sends one. Simulating the real §7.2.1 defect — the `socket.getfqdn()` fallback —
+  reds exactly one case, which is what makes the `host` row honest.
 - **`path` read percent-decoded killed nothing.** The adapter's own path is `/v1/messages`, which
   contains nothing encoded, so `request.path` and `rel_url.raw_path` are identical on this route
   and §7.2.1's trap was untestable here. The fix was to carry `%20` in the base URL's path

--- a/.system_design/TEST_SUITE.md
+++ b/.system_design/TEST_SUITE.md
@@ -2775,6 +2775,179 @@ saying so here stops a future reader reading it as an unpaid debt.
 
 [KBR-31]: https://shelpuk.atlassian.net/browse/KBR-31
 
+### 7.6 The proven vertical slice
+
+`tests/harness/test_vertical_slice.py` — plan task **T-W9** ([KBR-32]). §7.2 says what a
+recording upstream must observe, §7.5 how the product is put in front of one, and §3.3.1 what a
+projection reads. This is the first place all three are driven **together**: one request from a
+real `BridgeServer`, into the recorder, and out into T-W2's declared types. Small, and it is the
+moment the contracts become known to *compose* rather than merely to exist — six streams build
+on that afterwards.
+
+**Four claims, and the falsification that keeps each honest.**
+
+| Claim | Assertion | The defect it catches |
+|---|---|---|
+| One inbound request, one upstream request | Exactly one capture; inbound status 200 | A fired retry ladder. Scoped against §7.5.4's identical-looking assertion: T-W8's is about **one binding**, this is the product claim for a **driven request** |
+| The capture is complete | Each of T-W2's seven fields at its declared type and wire value; `arrival` and `peer_port` populated | A capture that silently stops carrying §5.2.1's join key, which nothing else would notice until T-E2 |
+| The capture is **readable** | A minimal reader satisfies `Projection`, and `verify_total` passes over what it produces | A capture that type-checks and that no projection can consume — the composition failure this task exists to rule out |
+| The query survives | The capture's `query` equals what the bridge sent, percent-encoding and duplicate names intact | A recorder that drops the query string, driven **end to end** |
+
+**The default binding carries no query, so the falsification had to be made non-vacuous.**
+Measured: `AiohttpTransport.bind()` returns `{"base_url": recorder.base_url}`, and the capture's
+`query` is then `""` — against which a query-dropping recorder passes perfectly. The slice
+therefore drives a binding whose `base_url` carries one, merged onto the adapter's endpoint path
+by `ProviderAdapter.compose_upstream_url` (the KBR-143 rule). That is the **product's own
+channel**, not a patch arranged for the test: a query the harness injected some other way would
+prove the recorder reads `raw_query_string` and nothing about whether the bridge preserves a
+query at all.
+
+**Both properties of the query literal are load-bearing, and an earlier draft had neither.** It is
+`kbr32=slice%20value&dup=1&dup=2`: the `%20` would become `+` under a `parse_qsl`/`urlencode`
+round trip, and `dup` appears **twice** so a recorder that collapses duplicates is
+distinguishable from one that preserves them. A first draft wrote `dup` once, which made the
+duplicate half of the claim untestable — §1.4's shape again, caught in review.
+
+**Byte-for-byte survival is specific to these two adapters.** `compose_upstream_url` *merges*
+when both sides carry a query and drops base parameters whose name the endpoint also uses;
+`custom_anthropic` and `custom_openai` contribute no endpoint query, so the base query survives
+verbatim. The same assertion against Azure would be false, which is why it is stated here rather
+than generalised.
+
+**The transports this module defines are never registered.** They are constructed directly and
+driven, following §7.5.4's rule that a shared registry must not hold things that are wrong on
+purpose. It is also load-bearing for the gate: `test_bridge.py`'s meta-test asserts
+`set(registered_transports()) == EXPECTED_TRANSPORTS`, and registration happens at **import
+time** on module-global state — so a stray `register_transport` here would leave this module
+green on its own and the full suite red. That is an order-dependent failure and a direct hit on
+plan §1.3(5), "it lands on `main` alone".
+
+**The `peer_port` assertion asserts the join, not the type.** §5.2.1 joins captures to tunnels on
+that key, and an `isinstance(..., int)` check passes for a port matching no connection — which is
+precisely the column T-E2 would then be joining against nothing. The slice asserts the capture's
+port is among the ports of the connections the upstream actually accepted.
+
+**§7.2.1's `has_content` claim is discharged here**, because it is the only place it can be. It is
+a local flag inside `BridgeServer._stream_chat_completions`, not a callable, so no unit test
+reaches it; T-W4's streams satisfy its precondition by construction. Driving one `stream: true`
+request end to end and asserting a single capture is the evidence that the flag was set and the
+empty-response retry never fired. Named by symbol, not by line: the plan's `server.py:5145`
+anchor is already stale, and §7.2.1 states this in prose rather than in a table.
+
+**That case asserts the capture count and nothing else, deliberately.** A downstream status
+assertion there would be unfalsifiable: `_stream_chat_completions` commits the 200 with
+`sr.prepare()` before it opens the upstream at all, so every outcome on that route is a 200 —
+measured, a bridge with `has_content` forced false does not answer non-200, it fails to complete.
+An assertion nothing can kill is what §7.5.4 removed from T-W8 and what §1.4 forbids, so it is
+not shipped. The non-streaming case **does** assert the status, where §7.5.4's measured row 3 (an
+upstream 400, one correct capture, a failed client) is reachable and T-W8's `_RefusingTransport`
+is the defect that proves the assertion bites.
+
+It is a claim about one **pair** of axes and not about either alone (§7.5.1): inbound
+`chat_completions` over upstream `CHAT_COMPLETIONS`, streaming.
+
+**A wall-clock bound, and why it is an assertion rather than a timeout.** `_EMPTY_RETRY_DELAYS`
++ `_EMPTY_FINAL_DELAYS` is 80 seconds of real `asyncio.sleep`, and a regression that reintroduces
+the ladder must make the suite **red**, not merely slow — the defect commit `691e974` fixed that
+once already. Three mechanisms were rejected before the one that ships:
+
+- `pytest-timeout` is **not** in the dev extras.
+- `asyncio.timeout` is **3.11+**, and the matrix is 3.10–3.13.
+- `BridgeFixture.post`'s own client timeout **does not bound the slice**. Measured: a `post()`
+  given 2 seconds against a still-sleeping ladder exited its block after **62 seconds**, because
+  `BridgeFixture.stop` waits for in-flight upstream handlers rather than aborting them — §7.5's
+  own documented property, and the reason §7.3 took the opposite decision for the proxy.
+
+What ships is `time.monotonic()` around each driven request, asserted against a **4.0 s** budget:
+200× the measured healthy time (0.01–0.02 s).
+
+**What that budget catches is not "a ladder".** An earlier draft justified it as "strictly below
+`_EMPTY_RETRY_DELAYS[0]`, so any ladder that sleeps trips it", and that is wrong twice over. Any
+ladder that fires leaves an **extra capture**, so the one-capture assertion sees it first and sees
+it deterministically, with no dependence on a runner's speed. And there are **two ladders, not
+one**: `_EMPTY_RETRY_DELAYS` is read at exactly one site, `_request_with_retry_single` — the
+*non-streaming* helper — while every streaming path sleeps `_BACKOFF_BASE * 2 ** (attempt % 4)`,
+i.e. 1, 2, 4, 8 s, reaching `_EMPTY_FINAL_DELAYS` only on its last two attempts. A streaming
+ladder can therefore fire **twice inside a 4-second budget**. That fact is recorded here because
+it is non-obvious and the next author will otherwise repeat the mistake.
+
+The honest division of labour, and the reason all three are kept:
+
+| Mechanism | The band only it covers |
+|---|---|
+| The one-capture assertion | **Any** retry, at any sleep length, deterministically |
+| The 4.0 s budget | **Slow with a single capture** — a connect grace, a wedged handler, a non-ladder regression |
+| `post()`'s `DEFAULT_TIMEOUT` (10 s) | Everything above ten seconds, with a message naming the transport and both ladder costs |
+
+The budget's failure message reports the capture count **first** and says so in words, because the
+gate is ~18.5 minutes on runners this repo has already seen OOM-killed under parallel load: a
+contended runner and a fired ladder must be distinguishable without a rerun. CI across 3.10–3.13
+is the authority for the number; a version-dependent failure means raising it, never skipping.
+
+**The fired ladder is shown, and it is shown on the non-streaming path.** Plan §1.4 requires the
+one-capture assertion to be caught detecting a real ladder rather than passing by construction,
+so the module ships an upstream reply the bridge judges *empty*, with the ladder's delays
+flattened to zero by `monkeypatch`: measured at **five captures in 0.008 s**, deterministic and
+free. It is deliberately **not** done on the streaming path: with `has_content` mutated to never
+become true, the driven request was measured **never completing at all**, so a streaming version
+of this defect would hang the gate rather than fail it. Flattening the delays rather than waiting
+them out is what keeps a falsification case affordable in a gate that already runs ~18.5 minutes
+per Python version.
+
+**The reader is local and minimal, and it is deliberately not T-A1's — which has now landed.**
+T-W9's declared dependencies are T-W1, T-W2, T-W4 and T-W8 and **no reader task** (§7.5.4), and
+that is worth keeping now that `reader_anthropic_messages.py` exists: a slice that went red
+because a reader had a bug would mis-attribute the failure, and the claim here is only that the
+recorder's output is readable **at all** by something shaped like a `Projection`. It is
+correspondingly **not** a `reader_<format>.py` module — §7.4.1 closes that set at six, one per
+`WireFormat` member, and this is evidence rather than a seventh projection. How a format *ought*
+to be projected stays T-A1–T-A6's question.
+
+**`consumed` is built from literal key names, and that is load-bearing.** `verify_total` computes
+`set(source) - (consumed | residual)`, so a reader deriving `consumed = frozenset(source)` passes
+unconditionally — the same shape §1.4 forbids. The deliberate consequence is that a product change
+adding a new top-level key to the upstream body turns the slice **red**, which is the signal worth
+having: an unregistered addition is exactly what §3.2's register exists to catch.
+
+**The falsification cases live in this module rather than a sibling.** T-W4 and T-W8 each split
+theirs out because each ships four or more deliberate defects. T-W9 ships two, and a separate
+60-line module would cost a reader a file hop to reach the defect that falsifies the assertion
+three lines above it. Recorded so the divergence reads as a decision and not as an oversight.
+
+**What the falsification sweep killed, and what it could not.** §1.4 asks for the procedure;
+what is worth recording is its result. Each of the recorder's capture fields was mutated in turn
+and the module re-run:
+
+- Ten of eleven mutations were caught by **exactly one** case each — wrong method, scheme, host,
+  headers, body, arrival, a wrong or absent peer port, a dropped query, a percent-decoded query,
+  and a duplicate-collapsing query.
+- **`path` read percent-decoded killed nothing.** The adapter's own path is `/v1/messages`, which
+  contains nothing encoded, so `request.path` and `rel_url.raw_path` are identical on this route
+  and §7.2.1's trap was untestable here. The fix was to carry `%20` in the base URL's path
+  component too, exactly as the query already did; the mutation then fails the field case. This
+  is the second time in this task that a claim turned out to be vacuous because the *driven
+  request* did not carry the thing the claim was about — the first being the query itself — and
+  it is the argument for running the sweep rather than reasoning about it.
+- **One assertion survived on purpose.** The non-streaming case's `status == 200` is falsified by
+  nothing in this module. It is not redundant — §7.5.4's measured row 3 is an upstream 400, which
+  yields one correct capture and a failed client — and T-W8's `_RefusingTransport` is the defect
+  that proves it bites. Re-shipping that defect here would duplicate T-W8 rather than add
+  evidence, so the assertion is kept with the argument written beside it rather than deleted or
+  left unexplained.
+- **One assertion is weaker than it looks.** `scheme` is built from a recorder *constant*, not
+  from anything on the wire, so asserting `"http"` pins the recorder's own declaration. T-B2's
+  TLS transport is where the field starts carrying information.
+
+**What this task does not settle.** Corpus-wide quantification is **T-D1**'s ([KBR-51]); the
+other five wire formats and the three custom transports are **T-B1–T-B3**'s; non-loopback
+addressing stays with **T-E1**/**T-E2** (§5.3). Bounding fixture *teardown* against a fired
+ladder is real — the 62 seconds above — but aborting in-flight handlers is a change to §7.5's
+module and a decision §7.3 already took for the proxy; it is left to **T-K6** and **T-B4** rather
+than taken here as a side effect.
+
+[KBR-32]: https://shelpuk.atlassian.net/browse/KBR-32
+[KBR-51]: https://shelpuk.atlassian.net/browse/KBR-51
+
 ---
 
 ## 8. CI cadence
@@ -2938,11 +3111,13 @@ business, together with the job that runs them; doing it earlier would remove th
 gate. T-H1 must take that reclassification into account before it measures a mutation
 baseline, because it selects on `l1`.
 
-**Six modules are bulleted below, and `tests/cli/test_stream_encoding.py` (KBR-10) is described
-after them — seven in all, named here so T-K6 inherits a list rather than a search** — the count
+**Seven modules are bulleted below, and `tests/cli/test_stream_encoding.py` (KBR-10) is described
+after them — eight in all, named here so T-K6 inherits a list rather than a search** — the count
 is what T-K6 and T-H1 plan against. (The bullet count and the KBR-10 paragraph were already
 drifting apart before T-W8 added two; spelling out both is what stops the next addition
-guessing which set it joins.)
+guessing which set it joins. T-W9 joins the **bulleted** set, not the paragraph above it, which
+still names `tests/test_egress_https_proxy.py` and `tests/harness/test_connect_proxy.py`
+separately.)
 
 - **KBR-132:** `tests/bridge/test_tls_certs.py` spawns a real `openssl` in one of its five cases.
   KBR-132 deliberately did **not** move it — the rule above applies to a test fixing a skip defect
@@ -2959,6 +3134,14 @@ guessing which set it joins.)
   knowing while planning that move: the timeout case cost **30 seconds** until its responder was
   released explicitly, because `stop_async` waits for in-flight upstream handlers rather than
   aborting them — the same property §7.3 handles deliberately for the proxy.
+- **T-W9 (KBR-32):** `tests/harness/test_vertical_slice.py` starts a real `BridgeServer` and a
+  recorder in nine of its ten cases. The module runs in **~0.5 seconds**, measured (0.42–0.54 s
+  over three runs), which is the number the fast-gate budget should carry until T-K6 moves it.
+  Its falsification cases are deliberately cheap: the empty-response ladder is flattened with
+  `monkeypatch` rather than waited out, because an 80-second falsification case is the defect
+  commit `691e974` fixed once already. Worth knowing while planning the move: when one of its
+  cases goes red on a fired ladder, the *bound* catches the regression but does not bound the
+  cost of catching it — teardown still waits out the in-flight handlers, measured at 62 seconds.
 - **KBR-144:** `tests/bridge/test_responses_string_input.py` starts a real `BridgeServer` on an
   ephemeral port in four of its classes, following the existing convention of
   `tests/bridge/test_crash_resilience.py` rather than inventing a second one. The whole module

--- a/tests/harness/test_vertical_slice.py
+++ b/tests/harness/test_vertical_slice.py
@@ -423,12 +423,24 @@ async def _drive(
     # The capture count is reported first and is the diagnosis, not decoration:
     # the gate runs ~18.5 minutes on contended runners, so "slow" must be
     # distinguishable from "a ladder fired" without a rerun.
-    diagnosis = (
-        "exactly one upstream request, so this is a slow runner and not a retry "
-        "ladder — raise the budget rather than hunting a regression"
-        if len(captures) == 1
-        else f"{len(captures)} upstream requests, so a retry ladder fired"
-    )
+    # Three arms, not two: a retry ladder cannot leave ZERO captures. Zero means
+    # the bridge reached some other upstream, which is §7.5.4's decoy — and a
+    # decoy pointed at a *slow* upstream lands in this assertion's own 4–10 s
+    # band, so the case is reachable rather than theoretical. Reporting it as a
+    # fired ladder would send the reader hunting the wrong regression, and would
+    # contradict `_assert_one_upstream_request`'s own words for the same state.
+    if not captures:
+        diagnosis = (
+            "zero upstream requests, so the bridge reached some other upstream "
+            "entirely and no retry ladder could have fired"
+        )
+    elif len(captures) == 1:
+        diagnosis = (
+            "exactly one upstream request, so this is a slow runner and not a retry "
+            "ladder — raise the budget rather than hunting a regression"
+        )
+    else:
+        diagnosis = f"{len(captures)} upstream requests, so a retry ladder fired"
     assert elapsed <= budget, (
         f"the driven slice took {elapsed:.2f}s, over its {budget}s budget, and the "
         f"upstream saw {diagnosis}. Reference costs: the empty-response ladder is "

--- a/tests/harness/test_vertical_slice.py
+++ b/tests/harness/test_vertical_slice.py
@@ -171,6 +171,14 @@ _UPSTREAM_PATH = f"{_PATH_PREFIX}/v1/messages"
 _EMPTY_LADDER_SECONDS = 80
 _CONNECT_LADDER_SECONDS = 30
 
+#: A budget no measurement can satisfy, for the case that proves :func:`_drive`
+#: applies one at all. **Negative, not zero.** Windows' clock cannot resolve a
+#: fast loopback request, so ``elapsed`` there measures exactly ``0.0`` and a
+#: zero budget is met rather than exceeded — which is how this was found, as a
+#: "DID NOT RAISE" on the Windows leg with every other leg green. An elapsed
+#: time cannot be negative on any platform, so this holds at any resolution.
+_IMPOSSIBLE_BUDGET = -1.0
+
 
 @dataclass
 class _EncodedRouteTransport(AiohttpTransport):
@@ -655,13 +663,25 @@ class TestTheWallClockBound:
 
         This is the §7.5.4 pattern rather than a unit test on a comparison: plan
         §1.4's own list of past harness failures includes "a guard proving a
-        function was *called* when the enforcement was the branch after it". A
-        budget of zero is over-budget for any real request, so what this proves
-        is that :func:`_drive` — the one path every case in this module takes —
-        actually applies it.
+        function was *called* when the enforcement was the branch after it".
+        What this proves is that :func:`_drive` — the one path every case in
+        this module takes — actually applies the budget.
+
+        **The impossible budget is negative, not zero, and that is the Windows
+        leg's doing.** An earlier version passed ``0.0`` and reasoned that zero
+        is over-budget for any real request. It is not: Windows' clock is too
+        coarse to resolve a fast loopback request, so ``elapsed`` measures
+        exactly ``0.0``, ``0.0 <= 0.0`` holds, and the case failed there with
+        "DID NOT RAISE" while every Linux and macOS leg passed. This is the same
+        coarse clock §8.3 carries arrival-ordering exemptions for (KBR-188).
+
+        A negative budget is unsatisfiable at **any** clock resolution, because
+        an elapsed time cannot be below zero. That is what makes this
+        deterministic rather than a bet on the granularity of whichever runner
+        picks it up.
         """
         with pytest.raises(AssertionError) as excinfo:
-            await _drive(AiohttpTransport(WireFormat.ANTHROPIC_MESSAGES), budget=0.0)
+            await _drive(AiohttpTransport(WireFormat.ANTHROPIC_MESSAGES), budget=_IMPOSSIBLE_BUDGET)
 
         message = str(excinfo.value)
         assert "budget" in message

--- a/tests/harness/test_vertical_slice.py
+++ b/tests/harness/test_vertical_slice.py
@@ -103,13 +103,15 @@ from harness.recorder import RecordingUpstream, Reply
 #: **slow with a single capture**: a connect grace period, a wedged handler, a
 #: non-ladder regression. That is a narrow band and it is a real one.
 #:
-#: **There are two ladders, not one, and only one of them uses the named
-#: delays.** ``_EMPTY_RETRY_DELAYS`` is read at exactly one site,
-#: ``_request_with_retry_single`` — the *non-streaming* helper. Every streaming
-#: path sleeps ``_BACKOFF_BASE * 2 ** (attempt % 4)``, i.e. 1, 2, 4, 8 s, and
-#: reaches ``_EMPTY_FINAL_DELAYS`` only on its last two attempts. So a streaming
-#: ladder can fire twice inside this budget. The capture count is what catches
-#: that, which is the whole reason both assertions are kept.
+#: **There are two ladders, not one, and only one of them sleeps the named
+#: delays.** ``_request_with_retry_single`` — the *non-streaming* helper — is the
+#: only site that **sleeps** ``_EMPTY_RETRY_DELAYS``. (One other site reads its
+#: *length*, to report an attempt total; that is why R7.2's monkeypatch changes
+#: the values and leaves the lengths alone.) Every streaming path sleeps
+#: ``_BACKOFF_BASE * 2 ** (attempt % 4)``, i.e. 1, 2, 4, 8 s, and reaches
+#: ``_EMPTY_FINAL_DELAYS`` only on its last two attempts. So a streaming ladder
+#: can fire twice inside this budget. The capture count is what catches that,
+#: which is the whole reason both assertions are kept.
 #:
 #: **Above ten seconds this never fires**, because ``BridgeFixture.post``'s own
 #: ``DEFAULT_TIMEOUT`` raises :class:`~harness.bridge.TransportTimeout` first —
@@ -225,7 +227,13 @@ class _QueryDroppingTransport(_EncodedRouteTransport):
     name = "slice-query-dropping"
 
     def __post_init__(self) -> None:
-        """Use the query-dropping recorder instead of the real one."""
+        """Use the query-dropping recorder instead of the real one.
+
+        Deliberately **replaces** the base's construction rather than extending
+        it — calling ``super()`` first would build a correct recorder and throw
+        it away. The arguments are the base's, so anything
+        ``AiohttpTransport.__post_init__`` gains later must be mirrored here.
+        """
         self._recorder = _QueryDroppingRecorder(default_format=self.format, responder=self.responder)
 
 
@@ -323,7 +331,6 @@ class _Slice:
 
     Attributes:
         status: The status the bridge answered the agent with.
-        text: The raw reply body.
         captures: What reached the upstream, in arrival order.
         sent: The marker this request carried, so a caller cannot assert against
             a different one than it sent.
@@ -333,7 +340,6 @@ class _Slice:
     """
 
     status: int
-    text: str
     captures: list[CapturedRequest]
     sent: str
     authority: str
@@ -372,7 +378,7 @@ async def _drive(
         # once it has stopped, and the connection log is the transport's.
         authority = f"{subject.recorder.host}:{subject.recorder.port}"
         started = time.monotonic()
-        status, text = await fixture.post(
+        status, _text = await fixture.post(
             inbound_path(route, stream=stream),
             minimal_inbound_body(route, sent, stream=stream),
         )
@@ -396,7 +402,6 @@ async def _drive(
     )
     return _Slice(
         status=status,
-        text=text,
         captures=captures,
         sent=sent,
         authority=authority,

--- a/tests/harness/test_vertical_slice.py
+++ b/tests/harness/test_vertical_slice.py
@@ -1,0 +1,726 @@
+"""The proven vertical slice: one request, bridge fixture to recorder to contract.
+
+`.system_design/TEST_SUITE.md` §6.3.1, §7.2.1, §7.5.4, §7.6 · plan task **T-W9**
+(KBR-32) · `.requirements/20260912T104328Z_proven_vertical_slice/REQUIREMENTS.md`.
+
+Milestone 0 built three contracts and tested each **alone**: T-W2's capture and
+projection types, T-W4's recording upstream, T-W8's bridge fixture. Nothing yet
+drove a request through all three. This module does, and it is the first moment
+the contracts are known to *compose* rather than merely to exist — six streams
+build on that afterwards.
+
+Four claims, plus the three obligations T-W4 and T-W8 could not discharge
+because neither starts a real :class:`~kitty.bridge.server.BridgeServer`:
+
+======================================  =========================================
+Claim                                   Why only a driven bridge can show it
+======================================  =========================================
+Exactly one upstream request            A *second* capture is the only real
+                                        evidence the empty-response retry ladder
+                                        never fired
+The capture satisfies T-W2's types      The recorder's output must be what a
+                                        projection expects to read
+A projection can actually read it       Type-compatible and *readable* are
+                                        different claims; only the second
+                                        composes
+The query string survives               §3.3.5: on Azure the query carries the
+                                        API version, so a lost query makes two
+                                        routes indistinguishable
+``has_content`` (§7.2.1)                A local flag in the streaming loop, not a
+                                        callable — unreachable except by driving
+                                        a bridge
+A wall-clock bound                      80 s of real sleep must fail the suite,
+                                        not merely slow it (commit ``691e974``)
+======================================  =========================================
+
+**Falsification (plan §1.4).** Two deliberate defects run here: a recorder that
+drops the query string, and an upstream reply the bridge judges empty. T-W4
+ships its **own** query-drop case against the recorder in isolation
+(``DroppedQueryRecorder`` in ``test_recorder_falsification.py``); plan §3 says
+the two must not be collapsed, so this one defines its own defect and drives a
+real bridge with it. Defining rather than importing follows T-W8, whose
+``_BlindRecorder`` is a local copy for the same reason.
+
+**The transports defined here are never registered.** They are constructed
+directly and handed to :func:`_drive`, following §7.5.4's own rule that a shared
+registry must not hold things that are wrong on purpose. It is also load-bearing
+for the gate: ``test_bridge.py``'s meta-test asserts
+``set(registered_transports()) == EXPECTED_TRANSPORTS``, and registration happens
+at **import time** on module-global state — so a stray ``register_transport``
+here would leave this module green on its own and the full suite red, which is
+an order-dependent failure and a direct hit on plan §1.3(5).
+
+**Layer.** No ``pytestmark``, so these take the ``l1`` path default, following
+T-W4 and T-W8. The reason is §8.2's and only §8.2's: ``l3`` is in
+``PENDING_ACTIVATION_LAYERS``, so an ``l3`` marker today would leave the slice
+checked by no job at all. §8.2 names this module so T-K6 inherits a list.
+
+**Evidence base.** Every number quoted here was measured on Python 3.12.3. CI
+across 3.10–3.13 is the authority; a version-dependent timing failure means
+raising :data:`_SLICE_BUDGET_SECONDS`, never skipping a case.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass, replace
+from typing import Any
+
+import pytest
+from aiohttp import web
+
+from harness.bridge import (
+    AiohttpTransport,
+    Binding,
+    BridgeFixture,
+    InboundProtocol,
+    inbound_path,
+    marker,
+    minimal_inbound_body,
+    protocol_for,
+)
+from harness.contract import (
+    CapturedRequest,
+    Conversation,
+    Envelope,
+    Projection,
+    Request,
+    Text,
+    Turn,
+    WireFormat,
+    verify_total,
+)
+from harness.recorder import RecordingUpstream, Reply
+
+#: The wall-clock ceiling on one driven request, 200× the healthy time measured
+#: against ``main`` (0.01–0.02 s).
+#:
+#: **What this catches that the capture count does not.** Not "a ladder that
+#: sleeps" — an earlier draft claimed that and it is wrong. Any ladder that fires
+#: leaves an extra capture, so :func:`_assert_one_upstream_request` sees it
+#: first and sees it deterministically. What is left for a wall-clock bound is
+#: **slow with a single capture**: a connect grace period, a wedged handler, a
+#: non-ladder regression. That is a narrow band and it is a real one.
+#:
+#: **There are two ladders, not one, and only one of them uses the named
+#: delays.** ``_EMPTY_RETRY_DELAYS`` is read at exactly one site,
+#: ``_request_with_retry_single`` — the *non-streaming* helper. Every streaming
+#: path sleeps ``_BACKOFF_BASE * 2 ** (attempt % 4)``, i.e. 1, 2, 4, 8 s, and
+#: reaches ``_EMPTY_FINAL_DELAYS`` only on its last two attempts. So a streaming
+#: ladder can fire twice inside this budget. The capture count is what catches
+#: that, which is the whole reason both assertions are kept.
+#:
+#: **Above ten seconds this never fires**, because ``BridgeFixture.post``'s own
+#: ``DEFAULT_TIMEOUT`` raises :class:`~harness.bridge.TransportTimeout` first —
+#: deliberately left alone, since that error already names the transport, the
+#: elapsed time and both ladder costs, which is a better diagnostic than a
+#: budget message.
+#:
+#: Asserted with :func:`time.monotonic`: ``pytest-timeout`` is not in the dev
+#: extras and ``asyncio.timeout`` is 3.11+ against a 3.10–3.13 matrix. CI across
+#: all four versions is the authority for this number — a version-dependent
+#: failure means raising it, never skipping the case.
+_SLICE_BUDGET_SECONDS = 4.0
+
+#: The query the driven request carries upstream. Both properties are load-bearing
+#: and an earlier draft had neither: ``%20`` would become ``+`` under a
+#: ``parse_qsl``/``urlencode`` round trip (``providers/base.py`` says so), and
+#: ``dup`` appears **twice** so a recorder that collapses duplicates is
+#: distinguishable from one that preserves them. A plain ``a=b`` exercises
+#: neither, which is the shape plan §1.4 objects to.
+#:
+#: **Byte-for-byte survival is specific to these adapters.**
+#: ``compose_upstream_url`` *merges* when both sides carry a query and drops base
+#: parameters whose name the endpoint also uses; ``custom_anthropic`` and
+#: ``custom_openai`` contribute no endpoint query, so here the base query
+#: survives verbatim. The same assertion against Azure would be false.
+_QUERY = "kbr32=slice%20value&dup=1&dup=2"
+
+#: A percent-encoded prefix on the upstream path, for the same reason the query
+#: carries ``%20``. §7.2.1 names ``raw_path`` and ``raw_query_string`` as the two
+#: percent-decoding traps, and the adapter's own path (``/v1/messages``) contains
+#: nothing encoded — so without this, a recorder reading ``request.path`` instead
+#: of ``rel_url.raw_path`` is **indistinguishable** from a correct one. Found by
+#: running the mutation sweep against this module and getting nothing red.
+#:
+#: It survives because ``compose_upstream_url`` prepends the base URL's path
+#: component to the endpoint's, and the recorder dispatches its reply format on
+#: the path **suffix**, which the prefix leaves intact.
+_PATH_PREFIX = "/kbr32%20prefix"
+
+#: The upstream path the driven Anthropic Messages request lands on.
+_UPSTREAM_PATH = f"{_PATH_PREFIX}/v1/messages"
+
+#: The two reference costs a budget failure cites, so a reader can tell a fired
+#: ladder from a slow machine without a rerun. §7.2.1's own numbers.
+_EMPTY_LADDER_SECONDS = 80
+_CONNECT_LADDER_SECONDS = 30
+
+
+@dataclass
+class _EncodedRouteTransport(AiohttpTransport):
+    """A transport whose binding carries an encoded path prefix and a query.
+
+    The default binding is ``{"base_url": recorder.base_url}``: the capture's
+    query is then ``""`` and its path is the adapter's bare ``/v1/messages``.
+    Against that, both a query-dropping recorder **and** a path-decoding one pass
+    perfectly — measured, and the second was found only by running the mutation
+    sweep. A claim is only non-vacuous if the driven request carries the thing
+    the claim is about.
+
+    Both travel through the **product's own channel**:
+    ``provider_config["base_url"]`` carries them and
+    :meth:`~kitty.providers.base.ProviderAdapter.compose_upstream_url` composes
+    them with the adapter's endpoint path (the KBR-143 rule). Injecting either
+    another way would prove the recorder reads ``raw_path`` and
+    ``raw_query_string`` and nothing about whether the bridge preserves them.
+    """
+
+    name = "slice-encoded-route"
+
+    def bind(self) -> Binding:
+        """Return a binding carrying :data:`_PATH_PREFIX` and :data:`_QUERY`.
+
+        Returns:
+            The adapter this transport's format calls for, pointed at the
+            recorder with an encoded path prefix and a query string attached.
+        """
+        adapter, config = super().bind()
+        return adapter, {**config, "base_url": f"{config['base_url']}{_PATH_PREFIX}?{_QUERY}"}
+
+
+class _QueryDroppingRecorder(RecordingUpstream):
+    """A recorder that observes the query and keeps none of it.
+
+    :meth:`~harness.recorder.RecordingUpstream.capture` is T-W4's seam for a
+    deliberate defect: overriding it disturbs what was captured without touching
+    the connection log or the recorded ordering, so the failure is attributable
+    to one assertion.
+    """
+
+    def capture(self, request: web.BaseRequest, body: bytes, arrival: float) -> CapturedRequest:
+        """Return the capture with its query string removed.
+
+        Args:
+            request: The inbound aiohttp request.
+            body: The entity body, already read.
+            arrival: The timestamp taken at handler entry.
+
+        Returns:
+            The deliberately wrong capture.
+        """
+        return replace(super().capture(request, body, arrival), query="")
+
+
+@dataclass
+class _QueryDroppingTransport(_EncodedRouteTransport):
+    """Carries a query upstream and records none of it.
+
+    Subclasses the encoded-route transport rather than the plain one: a defect
+    that drops something never sent would be undetectable, and a case that
+    cannot fail is what plan §1.4 objects to.
+    """
+
+    name = "slice-query-dropping"
+
+    def __post_init__(self) -> None:
+        """Use the query-dropping recorder instead of the real one."""
+        self._recorder = _QueryDroppingRecorder(default_format=self.format, responder=self.responder)
+
+
+class MessagesReader:
+    """The smallest thing shaped like a :class:`~harness.contract.Projection`.
+
+    Deliberately **not** ``harness.reader_anthropic_messages``, which T-A1
+    (KBR-33) landed while this task was being written. T-W9's declared
+    dependencies are T-W1, T-W2, T-W4 and T-W8 and **no reader task** (§7.5.4),
+    and that is worth keeping now that a reader exists: a slice that went red
+    because a reader had a bug would mis-attribute the failure, and the claim
+    under test is only that a recorder's capture is readable **at all** by
+    something shaped like a projection. This is therefore deliberately not a
+    ``reader_<format>.py`` module either — §7.4.1 closes that set at **six**,
+    one per :class:`~harness.contract.WireFormat` member, and this is evidence
+    rather than a seventh projection. How Anthropic Messages *ought* to be
+    projected is T-A1's question and is answered in T-A1's own tests.
+
+    ``consumed`` is built from **literal** key names. Deriving it as
+    ``frozenset(source)`` would make :func:`~harness.contract.verify_total`
+    pass unconditionally, which is the assertion-nothing-can-kill shape. The
+    deliberate consequence: if the bridge ever adds a new top-level key to the
+    upstream body, this slice goes red — which is the signal worth having, since
+    an unregistered addition is exactly what §3.2's register exists to catch.
+
+    Attributes:
+        wire_format: The format this reader claims, as the protocol requires.
+    """
+
+    wire_format = WireFormat.ANTHROPIC_MESSAGES
+
+    def read_request(self, captured: CapturedRequest) -> Request:
+        """Project a captured Anthropic Messages request.
+
+        Args:
+            captured: The request as observed on the wire.
+
+        Returns:
+            The wire-independent projection, with every top-level body key
+            accounted for in ``consumed`` so that
+            :func:`~harness.contract.verify_total` is a real check rather than a
+            formality.
+        """
+        body: dict[str, Any] = json.loads(captured.body)
+
+        # One turn per message, each carrying its text. The minimal inbound body
+        # sends a plain string, which is the only content shape this must read.
+        turns = tuple(Turn(role=m["role"], parts=(Text(m["content"]),)) for m in body["messages"])
+
+        # Sampling keys are closed (§3.3.1b), so only the ones this body can
+        # carry are lifted; anything else would raise rather than pass silently.
+        sampling = {key: body[key] for key in ("max_tokens", "temperature") if key in body}
+
+        return Request(
+            envelope=Envelope(model=body.get("model"), stream=body.get("stream")),
+            conversation=Conversation(turns=turns, sampling=sampling),
+            consumed=frozenset({"model", "messages", "stream", *sampling}),
+            source=body,
+        )
+
+
+async def _empty_reply(captured: CapturedRequest, reply: Reply) -> None:
+    """Answer 200 with a well-formed Anthropic Messages body carrying no content.
+
+    Well-formed on purpose. A malformed or unparseable body is a loud failure
+    down a different path; what fires the empty-response ladder is a reply the
+    bridge parses happily and judges contentless.
+
+    Args:
+        captured: The capture, unused.
+        reply: The unprepared response.
+    """
+    payload = json.dumps(
+        {
+            "id": "msg_empty",
+            "type": "message",
+            "role": "assistant",
+            "model": "recorder-model",
+            "content": [],
+            "stop_reason": "end_turn",
+        }
+    ).encode()
+    await reply.begin(200, {"content-type": "application/json", "content-length": str(len(payload))})
+    await reply.write(payload)
+
+
+@dataclass(frozen=True)
+class _Slice:
+    """What one driven request produced.
+
+    A record rather than a tuple because the upstream authority is only readable
+    **while the transport is running** — a caller that reads
+    ``transport.recorder.port`` after the fixture has torn down gets a
+    ``RuntimeError``, which is how this field came to exist.
+
+    Attributes:
+        status: The status the bridge answered the agent with.
+        text: The raw reply body.
+        captures: What reached the upstream, in arrival order.
+        sent: The marker this request carried, so a caller cannot assert against
+            a different one than it sent.
+        authority: The upstream's ``host:port``, read before teardown.
+        peer_ports: The peer port of every connection the upstream accepted,
+            read before teardown. §5.2.1 joins captures to tunnels on this.
+    """
+
+    status: int
+    text: str
+    captures: list[CapturedRequest]
+    sent: str
+    authority: str
+    peer_ports: set[int | None]
+
+
+async def _drive(
+    subject: AiohttpTransport,
+    *,
+    stream: bool = False,
+    budget: float = _SLICE_BUDGET_SECONDS,
+) -> _Slice:
+    """Drive one request end to end and return what the upstream saw.
+
+    The wall-clock bound is enforced **here**, so no case in this module can
+    silently cost the gate 80 seconds; a separate test proves this function
+    enforces it, which is the §7.5.4 pattern — a guard that only proves a check
+    exists does not prove anything calls it.
+
+    Args:
+        subject: An unstarted transport. Started and stopped by this function.
+        stream: Whether to ask the bridge for a streamed reply.
+        budget: The wall-clock ceiling on the request, in seconds.
+
+    Returns:
+        The record of the driven request.
+
+    Raises:
+        AssertionError: When the request outlived ``budget``.
+    """
+    route = protocol_for(subject.format)
+    sent = marker()
+
+    async with BridgeFixture(subject) as fixture:
+        # Both read while the transport is still running: `recorder.port` raises
+        # once it has stopped, and the connection log is the transport's.
+        authority = f"{subject.recorder.host}:{subject.recorder.port}"
+        started = time.monotonic()
+        status, text = await fixture.post(
+            inbound_path(route, stream=stream),
+            minimal_inbound_body(route, sent, stream=stream),
+        )
+        elapsed = time.monotonic() - started
+        captures = list(subject.captures)
+        peer_ports = {connection.peer_port for connection in subject.connections}
+
+    # The capture count is reported first and is the diagnosis, not decoration:
+    # the gate runs ~18.5 minutes on contended runners, so "slow" must be
+    # distinguishable from "a ladder fired" without a rerun.
+    diagnosis = (
+        "exactly one upstream request, so this is a slow runner and not a retry "
+        "ladder — raise the budget rather than hunting a regression"
+        if len(captures) == 1
+        else f"{len(captures)} upstream requests, so a retry ladder fired"
+    )
+    assert elapsed <= budget, (
+        f"the driven slice took {elapsed:.2f}s, over its {budget}s budget, and the "
+        f"upstream saw {diagnosis}. Reference costs: the empty-response ladder is "
+        f"~{_EMPTY_LADDER_SECONDS}s and an unreachable upstream ~{_CONNECT_LADDER_SECONDS}s"
+    )
+    return _Slice(
+        status=status,
+        text=text,
+        captures=captures,
+        sent=sent,
+        authority=authority,
+        peer_ports=peer_ports,
+    )
+
+
+def _assert_one_upstream_request(driven: _Slice) -> None:
+    """Assert the driven request produced exactly one upstream request.
+
+    A function rather than an inline assertion in each case, because the
+    falsification case below must exercise **this** assertion and not a copy of
+    it. A copy is an assertion no defect can kill: editing the real one would
+    leave the falsification passing against text that no longer ships.
+
+    Args:
+        driven: The record of a driven request.
+
+    Raises:
+        AssertionError: When the upstream saw any number of requests but one.
+    """
+    assert len(driven.captures) == 1, (
+        f"one inbound request produced {len(driven.captures)} upstream request(s); "
+        f"more than one means the empty-response retry ladder fired, and zero means "
+        f"the bridge reached some other upstream entirely and every assertion built "
+        f"on this fixture would be quantified over nothing"
+    )
+
+
+def _assert_query_survived(driven: _Slice) -> None:
+    """Assert the upstream saw the query string the bridge was pointed at.
+
+    Shared with the falsification case for the reason
+    :func:`_assert_one_upstream_request` records.
+
+    Args:
+        driven: The record of a driven request.
+
+    Raises:
+        AssertionError: When the captured query is not the one that was sent.
+    """
+    assert driven.captures[0].query == _QUERY, (
+        f"the upstream saw query {driven.captures[0].query!r}, not {_QUERY!r}; "
+        f"§3.3.5 puts routing in the request, so a lost or re-encoded query makes "
+        f"two different routes indistinguishable"
+    )
+
+
+# -- R1, R5 — one request in, one request out --------------------------------
+
+
+class TestOneRequestInOneRequestOut:
+    """The product claim T-W8's conformance check deliberately does not make."""
+
+    async def test_a_driven_request_reaches_the_upstream_exactly_once(self) -> None:
+        """One inbound request leaves exactly one capture, and the client is served.
+
+        §7.5.4 scopes T-W8's identical-looking assertion to the one binding its
+        conformance check drives, because a check tolerating a retry ladder
+        could not tell a working binding from a broken one. This is the product
+        claim for a driven request; quantifying it over the corpus is T-D1's.
+        """
+        driven = await _drive(AiohttpTransport(WireFormat.ANTHROPIC_MESSAGES))
+
+        _assert_one_upstream_request(driven)
+
+        # Not redundant with the count, and not falsifiable by anything in this
+        # module: §7.5.4's measured row 3 is an upstream 400, which produces one
+        # correct capture and a failed client. T-W8's `_RefusingTransport` is the
+        # defect that proves this assertion bites; re-shipping it here would
+        # duplicate that case rather than add evidence.
+        assert driven.status == 200
+
+    async def test_a_chat_completions_stream_never_retries(self) -> None:
+        """A streamed request is answered once, which is the ``has_content`` cell.
+
+        §7.2.1 records which judgement guards which reply shape, and every one
+        has T-W4-side evidence except this: ``has_content`` is a local flag
+        inside ``BridgeServer._stream_chat_completions``, not a callable, so no
+        unit test reaches it and T-W4's streams satisfy its precondition by
+        construction. A single capture here is the evidence that the flag was
+        set and the empty-response retry never fired. (Named by symbol, not by
+        line: the plan's ``server.py:5145`` anchor is already stale.)
+
+        This is a claim about one **pair** of axes and not about either alone
+        (§7.5.1): inbound ``chat_completions`` over upstream
+        ``CHAT_COMPLETIONS``, streaming. ``has_content`` exists only on that
+        pass-through loop.
+        """
+        driven = await _drive(AiohttpTransport(WireFormat.CHAT_COMPLETIONS), stream=True)
+
+        # A second capture here means `has_content` stayed false and the
+        # empty-response retry fired on a stream that did carry content.
+        #
+        # The capture count is the ONLY assertion this case can make. A status
+        # check would be unfalsifiable: `_stream_chat_completions` commits the
+        # downstream 200 with `sr.prepare()` before it opens the upstream at
+        # all, so every outcome on this route is a 200 — measured, a bridge with
+        # `has_content` forced false does not answer non-200, it never completes.
+        _assert_one_upstream_request(driven)
+
+
+# -- R2 — the capture satisfies T-W2's declared contract ---------------------
+
+
+class TestTheCaptureSatisfiesTheContract:
+    """Every field T-W2 declares, at its declared type and its wire value."""
+
+    async def test_the_capture_carries_every_contract_field(self) -> None:
+        """The seven contract fields each hold their declared type and wire value.
+
+        Type-compatibility is the half of T-W9 that makes the recorder's output
+        usable by a projection at all. Asserting the values as well as the types
+        is what stops a recorder satisfying this with seven well-typed blanks.
+        """
+        driven = await _drive(_EncodedRouteTransport(WireFormat.ANTHROPIC_MESSAGES))
+        captured = driven.captures[0]
+
+        assert isinstance(captured, CapturedRequest)
+        assert captured.method == "POST"
+
+        # The recorder's declared scheme, not something read off the wire — it
+        # is a plain-HTTP loopback double. T-B2's TLS transport is where this
+        # field starts carrying information.
+        assert captured.scheme == "http"
+        # The Host header the bridge sent, never `request.host`, which invents
+        # the build machine's name when the header is absent (§7.2.1).
+        assert captured.host == driven.authority
+        # Read from `rel_url.raw_path`, never `request.path`: the prefix carries
+        # a `%20`, so a percent-decoding recorder is distinguishable here.
+        assert captured.path == _UPSTREAM_PATH
+        assert captured.query == _QUERY
+        assert isinstance(captured.body, bytes)
+        assert driven.sent.encode() in captured.body
+
+        # A non-empty sequence of `(str, str)` pairs and never a mapping, which
+        # is the shape §4.3 C1's exact-header-set assertion needs. Whether
+        # duplicates and casing survive is T-W4's conformance check's claim, not
+        # this one's: the bridge sends no duplicate header on this route, so a
+        # duplicate assertion here would be untestable.
+        assert captured.headers
+        assert all(isinstance(name, str) and isinstance(value, str) for name, value in captured.headers)
+
+    async def test_the_capture_carries_the_connection_join_key(self) -> None:
+        """``arrival`` and ``peer_port`` are populated and correctly typed.
+
+        They are T-W4's to populate and §5.2.1's to consume — the join key
+        against the proxy's tunnel log. No fidelity assertion reads them, so a
+        capture that silently stopped carrying them would otherwise go unnoticed
+        until T-E2 tried to join on a column of ``None``.
+
+        The port is asserted to **join**, not merely to be an ``int``: a type
+        check passes for a port matching no connection, which is the column T-E2
+        would then be joining against nothing.
+        """
+        driven = await _drive(AiohttpTransport(WireFormat.ANTHROPIC_MESSAGES))
+        captured = driven.captures[0]
+
+        assert isinstance(captured.arrival, float)
+        assert captured.peer_port in driven.peer_ports, (
+            f"the capture's peer port {captured.peer_port!r} matches none of the "
+            f"upstream's accepted connections {sorted(driven.peer_ports, key=str)}; "
+            f"§5.2.1 joins captures to tunnels on exactly this key"
+        )
+
+
+# -- R3 — the capture is readable, not merely well-typed ---------------------
+
+
+class TestTheCaptureIsReadable:
+    """The composition claim: a projection can consume what the recorder made."""
+
+    async def test_a_projection_reads_the_capture_totally(self) -> None:
+        """A minimal reader projects the capture with nothing dropped or residual.
+
+        Type-compatible and *readable* are different claims and only the second
+        composes. :func:`~harness.contract.verify_total` is what makes this a
+        real check: a reader that silently ignored a body key would leave the
+        residual empty, so "the residual is empty" would pass it.
+        """
+        reader = MessagesReader()
+        driven = await _drive(AiohttpTransport(WireFormat.ANTHROPIC_MESSAGES))
+
+        # Member *presence* only — `contract.py` says so itself, and a protocol
+        # `isinstance` never checks signatures. The real evidence is the two
+        # lines below: the capture is read, and read totally.
+        assert isinstance(reader, Projection)
+
+        projected = reader.read_request(driven.captures[0])
+        verify_total(projected)
+
+        # The user's own text survived the whole slice, which is what makes this
+        # a fidelity claim rather than a parse that happened not to raise.
+        assert [part.text for turn in projected.conversation.turns for part in turn.parts] == [driven.sent]
+
+
+# -- R4 — the query string survives ------------------------------------------
+
+
+class TestTheQueryStringSurvives:
+    """§3.3.5: routing lives in the request, and the body cannot show it."""
+
+    async def test_the_query_string_survives_the_slice(self) -> None:
+        """The capture's query is what the bridge sent, encoding and order intact.
+
+        Read from ``raw_query_string`` (§7.2.1), so the percent-encoding and the
+        duplicate parameter name in :data:`_QUERY` both survive. On Azure the
+        query carries the API version while the path carries the deployment, and
+        P6 removes ``model`` from the body — so two different routes with a lost
+        query are indistinguishable.
+        """
+        driven = await _drive(_EncodedRouteTransport(WireFormat.ANTHROPIC_MESSAGES))
+
+        _assert_query_survived(driven)
+
+
+# -- R6 — the wall-clock bound -----------------------------------------------
+
+
+class TestTheWallClockBound:
+    """The bound is enforced on every driven request, not merely defined."""
+
+    async def test_the_budget_is_enforced_on_every_driven_request(self) -> None:
+        """A request over budget fails, and the failure names the ladder costs.
+
+        This is the §7.5.4 pattern rather than a unit test on a comparison: plan
+        §1.4's own list of past harness failures includes "a guard proving a
+        function was *called* when the enforcement was the branch after it". A
+        budget of zero is over-budget for any real request, so what this proves
+        is that :func:`_drive` — the one path every case in this module takes —
+        actually applies it.
+        """
+        with pytest.raises(AssertionError) as excinfo:
+            await _drive(AiohttpTransport(WireFormat.ANTHROPIC_MESSAGES), budget=0.0)
+
+        message = str(excinfo.value)
+        assert "budget" in message
+        assert str(_EMPTY_LADDER_SECONDS) in message
+
+
+# -- R7 — falsification (plan §1.4) ------------------------------------------
+
+
+class TestTheDefectsAreCaught:
+    """Two deliberate defects, each of which the slice must detect."""
+
+    async def test_a_query_dropping_recorder_fails_the_slice(self) -> None:
+        """A recorder that drops the query fails the end-to-end query claim.
+
+        T-W4 ships its own query-drop case against the recorder **in isolation**
+        (``DroppedQueryRecorder``). Plan §3 says the two must not be collapsed:
+        that one proves the recorder reads the field, this one proves the claim
+        survives a real bridge in front of it — which is the only version that
+        could catch the bridge dropping the query before the recorder ever saw
+        it.
+        """
+        driven = await _drive(_QueryDroppingTransport(WireFormat.ANTHROPIC_MESSAGES))
+
+        # The defect must have taken effect, or this case proves nothing.
+        assert driven.captures[0].query == ""
+
+        # The **shipped** assertion, run against the defect — not a copy of it.
+        with pytest.raises(AssertionError) as excinfo:
+            _assert_query_survived(driven)
+
+        assert _QUERY in str(excinfo.value)
+
+    async def test_a_fired_ladder_leaves_more_than_one_capture(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An empty upstream reply fires the ladder, breaking the one-capture claim.
+
+        Without this, "exactly one capture" could be an assertion that passes by
+        construction. The delays are flattened rather than waited out: the ladder
+        is 80 seconds of real sleep, and a falsification case that cost the gate
+        80 seconds is the defect commit ``691e974`` fixed once already. What is
+        under test is that the ladder **fired**, which the capture count shows
+        and the sleeping does not.
+
+        This drives R1's own pair — inbound ``messages`` over upstream
+        ``ANTHROPIC_MESSAGES``, non-streaming — which is what makes it a
+        falsification of R1 rather than of some neighbouring path. That route
+        reaches ``_request_with_retry_single``, the one site that reads
+        ``_EMPTY_RETRY_DELAYS``, which is why patching those two lists bites at
+        all. Measured with the delays flattened: five captures in 0.008 s.
+
+        **Values flattened, lengths unchanged.** ``max_attempts`` is computed as
+        ``len(_EMPTY_RETRY_DELAYS) + len(_EMPTY_FINAL_DELAYS) + 1``, so an empty
+        list would collapse the ladder to a single attempt and the defect would
+        stop being a defect.
+
+        Args:
+            monkeypatch: Pytest's monkeypatch fixture, which reverts the delays.
+        """
+        monkeypatch.setattr("kitty.bridge.server._EMPTY_RETRY_DELAYS", [0.0, 0.0])
+        monkeypatch.setattr("kitty.bridge.server._EMPTY_FINAL_DELAYS", [0.0, 0.0])
+
+        subject = AiohttpTransport(WireFormat.ANTHROPIC_MESSAGES, responder=_empty_reply)
+        driven = await _drive(subject)
+
+        # The defect must have taken effect, or this case proves nothing.
+        assert len(driven.captures) > 1, (
+            "an empty upstream reply did not fire the retry ladder, so the "
+            "one-capture assertion is not known to detect one"
+        )
+
+        # The **shipped** assertion, run against the defect — not a copy of it.
+        with pytest.raises(AssertionError) as excinfo:
+            _assert_one_upstream_request(driven)
+
+        assert str(len(driven.captures)) in str(excinfo.value)
+
+
+# -- The inbound routes this module drives -----------------------------------
+
+
+class TestTheDrivenRoutes:
+    """Pins which inbound route each format is driven through."""
+
+    def test_each_driven_format_uses_its_matching_route(self) -> None:
+        """The two formats this module drives map to the routes it assumes.
+
+        §7.5.1: inbound protocol and upstream format are independent axes, so
+        the pairing is a convenience and not an equivalence. Pinned here because
+        the path and body assertions above are written against these two routes
+        and would become confusing rather than red if the mapping changed.
+        """
+        assert protocol_for(WireFormat.ANTHROPIC_MESSAGES) is InboundProtocol.MESSAGES
+        assert protocol_for(WireFormat.CHAT_COMPLETIONS) is InboundProtocol.CHAT_COMPLETIONS

--- a/tests/harness/test_vertical_slice.py
+++ b/tests/harness/test_vertical_slice.py
@@ -279,6 +279,12 @@ class MessagesReader:
         """
         body: dict[str, Any] = json.loads(captured.body)
 
+        # Scope: `content` is read as a plain string, which is what
+        # `minimal_inbound_body` sends and all this module drives. Anthropic
+        # Messages also allows a list of content blocks, and this does not read
+        # that shape — deliberately, since handling it is T-A1's job and adding
+        # it here would make this a second projection rather than evidence.
+
         # One turn per message, each carrying its text. The minimal inbound body
         # sends a plain string, which is the only content shape this must read.
         turns = tuple(Turn(role=m["role"], parts=(Text(m["content"]),)) for m in body["messages"])
@@ -316,8 +322,16 @@ async def _empty_reply(captured: CapturedRequest, reply: Reply) -> None:
             "stop_reason": "end_turn",
         }
     ).encode()
-    await reply.begin(200, {"content-type": "application/json", "content-length": str(len(payload))})
+    # Shaped exactly like `RecordingUpstream._default_responder`'s non-streaming
+    # reply — content length through the attribute, and an explicit `write_eof`.
+    # Chunked encoding is that responder's *streaming* branch, not this one. The
+    # explicit finish is the point: leaving aiohttp to end a prepared response
+    # implicitly is an implementation detail, and a version bump that flipped it
+    # off would turn this falsification case into a hang instead of a red.
+    reply.content_length = len(payload)
+    await reply.begin(200, {"content-type": "application/json"})
     await reply.write(payload)
+    await reply.write_eof()
 
 
 @dataclass(frozen=True)
@@ -639,7 +653,12 @@ class TestTheWallClockBound:
 
         message = str(excinfo.value)
         assert "budget" in message
+
+        # Both reference costs, not one: the message promises them as the
+        # diagnostic that tells a fired ladder from a slow runner, and asserting
+        # only the first would let the other be dropped silently.
         assert str(_EMPTY_LADDER_SECONDS) in message
+        assert str(_CONNECT_LADDER_SECONDS) in message
 
 
 # -- R7 — falsification (plan §1.4) ------------------------------------------


### PR DESCRIPTION
Plan task **T-W9** — `.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md` §3 ·
design `.system_design/TEST_SUITE.md` §6.3.1, §7.2.1, §7.5.4 and the new §7.6 ·
Jira **[KBR-32](https://shelpuk.atlassian.net/browse/KBR-32)**.

Depends on T-W1 (KBR-24), T-W2 (KBR-25), T-W4 (KBR-27), T-W8 (KBR-31) — all merged.
No `src/kitty/` change: this adds evidence, not behaviour.

## Context for the Product Owner

Kitty Bridge sits between a coding agent and whichever LLM provider is being paid
for, and its core promise is that the conversation reaches the provider unchanged
apart from the edits it is licensed to make. Milestone 0 built three pieces of
machinery to check that promise: a fake provider that records exactly what
arrives, a way to stand a real bridge in front of it, and a shared vocabulary the
two describe requests in. Each landed working — **on its own**.

Nobody had yet run a single request through all three at once. That is this
change. It is a small ticket with disproportionate leverage: six later workstreams
are already planned on the assumption these pieces fit together, and until now
that assumption was untested. It now either holds or fails loudly on every commit.

It also closes three specific blind spots the earlier tickets could not reach,
because none of them started a real bridge:

- **One request in means one request out.** The bridge has an automatic retry
  system that fires when a provider returns nothing useful. It is invisible from
  the outside — the user still gets an answer — but it means paying for the same
  request several times. There was no test that would notice it firing when it
  should not. There is now.
- **A guard that nothing was watching.** One internal safety flag decides whether
  a streamed reply counts as real content. It is unreachable by ordinary testing;
  only a running bridge exercises it. It is now covered.
- **A slow failure is now a loud one.** That retry system costs 80 seconds of
  real waiting. A regression that switched it back on would have made the build
  slower rather than red — which has happened here before, costing roughly four
  minutes per pull request until it was found. The test now fails instead.

## What is in the diff

| File | Change |
|---|---|
| `tests/harness/test_vertical_slice.py` | New. Ten cases, ~0.5 s, `l1` by path default |
| `.system_design/TEST_SUITE.md` | New §7.6; §8.2's module registry and count updated |

## Measured before asserted

Every claim here was probed against a running bridge first, and two measurements
changed the design:

| Observation | Result |
|---|---|
| Healthy slice, non-streaming and streaming | 200, **0.01–0.02 s**, **1** capture |
| Default transport binding | Capture's query is **`""`** |
| Empty upstream reply, ladder delays flattened | **5** captures, 0.008 s |
| `has_content` forced false on a stream | The request **never completes** |
| `post()` timing out at 2 s against a sleeping ladder | Block exits after **62 s** |

- **The default binding carries no query string.** The falsification the plan
  names for this task — "a recorder that drops the query string fails it" — would
  have passed **vacuously**. The slice now drives a binding that carries one
  through `provider_config["base_url"]`, the product's own channel (KBR-143's
  merge rule), so the claim is about the bridge and not about the harness.
- **`post()`'s client timeout does not bound the slice.** Teardown waits for
  in-flight upstream handlers rather than aborting them. The wall-clock bound is
  therefore an assertion, not a reliance on that timeout.

## Three things the design review corrected

1. **The streaming case asserted a status that cannot fail.**
   `_stream_chat_completions` commits the downstream 200 with `sr.prepare()`
   before it opens the upstream, so every outcome on that route is a 200. The
   assertion is gone; the capture count is the whole claim there. The
   non-streaming case keeps its status assertion, where an upstream 400 is
   reachable and T-W8's `_RefusingTransport` is the defect that proves it bites.
2. **The query literal had no duplicate parameter name**, so half of what it
   claimed to prove was untestable. It is now `kbr32=slice%20value&dup=1&dup=2`.
3. **The budget's justification was wrong.** It claimed to catch "any ladder that
   sleeps". Any ladder that fires leaves an extra capture, which the count catches
   first and deterministically — and there are **two** ladders:
   `_EMPTY_RETRY_DELAYS` is read only by `_request_with_retry_single`, while every
   streaming path sleeps 1/2/4/8 s, so a streaming ladder fires twice inside a
   4-second budget. §7.6 now states the three mechanisms and the band each alone
   covers.

## The falsification sweep, and what it found

Plan §1.4 asks every harness to ship a deliberate defect it must detect. Both of
this module's falsification cases drive the **shipped** assertions — named
helpers — rather than copies of them, because a copied assertion falsifies
nothing about the one that ships.

Each of the recorder's capture fields was then mutated in turn and the module
re-run. Ten of eleven mutations were caught by exactly one case each. One was not:

> **A recorder reading `request.path` instead of `rel_url.raw_path` killed
> nothing** — the adapter's own path is `/v1/messages`, which contains nothing
> percent-encoded, so the two are identical on this route and §7.2.1's trap was
> untestable. The base URL now carries an encoded path prefix as well, and the
> mutation fails the field case.

That is the second claim in this task found vacuous because the *driven request*
did not carry the thing the claim was about, and it is the argument for running
the sweep rather than reasoning about it. §7.6 records the result, including the
one assertion that survives on purpose (and why) and one that is weaker than it
looks.

## Cost and safety

- Module runtime **~0.5 s** (0.42–0.54 s over three runs); §8.2 updated with it.
- The ladder falsification flattens the delays with `monkeypatch` rather than
  waiting them out — **values flattened, lengths unchanged**, since
  `max_attempts` is computed from the list lengths. An 80-second falsification
  case is the defect commit `691e974` fixed once already.
- The transports defined here are **never registered**. Registration is an
  import-time side effect on module-global state, so a stray `register_transport`
  would leave this module green alone and the full suite red under a different
  collection order. `test_bridge.py`'s registry meta-test is green.
- All measurements are Python 3.12.3; CI across 3.10–3.13 is the authority for
  the budget. A version-dependent failure means raising it, never skipping.

## Verification

- `pytest tests/harness/ -q --strict-markers` — **706 passed**
- `ruff check .` — clean · `mypy src/kitty` — clean · `lint-imports` — 5/5 kept
- `ruff format` applied to the new file only
- Layer guards (`test_layer_markers.py`, `test_layer_selection.py`) — 68 passed

## Out of scope, stated so it is not read as an omission

Corpus-wide quantification is T-D1's (KBR-51); the other five wire formats and
the three custom transports are T-B1–T-B3's; non-loopback addressing stays with
T-E1/T-E2. Bounding fixture *teardown* against a fired ladder is real — the 62
seconds above — but aborting in-flight handlers would change T-W8's module and is
a decision §7.3 already took for the proxy; it is left to T-K6 and T-B4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018b37S3LGuQABeEDr8jeeLv


[KBR-32]: https://shelpuk.atlassian.net/browse/KBR-32?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ