### PR TITLE
Observe the two upstream paths the bridge's own recorder cannot see (KBR-40 / T-B1)

### DIFF
--- a/.system_design/TEST_SUITE.md
+++ b/.system_design/TEST_SUITE.md
@@ -2136,7 +2136,7 @@ same interface to the tests:
 | Recorder | Serves | Observes |
 |---|---|---|
 | aiohttp server — bridge sessions | the 20 default-transport adapters | The primary; speaks Anthropic Messages and Chat Completions |
-| aiohttp server — provider sessions | `ollama_cloud`, and the `openai_subscription` **OAuth token legs** | Those adapters build their own sessions and never touch `_session_for`, so the bridge recorder never sees them. The OAuth leg runs at startup, before anything else has been proven (§5.5) |
+| aiohttp server — provider sessions | `ollama_cloud`, and the `openai_subscription` **OAuth login leg** | Those adapters build their own sessions and never touch `_session_for`, so the bridge recorder never sees them. The OAuth leg runs at startup, before anything else has been proven (§5.5). The **refresh** leg moved to `curl_cffi` in KBR-161 and is the row below's (§7.2.2) |
 | curl_cffi-reachable server | `openai_subscription` serving path | Must terminate TLS with the harness certificate; the only place `_cc_to_responses` output (P13, P17) can be seen |
 | botocore endpoint override | `bedrock` | Points the client at the local recorder rather than AWS; observes the Converse payload **after** the transport's `modelId`/`stream` pops (P18) |
 
@@ -2214,6 +2214,62 @@ A recorder's Anthropic SSE success is therefore guarded only by §6.2.2's gramma
 property of the product, not of the harness: an upstream returning a well-formed but
 contentless Anthropic stream reaches Claude Code with none of the retry the Chat Completions
 path has.
+
+#### 7.2.2 What T-B1 settled — the provider-session recorder
+
+**Delivered by T-B1 ([KBR-40]) in `tests/harness/provider_recorder.py` and
+`tests/harness/provider_aiohttp.py`**, registered as `provider_aiohttp` with a `CONFORMANCE_CASES`
+row naming `OLLAMA_CHAT` and the **Chat Completions** inbound route — named rather than derived,
+because `OLLAMA_CHAT` has no inbound route of its own (§7.5.1).
+
+**It subclasses T-W4's recorder rather than being a second server.** §7.2.1 catalogues six ways an
+aiohttp recorder can look correct and lie, and a second implementation is a second chance to get
+each of them wrong — §7.3's own argument, that "two proxy implementations is how two harnesses come
+to disagree". What differs between the two recorders is **vocabulary**: the format served, the
+suffix that selects a reply, and what a minimal success looks like. Those three are overridden and
+nothing else, so both recorders are judged by §7.2.1's fourteen checks over the same capture path.
+The claim that costs is `recorder_conformance`'s: running those checks against a subclass that
+overrides none of the capture path proves the overrides did not break it, not that a second
+implementation agrees. **What carries that weight instead is a falsification case against the
+overrides themselves** — a Chat Completions body and an SSE stream, each driven through the real
+adapter, which reads nothing out of either.
+
+**The OAuth token leg is served by this recorder and is *not* an `UpstreamTransport`** — §7.5's open
+question, decided. `bind()` must return `(adapter, provider_config)` and the conformance check drives
+a request through a real `BridgeServer`; the login leg has neither an adapter nor a bridge, so a
+transport for it could not satisfy the interface it joined. A seventh `WireFormat` was the other
+option and would mutate a contract six Epic A readers consume (T-W2, [KBR-25]) to add a value **no
+projection can read**: §3.3.1 pairs every format with a wire reader, and a form-encoded token grant
+is not an LLM request. So the recorder dispatches the leg by path suffix, `WireFormat` stays closed
+at six, and `oauth_token_endpoint()` is that leg's `bind()`.
+
+**Scope, after KBR-161: the login leg here, the refresh leg in T-B2.** §5.5's table records that the
+refresh leg now runs on the adapter's impersonating `curl_cffi` session, which an aiohttp recorder
+cannot observe. Note the consequence §5.5 already states from the other side: the `curl_cffi` leg
+"fires on every subsequent request, so that is the transport the harness must exercise first". T-B1
+therefore covers the **less** urgent of the two legs, deliberately — it is the one its stack can see
+— and T-B2 inherits the other. **Two constants named `OAUTH_TOKEN_URL` exist**, one per leg
+(`kitty.auth.openai_oauth` and `kitty.auth.oauth_session`); they are identical strings and unrelated
+variables, so a seam that swapped the wrong one would send a real request to `auth.openai.com`.
+
+**A one-format transport has one teardown check, and that is measured.** §7.5.4's row 4 — a declared
+format that was never under test — needs **two** served formats to stay silent: the recorder answers
+by path suffix, so the adapter parses the reply and the capture list comes out complete. With one
+served format the same mistake takes the fallback instead. Measured, against a transport whose
+adapter posted elsewhere and against one that posted at the OAuth endpoint: **4 captures and a
+10-second timeout each, 72 seconds including the teardown that waits out the retry ladder**. Both are
+caught loudly by the conformance check's first assertion, so a second teardown pass here would be an
+assertion no defect could falsify — which is what §7.5.4 found and removed in T-W8. The same
+measurement is why the reply-shape falsification cases are driven through the adapter and not
+through the bridge: the defect is caught either way, and one way costs milliseconds.
+
+**The OAuth endpoint is excluded from the declared-format claim by name, not by silence.** A token
+grant is answered before any format lookup — it has no `WireFormat` and must not be reported as a
+fallback — so `assert_teardown_clean()` passes over it, and a test pins that exclusion so it cannot
+be mistaken for a hole.
+
+[KBR-40]: https://shelpuk.atlassian.net/browse/KBR-40
+[KBR-25]: https://shelpuk.atlassian.net/browse/KBR-25
 
 ### 7.3 Recording CONNECT proxy
 
@@ -2504,7 +2560,9 @@ need it, and `tests/conftest.py` offers only `unused_tcp_port` today. Measured i
 their own stub adapter, fake upstream and `post()` helper; 25 of those *also* intercept the
 upstream with `aioresponses` rather than a real socket, and 24 start no server at all.
 
-**This is the one `tests/harness/` module that imports the product.** `contract.py` and
+**This was the one `tests/harness/` module that imports the product, and since T-B1 it is one of
+two** — an Epic B transport must build the adapter it binds, which is what `bind()` is for
+(§7.2.2). `contract.py` and
 `recorder.py` each carry a structural guard forbidding any `kitty` import, because §3.3.1's
 independent-oracle rule says a reader that asked kitty how to parse a body would inherit
 kitty's bugs. That rule governs what *judges* a request. This module *starts* the thing under
@@ -2938,8 +2996,8 @@ business, together with the job that runs them; doing it earlier would remove th
 gate. T-H1 must take that reclassification into account before it measures a mutation
 baseline, because it selects on `l1`.
 
-**Six modules are bulleted below, and `tests/cli/test_stream_encoding.py` (KBR-10) is described
-after them — seven in all, named here so T-K6 inherits a list rather than a search** — the count
+**Seven modules are bulleted below, and `tests/cli/test_stream_encoding.py` (KBR-10) is described
+after them — eight in all, named here so T-K6 inherits a list rather than a search** — the count
 is what T-K6 and T-H1 plan against. (The bullet count and the KBR-10 paragraph were already
 drifting apart before T-W8 added two; spelling out both is what stops the next addition
 guessing which set it joins.)
@@ -2959,6 +3017,15 @@ guessing which set it joins.)
   knowing while planning that move: the timeout case cost **30 seconds** until its responder was
   released explicitly, because `stop_async` waits for in-flight upstream handlers rather than
   aborting them — the same property §7.3 handles deliberately for the proxy.
+- **T-B1 (KBR-40):** `tests/harness/test_provider_aiohttp.py` binds a recorder in most of its
+  cases and a real `BridgeServer` in several, and drives the OpenAI login OAuth leg over loopback
+  in four more. It runs in **~0.6 seconds**, measured, which is the number the fast-gate budget
+  should carry until T-K6 moves it. It is one module rather than two because its falsification
+  cases are defects in the transport it ships, not a separate harness; where T-W8 put four defect
+  transports in their own file, a fifth file per Epic B ticket would be three more for T-K6 to
+  move. Worth knowing while planning that move: a **wrong-shaped reply** costs 72 seconds here —
+  10 s of retry ladder plus the teardown that waits it out — which is why §7.2.2's reply-shape
+  falsification is driven through the adapter rather than through the bridge.
 - **KBR-144:** `tests/bridge/test_responses_string_input.py` starts a real `BridgeServer` on an
   ephemeral port in four of its classes, following the existing convention of
   `tests/bridge/test_crash_resilience.py` rather than inventing a second one. The whole module

--- a/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
+++ b/.system_design/TEST_SUITE_IMPLEMENTATION_PLAN.md
@@ -276,10 +276,16 @@ Each task delivers a recorder **and its bridge-fixture integration** through T-W
 interface, and must pass T-W4's conformance test — including peer-port capture, which T-E2's
 tunnel join needs from every recorder.
 
+**The two OAuth legs are split across T-B1 and T-B2, not both in T-B1.** These rows were written
+before KBR-161 moved the **refresh** leg onto the adapter's impersonating `curl_cffi` session
+(§5.5), which an aiohttp recorder cannot observe. §5.5 also notes that the refresh leg is the one
+that "fires on every subsequent request", so T-B1 necessarily takes the less urgent of the two —
+deliberately, and recorded in §7.2.2 so the order does not read as an oversight.
+
 | ID | Task | Depends on | Design | Size |
 |---|---|---|---|---|
-| **T-B1** | Provider-aiohttp recorder + integration — `ollama_cloud`, and the `openai_subscription` **OAuth legs** that run at startup | T-W4, T-W8 | §5.5, §7.2 | M |
-| **T-B2** | curl_cffi recorder + integration, harness TLS — the only place `_cc_to_responses` output is observable | T-W4, T-W8 | §7.2 | M |
+| **T-B1** | Provider-aiohttp recorder + integration — `ollama_cloud`, and the `openai_subscription` OAuth **login** leg that runs at startup | T-W4, T-W8 | §5.5, §7.2, §7.2.2 | M |
+| **T-B2** | curl_cffi recorder + integration, harness TLS — the only place `_cc_to_responses` output is observable, **and the OAuth refresh leg**, which KBR-161 moved onto this stack | T-W4, T-W8 | §7.2, §7.2.2 | M |
 | **T-B3** | botocore recorder + integration — captures the Converse payload **after** the transport's `modelId`/`stream` pops | T-W4, T-W8 | §3.2.3, §7.2 | M |
 | **T-B4** | Scripted failure library — SSE variants, errors, Cloudflare, empty responses, context-too-large, mid-stream disconnect at each of the four injection points | T-W4 | §6.3.1 | M |
 

--- a/tests/harness/provider_aiohttp.py
+++ b/tests/harness/provider_aiohttp.py
@@ -1,0 +1,248 @@
+"""The provider-aiohttp transport, and the seam that redirects the OAuth leg.
+
+`.system_design/TEST_SUITE.md` §5.5, §7.2, §7.5 · plan task **T-B1** (KBR-40).
+
+:mod:`harness.provider_recorder` is the server; this module is how the product
+is pointed at it. Two products, two mechanisms, because the two paths differ in
+what they expose:
+
+* ``ollama_cloud`` is a :class:`~kitty.providers.base.ProviderAdapter` the
+  bridge drives, so it plugs into T-W8's ``UpstreamTransport`` interface and
+  inherits :func:`~harness.bridge.assert_transport_reaches_its_recorder` by
+  registering. It honours ``provider_config["base_url"]`` — resolved inside its
+  own request path rather than through ``build_base_url``, which is why
+  :func:`~harness.bridge.redirected` does not apply to it and ``bind()`` does.
+* The OpenAI **login** OAuth token leg has no adapter and no
+  ``provider_config``: it is driven from the CLI at login time and reaches a
+  module constant. :func:`oauth_token_endpoint` is its equivalent of ``bind()``.
+
+**Why the OAuth leg is not an ``UpstreamTransport`` (§7.5's open question).**
+``UpstreamTransport.bind()`` must return ``(adapter, provider_config)`` and the
+conformance check drives one request through a real ``BridgeServer``; the login
+leg has neither an adapter nor a bridge, so a transport for it could not satisfy
+the interface it joined. The other rejected option was a seventh
+:class:`~harness.contract.WireFormat`, which would mutate a contract six Epic A
+readers consume (T-W2, KBR-25) to add a value **no projection can read** — a
+form-encoded token grant is not an LLM request, and §3.3.1 pairs every format
+with a wire reader. Serving the leg by path suffix and redirecting it here costs
+no shared contract at all.
+
+**Scope, after KBR-161.** §7.2 assigns this recorder "the ``openai_subscription``
+OAuth token legs", written when both ran on aiohttp. Since KBR-161 the
+**refresh** leg runs on the adapter's impersonating ``curl_cffi`` session
+(:class:`kitty.auth.token_transport.CurlTokenTransport`, the only
+``TokenTransport`` implementation), which an aiohttp recorder cannot observe;
+§5.5 records the split. So this module covers the **login** leg, and the refresh
+leg belongs to T-B2's TLS-terminating recorder.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from collections.abc import Iterator, Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+from harness.bridge import Binding, register_transport
+from harness.contract import CapturedRequest, WireFormat
+from harness.provider_recorder import (
+    OAUTH_TOKEN_SUFFIX,
+    ProviderRecordingUpstream,
+)
+from harness.recorder import ConnectionRecord, Responder
+from kitty.auth import openai_oauth
+from kitty.providers.ollama_cloud import OllamaCloudAdapter
+
+__all__ = [
+    "ProviderAiohttpTransport",
+    "oauth_token_endpoint",
+]
+
+
+@dataclass
+class ProviderAiohttpTransport:
+    """The transport for adapters that own their aiohttp session.
+
+    Attributes:
+        format: The upstream wire format served. Only
+            :attr:`~harness.contract.WireFormat.OLLAMA_CHAT`; the recorder
+            rejects anything else at construction.
+        responder: What to reply with; the recorder's minimal success when
+            omitted. A closure over mutable state is how a reply is scripted to
+            change between attempts.
+    """
+
+    #: A class attribute, not a field: every instance answers to one registry key.
+    name = "provider_aiohttp"
+
+    format: WireFormat
+    responder: Responder | None = None
+    _recorder: ProviderRecordingUpstream = field(init=False, repr=False)
+    _adapter: OllamaCloudAdapter | None = field(init=False, default=None, repr=False)
+
+    def __post_init__(self) -> None:
+        """Build the recorder eagerly, so an unserved format fails here.
+
+        Raises:
+            ValueError: When ``format`` is not one this recorder serves.
+        """
+        self._recorder = ProviderRecordingUpstream(default_format=self.format, responder=self.responder)
+
+    @property
+    def recorder(self) -> ProviderRecordingUpstream:
+        """Return the underlying recorder.
+
+        Returns:
+            The :class:`~harness.provider_recorder.ProviderRecordingUpstream`,
+            for tests that need the parts of it the transport interface does not
+            expose — the OAuth captures among them.
+        """
+        return self._recorder
+
+    async def start(self) -> None:
+        """Bind an ephemeral loopback port and begin recording."""
+        await self._recorder.start()
+
+    async def stop(self) -> None:
+        """Release the recorder's port, and close the adapter's own session.
+
+        ``BridgeServer.stop_async`` closes the sessions **it** owns and knows
+        nothing about an adapter that built its own, so without this the
+        ``ollama_cloud`` session outlives every test that starts one — an
+        "Unclosed client session" warning per test, and a real leak in a gate
+        that runs thousands. Closing it here rather than in the product is
+        deliberate: the product's session is a per-process pool whose lifetime is
+        the process, and shortening it would be a change to the product to suit
+        a test.
+
+        The recorder is stopped in a ``finally``: a session that fails to close
+        must not leave a port bound, because the next test's ephemeral port
+        allocation is the only thing that would notice.
+        """
+        try:
+            if self._adapter is not None:
+                session = self._adapter._session
+                if session is not None and not session.closed:
+                    await session.close()
+        finally:
+            await self._recorder.stop()
+
+    def bind(self) -> Binding:
+        """Return the adapter and config that reach this recorder.
+
+        **One adapter per transport, reused.** The primary transport returns a
+        fresh adapter per call because its adapters are stateless; this one's
+        owns a connection pool that :meth:`stop` has to close, and a fresh
+        adapter per call would mean a session per call with only the last one
+        reachable. Every balancing member sharing one adapter is the shape
+        :func:`~harness.bridge.backend_for` already expects, which is why it
+        takes a ``binding`` to pass around.
+
+        Returns:
+            The ``ollama_cloud`` adapter, and the provider configuration naming
+            the recorder's base URL — the product's own channel, honoured by
+            ``OllamaCloudAdapter._build_url``.
+
+        Raises:
+            RuntimeError: When the transport has not been started, because the
+                recorder has no port until then.
+        """
+        base_url = self._recorder.base_url
+        if self._adapter is None:
+            self._adapter = OllamaCloudAdapter()
+        return self._adapter, {"base_url": base_url}
+
+    @property
+    def captures(self) -> Sequence[CapturedRequest]:
+        """Return the completed captures, in arrival order.
+
+        Returns:
+            What the recorder holds — including any OAuth token exchange, which
+            arrives on the same server and is evidence of the same kind.
+        """
+        return self._recorder.requests
+
+    @property
+    def connections(self) -> Sequence[ConnectionRecord]:
+        """Return every accepted connection.
+
+        Returns:
+            One record per connection, including any that carried no request —
+            §5.2.1's bypass shape, and the peer ports T-E5's tunnel join reads.
+        """
+        return self._recorder.connections
+
+    def assert_teardown_clean(self) -> None:
+        """Assert every request was answered in the format this transport declares.
+
+        **One check, not two, and that is measured rather than assumed.** The
+        primary transport follows ``assert_all_paths_matched`` with a second
+        pass catching a path that selected some *other* format — §7.5.4's row 4,
+        whose whole point is that the capture list comes out complete and
+        correct and nothing else reports it. That shape needs **two** served
+        formats. This recorder serves one, so the same mistake takes the
+        fallback instead: measured against a transport whose adapter posted
+        elsewhere, the bridge could parse nothing out of the reply, retried, and
+        the conformance check failed on **4 captures and a timeout** — loudly,
+        13 seconds in, naming this transport. A second pass here would be an
+        assertion no defect could falsify, which is exactly what §7.5.4 found
+        and removed when the same repeat appeared in T-W8.
+
+        **The OAuth endpoint is outside this claim, by name rather than by
+        silence.** A token grant is answered before any format lookup (it has no
+        :class:`~harness.contract.WireFormat` and must not be reported as a
+        fallback), so a capture at that endpoint is not evidence for or against
+        the declared format. Nothing a *bridge* drives can land there — the
+        adapter's upstream path is a constant — and a transport whose adapter
+        did was measured at the same 4 captures and a timeout.
+
+        Raises:
+            UnmatchedPathError: When a request took the recorder's fallback.
+        """
+        self._recorder.assert_all_paths_matched()
+
+
+register_transport(ProviderAiohttpTransport.name, ProviderAiohttpTransport)
+
+
+@contextlib.contextmanager
+def oauth_token_endpoint(recorder: ProviderRecordingUpstream) -> Iterator[str]:
+    """Point the OAuth login leg's token endpoint at ``recorder``.
+
+    The login leg reaches ``https://auth.openai.com/oauth/token`` through a
+    module constant, with no configuration channel of any kind — so this is the
+    only place it can be redirected, and it is this leg's ``bind()``.
+
+    **Two constants of that name exist, and this swaps one.**
+    :mod:`kitty.auth.openai_oauth` holds the login leg's, and
+    :mod:`kitty.auth.oauth_session` holds the **refresh** leg's. They are
+    identical strings and unrelated variables. Redirecting the refresh leg
+    through this function would swap a name that leg never reads and send its
+    request to the real host; it runs on ``curl_cffi`` since KBR-161 and is
+    T-B2's to redirect, over a recorder that terminates TLS.
+
+    Reading the constant before writing it is what makes the seam falsifiable:
+    if the leg is ever rewritten to read the endpoint from somewhere else, this
+    raises :class:`AttributeError` rather than swapping a name nothing consults
+    and leaving a test to pass with an empty capture list.
+
+    Args:
+        recorder: A **started** recorder; its base URL is read here.
+
+    Yields:
+        The URL the leg will now post to.
+
+    Raises:
+        AttributeError: When :mod:`kitty.auth.openai_oauth` no longer defines
+            ``OAUTH_TOKEN_URL``.
+    """
+    url = f"{recorder.base_url}{OAUTH_TOKEN_SUFFIX}"
+    original: Any = openai_oauth.OAUTH_TOKEN_URL
+    openai_oauth.OAUTH_TOKEN_URL = url
+    try:
+        yield url
+    finally:
+        # Restored in a `finally` rather than by pytest's monkeypatch, so the
+        # seam is usable from anything — a containment slice driving the leg
+        # outside a test function included.
+        openai_oauth.OAUTH_TOKEN_URL = original

--- a/tests/harness/provider_recorder.py
+++ b/tests/harness/provider_recorder.py
@@ -1,0 +1,305 @@
+"""The provider-session aiohttp recording upstream.
+
+`.system_design/TEST_SUITE.md` §5.5, §7.2 · plan task **T-B1** (KBR-40).
+
+§7.2 gives each of the bridge's five client configurations its own recorder. The
+primary one (T-W4, :mod:`harness.recorder`) observes the sessions
+:meth:`BridgeServer._session_for` owns, which is every default-transport
+adapter. This one observes the two product paths that build an **aiohttp session
+of their own** and therefore never appear there:
+
+* ``ollama_cloud``, which posts Ollama's native ``/api/chat`` and resolves
+  ``provider_config["base_url"]`` inside its own request path rather than
+  through ``build_base_url``;
+* the OpenAI **login** OAuth token leg (:mod:`kitty.auth.openai_oauth`), which
+  runs at startup, before anything else has been proven (§5.5).
+
+**Why this subclasses T-W4's recorder rather than being a second server.**
+§7.2.1 catalogues six ways an aiohttp recorder can look correct and lie —
+``raw_headers`` decoded latin-1, ``rel_url.raw_path`` rather than the decoded
+``path``, the ``Host`` header read directly rather than ``request.host``,
+``client_max_size=0`` supplied through a ``request_factory``,
+``auto_decompress=False``, and connection logging through
+``web.Server.connection_made`` keyed on the handler object. A second
+implementation of that server would be a second chance to get each of them
+wrong, and §7.3 states the principle from the proxy's side: *"two proxy
+implementations is how two harnesses come to disagree about what 'tunnelled'
+means."* What actually differs between the two recorders is **vocabulary** — the
+format served, the suffix that selects a reply, and what a minimal success looks
+like — so this subclass overrides those three things and nothing else.
+
+**It imports nothing from ``src/kitty``, and must not**, for the reason
+:mod:`harness.recorder` states: §3.3.1's independent-oracle rule. The product
+import this delivery needs lives in :mod:`harness.provider_aiohttp`, which binds
+an adapter; nothing here asks kitty how to read a request.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from harness.contract import CapturedRequest, WireFormat
+
+# ``_wants_stream`` is private and deliberately imported anyway: whether a body
+# asked for a stream is one decision, and Ollama spells it the same way the other
+# formats do. A copy here would be a second source of truth, and the alternative
+# — exporting it — means editing ``recorder.py``, which five tickets consume.
+from harness.recorder import RecordingUpstream, Reply, _wants_stream
+
+__all__ = [
+    "ProviderRecordingUpstream",
+    "OLLAMA_CHAT_SUFFIX",
+    "OAUTH_TOKEN_SUFFIX",
+    "format_for_provider_path",
+    "is_oauth_token_path",
+    "ollama_success_body",
+    "ollama_success_stream",
+    "oauth_token_body",
+]
+
+#: The suffix that selects an Ollama ``/api/chat`` reply. A **suffix** for the
+#: reason §7.2 gives: a recorder impersonates a provider, and providers dispatch
+#: on the URL. ``ollama_cloud`` posts to the bare path today, but a redirected
+#: base URL carrying a path prefix would still have to match.
+OLLAMA_CHAT_SUFFIX = "/api/chat"
+
+#: The suffix that selects an OAuth token reply. Both of the login leg's two
+#: POSTs — the authorization-code exchange and the id_token exchange — go to this
+#: one endpoint, so one suffix covers the whole leg.
+OAUTH_TOKEN_SUFFIX = "/oauth/token"
+
+#: The one wire format this recorder serves. §7.2 assigns it the Ollama
+#: ``/api/chat`` shape; OpenAI Responses is T-B2's and Bedrock Converse is T-B3's.
+_SERVED_FORMAT = WireFormat.OLLAMA_CHAT
+
+#: The model and text every minimal success carries. Non-empty deliberately:
+#: every emptiness judgement in ``server.py`` keys on content being present, and
+#: an empty reply costs the 80-second retry ladder (§7.2.1).
+_REPLY_MODEL = "recorder-model"
+_REPLY_TEXT = "ok"
+
+
+def format_for_provider_path(path: str) -> WireFormat | None:
+    """Return the wire format a request at ``path`` selects, or ``None``.
+
+    The counterpart of :func:`harness.recorder.format_for_path` for this
+    recorder's own suffix table, and pure for the same reason: it answers the
+    question and records nothing, so an assertion can use it without mutating
+    the evidence it judges.
+
+    Args:
+        path: The request's raw path.
+
+    Returns:
+        :attr:`~harness.contract.WireFormat.OLLAMA_CHAT` when ``path`` names the
+        Ollama chat endpoint, and ``None`` when no suffix matches — ``None``
+        rather than a default, because "no rule applies" and "the fallback
+        applies" are different facts and only the caller knows which it wants.
+    """
+    if path.endswith(OLLAMA_CHAT_SUFFIX):
+        return _SERVED_FORMAT
+    return None
+
+
+def is_oauth_token_path(path: str) -> bool:
+    """Return whether ``path`` addresses the OAuth token endpoint.
+
+    Separate from :func:`format_for_provider_path` because a token exchange has
+    no :class:`~harness.contract.WireFormat` and must not acquire one: §3.3.1
+    pairs every format with a wire reader, and no projection reads a
+    form-encoded token grant. §7.5 left that choice to this task; the decision
+    and its alternatives are recorded in §7.2.
+
+    Args:
+        path: The request's raw path.
+
+    Returns:
+        Whether the OAuth token reply applies.
+    """
+    return path.endswith(OAUTH_TOKEN_SUFFIX)
+
+
+def ollama_success_body() -> dict[str, Any]:
+    """Return the smallest non-streaming ``/api/chat`` success.
+
+    "Minimal" means the fewest keys that still read as a success to the bridge,
+    not a faithful sample of a provider's response — the same rule
+    :func:`harness.recorder.minimal_success_body` states. The keys are the ones
+    Ollama's own API reference documents for a non-streaming chat response and
+    the ones ``OllamaCloudAdapter.translate_from_upstream`` reads.
+
+    Returns:
+        The response body, ready to serialize.
+    """
+    return {
+        "model": _REPLY_MODEL,
+        "message": {"role": "assistant", "content": _REPLY_TEXT},
+        "done": True,
+        "done_reason": "stop",
+        "prompt_eval_count": 1,
+        "eval_count": 1,
+    }
+
+
+def ollama_success_stream() -> tuple[bytes, ...]:
+    """Return the smallest streamed ``/api/chat`` success.
+
+    **NDJSON, not SSE.** Ollama streams a series of JSON objects separated by
+    newlines, and ``OllamaCloudAdapter.stream_request`` splits on ``"\\n"`` and
+    parses each line; an SSE ``data:`` frame would parse as nothing, the adapter
+    would emit no content, and the bridge would judge the response empty — the
+    80-second ladder rather than a loud failure.
+
+    The final object carries ``done`` and ``done_reason`` and **no** message:
+    that is the shape the adapter's loop breaks on to emit its finish reason.
+
+    Returns:
+        The NDJSON lines, in order, each already newline-terminated.
+    """
+    return (
+        json.dumps(
+            {
+                "model": _REPLY_MODEL,
+                "message": {"role": "assistant", "content": _REPLY_TEXT},
+                "done": False,
+            }
+        ).encode()
+        + b"\n",
+        json.dumps(
+            {
+                "model": _REPLY_MODEL,
+                "done": True,
+                "done_reason": "stop",
+                "prompt_eval_count": 1,
+                "eval_count": 1,
+            }
+        ).encode()
+        + b"\n",
+    )
+
+
+def oauth_token_body() -> dict[str, Any]:
+    """Return a token response the OAuth login leg can read.
+
+    Carries every field the leg requires: ``_exchange_code_for_tokens`` rejects
+    a response missing ``access_token`` or ``id_token``, and
+    ``_exchange_id_token_for_api_key`` rejects one missing ``openai_api_key``.
+    Both are served from one body because both POSTs address one endpoint.
+
+    The ``id_token`` is a syntactically valid unsigned JWT with a trivial payload
+    — the leg base64-decodes the payload without verifying the signature — and
+    is not a credential of any kind.
+
+    Returns:
+        The token response, ready to serialize.
+    """
+    return {
+        "access_token": "recorder-access-token",
+        "refresh_token": "recorder-refresh-token",
+        "id_token": "eyJhbGciOiJub25lIn0.eyJzdWIiOiJyZWNvcmRlciJ9.",
+        "expires_in": 3600,
+        "openai_api_key": "recorder-api-key",
+    }
+
+
+class ProviderRecordingUpstream(RecordingUpstream):
+    """T-W4's recorder, speaking the provider-session vocabulary.
+
+    Everything the conformance contract judges — what is captured, in what
+    order, on which connection, from which peer port — is inherited unchanged,
+    so this recorder is judged by the same fourteen checks and cannot drift from
+    the primary one on any of them. Three things are overridden: the format it
+    accepts, the suffix table it dispatches on, and what it replies with.
+
+    A plain subclass rather than a ``@dataclass`` one, because it adds no
+    fields; ``test_bridge_falsification._BlindRecorder`` is the same shape.
+    """
+
+    def __post_init__(self) -> None:
+        """Reject a format this recorder does not serve.
+
+        The base implementation is **replaced, not extended**: it is validation
+        and nothing else today, and it would reject every format this recorder
+        serves. If T-W4 ever adds setup there, this override has to call it —
+        which is the one reason to re-read this docstring.
+
+        Raises:
+            ValueError: When ``default_format`` is not
+                :attr:`~harness.contract.WireFormat.OLLAMA_CHAT`. The base class
+                would reject it too, but for the wrong reason and with the wrong
+                message — it names the primary recorder's two formats, neither of
+                which this one serves.
+        """
+        if self.default_format is not _SERVED_FORMAT:
+            raise ValueError(
+                f"the provider-session recorder serves {_SERVED_FORMAT.value}, not {self.default_format.value}"
+            )
+
+    def _format_for(self, path: str) -> WireFormat:
+        """Return the wire format to answer a request at ``path`` in.
+
+        The recording half of the lookup, overridden rather than extended
+        because the two recorders' suffix tables are disjoint: neither serves a
+        format the other does, so a shared table would only ever answer a
+        request one of them could not reply to.
+
+        Args:
+            path: The request's raw path.
+
+        Returns:
+            The matched format, or :attr:`default_format` — recording the miss,
+            which :meth:`assert_all_paths_matched` turns into a failure at
+            teardown.
+        """
+        matched = format_for_provider_path(path)
+        if matched is not None:
+            return matched
+
+        self.unmatched.append(path)
+        return self.default_format
+
+    async def _default_responder(self, captured: CapturedRequest, response: Reply) -> None:
+        """Reply with the minimal success for the request's endpoint.
+
+        Args:
+            captured: The recorded request.
+            response: The unprepared response to write through.
+        """
+        # The OAuth leg is answered before any format lookup: it has no
+        # `WireFormat` and must not be recorded as an unmatched path, which is
+        # what consulting the format table would do.
+        if is_oauth_token_path(captured.path):
+            await self._reply_json(response, oauth_token_body())
+            return
+
+        # Called for its recording side effect as much as its answer: every
+        # reply this recorder sends is Ollama-shaped, but a path that selected
+        # none has to be reported at teardown.
+        self._format_for(captured.path)
+
+        if _wants_stream(captured.body):
+            await response.begin(200, {"Content-Type": "application/x-ndjson"})
+            for chunk in ollama_success_stream():
+                await response.write(chunk)
+            await response.write_eof()
+            return
+
+        await self._reply_json(response, ollama_success_body())
+
+    @staticmethod
+    async def _reply_json(response: Reply, payload: dict[str, Any]) -> None:
+        """Send one complete JSON body.
+
+        Args:
+            response: The unprepared response.
+            payload: The body to serialize.
+        """
+        encoded = json.dumps(payload).encode()
+        # Set the length before preparing: aiohttp would otherwise chunk the
+        # reply, and a chunked body is a difference from a real provider that
+        # nothing in the harness would explain to the next reader.
+        response.content_length = len(encoded)
+        await response.begin(200, {"Content-Type": "application/json"})
+        await response.write(encoded)
+        await response.write_eof()

--- a/tests/harness/test_bridge.py
+++ b/tests/harness/test_bridge.py
@@ -74,6 +74,7 @@ from kitty.providers.vertex import VertexAIAdapter
 #: property of the suite, not of the core.
 CONFORMANCE_CASES: tuple[tuple[str, str, WireFormat, InboundProtocol], ...] = (
     ("harness.bridge", "aiohttp", WireFormat.ANTHROPIC_MESSAGES, InboundProtocol.MESSAGES),
+    ("harness.provider_aiohttp", "provider_aiohttp", WireFormat.OLLAMA_CHAT, InboundProtocol.CHAT_COMPLETIONS),
 )
 
 #: What the modules above are expected to have registered between them. Derived
@@ -1045,11 +1046,13 @@ class TestTheConformanceCheck:
         await assert_transport_reaches_its_recorder(transport("aiohttp", fmt))
 
     @pytest.mark.parametrize(
-        ("name", "fmt", "route"),
-        [(name, fmt, route) for _module, name, fmt, route in CONFORMANCE_CASES],
+        ("module", "name", "fmt", "route"),
+        list(CONFORMANCE_CASES),
         ids=[name for _module, name, _fmt, _route in CONFORMANCE_CASES],
     )
-    async def test_every_registered_transport_passes(self, name: str, fmt: WireFormat, route: InboundProtocol) -> None:
+    async def test_every_registered_transport_passes(
+        self, module: str, name: str, fmt: WireFormat, route: InboundProtocol
+    ) -> None:
         """The meta-test: a transport inherits the check by registering.
 
         Each row carries its own format and inbound route, so an Epic B author
@@ -1058,11 +1061,24 @@ class TestTheConformanceCheck:
         none of them serves Anthropic Messages — which would make "inherits by
         registering" false for all three transports it was written for.
 
+        The row's module is imported here, not assumed imported. A name enters
+        the registry only when something imports the module that registers it,
+        and this module imports only ``harness.bridge`` — so every row but the
+        core's own would fail with ``LookupError`` under a selective run, and
+        under a full run would depend on collection order. That is the same
+        reasoning the completeness test below states, applied to the test that
+        actually drives the check.
+
         Args:
+            module: The module that registers this transport.
             name: A registered transport name.
             fmt: The upstream format to construct it with.
             route: The inbound route that exercises it.
         """
+        import importlib
+
+        importlib.import_module(module)
+
         await assert_transport_reaches_its_recorder(transport(name, fmt), protocol=route)
 
     def test_the_meta_test_iterates_a_complete_set_not_whatever_was_imported(self) -> None:

--- a/tests/harness/test_provider_aiohttp.py
+++ b/tests/harness/test_provider_aiohttp.py
@@ -1,0 +1,861 @@
+"""The provider-session recorder and its transport, against real sockets.
+
+`.system_design/TEST_SUITE.md` §5.5, §7.2, §7.5 · plan task **T-B1** (KBR-40) ·
+`.requirements/20260912T114422Z_provider_aiohttp_recorder/REQUIREMENTS.md`.
+
+Two products are under observation here and they are driven differently, because
+they are reached differently. ``ollama_cloud`` is driven through a real
+``BridgeServer`` on T-W8's fixture; the OpenAI login OAuth leg is driven by
+calling the product's own token-exchange coroutines, because that leg has no
+adapter, never passes through the bridge, and its interactive half waits five
+minutes for a browser.
+
+Every conformance probe writes its request bytes itself, for the reason
+``test_recorder.py`` records: a client library reorders, re-cases, adds and drops
+headers, so a probe sent through one could not tell a recorder that *loses*
+casing from a client that never *sent* mixed casing.
+
+**Layer.** These bind real sockets and read as `l3`, but they carry the `l1` path
+default deliberately: §8.2 states *"a test may not be moved to `l3` before the
+Subsystem job exists"*, and no job selects `l3` today, so an `l3` marker would
+remove them from every gate.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass, field, replace
+from pathlib import Path
+
+import aiohttp
+import pytest
+
+import harness.provider_recorder as provider_recorder_module
+from harness.bridge import (
+    MODEL,
+    Binding,
+    BridgeFixture,
+    InboundProtocol,
+    UpstreamTransport,
+    assert_transport_reaches_its_recorder,
+    inbound_path,
+    marker,
+    minimal_inbound_body,
+    registered_transports,
+    transport,
+)
+from harness.connect_proxy import unattributable_peer_ports
+from harness.contract import CapturedRequest, WireFormat
+from harness.provider_aiohttp import ProviderAiohttpTransport, oauth_token_endpoint
+from harness.provider_recorder import (
+    OAUTH_TOKEN_SUFFIX,
+    OLLAMA_CHAT_SUFFIX,
+    ProviderRecordingUpstream,
+    format_for_provider_path,
+    is_oauth_token_path,
+    oauth_token_body,
+    ollama_success_body,
+    ollama_success_stream,
+)
+from harness.recorder import Reply, UnmatchedPathError, minimal_success_body, minimal_success_stream
+from harness.recorder_conformance import (
+    PER_EXCHANGE_CHECKS,
+    PER_SESSION_CHECKS,
+    RICH_PROBE,
+    correlate,
+    probe,
+    recording_of,
+    send,
+)
+from harness.test_contract import _KITTY_IMPORT
+from kitty.auth import openai_oauth
+from kitty.auth.oauth_session import OAuthSession
+from kitty.providers.ollama_cloud import OllamaCloudAdapter
+
+#: The format this transport serves, named once so a case differs from its
+#: neighbours only in the thing it is about.
+FORMAT = WireFormat.OLLAMA_CHAT
+
+#: The inbound route that exercises it. ``OLLAMA_CHAT`` has no inbound route of
+#: its own — the bridge reaches it upstream and never serves it — so this is
+#: named, not derived (§7.5.1).
+ROUTE = InboundProtocol.CHAT_COMPLETIONS
+
+#: T-W4's rich probe, re-aimed at this recorder's endpoint. Derived rather than
+#: copied: what makes that constant valuable is its mixed header casing, its
+#: duplicated header, its obs-text value and its two differently-cased percent
+#: escapes, and a hand-written near-copy is a second source of truth that stays
+#: green when T-W4 adds a hostile case to the original. Only the dispatch suffix
+#: differs, and §7.2's own note on ``RICH_PROBE`` says why that matters: a probe
+#: matching no suffix would silently exercise the wrong-format fallback in every
+#: test that used it.
+RICH_OLLAMA_PROBE = RICH_PROBE.replace(b"/chat/completions", OLLAMA_CHAT_SUFFIX.encode(), 1)
+
+
+@pytest.fixture
+async def recorder():
+    """Start a provider recorder on an ephemeral loopback port, and stop it after.
+
+    One instance per test, deliberately: a shared recorder mixes captures across
+    tests, and the ordering claims are only meaningful per-instance.
+
+    Yields:
+        The running :class:`~harness.provider_recorder.ProviderRecordingUpstream`.
+    """
+    upstream = ProviderRecordingUpstream(default_format=FORMAT)
+    await upstream.start()
+    try:
+        yield upstream
+    finally:
+        await upstream.stop()
+        # The loud fallback, enforced structurally rather than by each test
+        # remembering to ask: a wrong-format reply is not a loud failure on its
+        # own, it is an apparently empty response and the retry ladder.
+        upstream.assert_all_paths_matched()
+
+
+def test_the_rich_probe_really_targets_this_recorder() -> None:
+    """The derived probe must differ from the original and select this format.
+
+    A ``replace`` that matched nothing would leave the probe aimed at the
+    primary recorder's suffix, and every per-exchange check below would then be
+    run over a request that took the fallback — the self-check §6.2 requires of
+    anything that derives its own subject.
+    """
+    assert RICH_OLLAMA_PROBE != RICH_PROBE, "the suffix rewrite matched nothing"
+
+    target = RICH_OLLAMA_PROBE.split(b" ")[1].split(b"?")[0].decode()
+    assert format_for_provider_path(target) is FORMAT
+
+
+class TestTheRecorderPassesEveryConformanceCheck:
+    """R3 — this recorder satisfies the contract T-W4 judges all four against."""
+
+    @pytest.mark.parametrize("check", PER_EXCHANGE_CHECKS, ids=lambda c: c.__name__)
+    async def test_per_exchange_check(self, recorder: ProviderRecordingUpstream, check) -> None:
+        """Assert one capture matches the request that produced it.
+
+        Args:
+            recorder: The running recorder.
+            check: One of the ten per-exchange checks, ``check_peer_port``
+                among them — the field T-E5's tunnel join reads.
+        """
+        sent = await send(recorder.host, recorder.port, RICH_OLLAMA_PROBE, marker="rich")
+        captured = correlate(recording_of(recorder), sent)
+        check(captured, sent, scheme=recorder.scheme)
+
+    @pytest.mark.parametrize("check", PER_SESSION_CHECKS, ids=lambda c: c.__name__)
+    async def test_per_session_check(self, recorder: ProviderRecordingUpstream, check) -> None:
+        """Assert the recording as a whole is faithful.
+
+        Args:
+            recorder: The running recorder.
+            check: One of the four per-session checks.
+        """
+        sent = [
+            await send(recorder.host, recorder.port, probe(name, path=OLLAMA_CHAT_SUFFIX), marker=name)
+            for name in ("first", "second")
+        ]
+        check(recording_of(recorder), sent, [s.source_port for s in sent])
+
+
+class TestTheRepliesItSends:
+    """R1, R2 — the three bodies, judged by what actually has to read them."""
+
+    def test_the_non_streaming_success_reads_as_a_success_to_the_product(self) -> None:
+        """The real adapter must get content and a finish reason out of it.
+
+        Asserting the keys instead would assert this module agrees with itself.
+        ``translate_from_upstream`` is what stands between this body and the
+        bridge's emptiness judgement, so it is what decides whether the reply is
+        a success or an 80-second retry ladder.
+        """
+        translated = OllamaCloudAdapter().translate_from_upstream(ollama_success_body())
+
+        choice = translated["choices"][0]
+        assert choice["message"]["content"], "the reply reads as empty, which costs the retry ladder"
+        assert choice["finish_reason"] == "stop"
+
+    def test_the_streamed_success_is_newline_delimited_json(self) -> None:
+        """NDJSON, not SSE: the adapter splits on newlines and parses each line."""
+        lines = [line for chunk in ollama_success_stream() for line in chunk.split(b"\n") if line.strip()]
+        parsed = [json.loads(line) for line in lines]
+
+        assert parsed[-1]["done"] is True, "nothing tells the adapter's loop to finish"
+        assert any(obj.get("message", {}).get("content") for obj in parsed), "the stream carries no content"
+
+    def test_the_oauth_body_carries_every_field_the_leg_requires(self) -> None:
+        """Every field is judged by the code that reads it, not by this module.
+
+        The two exchanges validate three fields between them. The other two are
+        read one frame further out, where ``run_oauth_flow`` builds the session
+        it returns — and ``from_token_response`` subscripts ``refresh_token``
+        rather than defaulting it, so a body missing that field ends the login
+        flow in a ``KeyError`` after both requests have already succeeded.
+        """
+        body = oauth_token_body()
+
+        assert body["access_token"] and body["id_token"], "the code exchange rejects this"
+        assert body["openai_api_key"], "the id_token exchange rejects this"
+
+        session = OAuthSession.from_token_response(body, "client-id")
+        assert session.refresh_token, "the flow's last step raises KeyError without it"
+        assert session.access_token_expires_at > time.time(), "expires_in was not read"
+
+    def test_a_format_this_recorder_does_not_serve_is_refused_at_construction(self) -> None:
+        """Failing here beats replying in a format no adapter asked for."""
+        with pytest.raises(ValueError, match="ollama_chat"):
+            ProviderRecordingUpstream(default_format=WireFormat.CHAT_COMPLETIONS)
+
+    async def test_the_oauth_endpoint_is_answered_and_is_not_an_unmatched_path(
+        self, recorder: ProviderRecordingUpstream
+    ) -> None:
+        """R2 — a token exchange has no wire format and must not be reported as one.
+
+        Args:
+            recorder: The running recorder.
+        """
+        async with aiohttp.ClientSession() as session, session.post(
+            f"{recorder.base_url}{OAUTH_TOKEN_SUFFIX}", data={"grant_type": "authorization_code"}
+        ) as response:
+            assert response.status == 200
+            assert await response.json() == oauth_token_body()
+
+        assert recorder.unmatched == []
+
+    async def test_the_replies_carry_the_headers_a_provider_would_send(
+        self, recorder: ProviderRecordingUpstream
+    ) -> None:
+        """A recorder impersonates a provider, and headers are part of that.
+
+        Neither claim is visible to the adapter — it reads the body and ignores
+        both — so nothing else in this module goes red if either is wrong.
+        Ollama declares NDJSON on the streamed reply, and a complete JSON body
+        arrives with a length rather than chunked.
+
+        Args:
+            recorder: The running recorder.
+        """
+        async with aiohttp.ClientSession() as session:
+            async with session.post(f"{recorder.base_url}{OLLAMA_CHAT_SUFFIX}", json={"stream": True}) as streamed:
+                assert streamed.headers["Content-Type"] == "application/x-ndjson"
+                await streamed.read()
+
+            async with session.post(f"{recorder.base_url}{OLLAMA_CHAT_SUFFIX}", json={"stream": False}) as whole:
+                assert whole.headers["Content-Type"] == "application/json"
+                assert "Content-Length" in whole.headers
+                assert "Transfer-Encoding" not in whole.headers
+
+    async def test_a_path_matching_no_suffix_is_recorded(self, recorder: ProviderRecordingUpstream) -> None:
+        """The teardown assertion has to have something to report.
+
+        Args:
+            recorder: The running recorder.
+        """
+        await send(recorder.host, recorder.port, probe("stray", path="/v1/chat/completions"), marker="stray")
+
+        assert recorder.unmatched == ["/v1/chat/completions"]
+        with pytest.raises(UnmatchedPathError, match="/v1/chat/completions"):
+            recorder.assert_all_paths_matched()
+
+        # Clear it, or the fixture's own teardown check reports this deliberate
+        # miss as a failure.
+        recorder.unmatched.clear()
+
+    def test_the_oauth_suffix_and_the_format_suffix_are_distinct_questions(self) -> None:
+        """Neither endpoint may answer for the other.
+
+        The two lookups are separate functions rather than one table because
+        only one of them yields a :class:`WireFormat`; asserting they do not
+        overlap is what keeps that separation real.
+        """
+        assert is_oauth_token_path(f"/v1{OAUTH_TOKEN_SUFFIX}")
+        assert format_for_provider_path(f"/v1{OAUTH_TOKEN_SUFFIX}") is None
+        assert not is_oauth_token_path(OLLAMA_CHAT_SUFFIX)
+
+
+class TestTheTransport:
+    """R4 — what T-W8's interface asks of a transport, on this one."""
+
+    def test_it_satisfies_the_extension_interface(self) -> None:
+        """The check is structural: T-W8's protocol is ``runtime_checkable``."""
+        assert isinstance(ProviderAiohttpTransport(FORMAT), UpstreamTransport)
+
+    def test_importing_the_module_registers_it(self) -> None:
+        """An Epic B transport is reachable by name once its module is imported."""
+        assert ProviderAiohttpTransport.name in registered_transports()
+
+    def test_binding_before_starting_raises(self) -> None:
+        """There is no port to name until the recorder has one."""
+        with pytest.raises(RuntimeError, match="not running"):
+            ProviderAiohttpTransport(FORMAT).bind()
+
+    async def test_it_binds_the_ollama_adapter_at_its_own_recorder(self) -> None:
+        """``bind()`` is the seam: the fixture never builds this config itself."""
+        subject = ProviderAiohttpTransport(FORMAT)
+        await subject.start()
+        try:
+            adapter, config = subject.bind()
+
+            assert isinstance(adapter, OllamaCloudAdapter)
+            assert config == {"base_url": subject.recorder.base_url}
+        finally:
+            await subject.stop()
+
+    async def test_every_bind_returns_the_one_adapter_whose_session_it_closes(self) -> None:
+        """A fresh adapter per call would leave a session per call unreachable."""
+        subject = ProviderAiohttpTransport(FORMAT)
+        await subject.start()
+        try:
+            assert subject.bind()[0] is subject.bind()[0]
+        finally:
+            await subject.stop()
+
+    async def test_the_session_closes_before_the_port_is_released(self) -> None:
+        """The order is a requirement, so it is observed rather than asserted in prose.
+
+        Closing the port first would reset a keep-alive connection the adapter's
+        pool still holds. Swapping the two statements leaves every other test in
+        this module green — measured — so without this the ordering claim is one
+        no defect could falsify.
+        """
+        subject = ProviderAiohttpTransport(FORMAT)
+        await subject.start()
+        adapter, config = subject.bind()
+        await adapter.make_request(
+            {
+                "model": MODEL,
+                "messages": [{"role": "user", "content": "hi"}],
+                "_resolved_key": "harness-key",
+                "_provider_config": config,
+            }
+        )
+
+        # Wrap the recorder's own stop, which is the step the session must
+        # precede, and record what the session looked like when it ran.
+        closed_when_port_released: list[bool] = []
+        original_stop = subject.recorder.stop
+
+        async def _observe() -> None:
+            """Record the session's state, then release the port."""
+            closed_when_port_released.append(adapter._session is not None and adapter._session.closed)
+            await original_stop()
+
+        subject.recorder.stop = _observe  # type: ignore[method-assign]
+        await subject.stop()
+
+        assert closed_when_port_released == [True]
+
+    async def test_stopping_closes_the_session_the_adapter_owns(self) -> None:
+        """``BridgeServer.stop_async`` closes only the sessions it owns.
+
+        Without this the ``ollama_cloud`` session outlives every test that
+        started one: an "Unclosed client session" per test, and a real leak in a
+        gate that runs thousands.
+        """
+        subject = ProviderAiohttpTransport(FORMAT)
+        async with BridgeFixture(subject) as fixture:
+            await fixture.post(inbound_path(ROUTE), minimal_inbound_body(ROUTE, marker()))
+            adapter, _config = subject.bind()
+            session = adapter._session
+
+        assert session is not None, "the request did not go through the adapter's own session"
+        assert session.closed
+
+
+class TestThroughARealBridge:
+    """R1, R4, R5 — the claim the whole delivery exists to support."""
+
+    async def test_a_request_reaches_the_recorder_as_ollama_chat(self) -> None:
+        """The user's text survives the bridge's CC → Ollama translation."""
+        subject = ProviderAiohttpTransport(FORMAT)
+        sent = marker()
+
+        async with BridgeFixture(subject) as fixture:
+            status, _text = await fixture.post(inbound_path(ROUTE), minimal_inbound_body(ROUTE, sent))
+            captures = list(subject.captures)
+
+        assert status == 200
+        assert len(captures) == 1
+        assert captures[0].path == OLLAMA_CHAT_SUFFIX
+        assert sent.encode() in (captures[0].body or b"")
+
+    async def test_the_capture_carries_the_peer_port_containment_joins_on(self) -> None:
+        """§5.2.1's join key, required of every recorder and not only the primary."""
+        subject = ProviderAiohttpTransport(FORMAT)
+
+        async with BridgeFixture(subject) as fixture:
+            await fixture.post(inbound_path(ROUTE), minimal_inbound_body(ROUTE, marker()))
+            captures = list(subject.captures)
+            connections = list(subject.connections)
+
+        assert captures[0].peer_port
+        assert [c.peer_port for c in connections] == [captures[0].peer_port]
+        assert sum(c.requests for c in connections) == 1
+
+        # The join is over **connections**, never requests (§5.2.1), and
+        # `unattributable_peer_ports` raises rather than guess when a port is
+        # unset -- so putting this transport's own connection log through it is
+        # what proves the field satisfies T-E5's precondition, not merely that
+        # something was recorded. With no tunnels to explain them, every port
+        # comes back unattributed; that is the shape, and T-E5 supplies the
+        # proxy that makes the list empty.
+        assert unattributable_peer_ports([c.peer_port for c in connections], []) == [captures[0].peer_port]
+
+    async def test_a_streamed_request_is_translated_back_to_chat_completions_sse(self) -> None:
+        """The reply is NDJSON upstream and SSE downstream; both sides must hold."""
+        subject = ProviderAiohttpTransport(FORMAT)
+        sent = marker()
+
+        async with BridgeFixture(subject) as fixture:
+            status, text = await fixture.post(
+                inbound_path(ROUTE), minimal_inbound_body(ROUTE, sent, stream=True)
+            )
+            captures = list(subject.captures)
+
+        assert status == 200
+        assert "data: [DONE]" in text
+        assert '"content": "ok"' in text or '"content":"ok"' in text
+        # The finish reason comes only from the final NDJSON object. Without
+        # this the stream's last line could be malformed and the test would
+        # still pass on the content chunk alone -- measured, not supposed.
+        assert '"finish_reason": "stop"' in text or '"finish_reason":"stop"' in text
+        assert json.loads(captures[0].body)["stream"] is True
+
+    async def test_it_passes_the_integration_conformance_check(self) -> None:
+        """R5 — the check every transport is judged by, on this one by name.
+
+        The meta-test in ``test_bridge.py`` runs the same check from the
+        ``CONFORMANCE_CASES`` row. Both are wanted: that one proves the row is
+        wired, this one fails in this module when the transport is what broke.
+        """
+        await assert_transport_reaches_its_recorder(transport(ProviderAiohttpTransport.name, FORMAT), protocol=ROUTE)
+
+
+class TestTheOAuthLoginLeg:
+    """R6 — the leg with no adapter, and the seam that redirects it."""
+
+    async def test_the_seam_swaps_the_endpoint_and_restores_it(
+        self, recorder: ProviderRecordingUpstream
+    ) -> None:
+        """The constant is the leg's only channel; it must not stay swapped.
+
+        Args:
+            recorder: The running recorder.
+        """
+        original = openai_oauth.OAUTH_TOKEN_URL
+
+        with oauth_token_endpoint(recorder) as url:
+            assert url == openai_oauth.OAUTH_TOKEN_URL
+            assert url.startswith(recorder.base_url)
+
+        assert original == openai_oauth.OAUTH_TOKEN_URL
+
+    async def test_the_seam_restores_the_endpoint_when_the_body_raises(
+        self, recorder: ProviderRecordingUpstream
+    ) -> None:
+        """A failing test must not leave the next one posting at a dead port.
+
+        Args:
+            recorder: The running recorder.
+        """
+        original = openai_oauth.OAUTH_TOKEN_URL
+
+        with pytest.raises(RuntimeError), oauth_token_endpoint(recorder):
+            raise RuntimeError("boom")
+
+        assert original == openai_oauth.OAUTH_TOKEN_URL
+
+    async def test_the_seam_refuses_to_swap_a_name_nothing_defines(
+        self, recorder: ProviderRecordingUpstream, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A silent no-op would leave a test passing over an empty capture list.
+
+        If the leg is ever rewritten to read its endpoint from somewhere else,
+        this is what says so — rather than the seam setting a name nothing
+        consults while the test that used it captures nothing and asserts on it.
+
+        Args:
+            recorder: The running recorder.
+            monkeypatch: Removes the attribute, standing in for that rewrite.
+        """
+        monkeypatch.delattr(openai_oauth, "OAUTH_TOKEN_URL")
+
+        with pytest.raises(AttributeError), oauth_token_endpoint(recorder):
+            pass  # pragma: no cover - the context manager raises on entry
+
+    async def test_both_token_exchanges_are_captured_in_full(
+        self, recorder: ProviderRecordingUpstream
+    ) -> None:
+        """The product's own coroutines, against the recorder, at startup fidelity.
+
+        Driven directly rather than through ``run_oauth_flow``: that orchestrator
+        binds a local callback server, opens a browser and waits five minutes for
+        a human. These two coroutines are the whole of what reaches the network.
+
+        Args:
+            recorder: The running recorder.
+        """
+        with oauth_token_endpoint(recorder):
+            async with aiohttp.ClientSession() as http:
+                tokens = await openai_oauth._exchange_code_for_tokens("code", "verifier", "client-id", http)
+                key = await openai_oauth._exchange_id_token_for_api_key(
+                    tokens["id_token"], tokens["access_token"], "client-id", http
+                )
+
+        assert key == oauth_token_body()["openai_api_key"]
+
+        captures = recorder.requests
+        assert [c.method for c in captures] == ["POST", "POST"]
+        assert [c.path for c in captures] == [OAUTH_TOKEN_SUFFIX, OAUTH_TOKEN_SUFFIX]
+        assert all(c.peer_port for c in captures), "containment cannot join a capture with no peer port"
+
+        grants = [c.body.decode().split("&")[0] for c in captures]
+        assert grants[0] == "grant_type=authorization_code"
+        assert grants[1].startswith("grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Atoken-exchange")
+
+    async def test_a_token_exchange_does_not_fail_the_declared_format_claim(self) -> None:
+        """The exclusion is deliberate, so it is asserted rather than left to silence.
+
+        The leg is answered before any format lookup — it has no
+        :class:`WireFormat` and must not be reported as a fallback — which means
+        ``assert_teardown_clean`` passes over it. That is a decision, and an
+        undocumented, untested decision is indistinguishable from a hole.
+        """
+        subject = ProviderAiohttpTransport(FORMAT)
+        await subject.start()
+        try:
+            with oauth_token_endpoint(subject.recorder):
+                async with aiohttp.ClientSession() as http:
+                    await openai_oauth._exchange_code_for_tokens("code", "verifier", "client-id", http)
+
+            assert len(subject.captures) == 1
+            subject.assert_teardown_clean()
+        finally:
+            await subject.stop()
+
+    async def test_the_leg_is_recorded_as_a_request_like_any_other(
+        self, recorder: ProviderRecordingUpstream
+    ) -> None:
+        """One recorder, two products: §7.2 assigns both to this row.
+
+        Args:
+            recorder: The running recorder.
+        """
+        with oauth_token_endpoint(recorder):
+            async with aiohttp.ClientSession() as http:
+                await openai_oauth._exchange_code_for_tokens("code", "verifier", "client-id", http)
+
+        captured = recorder.requests[0]
+        assert dict(captured.headers).get("Content-Type") == "application/x-www-form-urlencoded"
+        assert recorder.connections[0].requests == 1
+
+
+# ── Falsification (plan §1.4) ────────────────────────────────────────────────
+
+
+class _BlindProviderRecorder(ProviderRecordingUpstream):
+    """A recorder that counts a request and keeps none of its content."""
+
+    def store(self, index: int, captured: CapturedRequest) -> None:
+        """Store the capture with its body removed.
+
+        ``store`` is T-W4's seam for exactly this: a defect that disturbs one
+        thing and leaves the connection log and the ordering intact.
+
+        Args:
+            index: The reserved slot.
+            captured: The capture, stored without its body.
+        """
+        super().store(index, replace(captured, body=b""))
+
+
+@dataclass
+class _BlindProviderTransport(ProviderAiohttpTransport):
+    """Counts the request and records nothing about it.
+
+    Plan §1.4's fourth named harness failure — "a projection that could not see
+    the model name, in a product whose purpose is changing the model name" — in
+    this transport's own terms.
+    """
+
+    name = "falsify-provider-blind"
+
+    def __post_init__(self) -> None:
+        """Use the body-dropping recorder instead of the real one."""
+        self._recorder = _BlindProviderRecorder(default_format=self.format, responder=self.responder)
+
+
+@dataclass
+class _DecoyProviderTransport(ProviderAiohttpTransport):
+    """Points the bridge at a *different* live recorder than the one it reports.
+
+    §7.5.4's measured row 3, and the expensive failure: the request succeeds,
+    the client gets 200, and this transport's capture list is empty — so every
+    assertion built on it would be quantified over nothing and pass for free.
+    """
+
+    name = "falsify-provider-decoy"
+
+    _decoy: ProviderRecordingUpstream = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        """Build both recorders: the one reported, and the one actually reached."""
+        super().__post_init__()
+        self._decoy = ProviderRecordingUpstream(default_format=self.format)
+
+    async def start(self) -> None:
+        """Start both, so the decoy really answers rather than timing out."""
+        await super().start()
+        await self._decoy.start()
+
+    async def stop(self) -> None:
+        """Stop both, in a ``finally`` so neither leaks if the other raises."""
+        try:
+            await super().stop()
+        finally:
+            await self._decoy.stop()
+
+    def bind(self) -> Binding:
+        """Return a binding that reaches the decoy.
+
+        Returns:
+            This transport's adapter, pointed elsewhere.
+        """
+        adapter, _config = super().bind()
+        return adapter, {"base_url": self._decoy.base_url}
+
+
+async def _failure_message(subject: ProviderAiohttpTransport) -> str:
+    """Run the conformance check against a defect and return why it failed.
+
+    Args:
+        subject: An unstarted defective transport.
+
+    Returns:
+        The failure message.
+
+    Raises:
+        Failed: When the check passed, which is the whole point of this section.
+    """
+    with pytest.raises(AssertionError) as excinfo:
+        await assert_transport_reaches_its_recorder(subject, protocol=ROUTE)
+    return str(excinfo.value)
+
+
+class TestEachDefectIsCaught:
+    """R7 — the deliberate defects this harness must detect, running in the suite."""
+
+    async def test_a_binding_that_reaches_another_upstream_is_caught(self) -> None:
+        """The decoy — the failure no status check can see."""
+        message = await _failure_message(_DecoyProviderTransport(FORMAT))
+
+        assert "0 capture" in message
+        assert "quantified over nothing" in message
+
+    async def test_a_capture_that_cannot_see_the_content_is_caught(self) -> None:
+        """The blind capture — right count, right status, no evidence."""
+        message = await _failure_message(_BlindProviderTransport(FORMAT))
+
+        assert "marker" in message
+
+    async def test_a_reply_in_the_fallback_format_is_caught_at_teardown(self) -> None:
+        """The mis-declared format, in the shape this recorder can actually have.
+
+        T-W8's own case for this binds an adapter posting to the *other* format
+        the primary recorder serves, so the reply is correct and nothing is
+        recorded. This recorder serves one format, so the same mistake takes the
+        fallback instead and ``assert_teardown_clean`` is what reports it — which
+        is why the transport has one teardown check and not two.
+        """
+        subject = ProviderAiohttpTransport(FORMAT)
+        await subject.start()
+        try:
+            await send(
+                subject.recorder.host,
+                subject.recorder.port,
+                probe("stray", path="/v1/chat/completions"),
+                marker="stray",
+            )
+            with pytest.raises(UnmatchedPathError, match="/v1/chat/completions"):
+                subject.assert_teardown_clean()
+        finally:
+            await subject.stop()
+
+    async def test_the_defects_are_distinguishable(self) -> None:
+        """Each must break its own assertion, or the suite has halved its evidence.
+
+        Without this, a later tidy-up that collapsed two assertions into one
+        would leave both cases above green while they tested one thing.
+        """
+        decoy = await _failure_message(_DecoyProviderTransport(FORMAT))
+        blind = await _failure_message(_BlindProviderTransport(FORMAT))
+
+        assert decoy != blind
+        assert "capture" in decoy and "marker" not in decoy
+        assert "marker" in blind
+
+    async def test_the_blind_defect_still_reaches_its_own_recorder(self) -> None:
+        """Stated positively, so the decoy's emptiness stays the decoy's alone.
+
+        If a change made every defect produce an empty recording, both cases
+        above would still pass and both would be testing the decoy.
+        """
+        blind = _BlindProviderTransport(FORMAT)
+        with pytest.raises(AssertionError):
+            await assert_transport_reaches_its_recorder(blind, protocol=ROUTE)
+
+        assert len(blind.captures) == 1
+        assert blind.captures[0].body == b""
+
+
+class _CcBodyRecorder(ProviderRecordingUpstream):
+    """Answers with the Chat Completions body the *parent* recorder would send.
+
+    The defect a lost responder override would produce, and the one no
+    inherited machinery can catch: T-W4's recorder and T-W8's fixture are both
+    intact here, and the only thing wrong is the reply shape this task chose.
+    """
+
+    async def _default_responder(self, captured: CapturedRequest, response: Reply) -> None:
+        """Reply in the format the primary recorder serves.
+
+        Args:
+            captured: The recorded request, unused.
+            response: The unprepared response.
+        """
+        await self._reply_json(response, minimal_success_body(WireFormat.CHAT_COMPLETIONS))
+
+
+class _SseStreamRecorder(ProviderRecordingUpstream):
+    """Streams SSE frames where ``/api/chat`` speaks NDJSON."""
+
+    async def _default_responder(self, captured: CapturedRequest, response: Reply) -> None:
+        """Reply with the primary recorder's SSE stream.
+
+        Args:
+            captured: The recorded request, unused.
+            response: The unprepared response.
+        """
+        await response.begin(200, {"Content-Type": "text/event-stream"})
+        for chunk in minimal_success_stream(WireFormat.CHAT_COMPLETIONS):
+            await response.write(chunk)
+        await response.write_eof()
+
+
+async def _through_the_adapter(recorder: ProviderRecordingUpstream, *, stream: bool) -> str:
+    """Drive the real ``ollama_cloud`` adapter against ``recorder`` and return what it produced.
+
+    The product is the judge here, not this module: whether a reply is a success
+    or an empty response is ``translate_from_upstream``'s answer and the stream
+    parser's, and those are the two things a wrong reply shape actually meets.
+
+    Args:
+        recorder: A started recorder.
+        stream: Whether to drive the streaming path.
+
+    Returns:
+        The assistant text the adapter produced, empty when it could read none.
+    """
+    adapter = OllamaCloudAdapter()
+    request = {
+        "model": MODEL,
+        "messages": [{"role": "user", "content": "hi"}],
+        "stream": stream,
+        "_resolved_key": "harness-key",
+        "_provider_config": {"base_url": recorder.base_url},
+    }
+    try:
+        if not stream:
+            translated = await adapter.make_request(request)
+            return translated["choices"][0]["message"]["content"] or ""
+
+        written: list[bytes] = []
+
+        async def _collect(chunk: bytes) -> None:
+            """Collect one written chunk.
+
+            Args:
+                chunk: The bytes the adapter wrote downstream.
+            """
+            written.append(chunk)
+
+        await adapter.stream_request(request, _collect)
+        return "".join(
+            json.loads(line[6:])["choices"][0]["delta"].get("content") or ""
+            for line in b"".join(written).decode().splitlines()
+            if line.startswith("data: ") and line[6:].strip() != "[DONE]"
+        )
+    finally:
+        if adapter._session is not None:
+            await adapter._session.close()
+
+
+class TestTheReplyShapeIsLoadBearing:
+    """R7 — a falsification case against what **this task** wrote.
+
+    The two defects above ride on inherited machinery: ``store`` is T-W4's seam
+    and ``bind`` is T-W8's. Neither goes red if this task's own reply overrides
+    are wrong, and plan §1.4 asks for a defect *this* harness must detect.
+
+    **These are judged through the adapter rather than through the bridge, and
+    that is measured.** A defective reply driven through
+    ``assert_transport_reaches_its_recorder`` was measured at **4 captures, a
+    10-second timeout, and 72 seconds** including the teardown that waits for
+    the retry ladder — against §8.2's 1.6-second budget for the whole T-W8 pair.
+    The defect is real and caught either way; this way costs milliseconds and
+    says which of the two shapes was wrong.
+    """
+
+    async def test_a_chat_completions_body_leaves_the_product_with_nothing(
+        self, recorder: ProviderRecordingUpstream
+    ) -> None:
+        """Positive control first, then the defect, so neither can pass vacuously.
+
+        Args:
+            recorder: The running recorder, serving the real Ollama body.
+        """
+        assert await _through_the_adapter(recorder, stream=False) == "ok"
+
+        defective = _CcBodyRecorder(default_format=FORMAT)
+        await defective.start()
+        try:
+            assert await _through_the_adapter(defective, stream=False) == ""
+        finally:
+            await defective.stop()
+
+    async def test_an_sse_stream_leaves_the_product_with_nothing(
+        self, recorder: ProviderRecordingUpstream
+    ) -> None:
+        """The NDJSON choice is the delivery's, and this is what makes it falsifiable.
+
+        Args:
+            recorder: The running recorder, serving the real NDJSON stream.
+        """
+        assert await _through_the_adapter(recorder, stream=True) == "ok"
+
+        defective = _SseStreamRecorder(default_format=FORMAT)
+        await defective.start()
+        try:
+            assert await _through_the_adapter(defective, stream=True) == ""
+        finally:
+            await defective.stop()
+
+
+class TestTheRecorderStaysIndependentOfKitty:
+    """The rule ``contract.py`` enforces, extended to this recorder.
+
+    Asserting the property in prose only is what ``contract.py``'s own docstring
+    calls a defect: *"a rule that reads like a guarantee and guarantees
+    nothing"*. The **transport** module is deliberately not guarded — binding an
+    adapter is what it is for — and neither is this test module.
+    """
+
+    def test_the_recorder_imports_nothing_from_kitty(self) -> None:
+        """A recorder that asked kitty how to read a request would inherit its bugs."""
+        source = Path(provider_recorder_module.__file__).read_text(encoding="utf-8")
+        assert len(source) > 1000, "read no meaningful source; the guard would pass vacuously"
+
+        offending = [line.strip() for line in source.splitlines() if _KITTY_IMPORT.search(line)]
+        assert offending == [], f"the provider recorder must not import kitty: {offending}"


### PR DESCRIPTION
## Context for the Product Owner

Kitty Bridge's whole promise is that a provider cannot tell a session came through it. Proving that needs a fake provider on the other end of the wire that records exactly what we sent. One such recorder already exists — but it only sees traffic sent by the bridge's own HTTP client, and **two paths bypass it completely**:

- **Ollama Cloud**, whose adapter builds its own HTTP client. Nothing observed what we send to Ollama.
- **The OpenAI sign-in token exchange**, which runs at *startup* — before anything else has been proven, and the first thing to fire on a fresh machine.

This PR puts both under observation. Three downstream tickets — the fidelity oracle slice (KBR-57), the containment slice (KBR-65) and the wire-shape guard (KBR-80) — are blocked on it and can now proceed. No product code changes: this is test infrastructure only.

## What landed

Plan task **T-B1** (`TEST_SUITE.md` §5.5, §7.2, §7.5), Jira **KBR-40**.

- `tests/harness/provider_recorder.py` — the provider-session recording upstream. Serves Ollama's native `/api/chat` (NDJSON) and the OAuth token endpoint, dispatched by path suffix.
- `tests/harness/provider_aiohttp.py` — the `provider_aiohttp` transport, which binds `ollama_cloud` at the recorder through T-W8's `bind()` seam, plus `oauth_token_endpoint()`, the equivalent seam for a leg that has no adapter.
- `tests/harness/test_provider_aiohttp.py` — 46 tests: T-W4's fourteen conformance checks, the bridge end-to-end paths, the OAuth leg, and five falsification cases.
- `tests/harness/test_bridge.py` — one `CONFORMANCE_CASES` row, and a fix to the meta-test that drives it (see below).
- Design docs updated: `TEST_SUITE.md` §7.2.2 (new), §7.5, §8.2; the plan's Epic B rows.

## Three decisions worth reading

**1. The recorder subclasses T-W4's rather than being a second server.** §7.2.1 catalogues six ways an aiohttp recorder can look correct and lie; a second implementation is a second chance to get each one wrong — §7.3's own argument about the proxy. What differs is *vocabulary*, so exactly three things are overridden and `recorder.py` is untouched. The cost is that running the fourteen checks over a subclass proves the overrides did not break them, not that two implementations agree — so two falsification cases target the overrides directly.

**2. The OAuth token leg is served by the recorder but is not an `UpstreamTransport`.** §7.5 left this open for T-B1. `bind()` must return an adapter and the conformance check drives a real bridge; the login leg has neither. The alternative — a seventh `WireFormat` — would change a contract six Epic A readers consume to add a value no projection can read. `WireFormat` stays closed at six.

**3. Scope, after KBR-161.** This ticket was written as "the OAuth **legs**". KBR-161 moved the *refresh* leg onto `curl_cffi` so it presents one identity to OpenAI, and an aiohttp recorder cannot see it. T-B1 takes the **login** leg; the refresh leg is T-B2's, whose recorder speaks that stack. §5.5 already recorded the split; the plan's rows now agree with it.

## One fix to a shared file

`test_every_registered_transport_passes` resolved each row's transport by name without importing the module that registers it. That worked for the single row that existed and fails with `LookupError` for every row after it. It now imports the row's module, which is the same reasoning the completeness test beside it already states.

## Evidence

- Four gates green: `ruff`, `lint-imports`, `mypy src/kitty`, `pytest -m "l1 or l2"`.
- **Twelve deliberate mutations**, each caught by exactly the test that should catch it, with a clean control run.
- Two disputed review findings settled by measurement rather than argument: a wrong-shaped reply and an adapter posting at the wrong endpoint both fail **loudly** (4 captures, a 10 s timeout, 72 s with teardown), not silently — so the transport keeps one teardown check, and the reply-shape falsification runs through the adapter, where it costs milliseconds instead of 72 seconds against §8.2's 1.6 s budget.
- Ollama's `/api/chat` wire shapes confirmed against `ollama/ollama`'s own API reference.

## Filed along the way

**KBR-190** (Low) — stopping the bridge never closes the HTTP session a custom-transport adapter builds for itself; `stop_async` closes only its own two. Harmless at process exit, a leak per cycle on an in-process restart. Not fixed here: it is a product change and this task carries no `src` flag. The transport closes the session at teardown and a test pins that.
