### PR TITLE
KBR-36 — T-A4: Gemini wire projection, URL included

### DIFF
--- a/.system_design/TEST_SUITE.md
+++ b/.system_design/TEST_SUITE.md
@@ -443,10 +443,21 @@ because Gemini puts every sampling parameter under `generationConfig` and Conver
 > empty across the whole corpus" for all seven readers. T-W2 pins this boundary with its own test,
 > so it stays a decision rather than an assumption.
 
-**Optional ids, because two formats have none.** Gemini's `functionCall`/`functionResponse` carry
-no id; pairing there is by tool name and the k-th unanswered call of that name in the most recent
-assistant turn. A required id would force those readers to synthesise one and show a delta on every
-tool turn.
+**Optional ids, because a format may carry none.** Where an id is absent, pairing is by tool name
+and the k-th unanswered call of that name in the most recent assistant turn. A required id would
+force such a reader to synthesise one and show a delta on every tool turn.
+
+> ⚠️ **Corrected by T-A4 (KBR-36).** This section previously read "two formats have none" and named
+> Gemini as one of them, on the strength of Google's Cloud / Agent-Platform reference. The
+> **Developer API** surface kitty actually serves differs: `v1beta`'s `FunctionCall` publishes an
+> optional `id` ("If populated, the client to execute the `function_call` and return the response
+> with the matching `id`") and `FunctionResponse` an optional `id` the client populates to match —
+> verified against the discovery document at revision `20260910`. Optional either way, so the
+> *decision* to make `ToolUse.id` and `ToolResult.tool_use_id` optional is unchanged and still
+> right; only its stated reason was wrong. The Gemini reader therefore **reads the wire id when one
+> is sent** and falls back to the name-and-position rule when it is not. KBR-36's own acceptance
+> asked for this to be confirmed rather than assumed, which is why it is recorded here rather than
+> left as a reader's private finding.
 
 **`ToolResult.content` is wider than text and images**, because Converse's `toolResult.content`
 carries `json` (the common case), `document`, `video` and `searchResult`, Anthropic's carries
@@ -784,7 +795,8 @@ the request went. Three providers carry routing outside the body:
 |---|---|---|
 | Azure | The deployment id, which **is** the request's normalized model (P20) — and P6 deliberately removes `model` from the body | Two requests to two different deployments have **byte-identical bodies**. A body-only oracle cannot tell them apart, so a misrouted request is invisible. |
 | Vertex | `project_id` and `location` (P21) | The account being billed is a URL component |
-| Gemini | Model and operation (`:generateContent` vs `:streamGenerateContent`) in the inbound path | M10 lifts the model into the body precisely because it is not there to begin with |
+| Gemini | Model and operation (`:generateContent` vs `:streamGenerateContent`) in the inbound path | M10 lifts the model into the **outbound Chat Completions** body precisely because it is not in
+the inbound one to begin with |
 
 So the oracle takes the **whole captured request** — method, scheme, host, path, query, headers,
 body — and asserts routing separately from content.
@@ -2493,6 +2505,147 @@ That is the correct signal and it is also a deadline. Claude Code sets a block-l
 `cache_control` on nearly every request and the grammar has no slot for it, so **T-C2's corpus
 entry — `system` with `cache_control` — fails the first oracle run.** Tracked as a blocking edge
 onto T-D1, not as a note here.
+
+#### 7.4.2 What T-A4 settled — seven more rules, and which readers each one binds
+
+§7.4.1 fixed ten decisions writing T-A1. Writing **T-A4** (Gemini, [KBR-36]) reached seven more, each
+of which the remaining authors would otherwise answer differently, and each recorded here for the
+same reason: paths are index-based and `envelope.extra` is keyed, so two readers that disagree
+report a delta on content nobody changed.
+
+**Two of the seven are Google-specific and five are not**, which matters because only the five are a
+standing obligation on the rest of Epic A. **Rule 7 is different in kind from the other six**: it is
+not a new question this format raised but one the three shipped readers have already answered three
+different ways, which makes it the only rule here that is also a correction.
+
+| Rule | Binds |
+|---|---|
+| 1 — the route as a reader input | Gemini alone; no other format puts routing in the inbound URL (§3.3.5) |
+| 2 — a nested control field flattens to its leaf published key | **T-A5**, whose `inferenceConfig` and `toolConfig` nest the same way |
+| 3 — ProtoJSON's two spellings, and case-insensitive enum values | Google formats; a **Vertex** reader, if one is ever added, inherits it |
+| 4 — `envelope.extra` keyed by the *published* spelling | every reader of a format with more than one legal spelling, so today rule 3's set |
+| 5 — a capability toggle the wire does not name is control, not a `ToolDecl` | **T-A5** and **T-A6** |
+| 6 — digest the payload, not the carrier, where the field name discriminates | any format whose content union is discriminated by field name rather than by a `type` member |
+| 7 — a union member's own value is wrong: raise, residualise, or drop? | **every** reader; three answers are already shipped |
+
+**1. The route is a reader input, and only for what the body cannot show.** Gemini alone puts the
+model and the operation in the URL (§3.3.5), so its reader derives `envelope.model` from the path
+segment and `envelope.stream` from the operation suffix — `:streamGenerateContent` versus
+`:generateContent`, and **never** from `?alt=sse`, which selects SSE framing over JSON-array framing
+for a method that streams either way. The **query string is not read at all**: `verify_total`
+compares `consumed | residual` against the *body*, so a query key in either account would be
+reported as a claim on a key the body does not have. Asserting the route is T-D2's.
+
+A path that is not a published generate route raises `UnreadableBodyError`. That widens a type §7.4
+describes as "a body that cannot be read" to cover a *route* problem, which is defensible only on
+the inbound direction, where the path is the client's — and it is stated here because T-D1 uses that
+one exception type to tell a malformed corpus entry from an I1 breach.
+
+**2. A nested control field is addressed by its leaf published key.** Gemini puts sampling under
+`generationConfig` and the tool choice under `toolConfig.functionCallingConfig`; Converse nests
+`inferenceConfig` and `toolConfig` the same way, so T-A5 inherits this. `extra_path()` **raises** on
+a dotted key, which leaves exactly two dotless candidates, and the container loses:
+`envelope.extra[generationConfig]` cannot collide and survives a schema revision, but §3.3.1a
+compares an `extra` value **whole**, so it would collapse fourteen independently registrable fields
+into one address and make any row anchored there claim all of them — the coarse-anchor failure
+§3.3.1a warns about by name. The leaf key wins on the narrowest-anchor rule.
+
+The cost is a flat namespace assembled from several nested objects, so **each reader that flattens
+owes a test that its `extra` key sets are pairwise disjoint.** The namespace is not naturally
+disjoint — Gemini publishes `mediaResolution` on both `GenerationConfig` and `Part`, and the only
+reason there is no clash is that the `Part` one residualises. A collision would be introduced by a
+*schema revision*, not by a request, and the loser would overwrite the winner with no residual and
+no delta.
+
+**3. Google's JSON has two legal spellings of every field, and both must read.** Gemini's wire
+format is ProtoJSON, whose parsers "accept both the lowerCamelCase name … and the original proto
+field name" (`protobuf.dev/programming-guides/json/`). This is not theoretical: Google's own
+published examples mix them freely — `system_instruction`, `function_declarations`, `tool_config`,
+`file_data` and `response_mime_type` in snake_case, beside `generationConfig`, `stopSequences`,
+`maxOutputTokens` and `topP` in camelCase. A reader that knew only the schema's spelling would
+residualise the other and **fail the run on Google's own published example**, which §7.4.1 already
+calls "a harness defect and not a finding". Enum *values* are matched case-insensitively for the
+same reason: the published `FunctionCallingConfig.mode` enumeration is upper case and Google's
+`function_calling.sh` sends `"mode": "auto"`.
+
+Where one object carries both spellings of one field, the **published** spelling is read and the
+other residualises. Not "the first wins": §7.4.1 designs key order out of the projection elsewhere —
+"canonical JSON rather than the raw wire slice, because a translator that reorders keys must not
+change the digest" — and resolving by position would put it back, projecting one semantic body two
+ways depending on which alias a serialiser emitted first.
+
+**4. `envelope.extra` is keyed by the *published* wire key.** §3.3.1b says "keyed by the wire key",
+which named one thing until rule 3; it now names two. A register row can name only one, and T-D9's
+matrix needs one, so the published lowerCamelCase name is the address and the snake_case original
+resolves onto it. This is the one place where `extra` and the residual diverge deliberately:
+`consumed` and residual keys stay in the **wire** spelling, because `verify_total` compares them
+against the body's own keys.
+
+**5. A server-side capability toggle in the tools array is control, not a tool declaration.**
+Gemini's `Tool` message carries eight of them beside `functionDeclarations` — `googleSearch`,
+`codeExecution`, `urlContext`, `fileSearch`, `computerUse`, `googleMaps`, `googleSearchRetrieval`,
+`mcpServers` — each an unnamed toggle object such as `{"googleSearch": {}}`. They map to
+`envelope.extra[<key>]`.
+
+**This departs from T-A3**, which makes a non-`function` Responses tool a `ToolDecl` whose name is
+the tool type, and the departure is the point: a Responses built-in tool *has* a name to be
+addressed by, and §3.3.1a's tool paths are by name. Gemini's has none, so a `ToolDecl` would have to
+invent one — putting a vendor spelling into a form whose purpose is wire independence — while
+residualising would fail the run on every request that enables Google Search. The distinguishing
+question is therefore **"does the wire name this tool?"**, not "is it built in".
+
+**6. Digest the payload, not the carrier, where the field name is the discriminator.** §7.4.1's
+recipe says `rest` is "the block without `type` and without `cache_control`", which assumes a block
+discriminated by a `type` member. A Gemini `Part` is a union discriminated by **field name** and
+defines no `cache_control`, so the digest is taken over the *payload object* — `part["executableCode"]`
+— and neither exclusion has anything to remove. Sibling members on the same part residualise, which
+is exactly the role `cache_control` plays on a `type`-discriminated block. The recipe itself is
+unchanged, `ensure_ascii` included.
+
+**7. When a union member's own value is wrong: raise, residualise, or drop — and never drop.** Three
+readers have shipped and all three answer differently, which is the coordination failure §7.4.1
+exists to prevent, so it is settled here rather than left to T-A5 and T-A6 to pick a precedent from.
+The distinction is **what the bad value is a value *of***:
+
+| The wrong value is… | Outcome | Because |
+|---|---|---|
+| the value that **is** the part — `Part.text`, a `Thinking`'s text, `Opaque.kind` | **raise** `UnreadableBodyError` | the grammar has no absent value to fall back to, and `Text("")` fabricates an empty part — which is *meaningful* here, since P5e and P8 both inject one |
+| a **required field** of a part — a tool `name` | **residualise**, project the part with `""` | §3.3.1b settles it in those words: "an absent `name` *does* residualise … a call nobody can name cannot be paired or addressed" |
+| a **payload** the reader cannot canonicalise — base64 that does not decode | **residualise the leaf**, project the part with the grammar's absent value | `Image.digest` is `str \| None`, so an absent value exists, and §7.4.1: "raising is the other wrong answer: it blinds the oracle to everything else in a request it could otherwise diff" |
+| the **member itself**, where the schema declares an object and the wire sent a scalar — `{"functionCall": 7}` | **raise** | there is no value to put in the position, and the position cannot be vacated |
+
+**The line between the last two rows is where the member sits, not how bad the value is.** A
+container under the **envelope** — `generationConfig`, `toolConfig` — residualises whole when it is
+not an object, because every envelope field has an absent value and the rest of the request still
+projects. A container that **is a part or a turn** raises, because a part must occupy its index and
+the grammar offers nothing to put there: residualising it would leave the position empty, which is
+the drop this rule forbids. State the question as *"can the projection still fill this position?"*
+and every case above falls out of it.
+
+**No branch ever returns *no part*.** That is the load-bearing half, and it is where two of the three
+shipped readers are wrong: `reader_responses.py` returns `None` for both a wrongly-typed `input_text`
+and an undecodable data URL, which drops the part and shifts every later part's index — §7.4.1's own
+warning that "that invented delta lands on every part of the turn and on every turn after it". A
+reader that cannot read a part must still *occupy its position*.
+
+> **Reconciliation owed.** `reader_anthropic_messages.py` raises on undecodable base64 where this
+> rule residualises, and `reader_responses.py` drops a part where this rule keeps it. Both predate
+> this section. T-A4 is the reference implementation; the two landed readers need conforming, and
+> that is a change to shipped code rather than a note, so it is tracked as its own ticket.
+
+> **What this reader leaves on the record.** Six fields the format publishes, real clients send, and
+> the grammar cannot carry now residualise and so **fail the first oracle run** — the same shape as
+> the `cache_control` deadline above, and tracked as its own defect rather than as a note here. The
+> sharpest is `thoughtSignature` on a `functionCall` part, which Gemini 3 *requires* clients to echo
+> back verbatim. Unlike `cache_control` the grammar nearly has the slot — `contract.py` already says
+> `Thinking.signature` carries "Anthropic's `signature` or Gemini's `thoughtSignature`" — so the fix
+> is small and specific rather than open-ended.
+>
+> A second consequence, on the oracle rather than the reader: `GeminiTranslator` **discards** the
+> inbound tool-call id and synthesises one per call (`_make_tool_call_id`). Now that the §3.3.1 correction above
+> projects the wire id, every tool turn from a client that populates one shows a delta with no
+> register row to claim it. That is a correct oracle finding, not a reader defect, and it needs a
+> row or a ticket before T-D9 runs.
 
 ### 7.5 The bridge fixture
 

--- a/tests/harness/contract.py
+++ b/tests/harness/contract.py
@@ -131,10 +131,15 @@ class ToolUse:
     """A tool call the assistant made.
 
     Attributes:
-        id: The call id, or ``None`` where the format carries none. Gemini's
-            ``functionCall`` is ``{name, args}`` with no id, so a required id
-            would force T-A4 to synthesise one and show a delta on every tool
-            turn.
+        id: The call id, or ``None`` where the format carries none — a
+            required id would force such a reader to synthesise one and show a
+            delta on every tool turn. **Not Gemini**, contrary to this
+            docstring's original wording: `v1beta`'s ``FunctionCall`` publishes
+            an optional ``id`` and ``FunctionResponse`` an optional ``id`` the
+            client populates to match it (discovery document, revision
+            ``20260910``; corrected by T-A4/KBR-36, which was asked to confirm
+            rather than assume it). Optional either way, so the decision this
+            sentence justifies is unchanged.
         name: The tool's name.
         arguments: The parsed arguments. Chat Completions encodes these as a
             JSON *string* and Messages as an object; normalising here stops a

--- a/tests/harness/reader_gemini.py
+++ b/tests/harness/reader_gemini.py
@@ -943,6 +943,15 @@ def _read_required_name(view: Mapping[str, tuple[str, Any]], path: str, residual
     because dropping or raising on it would blind the oracle to the rest of a
     request it could otherwise diff. T-A3 takes the same branch.
 
+    **Two call sites, and they are only interchangeable by coincidence.** This is
+    reached from a ``FunctionDeclaration`` view and from a ``FunctionCall`` view,
+    which today publish ``name`` alike. A future schema that gave one of them a
+    second name-shaped key would silently mis-route here, because the helper
+    takes the aliased view rather than the schema it came from. Named so that a
+    change to one call site is not made on the assumption that the other
+    followed; each has its own wrongly-typed case in
+    ``TestEveryOptionalLeafFailsClosed``.
+
     Args:
         view: The aliased view of the object carrying the name.
         path: That object's path from the body root.

--- a/tests/harness/reader_gemini.py
+++ b/tests/harness/reader_gemini.py
@@ -1,0 +1,1600 @@
+"""The Gemini wire projection — one of the six independent readers.
+
+`.system_design/TEST_SUITE.md` §3.3.1, §3.3.1a, §3.3.1b, §3.3.5, §7.4.1 · plan
+task **T-A4** (KBR-36).
+
+Projects a captured Gemini ``generateContent`` / ``streamGenerateContent``
+request into :class:`harness.contract.Request`, so the fidelity oracle can
+compare what an agent sent against what kitty actually put on the wire.  Gemini
+is an **inbound-only** format in kitty: ``BridgeServer`` serves
+``/v1beta/models/{model}:generateContent`` for the Gemini CLI and translates to
+Chat Completions upstream, so this reader reads the *agent* side of the
+comparison.
+
+**Written against the published schema, never against kitty's output.**  Every
+key table below was read from the Gemini API discovery document,
+``https://generativelanguage.googleapis.com/$discovery/rest?version=v1beta``,
+``revision`` :data:`SCHEMA_VERSION` — not from a kitty request and not from
+memory.  §3.3.1's independent-oracle rule: a reader validated against kitty's
+output inherits kitty's bugs, and the whole of I1 then proves only that kitty
+agrees with itself.
+
+**It imports nothing from ``src/kitty``, and must not.**
+``test_reader_gemini.py`` asserts the absence structurally.
+
+**Three things this format forces that no earlier reader met.**  Each is
+recorded in §7.4.1 so T-A5 and T-A6 inherit the answer rather than inventing one:
+
+1. **The route is an input** (§3.3.5).  :attr:`~harness.contract.Envelope.model`
+   comes from the path segment and :attr:`~harness.contract.Envelope.stream`
+   from the operation suffix.  Nothing in the body shows either.
+2. **Control fields nest.**  Sampling lives under ``generationConfig`` and the
+   tool choice under ``toolConfig.functionCallingConfig``, while
+   :func:`harness.contract.extra_path` *raises* on a dotted key.  So a nested
+   control field maps to ``envelope.extra[<leaf published key>]``.
+3. **Every field has two legal spellings.**  Gemini's JSON is ProtoJSON, whose
+   parsers "accept both the lowerCamelCase name … and the original proto field
+   name" (``protobuf.dev/programming-guides/json/``), and Google's own published
+   examples mix the two freely — ``system_instruction`` and
+   ``function_declarations`` beside ``maxOutputTokens`` and ``stopSequences``.
+   A reader that knew one spelling would residualise the other and fail the run
+   on Google's own published example.
+
+**What totality means here, and where it stops.**  Every one of the nine
+published top-level body keys is classified into the envelope, the conversation, or
+the residual, and :func:`harness.contract.verify_total` fails the run on
+anything left over.  Two boundaries are deliberate and named rather than
+implied: ``consumed`` covers *top-level* keys only (§3.3.1's stated boundary),
+and the **query string is not read at all** — ``?alt=sse`` and ``?key=`` are
+route surface, and ``verify_total`` compares ``consumed | residual`` against the
+*body*, so a query key in either account would be reported as a claim on a key
+the body does not have.  Asserting the route is T-D2's (KBR-52).
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+import json
+import re
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from harness import contract as c
+
+#: The published schema version every table in this module was derived from —
+#: the discovery document's ``revision``, which is how Google versions it.
+#: Spelled ``SCHEMA_VERSION`` to match ``reader_responses.py``, so T-D8 does not
+#: have to learn six names for one idea.  Recorded so a future divergence is
+#: traceable rather than mysterious: when Google adds a top-level key or a
+#: ``Part`` member, the schema-agreement tests go red and this string says which
+#: revision the reader last agreed with.
+SCHEMA_VERSION = "20260910"
+
+# --------------------------------------------------------------------------
+# The route — §3.3.5
+# --------------------------------------------------------------------------
+
+#: The published REST path shape, ``v1beta/{+model}:generateContent``.  ``model``
+#: is greedy up to the operation's colon because the segment may itself contain
+#: a slash, which is how ``models/gemini-2.5-pro`` reaches the route.
+_ROUTE = re.compile(r"^/(?P<version>v[^/]+)/models/(?P<model>[^:]+):(?P<operation>[A-Za-z]+)$")
+
+#: The two published generate operations, and the ``stream`` each implies.
+#: ``countTokens`` and ``embedContent`` are published methods on the same
+#: resource, so accepting "any operation" would project a token count as a
+#: conversation.
+_OPERATIONS: Mapping[str, bool] = {"generateContent": False, "streamGenerateContent": True}
+
+#: The prefix the published path form puts before a model name.  A profile that
+#: names ``models/gemini-2.5-pro`` and one that names ``gemini-2.5-pro`` reach
+#: the same destination, so they must project the same model.
+_MODEL_PREFIX = "models/"
+
+# --------------------------------------------------------------------------
+# Top-level key classification — `GenerateContentRequest`, 9 REST body keys
+# --------------------------------------------------------------------------
+
+#: Keys carrying semantic content rather than control.
+_CONVERSATION_KEYS = frozenset({"contents", "systemInstruction", "tools", "toolConfig"})
+
+#: Top-level control fields that map to ``envelope.extra`` under their own
+#: published key.
+_TOP_LEVEL_EXTRA_KEYS = frozenset({"serviceTier", "safetySettings", "cachedContent"})
+
+#: All nine, for the totality check and for the test that asserts this module's
+#: tables still agree with the published schema.
+#:
+#: **Nine, not the discovery document's ten.**  That document carries the proto
+#: message, whose ``model`` field the REST surface exposes as the *path
+#: parameter* — the endpoint is ``/v1beta/{model=models/*}:generateContent`` and
+#: the reference's own "Request body" table lists exactly these nine, omitting
+#: ``model``.  So a body-level ``model`` is an unrecognised key and residualises
+#: like any other.  An earlier draft made it a second carrier to reconcile
+#: against the path, which put an *assertion* inside a reader: a comparison whose
+#: only outcome is a residual can never be claimed by a register row (§3.3.1a
+#: makes ``residual`` an illegal anchor), so it could only ever kill the run —
+#: and finding disagreements is §3.3.2's job, over a route T-D2 already owns.
+PUBLISHED_TOP_LEVEL_KEYS = _CONVERSATION_KEYS | _TOP_LEVEL_EXTRA_KEYS | frozenset({"generationConfig", "store"})
+
+# --------------------------------------------------------------------------
+# `GenerationConfig`, 25 keys
+# --------------------------------------------------------------------------
+
+#: A JSON number, which may arrive as an ``int``.  ``bool`` is excluded by
+#: :func:`_typed_leaf` rather than here, because it is a subclass of ``int``.
+_NUMBER = (int, float)
+
+#: The eleven ``generationConfig`` members with a canonical Chat Completions
+#: spelling (§3.3.1b), each with the type the schema publishes for it.
+#:
+#: ⚠️ The last two are a **name collision**, and mapping either onto its own
+#: spelling would be wrong.  Gemini's ``logprobs`` is an *integer* — "the number
+#: of top logprobs … to return at each decoding step" — which Chat Completions
+#: calls ``top_logprobs``; Gemini's ``responseLogprobs`` is the *boolean* Chat
+#: Completions calls ``logprobs``.  A reader that carried ``logprobs`` across
+#: unchanged would show a cross-format delta on every request that asks for them.
+_SAMPLING_KEYS: Mapping[str, tuple[str, tuple[type, ...]]] = {
+    "temperature": ("temperature", _NUMBER),
+    "topP": ("top_p", _NUMBER),
+    "topK": ("top_k", (int,)),
+    "maxOutputTokens": ("max_tokens", (int,)),
+    "presencePenalty": ("presence_penalty", _NUMBER),
+    "frequencyPenalty": ("frequency_penalty", _NUMBER),
+    "seed": ("seed", (int,)),
+    "candidateCount": ("n", (int,)),
+    "stopSequences": ("stop", (list,)),
+    "responseLogprobs": ("logprobs", (bool,)),
+    "logprobs": ("top_logprobs", (int,)),
+}
+
+#: Every other published ``generationConfig`` member.  These are recognised
+#: declared control fields of the format, so §3.3.1b maps them to
+#: ``envelope.extra`` rather than the residual — that section names
+#: ``generationConfig.responseSchema`` as exactly this case.
+#:
+#: None of ``responseMimeType``, ``responseSchema``, ``responseJsonSchema``,
+#: ``_responseJsonSchema`` or ``responseFormat`` maps onto the canonical
+#: ``response_format``: ``responseFormat`` is per-modality output configuration
+#: and the others are schema constraints, so folding any of them onto the Chat
+#: Completions union would put a claim into the projection that the wire does
+#: not make.
+_GENERATION_EXTRA_KEYS = frozenset(
+    {
+        "_responseJsonSchema",
+        "audioTranscriptionConfig",
+        "enableAffectiveDialog",
+        "enableEnhancedCivicAnswers",
+        "imageConfig",
+        "mediaResolution",
+        "responseFormat",
+        "responseJsonSchema",
+        "responseMimeType",
+        "responseModalities",
+        "responseSchema",
+        "speechConfig",
+        "thinkingConfig",
+        "translationConfig",
+    }
+)
+
+#: All 25.
+PUBLISHED_GENERATION_CONFIG_KEYS = frozenset(_SAMPLING_KEYS) | _GENERATION_EXTRA_KEYS
+
+# --------------------------------------------------------------------------
+# `ToolConfig` and `Tool`
+# --------------------------------------------------------------------------
+
+#: ``ToolConfig`` members other than ``functionCallingConfig``, which becomes
+#: ``tool_choice``.  Flattened to their leaf key for the same reason as
+#: ``generationConfig``'s.
+_TOOL_CONFIG_EXTRA_KEYS = frozenset({"retrievalConfig", "includeServerSideToolInvocations"})
+
+#: All three.
+PUBLISHED_TOOL_CONFIG_KEYS = _TOOL_CONFIG_EXTRA_KEYS | frozenset({"functionCallingConfig"})
+
+#: ``FunctionCallingConfig``'s two published members.
+PUBLISHED_FUNCTION_CALLING_CONFIG_KEYS = frozenset({"mode", "allowedFunctionNames"})
+
+#: The three published modes with a canonical value.  ``MODE_UNSPECIFIED`` and
+#: ``VALIDATED`` have none and residualise instead — :class:`Envelope` enforces
+#: :data:`~harness.contract.TOOL_CHOICE_VALUES`, so inventing one would raise.
+#:
+#: Matched **case-insensitively**: the published enumeration spells them in
+#: upper case, and Google's own published ``function_calling.sh`` example sends
+#: ``"mode": "auto"``.
+_TOOL_CHOICE_MODES: Mapping[str, str] = {"AUTO": "auto", "ANY": "any", "NONE": "none"}
+
+#: ``Tool``'s eight built-in capability toggles.  These configure server-side
+#: capabilities rather than declaring a function the agent wrote, so they are
+#: control and map to ``envelope.extra`` — :class:`~harness.contract.ToolDecl`
+#: requires a name, and inventing ``ToolDecl("googleSearch")`` would put a
+#: vendor spelling into a form whose purpose is wire independence.
+_BUILT_IN_TOOL_KEYS = frozenset(
+    {
+        "codeExecution",
+        "computerUse",
+        "fileSearch",
+        "googleMaps",
+        "googleSearch",
+        "googleSearchRetrieval",
+        "mcpServers",
+        "urlContext",
+    }
+)
+
+#: All nine.
+PUBLISHED_TOOL_KEYS = _BUILT_IN_TOOL_KEYS | frozenset({"functionDeclarations"})
+
+#: ``FunctionDeclaration``'s seven published members.  ``behavior``, ``response``
+#: and ``responseJsonSchema`` have no slot in :class:`~harness.contract.ToolDecl`
+#: and residualise; ``parametersJsonSchema`` is the published mutually-exclusive
+#: alternative to ``parameters`` and fills the same slot.
+PUBLISHED_FUNCTION_DECLARATION_KEYS = frozenset(
+    {
+        "behavior",
+        "description",
+        "name",
+        "parameters",
+        "parametersJsonSchema",
+        "response",
+        "responseJsonSchema",
+    }
+)
+
+# --------------------------------------------------------------------------
+# `Content` and `Part`
+# --------------------------------------------------------------------------
+
+#: ``Content``'s two published members.
+PUBLISHED_CONTENT_KEYS = frozenset({"parts", "role"})
+
+#: The published producer values, onto §3.3.1b's closed role set.  An absent or
+#: empty role is ``user``: the schema says the field "can be left blank or unset"
+#: for a single-turn query, and request content with no producer is the client's.
+_ROLES: Mapping[str, str] = {"user": "user", "model": "assistant"}
+
+#: One producer value the published schema does **not** list, recognised on
+#: §7.4.1's first evidence rule: the client demonstrably sends it, so rejecting
+#: it would fail the run on real traffic, "which is a harness defect and not a
+#: finding".  The evidence is ``src/kitty/bridge/gemini/translator.py``'s
+#: ``_ROLE_MAP``, which reads ``role: "function"`` straight off the inbound body
+#: — the same shape as that section's worked example, Anthropic's ``effort``.
+#: It is the spelling older Google SDKs used for a function-response turn, and
+#: ``user`` is where §3.3.1b already puts a tool result, so nothing is invented.
+#:
+#: Kept in its own table rather than folded into :data:`_ROLES`, so that a
+#: reader of this module can see one deliberate exception to the published
+#: schema rather than a fourth undocumented producer value.
+_EVIDENCED_ROLES: Mapping[str, str] = {"function": "user"}
+
+#: ``Part`` members the grammar models semantically.
+_MODELLED_PART_KEYS = frozenset({"text", "inlineData", "fileData", "functionCall", "functionResponse"})
+
+#: ``Part`` members with no slot in the grammar, which therefore project as
+#: :class:`~harness.contract.Opaque`.  All four name a concept no other format
+#: has, so KBR-35's stated exception applies and the wire name in snake_case is
+#: the canonical ``kind``; no cross-vendor alias table is needed here.  **T-A5
+#: does need one** — Converse writes ``searchResult`` where Anthropic writes
+#: ``search_result`` — so this module is not the precedent for that case.
+_OPAQUE_PART_KEYS: Mapping[str, str] = {
+    "executableCode": "executable_code",
+    "codeExecutionResult": "code_execution_result",
+    "toolCall": "tool_call",
+    "toolResponse": "tool_response",
+}
+
+#: ``Part`` members that modify another member rather than being content of
+#: their own.  The grammar has no slot for any of them, so they residualise at
+#: their own path — ``thoughtSignature`` only when the part is not a thought,
+#: since :class:`~harness.contract.Thinking` carries it when it is.
+_PART_MODIFIER_KEYS = frozenset(
+    {
+        "audioTranscription",
+        "mediaProcessing",
+        "mediaResolution",
+        "partMetadata",
+        "thought",
+        "thoughtSignature",
+        "videoMetadata",
+    }
+)
+
+#: All sixteen.
+PUBLISHED_PART_KEYS = _MODELLED_PART_KEYS | frozenset(_OPAQUE_PART_KEYS) | _PART_MODIFIER_KEYS
+
+#: ``FunctionCall``'s three published members.
+PUBLISHED_FUNCTION_CALL_KEYS = frozenset({"id", "name", "args"})
+
+#: ``FunctionResponse``'s six published members.  ``scheduling`` and
+#: ``willContinue`` govern NON_BLOCKING call scheduling, which the grammar does
+#: not model, so they residualise.
+PUBLISHED_FUNCTION_RESPONSE_KEYS = frozenset({"id", "name", "response", "parts", "scheduling", "willContinue"})
+
+#: ``Blob``'s and ``FileData``'s published members.  ``displayName`` names the
+#: blob to the model and has no slot, so it residualises.
+PUBLISHED_BLOB_KEYS = frozenset({"data", "mimeType", "displayName"})
+PUBLISHED_FILE_DATA_KEYS = frozenset({"fileUri", "mimeType", "displayName"})
+
+
+class GeminiProjection:
+    """Reads a Gemini ``generateContent`` request into :class:`~harness.contract.Request`.
+
+    Implements :class:`~harness.contract.Projection` for
+    :attr:`~harness.contract.WireFormat.GEMINI`.
+
+    Attributes:
+        wire_format: Always :attr:`~harness.contract.WireFormat.GEMINI`.
+    """
+
+    wire_format = c.WireFormat.GEMINI
+
+    def read_request(self, captured: c.CapturedRequest) -> c.Request:
+        """Project a captured Gemini request.
+
+        Args:
+            captured: The request as observed on the wire. **Both the path and
+                the body are read**: the model and the operation live in the
+                URL (§3.3.5), so a body-only reader could not project a Gemini
+                request at all. The query is deliberately not read — see the
+                module docstring.
+
+        Returns:
+            The wire-independent projection, total over the body.
+
+        Raises:
+            UnreadableBodyError: When the path is not a published generate
+                route, or the body is not a readable Gemini request. The
+                catch-all below is the actual guarantee: the contract names
+                three failure shapes, and an escaping ``KeyError`` would be an
+                undefined fourth on the one path T-D1 uses to tell an unreadable
+                body from an I1 breach. ``IndexError`` is deliberately **not** in
+                the tuple: no sequence in this module is indexed positionally
+                except under a guard, so catching it would be handling an
+                impossible case.
+        """
+        model, stream = _read_route(captured.path)
+        body = _parse_body(captured.body)
+
+        # `ValueError` is deliberately NOT caught: from inside a reader it means
+        # the reader mis-routed a field, which is a reader bug and must surface.
+        try:
+            return _project(body, model, stream)
+        except (KeyError, TypeError, AttributeError) as exc:
+            raise c.UnreadableBodyError(f"unreadable Gemini body: {exc!r}") from exc
+
+
+def _read_route(path: str) -> tuple[str, bool]:
+    """Read the model and the streaming flag out of the request path.
+
+    §3.3.5: "Gemini carries the model and the operation in the path … which is
+    why M10 lifts the model into the body in the first place."
+
+    ``stream`` comes from the **operation**, never from ``?alt=sse``: ``alt``
+    selects SSE framing over JSON-array framing for a method that streams either
+    way, so reading it instead would project a streaming request as
+    non-streaming and let P17's register row claim a delta nobody caused.
+
+    Args:
+        path: :attr:`~harness.contract.CapturedRequest.path`, including the
+            ``:generateContent`` operation.
+
+    Returns:
+        The model name, with any ``models/`` prefix stripped, and whether the
+        operation streams.
+
+    Raises:
+        UnreadableBodyError: When the path is not one of the two published
+            generate routes. Structural, not residualisable: there is no partial
+            projection to salvage when the model cannot be read at all.
+    """
+    matched = _ROUTE.match(path)
+    if matched is None:
+        raise c.UnreadableBodyError(
+            f"path {path!r} is not a published Gemini generate route (/{{version}}/models/{{model}}:generateContent)"
+        )
+
+    operation = matched.group("operation")
+    if operation not in _OPERATIONS:
+        raise c.UnreadableBodyError(
+            f"operation {operation!r} is not one of {sorted(_OPERATIONS)}; "
+            "countTokens and embedContent are published on the same resource and are not requests"
+        )
+
+    model = matched.group("model")
+    return model.removeprefix(_MODEL_PREFIX), _OPERATIONS[operation]
+
+
+def _parse_body(raw: bytes) -> Mapping[str, Any]:
+    """Decode the request body into a JSON object.
+
+    Args:
+        raw: The raw body bytes.
+
+    Returns:
+        The parsed body.
+
+    Raises:
+        UnreadableBodyError: When the bytes are not JSON, or are JSON that is
+            not an object. A JSON array is valid JSON and an invalid request.
+    """
+    try:
+        body = json.loads(raw)
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise c.UnreadableBodyError(f"body is not valid JSON: {exc}") from exc
+
+    if not isinstance(body, dict):
+        raise c.UnreadableBodyError(f"body must be a JSON object, got {type(body).__name__}")
+
+    return body
+
+
+# --------------------------------------------------------------------------
+# ProtoJSON's two spellings
+# --------------------------------------------------------------------------
+
+
+def _camel(key: str) -> str:
+    """Convert a proto ``snake_case`` field name to its lowerCamelCase JSON name.
+
+    Args:
+        key: A wire key.
+
+    Returns:
+        The lowerCamelCase form. A key with no underscore is returned unchanged.
+    """
+    head, *rest = key.split("_")
+    return head + "".join(word[:1].upper() + word[1:] for word in rest)
+
+
+def _resolve(key: str, published: frozenset[str]) -> str:
+    """Return the published name a wire key stands for, or the key itself.
+
+    ProtoJSON parsers "accept both the lowerCamelCase name … and the original
+    proto field name", and Google's published examples use both — so a reader
+    that knew only the schema's spelling would residualise ``system_instruction``
+    and fail the run on Google's own ``system_instruction.sh``.
+
+    The published name is tried **first**, which is what keeps
+    ``_responseJsonSchema`` resolving to itself rather than to the
+    ``ResponseJsonSchema`` that naive conversion of its leading underscore
+    would produce.
+
+    Args:
+        key: The wire key as the client spelled it.
+        published: The published names of the object being read.
+
+    Returns:
+        The published name when one matches, otherwise ``key`` unchanged, which
+        leaves it unrecognised and so bound for the residual.
+    """
+    if key in published:
+        return key
+
+    camel = _camel(key)
+    return camel if camel in published else key
+
+
+def _aliased(
+    source: Mapping[str, Any], published: frozenset[str], prefix: str, residual: dict[str, Any]
+) -> dict[str, tuple[str, Any]]:
+    """Return a published-name view of an object, keeping each key's wire spelling.
+
+    The wire spelling has to survive because a residual key is "the body's own
+    path" (§7.4.1) and ``consumed`` is compared against the body's own keys by
+    :func:`~harness.contract.verify_total`; the published name is what the
+    reader dispatches on.
+
+    Args:
+        source: The object being read.
+        published: The published names of that object.
+        prefix: The object's path from the body root, ``""`` at the top level.
+        residual: The residual mapping, extended in place with any key that
+            collides with one already seen.
+
+    Returns:
+        A mapping of published name to ``(wire key, value)``, in wire order.
+
+    Note:
+        When two wire keys resolve to the same published name, the **published**
+        spelling is read and the other residualises at its own wire path — a
+        body cannot mean two things, and resolving by position would make the
+        projection depend on the order a serialiser emitted them in.
+    """
+    view: dict[str, tuple[str, Any]] = {}
+
+    for wire_key, value in source.items():
+        name = _resolve(wire_key, published)
+        if name not in view:
+            view[name] = (wire_key, value)
+            continue
+
+        # The **published** spelling wins wherever it appears, so the projection
+        # does not depend on the order a serialiser emitted two aliases in.
+        # §7.4.1 designs key order out of the projection elsewhere for the same
+        # reason — "canonical JSON rather than the raw wire slice, because a
+        # translator that reorders keys must not change the digest".
+        held_key, held_value = view[name]
+        if wire_key == name and held_key != name:
+            view[name] = (wire_key, value)
+            residual[_join(prefix, held_key)] = held_value
+        else:
+            residual[_join(prefix, wire_key)] = value
+
+    return view
+
+
+def _join(prefix: str, key: str) -> str:
+    """Return a residual key for ``key`` inside the object at ``prefix``.
+
+    Args:
+        prefix: The object's path from the body root, ``""`` at the top level.
+        key: The wire key.
+
+    Returns:
+        The dotted path, or the bare key at the top level — where the bare form
+        is required, because :func:`~harness.contract.verify_total` compares the
+        residual's keys against the body's own.
+    """
+    return f"{prefix}.{key}" if prefix else key
+
+
+def _residualise(
+    view: Mapping[str, tuple[str, Any]],
+    mapped: frozenset[str] | set[str],
+    prefix: str,
+    residual: dict[str, Any],
+) -> None:
+    """Record every key of an aliased view the reader did not map.
+
+    §3.3.1's "unknown fields fail closed", applied at depth:
+    :func:`~harness.contract.verify_total` sees top-level keys only, so this is
+    what closes the gap beneath them.
+
+    Args:
+        view: The aliased view, from :func:`_aliased`.
+        mapped: The published names the caller accounted for.
+        prefix: The object's path from the body root.
+        residual: The residual mapping, extended in place.
+    """
+    for name, (wire_key, value) in view.items():
+        if name not in mapped:
+            residual[_join(prefix, wire_key)] = value
+
+
+def _typed_leaf(
+    view: Mapping[str, tuple[str, Any]],
+    name: str,
+    expected: tuple[type, ...],
+    prefix: str,
+    residual: dict[str, Any],
+    default: Any = None,
+) -> Any:
+    """Return an optional leaf, residualising it when the wire carried the wrong type.
+
+    §7.4.1's wrongly-typed-leaf rule, applied wherever the grammar has an absent
+    value to fall back to. Without it these fields *fail open*: the contract
+    validates only roles, sampling keys and ``tool_choice``, so a dict in a field
+    declared ``str | None`` is carried silently and the residual stays empty.
+    T-A1 measured eight of nine leaves failing open when the rule was applied
+    field by field rather than through one helper, which is why every optional
+    leaf in this module goes through this one.
+
+    Args:
+        view: The aliased view of the object being read.
+        name: The leaf's published name.
+        expected: The types the schema publishes for it.
+        prefix: The object's path from the body root.
+        residual: The residual mapping, extended in place.
+        default: The grammar's absent value for this field.
+
+    Returns:
+        The leaf, or ``default`` when the wire value was the wrong type.
+    """
+    if name not in view:
+        return default
+
+    wire_key, value = view[name]
+    if value is None:
+        # ProtoJSON reads `null` as the field's default, so an explicit null is
+        # the absent value rather than a type error.
+        return default
+
+    # `bool` is a subclass of `int`, so an unguarded `isinstance` would carry
+    # `"topK": true` through as the integer 1 — a value the agent never sent.
+    wrong = not isinstance(value, expected) or (isinstance(value, bool) and bool not in expected)
+    if wrong:
+        residual[_join(prefix, wire_key)] = value
+        return default
+
+    return value
+
+
+def _members(value: Any) -> tuple[Any, ...] | None:
+    """Return a repeated field's members, accepting the published singleton form.
+
+    Google's published ``system_instruction.sh`` and ``function_calling.sh``
+    examples send ``contents`` and ``parts`` as **single objects** where the
+    schema declares repeated fields, and they are the examples this reader is
+    validated against. Accepting only a list would fail the run on two of
+    Google's own samples.
+
+    Args:
+        value: The field's wire value.
+
+    Returns:
+        The members in order, or ``None`` when the value is neither a list nor
+        an object and so cannot be read as either.
+    """
+    if isinstance(value, Mapping):
+        return (value,)
+    if isinstance(value, list):
+        return tuple(value)
+    return None
+
+
+# --------------------------------------------------------------------------
+# The top-level walk
+# --------------------------------------------------------------------------
+
+
+def _project(body: Mapping[str, Any], model: str, stream: bool) -> c.Request:
+    """Classify every top-level key into the envelope, the conversation or the residual.
+
+    Args:
+        body: The parsed request body.
+        model: The model, read from the path.
+        stream: Whether the path's operation streams.
+
+    Returns:
+        The projection.
+
+    Raises:
+        UnreadableBodyError: Propagated from the per-field readers.
+    """
+    residual: dict[str, Any] = {}
+    extra: dict[str, Any] = {}
+    view = _aliased(body, PUBLISHED_TOP_LEVEL_KEYS, "", residual)
+
+    # Every other control field the format defines, keyed by its **published**
+    # name. §3.3.1a says "keyed by the wire key"; ProtoJSON gives every field two
+    # legal wire keys, and a register row can name only one, so the published
+    # lowerCamelCase name is the address and the snake_case original resolves
+    # onto it.
+    for name in _TOP_LEVEL_EXTRA_KEYS:
+        if name in view:
+            extra[name] = view[name][1]
+
+    sampling, generation_extra = _read_generation_config(view, residual)
+    extra.update(generation_extra)
+    extra.update(_read_tool_config(view, residual))
+
+    tools, tool_extra = _read_tools(view, residual)
+    extra.update(tool_extra)
+
+    conversation = c.Conversation(
+        system=_read_system_instruction(view, residual),
+        turns=_read_contents(view, residual),
+        tools=tools,
+        sampling=sampling,
+    )
+
+    envelope = c.Envelope(
+        model=model,
+        stream=stream,
+        store=_typed_leaf(view, "store", (bool,), "", residual),
+        extra=extra,
+    )
+
+    _residualise(view, PUBLISHED_TOP_LEVEL_KEYS, "", residual)
+
+    return c.Request(
+        envelope=envelope,
+        conversation=conversation,
+        residual=residual,
+        consumed=frozenset(wire_key for name, (wire_key, _) in view.items() if name in PUBLISHED_TOP_LEVEL_KEYS),
+        source=body,
+    )
+
+
+# --------------------------------------------------------------------------
+# Control fields
+# --------------------------------------------------------------------------
+
+
+def _read_generation_config(
+    view: Mapping[str, tuple[str, Any]], residual: dict[str, Any]
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Split ``generationConfig`` into canonical sampling and format-specific control.
+
+    §3.3.1b: sampling normalises onto a **closed** set of fifteen canonical
+    keys, and "a key outside the set that the reader recognises as a declared
+    control field of that format maps to ``envelope.extra[<wire key>]`` — only
+    an *unrecognised* key residualises." That section names
+    ``generationConfig.responseSchema`` as exactly this case.
+
+    Args:
+        view: The aliased top-level view.
+        residual: The residual mapping, extended in place.
+
+    Returns:
+        The canonical sampling mapping and the extra entries, each keyed by the
+        **leaf** published name — ``envelope.extra[responseSchema]``, never
+        ``envelope.extra[generationConfig.responseSchema]``, because
+        :func:`~harness.contract.extra_path` raises on a dotted key.
+    """
+    if "generationConfig" not in view:
+        return {}, {}
+
+    wire_key, value = view["generationConfig"]
+    if not isinstance(value, Mapping):
+        residual[wire_key] = value
+        return {}, {}
+
+    nested = _aliased(value, PUBLISHED_GENERATION_CONFIG_KEYS, wire_key, residual)
+
+    sampling: dict[str, Any] = {}
+    for name, (canonical, expected) in _SAMPLING_KEYS.items():
+        read = _typed_leaf(nested, name, expected, wire_key, residual)
+        if read is not None:
+            sampling[canonical] = read
+
+    extra = {name: nested[name][1] for name in _GENERATION_EXTRA_KEYS if name in nested}
+
+    _residualise(nested, PUBLISHED_GENERATION_CONFIG_KEYS, wire_key, residual)
+    return sampling, extra
+
+
+def _read_tool_config(view: Mapping[str, tuple[str, Any]], residual: dict[str, Any]) -> dict[str, Any]:
+    """Read ``toolConfig`` into ``tool_choice`` and the rest of the envelope's extra.
+
+    Args:
+        view: The aliased top-level view.
+        residual: The residual mapping, extended in place.
+
+    Returns:
+        The extra entries, ``tool_choice`` among them when a mode maps.
+    """
+    if "toolConfig" not in view:
+        return {}
+
+    wire_key, value = view["toolConfig"]
+    if not isinstance(value, Mapping):
+        residual[wire_key] = value
+        return {}
+
+    nested = _aliased(value, PUBLISHED_TOOL_CONFIG_KEYS, wire_key, residual)
+    extra = {name: nested[name][1] for name in _TOOL_CONFIG_EXTRA_KEYS if name in nested}
+
+    choice = _read_tool_choice(nested, wire_key, residual)
+    if choice is not None:
+        extra[c.TOOL_CHOICE_KEY] = choice
+
+    _residualise(nested, PUBLISHED_TOOL_CONFIG_KEYS, wire_key, residual)
+    return extra
+
+
+def _read_tool_choice(nested: Mapping[str, tuple[str, Any]], prefix: str, residual: dict[str, Any]) -> str | None:
+    """Normalise ``functionCallingConfig`` onto the canonical tool-choice vocabulary.
+
+    §3.3.1b: four wire keys name one concept, so ``tool_choice`` is the single
+    deliberate exception to keying ``extra`` by the wire key.
+
+    Args:
+        nested: The aliased ``toolConfig`` view.
+        prefix: ``toolConfig``'s path from the body root.
+        residual: The residual mapping, extended in place.
+
+    Returns:
+        One of :data:`~harness.contract.TOOL_CHOICE_VALUES`, a ``tool:<name>``
+        selection, or ``None`` when the config names no mode the vocabulary
+        carries.
+    """
+    if "functionCallingConfig" not in nested:
+        return None
+
+    wire_key, value = nested["functionCallingConfig"]
+    path = _join(prefix, wire_key)
+    if not isinstance(value, Mapping):
+        residual[path] = value
+        return None
+
+    config = _aliased(value, PUBLISHED_FUNCTION_CALLING_CONFIG_KEYS, path, residual)
+    mode = _typed_leaf(config, "mode", (str,), path, residual)
+
+    # Case-insensitively: the published enumeration is upper case, and Google's
+    # own `function_calling.sh` example sends `"mode": "auto"`.
+    choice = _TOOL_CHOICE_MODES.get(mode.upper()) if isinstance(mode, str) else None
+    if choice is None and "mode" in config:
+        # MODE_UNSPECIFIED and VALIDATED have no canonical value, and `Envelope`
+        # enforces the closed set, so inventing one would raise a `ValueError`
+        # that T-D1 would read as a reader bug.
+        #
+        # `setdefault` with the **wire** value, not `mode`: a wrongly-typed mode
+        # has already been residualised correctly by `_typed_leaf`, and `mode` is
+        # by then the default it fell back to. Overwriting would tell a
+        # maintainer the client sent `null` when it sent an object.
+        residual.setdefault(_join(path, config["mode"][0]), config["mode"][1])
+
+    allowed = _typed_leaf(config, "allowedFunctionNames", (list,), path, residual)
+    if allowed is not None:
+        if choice == "any" and len(allowed) == 1 and isinstance(allowed[0], str):
+            # "must call a function, and only this one" is exactly `tool:<name>`.
+            choice = f"tool:{allowed[0]}"
+        else:
+            # A restriction to several names has no canonical form; the mode
+            # still projects, so the residual names only what was lost.
+            residual[_join(path, config["allowedFunctionNames"][0])] = allowed
+
+    _residualise(config, PUBLISHED_FUNCTION_CALLING_CONFIG_KEYS, path, residual)
+    return choice
+
+
+def _read_tools(
+    view: Mapping[str, tuple[str, Any]], residual: dict[str, Any]
+) -> tuple[tuple[c.ToolDecl, ...], dict[str, Any]]:
+    """Read the declared tools and the built-in capability toggles beside them.
+
+    Args:
+        view: The aliased top-level view.
+        residual: The residual mapping, extended in place.
+
+    Returns:
+        The function declarations in order, and the built-in toggles as extra
+        entries.
+
+    Raises:
+        UnreadableBodyError: When ``tools`` is not a list, or an entry is not an
+            object.
+    """
+    if "tools" not in view:
+        return (), {}
+
+    wire_key, value = view["tools"]
+    entries = _members(value)
+    if entries is None:
+        raise c.UnreadableBodyError(f"tools must be a list, got {type(value).__name__}")
+
+    declared: list[c.ToolDecl] = []
+    extra: dict[str, Any] = {}
+
+    for index, entry in enumerate(entries):
+        path = f"{wire_key}[{index}]"
+        if not isinstance(entry, Mapping):
+            raise c.UnreadableBodyError(f"{path} must be an object, got {type(entry).__name__}")
+
+        tool = _aliased(entry, PUBLISHED_TOOL_KEYS, path, residual)
+        for name in _BUILT_IN_TOOL_KEYS:
+            if name not in tool:
+                continue
+            if name in extra:
+                # A second entry re-declaring one has no second address; the
+                # first is the one `envelope.extra[<key>]` names.
+                residual[_join(path, tool[name][0])] = tool[name][1]
+                continue
+            extra[name] = tool[name][1]
+
+        declared.extend(_read_function_declarations(tool, path, residual))
+        _residualise(tool, PUBLISHED_TOOL_KEYS, path, residual)
+
+    return tuple(declared), extra
+
+
+def _read_function_declarations(
+    tool: Mapping[str, tuple[str, Any]], prefix: str, residual: dict[str, Any]
+) -> list[c.ToolDecl]:
+    """Read one ``Tool`` entry's function declarations.
+
+    Args:
+        tool: The aliased ``Tool`` view.
+        prefix: The entry's path from the body root.
+        residual: The residual mapping, extended in place.
+
+    Returns:
+        The declarations, in order.
+
+    Raises:
+        UnreadableBodyError: When ``functionDeclarations`` is not a list or an
+            entry is not an object. An entry with no usable name residualises
+            instead — see :func:`_read_required_name`.
+    """
+    if "functionDeclarations" not in tool:
+        return []
+
+    wire_key, value = tool["functionDeclarations"]
+    path = _join(prefix, wire_key)
+    entries = _members(value)
+    if entries is None:
+        raise c.UnreadableBodyError(f"{path} must be a list, got {type(value).__name__}")
+
+    declared: list[c.ToolDecl] = []
+    for index, entry in enumerate(entries):
+        item = f"{path}[{index}]"
+        if not isinstance(entry, Mapping):
+            raise c.UnreadableBodyError(f"{item} must be an object, got {type(entry).__name__}")
+
+        declaration = _aliased(entry, PUBLISHED_FUNCTION_DECLARATION_KEYS, item, residual)
+        name = _read_required_name(declaration, item, residual)
+        schema, mapped = _read_declaration_schema(declaration, item, residual)
+        declared.append(
+            c.ToolDecl(
+                name=name,
+                description=_typed_leaf(declaration, "description", (str,), item, residual),
+                schema=schema,
+                # Absent, not False: Gemini defines no `strict`, and P15's
+                # presence and absence must stay distinguishable.
+                strict=None,
+            )
+        )
+        _residualise(declaration, mapped, item, residual)
+
+    return declared
+
+
+def _read_required_name(view: Mapping[str, tuple[str, Any]], path: str, residual: dict[str, Any]) -> str:
+    """Return a required ``name``, residualising it when the wire carried none.
+
+    §3.3.1b settles this and the answer is **not** the wrongly-typed-leaf rule's
+    usual one: "an absent ``name`` *does* residualise … ``ToolUse.name`` is a
+    ``str`` with no such value: ``""`` claims a tool *named* empty-string, and a
+    call nobody can name cannot be paired or addressed." So absent and ``null``
+    residualise too, not only a wrong type — and the part is still **projected**,
+    because dropping or raising on it would blind the oracle to the rest of a
+    request it could otherwise diff. T-A3 takes the same branch.
+
+    Args:
+        view: The aliased view of the object carrying the name.
+        path: That object's path from the body root.
+        residual: The residual mapping, extended in place.
+
+    Returns:
+        The name, or ``""`` when the wire carried none — which the residual then
+        names, so the run fails with the field identified.
+    """
+    # `_typed_leaf` has already residualised a wrongly-typed value; what is left
+    # is absent or explicitly null, which this records in its place.
+    name: str | None = _typed_leaf(view, "name", (str,), path, residual)
+    if name is None:
+        residual.setdefault(
+            _join(path, view["name"][0] if "name" in view else "name"),
+            view["name"][1] if "name" in view else None,
+        )
+        return ""
+
+    return name
+
+
+def _read_declaration_schema(
+    declaration: Mapping[str, tuple[str, Any]], path: str, residual: dict[str, Any]
+) -> tuple[Mapping[str, Any] | None, set[str]]:
+    """Read a declaration's parameter schema from whichever key carries it.
+
+    ``parameters`` (OpenAPI) and ``parametersJsonSchema`` (JSON Schema) are
+    published as mutually exclusive alternatives filling one slot. When a
+    declaration carries both it is outside the schema, so ``parameters`` — the
+    older and far commoner spelling — wins and the other residualises.
+
+    Args:
+        declaration: The aliased ``FunctionDeclaration`` view.
+        path: The declaration's path from the body root.
+        residual: The residual mapping, extended in place.
+
+    Returns:
+        The schema or ``None``, and the published names this consumed, so the
+        caller's :func:`_residualise` does not also claim the loser.
+    """
+    mapped = {"name", "description"}
+
+    # The first of the two that is present wins, so `parameters` beats
+    # `parametersJsonSchema` on a declaration carrying both — which is outside
+    # the published schema. The loser is left out of `mapped`, so the caller's
+    # `_residualise` puts it in the residual rather than dropping it.
+    for name in ("parameters", "parametersJsonSchema"):
+        if name not in declaration:
+            continue
+        # A wrongly-typed schema residualises rather than coercing: `dict()` on
+        # a list of two-character strings *fabricates* a schema the agent never
+        # sent, and on a plain string raises a bare `ValueError`.
+        return _typed_leaf(declaration, name, (dict,), path, residual), mapped | {name}
+
+    return None, mapped
+
+
+# --------------------------------------------------------------------------
+# The conversation
+# --------------------------------------------------------------------------
+
+
+def _read_system_instruction(view: Mapping[str, tuple[str, Any]], residual: dict[str, Any]) -> tuple[c.Text, ...]:
+    """Lift ``systemInstruction`` into :attr:`~harness.contract.Conversation.system`.
+
+    §3.3.1b: system instructions lift here, never into a turn, from whichever of
+    the four carriers the format uses — Gemini's is this dedicated field.
+
+    Args:
+        view: The aliased top-level view.
+        residual: The residual mapping, extended in place.
+
+    Returns:
+        One entry per text part, in order.
+
+    Raises:
+        UnreadableBodyError: When the field is not an object.
+    """
+    if "systemInstruction" not in view:
+        return ()
+
+    wire_key, value = view["systemInstruction"]
+    if not isinstance(value, Mapping):
+        raise c.UnreadableBodyError(f"{wire_key} must be a Content object, got {type(value).__name__}")
+
+    content = _aliased(value, PUBLISHED_CONTENT_KEYS, wire_key, residual)
+    parts = _members(content["parts"][1]) if "parts" in content else ()
+    if parts is None:
+        raise c.UnreadableBodyError(f"{wire_key}.parts must be a list or an object")
+
+    system: list[c.Text] = []
+    for index, part in enumerate(parts):
+        path = f"{_join(wire_key, content['parts'][0])}[{index}]"
+        if not isinstance(part, Mapping):
+            raise c.UnreadableBodyError(f"{path} must be an object, got {type(part).__name__}")
+
+        # The schema says system instructions are "text only", so anything else
+        # in one has no slot in `Conversation.system` and residualises whole.
+        member = _aliased(part, PUBLISHED_PART_KEYS, path, residual)
+        text = _typed_leaf(member, "text", (str,), path, residual)
+        if text is not None:
+            system.append(c.Text(text))
+        _residualise(member, {"text"}, path, residual)
+
+    # `role` is meaningless on a system instruction and the grammar has no slot
+    # for it, so it residualises like any other key the grammar cannot carry.
+    _residualise(content, {"parts"}, wire_key, residual)
+    return tuple(system)
+
+
+def _read_contents(view: Mapping[str, tuple[str, Any]], residual: dict[str, Any]) -> tuple[c.Turn, ...]:
+    """Read ``contents`` into normalised turns.
+
+    Args:
+        view: The aliased top-level view.
+        residual: The residual mapping, extended in place.
+
+    Returns:
+        The turns, normalised per §3.3.1b's ordered pipeline.
+
+    Raises:
+        UnreadableBodyError: When ``contents`` is neither a list nor an object,
+            a member is not an object, or a member's role is outside the
+            published ``user``/``model``.
+    """
+    if "contents" not in view:
+        # Absent is not an error: the oracle catches a vanished conversation as
+        # a `conversation.turns` delta, which is a better diagnosis than an
+        # unreadable body — and a reader that rejected an incomplete body could
+        # not project the very mutation M5, M6 and M7 produce.
+        return ()
+
+    wire_key, value = view["contents"]
+    members = _members(value)
+    if members is None:
+        raise c.UnreadableBodyError(f"{wire_key} must be a list or an object")
+
+    turns: list[c.Turn] = []
+    for index, member in enumerate(members):
+        path = f"{wire_key}[{index}]"
+        if not isinstance(member, Mapping):
+            raise c.UnreadableBodyError(f"{path} must be an object, got {type(member).__name__}")
+
+        content = _aliased(member, PUBLISHED_CONTENT_KEYS, path, residual)
+        role = _read_role(content, path)
+        parts = _read_parts(content, path, residual)
+        turns.append(c.Turn(role=role, parts=_clause_three(role, parts)))
+        _residualise(content, PUBLISHED_CONTENT_KEYS, path, residual)
+
+    return _normalise_turns(turns)
+
+
+def _read_role(content: Mapping[str, tuple[str, Any]], path: str) -> str:
+    """Map a ``Content``'s producer onto §3.3.1b's closed role set.
+
+    Args:
+        content: The aliased ``Content`` view.
+        path: The content's path from the body root.
+
+    Returns:
+        ``user`` or ``assistant``.
+
+    Raises:
+        UnreadableBodyError: When the role is present and is neither a published
+            value nor the one evidenced value :data:`_EVIDENCED_ROLES` names.
+            Structural, not residualisable: §7.4.1 makes "a role outside
+            ``user``/``assistant``" its own example of a failure with no partial
+            projection to salvage, because the turn cannot be built at all.
+    """
+    if "role" not in content:
+        return "user"
+
+    role = content["role"][1]
+    if role in (None, ""):
+        # The schema says the field "can be left blank or unset", and request
+        # content with no stated producer is the client's.
+        return "user"
+
+    if isinstance(role, str) and role in _ROLES:
+        return _ROLES[role]
+
+    if isinstance(role, str) and role in _EVIDENCED_ROLES:
+        return _EVIDENCED_ROLES[role]
+
+    raise c.UnreadableBodyError(
+        f"{path}.role must be one of {sorted(set(_ROLES) | set(_EVIDENCED_ROLES))}, got {role!r}; "
+        "Gemini has no system role — a system prompt is the top-level systemInstruction"
+    )
+
+
+def _read_parts(content: Mapping[str, tuple[str, Any]], prefix: str, residual: dict[str, Any]) -> tuple[c.Part, ...]:
+    """Read one ``Content``'s parts, in order.
+
+    Args:
+        content: The aliased ``Content`` view.
+        prefix: The content's path from the body root.
+        residual: The residual mapping, extended in place.
+
+    Returns:
+        The parts, in wire order.
+
+    Raises:
+        UnreadableBodyError: When ``parts`` is neither a list nor an object, or
+            a member is not an object.
+    """
+    if "parts" not in content:
+        return ()
+
+    wire_key, value = content["parts"]
+    path = _join(prefix, wire_key)
+    members = _members(value)
+    if members is None:
+        raise c.UnreadableBodyError(f"{path} must be a list or an object")
+
+    parts: list[c.Part] = []
+    for index, member in enumerate(members):
+        item = f"{path}[{index}]"
+        if not isinstance(member, Mapping):
+            raise c.UnreadableBodyError(f"{item} must be an object, got {type(member).__name__}")
+        parts.append(_read_part(member, item, residual))
+
+    return tuple(parts)
+
+
+def _read_part(part: Mapping[str, Any], path: str, residual: dict[str, Any]) -> c.Part:
+    """Read one ``Part`` into a projection part.
+
+    ``Part`` is a union whose members are distinguished by **field name**, not
+    by a ``type`` discriminator, which is why nothing here reads a ``type`` and
+    why the opaque digest excludes nothing.
+
+    Args:
+        part: The part object.
+        path: The part's path from the body root.
+        residual: The residual mapping, extended in place.
+
+    Returns:
+        The projected part.
+
+    Raises:
+        UnreadableBodyError: When the part carries none of the published data
+            members — §7.4.1's "a content block with no type": there is no
+            partial part to salvage.
+    """
+    view = _aliased(part, PUBLISHED_PART_KEYS, path, residual)
+
+    for name, kind in _OPAQUE_PART_KEYS.items():
+        if name in view:
+            return _read_opaque(view, name, kind, path, residual)
+
+    if "inlineData" in view:
+        return _read_inline_data(view, path, residual)
+
+    if "fileData" in view:
+        return _read_file_data(view, path, residual)
+
+    if "functionCall" in view:
+        return _read_function_call(view, path, residual)
+
+    if "functionResponse" in view:
+        return _read_function_response(view, path, residual)
+
+    # Last, because `thought` is a part-level flag rather than a data member: a
+    # `thought` beside a `functionCall` marks that call, and only a part with no
+    # data member at all is itself a thought. Gemini returns signature-only
+    # thought parts — `{"thought": true, "thoughtSignature": …}` with no text —
+    # and §3.3.1 settles what they project as: "An empty block is a part with an
+    # empty string, never nothing."
+    if "text" in view or view.get("thought", ("", None))[1] is True:
+        return _read_text(view, path, residual)
+
+    raise c.UnreadableBodyError(f"{path} carries none of the published Part members {sorted(PUBLISHED_PART_KEYS)}")
+
+
+def _read_text(view: Mapping[str, tuple[str, Any]], path: str, residual: dict[str, Any]) -> c.Text | c.Thinking:
+    """Read a text part, as thinking when the part is marked as a thought.
+
+    Args:
+        view: The aliased ``Part`` view.
+        path: The part's path from the body root.
+        residual: The residual mapping, extended in place.
+
+    Returns:
+        :class:`~harness.contract.Thinking` when ``thought`` is true, carrying
+        ``thoughtSignature`` — what M8's carrier repair manipulates — otherwise
+        :class:`~harness.contract.Text`.
+
+    Raises:
+        UnreadableBodyError: When ``text`` is present and is not a string.
+    """
+    # A wrongly-typed `text` is **structural** and raises, where every other
+    # optional leaf in this module residualises. §7.4.1's exception: `Text` and
+    # `Thinking` *are* their value, so the grammar has no absent value to carry
+    # and `Text("")` would fabricate an empty part the agent never sent — and an
+    # empty part is meaningful here, since P5e and P8 both inject one. T-A1 takes
+    # the same branch; T-A3 residualises the whole entry and returns no part,
+    # which shifts every later part's index (§7.4.2 rule 7).
+    if "text" in view and not isinstance(view["text"][1], str):
+        raise c.UnreadableBodyError(f"{path} text must be a string, got {type(view['text'][1]).__name__}")
+
+    text = _typed_leaf(view, "text", (str,), path, residual, default="")
+    thought = _typed_leaf(view, "thought", (bool,), path, residual)
+
+    if thought:
+        signature = _typed_leaf(view, "thoughtSignature", (str,), path, residual)
+        _residualise(view, {"text", "thought", "thoughtSignature"}, path, residual)
+        return c.Thinking(text=text, signature=signature)
+
+    # An empty block is a part with an empty string, never nothing (§3.3.1).
+    _residualise(view, {"text", "thought"}, path, residual)
+    return c.Text(text)
+
+
+def _read_inline_data(view: Mapping[str, tuple[str, Any]], path: str, residual: dict[str, Any]) -> c.Image:
+    """Read an inline ``Blob``, identifying it by digest rather than carrying bytes.
+
+    ``inlineData`` is the format's only bytes carrier, whatever the media type,
+    so audio and PDF payloads project the same way an image does and
+    ``media_type`` records which it was.
+
+    Args:
+        view: The aliased ``Part`` view.
+        path: The part's path from the body root.
+        residual: The residual mapping, extended in place.
+
+    Returns:
+        The image part.
+
+    Raises:
+        UnreadableBodyError: When the blob is not an object. A payload that does
+            not decode residualises instead — see the comment below.
+    """
+    wire_key, value = view["inlineData"]
+    item = _join(path, wire_key)
+    if not isinstance(value, Mapping):
+        raise c.UnreadableBodyError(f"{item} must be an object, got {type(value).__name__}")
+
+    blob = _aliased(value, PUBLISHED_BLOB_KEYS, item, residual)
+    raw = _typed_leaf(blob, "data", (str,), item, residual, default="")
+    try:
+        decoded: bytes | None = base64.b64decode(raw, validate=True)
+    except (binascii.Error, ValueError):
+        # Residualised, not raised on: `Image.digest` is `str | None`, so the
+        # grammar *has* an absent value here, and §7.4.1 is explicit that
+        # "raising is the other wrong answer: it blinds the oracle to everything
+        # else in a request it could otherwise diff". The case is real rather
+        # than hypothetical — `validate=True` rejects every RFC 2045 line break,
+        # and Google's own image sample passes `-w0` to `base64(1)` precisely
+        # because its default output is wrapped. Nor is the part dropped: the
+        # index would shift and invent a delta on every later part.
+        residual[_join(item, blob["data"][0] if "data" in blob else "data")] = raw
+        decoded = None
+
+    _residualise(blob, {"data", "mimeType"}, item, residual)
+    _residualise(view, {"inlineData"}, path, residual)
+    # The media type is excluded from the digest and carried separately, so a
+    # changed media type is its own delta rather than an unexplained change.
+    return c.Image(
+        digest=c.image_digest(decoded) if decoded is not None else None,
+        media_type=_typed_leaf(blob, "mimeType", (str,), item, residual),
+    )
+
+
+def _read_file_data(view: Mapping[str, tuple[str, Any]], path: str, residual: dict[str, Any]) -> c.Image:
+    """Read a ``FileData`` reference, which carries a URI rather than bytes.
+
+    §3.3.1: "Gemini's ``fileData.fileUri`` has no bytes: ``digest`` is then
+    absent and ``ref`` holds the URI."
+
+    Args:
+        view: The aliased ``Part`` view.
+        path: The part's path from the body root.
+        residual: The residual mapping, extended in place.
+
+    Returns:
+        The image part, by reference.
+
+    Raises:
+        UnreadableBodyError: When the file data is not an object.
+    """
+    wire_key, value = view["fileData"]
+    item = _join(path, wire_key)
+    if not isinstance(value, Mapping):
+        raise c.UnreadableBodyError(f"{item} must be an object, got {type(value).__name__}")
+
+    data = _aliased(value, PUBLISHED_FILE_DATA_KEYS, item, residual)
+    projected = c.Image(
+        ref=_typed_leaf(data, "fileUri", (str,), item, residual),
+        media_type=_typed_leaf(data, "mimeType", (str,), item, residual),
+    )
+    _residualise(data, {"fileUri", "mimeType"}, item, residual)
+    _residualise(view, {"fileData"}, path, residual)
+    return projected
+
+
+def _read_function_call(view: Mapping[str, tuple[str, Any]], path: str, residual: dict[str, Any]) -> c.ToolUse:
+    """Read a ``functionCall`` into a tool use.
+
+    **Gemini ``v1beta`` publishes an optional ``id``** on ``FunctionCall``, and
+    the client echoes it back on the matching ``FunctionResponse``. An earlier
+    note in ``contract.py`` said Gemini carried none, from the Cloud /
+    Agent-Platform reference; the Developer API surface this reader reads
+    differs, and KBR-36's own comment asked for it to be confirmed rather than
+    assumed. Optional either way, so pairing still falls back to §3.3.1's
+    name-and-position rule when no id is sent.
+
+    ``args`` is a JSON **object** on the wire, so nothing here decodes a string:
+    KBR-174's shared ``arguments`` helper is for the two formats that carry it
+    as a string and is not a dependency of this reader.
+
+    Args:
+        view: The aliased ``Part`` view.
+        path: The part's path from the body root.
+        residual: The residual mapping, extended in place.
+
+    Returns:
+        The tool use.
+
+    Raises:
+        UnreadableBodyError: When the call is not an object. A call with no
+            usable name residualises instead — see :func:`_read_required_name`.
+    """
+    wire_key, value = view["functionCall"]
+    item = _join(path, wire_key)
+    if not isinstance(value, Mapping):
+        raise c.UnreadableBodyError(f"{item} must be an object, got {type(value).__name__}")
+
+    call = _aliased(value, PUBLISHED_FUNCTION_CALL_KEYS, item, residual)
+    name = _read_required_name(call, item, residual)
+    projected = c.ToolUse(
+        name=name,
+        arguments=_typed_leaf(call, "args", (dict,), item, residual, default={}),
+        id=_typed_leaf(call, "id", (str,), item, residual),
+    )
+    _residualise(call, PUBLISHED_FUNCTION_CALL_KEYS, item, residual)
+    _residualise(view, {"functionCall"}, path, residual)
+    return projected
+
+
+def _read_function_response(view: Mapping[str, tuple[str, Any]], path: str, residual: dict[str, Any]) -> c.ToolResult:
+    """Read a ``functionResponse`` into a tool result.
+
+    ``response`` is a bare struct, which is why
+    :class:`~harness.contract.Json` exists — §3.3.1: "Gemini's
+    ``functionResponse.response`` is a bare struct", so a text-only result type
+    would discard the usual payload entirely.
+
+    ``is_error`` is always ``False``: Gemini publishes no error flag on a
+    function response, and inventing one would make an absent flag and a
+    reported success indistinguishable.
+
+    Args:
+        view: The aliased ``Part`` view.
+        path: The part's path from the body root.
+        residual: The residual mapping, extended in place.
+
+    Returns:
+        The tool result.
+
+    Raises:
+        UnreadableBodyError: When the response is not an object.
+    """
+    wire_key, value = view["functionResponse"]
+    item = _join(path, wire_key)
+    if not isinstance(value, Mapping):
+        raise c.UnreadableBodyError(f"{item} must be an object, got {type(value).__name__}")
+
+    answer = _aliased(value, PUBLISHED_FUNCTION_RESPONSE_KEYS, item, residual)
+    content: list[c.Text | c.Image | c.Json | c.Opaque] = []
+
+    payload = _typed_leaf(answer, "response", (dict,), item, residual)
+    if payload is not None:
+        content.append(c.Json(payload))
+
+    content.extend(_read_response_parts(answer, item, residual))
+
+    projected = c.ToolResult(
+        content=content,
+        tool_use_id=_typed_leaf(answer, "id", (str,), item, residual),
+        is_error=False,
+    )
+    # `name` pairs the result with its call where no id was sent, and the
+    # grammar's pairing rule is by name and position, so it is accounted for
+    # rather than residualised.
+    _residualise(answer, {"response", "parts", "id", "name"}, item, residual)
+    _residualise(view, {"functionResponse"}, path, residual)
+    return projected
+
+
+def _read_response_parts(answer: Mapping[str, tuple[str, Any]], prefix: str, residual: dict[str, Any]) -> list[c.Image]:
+    """Read a function response's inline media parts.
+
+    Args:
+        answer: The aliased ``FunctionResponse`` view.
+        prefix: The response's path from the body root.
+        residual: The residual mapping, extended in place.
+
+    Returns:
+        One image per ``inlineData`` member, in order.
+
+    Raises:
+        UnreadableBodyError: When ``parts`` is neither a list nor an object, or
+            a member is not an object.
+    """
+    if "parts" not in answer:
+        return []
+
+    wire_key, value = answer["parts"]
+    path = _join(prefix, wire_key)
+    members = _members(value)
+    if members is None:
+        raise c.UnreadableBodyError(f"{path} must be a list or an object")
+
+    images: list[c.Image] = []
+    for index, member in enumerate(members):
+        item = f"{path}[{index}]"
+        if not isinstance(member, Mapping):
+            raise c.UnreadableBodyError(f"{item} must be an object, got {type(member).__name__}")
+
+        part = _aliased(member, frozenset({"inlineData"}), item, residual)
+        if "inlineData" in part:
+            images.append(_read_inline_data(part, item, residual))
+        else:
+            _residualise(part, set(), item, residual)
+
+    return images
+
+
+def _read_opaque(
+    view: Mapping[str, tuple[str, Any]], name: str, kind: str, path: str, residual: dict[str, Any]
+) -> c.Opaque:
+    """Read a part the grammar does not model, keeping it detectable.
+
+    §3.3.1 put ``digest`` on :class:`~harness.contract.Opaque` precisely so that
+    unmodelled content stays detectable: a bare ``Opaque("executable_code")``
+    would make two different programs project identically, and a swapped one
+    would produce no delta at all.
+
+    Args:
+        view: The aliased ``Part`` view.
+        name: The published ``Part`` member carrying the payload.
+        kind: The canonical snake_case name for it.
+        path: The part's path from the body root.
+        residual: The residual mapping, extended in place.
+
+    Returns:
+        The opaque part, carrying a digest of its payload.
+    """
+    payload = view[name][1]
+    _residualise(view, {name}, path, residual)
+    return c.Opaque(kind=kind, digest=_payload_digest(payload))
+
+
+def _payload_digest(payload: Any) -> str:
+    """Return the digest of an unmodelled part's payload.
+
+    §7.4.1's recipe, exactly. Over **canonical** JSON rather than the raw wire
+    slice, so a translator that reorders keys does not change the digest.
+    ``ensure_ascii`` is pinned alongside ``sort_keys`` and ``separators``
+    because its default is ``True`` while the surrounding prose says UTF-8: an
+    author who passed ``False`` would get a different digest for the same part,
+    visible only on non-ASCII content, which is the cross-reader disagreement
+    §7.4.1 exists to prevent. In T-A1 all three wrong spellings survived
+    mutation testing until one digest was pinned to an external literal.
+
+    Nothing is excluded. §7.4.1 excludes ``type`` because it is already
+    :attr:`~harness.contract.Opaque.kind` and ``cache_control`` because it
+    residualises; a Gemini ``Part`` is discriminated by **field name** and
+    defines no ``cache_control``, so neither exclusion has anything to remove.
+
+    Args:
+        payload: The unmodelled member's value.
+
+    Returns:
+        Lowercase hex SHA-256 of the canonical payload.
+    """
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+# --------------------------------------------------------------------------
+# §3.3.1b's merge pipeline
+# --------------------------------------------------------------------------
+
+
+def _clause_three(role: str, parts: Sequence[c.Part]) -> tuple[c.Part, ...]:
+    """Order one ``Content``'s parts, results first, for a ``user`` content.
+
+    §3.3.1b's third clause, applied where §7.4.1 says it is **not** idle: "it
+    governs the formats that carry text and results inside **one message**,
+    where the run has no natural boundary". Gemini is that case — a single
+    ``parts`` array may hold text and ``functionResponse`` members together, so
+    there is no message boundary to delimit a run and clause 1 cannot do the
+    work by splitting.
+
+    **Scoped to one content, and to ``user``.** Applying it to a *merged* turn
+    projects ``functionResponse -> user(text) -> functionResponse`` as
+    ``[ToolResult, ToolResult, Text]``, hoisting a result ahead of text the
+    agent sent *before* it. Per content, that sequence keeps its three separate
+    groups and concatenates to ``[ToolResult, Text, ToolResult]``, which is what
+    §3.3.1b requires.
+
+    Args:
+        role: The content's projected role.
+        parts: The content's parts, in wire order.
+
+    Returns:
+        The parts, results first for a ``user`` content, stable within each
+        group so a reader never sorts.
+    """
+    if role != "user":
+        return tuple(parts)
+
+    results = [part for part in parts if isinstance(part, c.ToolResult)]
+    others = [part for part in parts if not isinstance(part, c.ToolResult)]
+    return tuple(results) + tuple(others)
+
+
+def _normalise_turns(turns: Sequence[c.Turn]) -> tuple[c.Turn, ...]:
+    """Merge consecutive same-role turns, preserving the order of their groups.
+
+    The fourth and last clause of §3.3.1b's ordered pipeline. Clause 3 has
+    already run, per content, in :func:`_clause_three`; this one only
+    concatenates, and **never re-sorts what it concatenates**.
+
+    **A re-sort here would be a defect, not a simplification.** It hoists a
+    result ahead of text the agent sent *before* it — moving history the bridge
+    did not move — and because paths are index-based that invented delta lands
+    on every part of the turn and every turn after it.
+
+    **What the merge still hides**, recorded because §3.3.1 requires a
+    projection's blind spots to be on the record: a mutation whose only effect
+    is to split or join two consecutive same-role turns produces no delta, which
+    weakens §3.3.2 assertion 2 for M5, M6 and M7. Accepted, because without the
+    merge this reader and the Chat Completions reader disagree about turn
+    boundaries on the standard ``assistant(tool_calls) -> tool -> tool``
+    exchange, and that disagreement reports a false delta on every subsequent
+    turn.
+
+    Args:
+        turns: The turns, one per content, in wire order.
+
+    Returns:
+        The normalised turns.
+    """
+    merged: list[c.Turn] = []
+    for turn in turns:
+        if merged and merged[-1].role == turn.role:
+            previous = merged.pop()
+            merged.append(c.Turn(role=turn.role, parts=tuple(previous.parts) + tuple(turn.parts)))
+        else:
+            merged.append(turn)
+
+    return tuple(merged)

--- a/tests/harness/test_reader_gemini.py
+++ b/tests/harness/test_reader_gemini.py
@@ -1898,6 +1898,11 @@ class TestEveryOptionalLeafFailsClosed:
             "tools[0].functionDeclarations[0].description",
             lambda p: p.conversation.tools[0].description is None,
         ),
+        "functionDeclaration.name": (
+            {"tools": [{"functionDeclarations": [{"name": 7}]}]},
+            "tools[0].functionDeclarations[0].name",
+            lambda p: p.conversation.tools[0] == c.ToolDecl(name=""),
+        ),
         "functionDeclaration.parametersJsonSchema": (
             {"tools": [{"functionDeclarations": [{"name": "f", "parametersJsonSchema": ["ab", "cd"]}]}]},
             "tools[0].functionDeclarations[0].parametersJsonSchema",
@@ -1908,7 +1913,7 @@ class TestEveryOptionalLeafFailsClosed:
             "tools[0].functionDeclarations[0].parameters",
             lambda p: p.conversation.tools[0].schema is None,
         ),
-        "part.thoughtSignature-as-name-placeholder": (
+        "functionCall.name": (
             {"contents": [{"parts": [{"functionCall": {"name": 7}}]}]},
             "contents[0].parts[0].functionCall.name",
             lambda p: p.conversation.turns[0].parts[0] == c.ToolUse(name=""),

--- a/tests/harness/test_reader_gemini.py
+++ b/tests/harness/test_reader_gemini.py
@@ -1,0 +1,2508 @@
+"""L1 tests for the Gemini projection.
+
+`.system_design/TEST_SUITE.md` §3.3.1, §3.3.1a, §3.3.1b, §3.3.5, §7.4.1 · plan
+task **T-A4** (KBR-36).
+
+**Every fixture is a published example or is assembled from the published
+schema.**  :class:`TestPublishedExamples` carries the ten request bodies the
+Gemini API reference publishes as ``curl`` samples at
+``https://ai.google.dev/api/generate-content`` (retrieved 2026-09-12), with two
+stated deviations and no others: two of them carry a trailing comma and are
+therefore not JSON, and file URIs are replaced with ``files/example`` so the
+suite names no host it does not control.  Everything else is assembled from the
+discovery document at revision
+:data:`~harness.reader_gemini.SCHEMA_VERSION`.  None is copied from kitty's
+output — §3.3.1's independent-oracle rule makes a reader validated against
+kitty's output circular.
+
+**This reader consumes the URL**, which no other does, so the route cases are
+first-class here: :class:`TestRoute` owns §3.3.5's claim that two requests with
+byte-identical bodies are told apart by their paths.
+
+**The falsification set is required, not decorative.**  Plan §1.4:
+:class:`TestFalsification` holds five deliberate defects the reader must detect,
+running in the suite.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import re
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from harness import contract as c
+from harness import reader_gemini as r
+
+# --------------------------------------------------------------------------
+# Helpers
+# --------------------------------------------------------------------------
+
+#: The published endpoint, as every example spells it.
+_HOST = "generativelanguage.googleapis.com"
+
+#: A model name the examples use, so a route assertion names something real.
+_MODEL = "gemini-2.0-flash"
+
+
+def captured(
+    body: Any,
+    *,
+    model: str = _MODEL,
+    operation: str = "generateContent",
+    query: str = "",
+    path: str | None = None,
+) -> c.CapturedRequest:
+    """Wrap a body as a capture aimed at the published Gemini endpoint.
+
+    Args:
+        body: A mapping to encode as JSON, or raw bytes to pass through
+            undecoded for the failure-shape tests.
+        model: The model segment of the path.
+        operation: The operation suffix, ``generateContent`` or
+            ``streamGenerateContent``.
+        query: The raw query string.
+        path: A complete path, overriding ``model`` and ``operation`` for the
+            tests that hand the reader a path it must reject.
+
+    Returns:
+        A capture the reader can be handed directly.
+    """
+    raw = body if isinstance(body, bytes) else json.dumps(body).encode("utf-8")
+
+    return c.CapturedRequest(
+        method="POST",
+        scheme="https",
+        host=_HOST,
+        path=path if path is not None else f"/v1beta/models/{model}:{operation}",
+        query=query,
+        headers=(("content-type", "application/json"),),
+        body=raw,
+    )
+
+
+def project(body: Any, **route: Any) -> c.Request:
+    """Project a body and assert it accounted for itself.
+
+    Running :func:`harness.contract.verify_total` here rather than in each test
+    means no test can pass while quietly leaving a key unaccounted for.
+
+    Args:
+        body: The request body.
+        **route: Route overrides, forwarded to :func:`captured`.
+
+    Returns:
+        The projection.
+    """
+    projected = r.GeminiProjection().read_request(captured(body, **route))
+    c.verify_total(projected)
+
+    return projected
+
+
+def project_untotalled(body: Any, **route: Any) -> c.Request:
+    """Project a body without asserting totality.
+
+    Args:
+        body: The request body.
+        **route: Route overrides, forwarded to :func:`captured`.
+
+    Returns:
+        The projection, residual and all — which is what the residual tests
+        assert on and what :func:`project` would refuse to return.
+    """
+    return r.GeminiProjection().read_request(captured(body, **route))
+
+
+# --------------------------------------------------------------------------
+# R0 — protocol conformance
+# --------------------------------------------------------------------------
+
+
+class TestProtocolConformance:
+    """The reader is a `Projection` for the Gemini format."""
+
+    def test_it_declares_the_gemini_wire_format(self) -> None:
+        """A `str` would let six authors spell one format three ways (§7.4)."""
+        assert r.GeminiProjection.wire_format is c.WireFormat.GEMINI
+
+    def test_it_satisfies_the_projection_protocol(self) -> None:
+        """`isinstance`, never `issubclass` — the protocol carries a data member."""
+        assert isinstance(r.GeminiProjection(), c.Projection)
+
+    def test_it_actually_projects_rather_than_merely_having_the_members(self) -> None:
+        """The paired assertion `isinstance` cannot make.
+
+        `contract.Projection` checks member *presence* only, never signatures,
+        so the test above passes against any object with two attributes.
+        """
+        projected = project({"contents": [{"parts": [{"text": "hello"}]}]})
+
+        assert projected.envelope.model == _MODEL
+        assert projected.conversation.turns == (c.Turn("user", [c.Text("hello")]),)
+
+    def test_it_imports_nothing_from_kitty(self) -> None:
+        """§3.3.1: a reader written in terms of the code under test proves nothing.
+
+        Asserted structurally rather than by convention, because the import that
+        would break it is one line and reads as harmless.
+        """
+        source = Path(r.__file__).read_text(encoding="utf-8")
+        offenders = re.findall(r"^\s*(?:from|import)\s+kitty\b.*$", source, flags=re.MULTILINE)
+
+        assert offenders == [], f"the reader must not import from src/kitty: {offenders}"
+
+
+# --------------------------------------------------------------------------
+# R1 — the route is an input
+# --------------------------------------------------------------------------
+
+
+class TestRoute:
+    """§3.3.5: Gemini carries the model and the operation in the URL.
+
+    This is the claim no body-only oracle can make, and the reason
+    `Projection.read_request` takes a whole capture rather than a body.
+    """
+
+    def test_the_model_comes_from_the_path(self) -> None:
+        """R1.1 — the inbound path is where the model actually is."""
+        projected = project({"contents": []}, model="gemini-2.5-pro")
+
+        assert projected.envelope.model == "gemini-2.5-pro"
+
+    def test_a_models_prefix_on_the_path_segment_is_stripped(self) -> None:
+        """R1.1 — the published path form is `/{version}/models/{model}:{method}`.
+
+        A profile naming `models/gemini-2.5-pro` and one naming
+        `gemini-2.5-pro` reach the same destination, so they must project the
+        same model or M1's register row reports a delta on the spelling.
+        """
+        projected = project({"contents": []}, path="/v1beta/models/models/x:generateContent")
+
+        assert projected.envelope.model == "x"
+
+    @pytest.mark.parametrize(
+        ("operation", "expected"),
+        [("generateContent", False), ("streamGenerateContent", True)],
+    )
+    def test_stream_comes_from_the_operation_suffix(self, operation: str, expected: bool) -> None:
+        """R1.2 — M11 forces `stream` false, so it must be projectable."""
+        projected = project({"contents": []}, operation=operation)
+
+        assert projected.envelope.stream is expected
+
+    @pytest.mark.parametrize(
+        ("operation", "query", "expected"),
+        [
+            ("streamGenerateContent", "", True),
+            ("streamGenerateContent", "alt=sse&key=SECRET", True),
+            ("generateContent", "alt=sse", False),
+        ],
+    )
+    def test_stream_is_the_operation_and_never_alt_sse(self, operation: str, query: str, expected: bool) -> None:
+        """R1.3 — `alt` picks the framing of a method that streams either way.
+
+        Reading `stream` off `alt=sse` would make a streaming request with the
+        JSON-array framing project as non-streaming, and P17's register row
+        anchored at `envelope.stream` would then claim a delta nobody caused.
+        """
+        projected = project({"contents": []}, operation=operation, query=query)
+
+        assert projected.envelope.stream is expected
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/v1beta/models/x:countTokens",
+            "/v1beta/models/x:embedContent",
+            "/v1beta/models/x",
+            "/v1beta/chat",
+            "/v1beta/tunedModels/x:generateContent",
+            "",
+        ],
+    )
+    def test_a_path_that_is_not_a_published_generate_route_is_unreadable(self, path: str) -> None:
+        """R1.4 — structural: there is no partial projection without a model.
+
+        `countTokens` and `embedContent` are published methods on the same
+        resource, so "any method" would silently project a token count as a
+        conversation.
+        """
+        with pytest.raises(c.UnreadableBodyError):
+            project_untotalled({"contents": []}, path=path)
+
+    def test_the_query_is_left_entirely_to_the_route_assertion(self) -> None:
+        """R1.5 — a boundary, stated so a green run is not over-read.
+
+        `verify_total` compares `consumed | residual` against the **body**, so a
+        query key in either account is reported as a claim on a key the body
+        does not have. Asserting the route is T-D2's (KBR-52).
+        """
+        projected = project_untotalled({"contents": []}, operation="streamGenerateContent", query="alt=sse&key=SECRET")
+
+        assert "alt" not in projected.consumed and "alt" not in projected.residual
+        assert "key" not in projected.consumed and "key" not in projected.residual
+
+
+# --------------------------------------------------------------------------
+# R7 — falsification (plan §1.4)
+# --------------------------------------------------------------------------
+
+
+class TestFalsification:
+    """Five deliberate defects the reader must detect, running in the suite.
+
+    Plan §1.4: "The first working version of every harness ships with at least
+    one falsification case — a deliberate defect it must detect, running in the
+    suite." Four review rounds on the design produced four harnesses that would
+    have passed while proving nothing, and one of them was "a projection that
+    could not see the model name, in a product whose purpose is changing the
+    model name" — which is exactly what R7.4 pins here.
+    """
+
+    def test_an_unrecognised_top_level_key_produces_a_residual(self) -> None:
+        """R7.1 — §3.3.1's fifth mandatory oracle falsification case."""
+        projected = project_untotalled({"contents": [], "x-kitty-trace": "abc"})
+
+        assert projected.residual == {"x-kitty-trace": "abc"}
+        with pytest.raises(c.ResidualFieldsError):
+            c.verify_total(projected)
+
+    def test_an_unrecognised_key_inside_a_part_produces_a_residual_at_its_path(self) -> None:
+        """R7.2 — §7.4.1: failing closed is not a top-level rule.
+
+        `verify_total` cannot see past the top level, so this is the rule that
+        closes it, and this test is what holds the rule.
+        """
+        projected = project_untotalled({"contents": [{"parts": [{"text": "hi", "x-kitty-trace": "abc"}]}]})
+
+        assert projected.residual == {"contents[0].parts[0].x-kitty-trace": "abc"}
+
+    def test_consumed_claims_only_what_the_reader_actually_mapped(self) -> None:
+        """A reader that over-claims defeats the check `consumed` exists to be.
+
+        `verify_total` still fails such a body — the residual is non-empty — so
+        the falsification case above passes either way and cannot see this.
+        But `consumed` would be *wrong data*: it is what makes a **dropped** key
+        detectable, and T-D8 diffs these key sets across all six readers.
+        Mutation testing found this one; no behavioural test could.
+        """
+        projected = project_untotalled({"contents": [], "x-kitty-trace": "abc"})
+
+        assert set(projected.consumed) == {"contents"}
+        assert "x-kitty-trace" not in projected.consumed
+
+    def test_a_dropping_reader_is_caught_by_totality_not_by_the_residual(self) -> None:
+        """R7.3 — the case a "residual must be empty" rule cannot see.
+
+        A reader that *drops* an unknown key leaves the residual empty and
+        sails through. `Request.consumed` exists for this, and this is the
+        deliberate defect that proves it does its job.
+        """
+        body = {"contents": [], "cachedContent": "cachedContents/abc"}
+        honest = project(body)
+        assert honest.envelope.extra["cachedContent"] == "cachedContents/abc"
+
+        # The defect: the same projection with the key claimed by neither account.
+        dropping = c.Request(
+            envelope=honest.envelope,
+            conversation=honest.conversation,
+            residual={},
+            consumed=frozenset({"contents"}),
+            source=honest.source,
+        )
+
+        with pytest.raises(c.DroppedFieldsError):
+            c.verify_total(dropping)
+
+    def test_two_identical_bodies_to_two_models_are_told_apart(self) -> None:
+        """R7.4 — §3.3.5's headline claim, for the format that needs it most.
+
+        The bodies are asserted byte-identical first: without that the test
+        would pass against a reader that read the model out of the body and
+        never looked at the path at all.
+        """
+        body = {"contents": [{"parts": [{"text": "hi"}]}]}
+        left = captured(body, model="gemini-2.0-flash")
+        right = captured(body, model="gemini-2.5-pro")
+        assert left.body == right.body
+
+        reader = r.GeminiProjection()
+        assert reader.read_request(left).envelope.model == "gemini-2.0-flash"
+        assert reader.read_request(right).envelope.model == "gemini-2.5-pro"
+
+    def test_two_identical_bodies_on_two_operations_are_told_apart(self) -> None:
+        """R7.5 — M11 forces `stream` false, and the body cannot show it."""
+        body = {"contents": [{"parts": [{"text": "hi"}]}]}
+        left = captured(body, operation="generateContent")
+        right = captured(body, operation="streamGenerateContent")
+        assert left.body == right.body
+
+        reader = r.GeminiProjection()
+        assert reader.read_request(left).envelope.stream is False
+        assert reader.read_request(right).envelope.stream is True
+
+
+# --------------------------------------------------------------------------
+# R3 — ProtoJSON's two spellings
+# --------------------------------------------------------------------------
+
+
+class TestBothSpellings:
+    """Gemini's JSON is ProtoJSON, and every field has two legal names.
+
+    "Parsers accept both the lowerCamelCase name … and the original proto field
+    name" (``protobuf.dev/programming-guides/json/``), and Google's own
+    published examples mix the two — ``system_instruction`` and
+    ``function_declarations`` beside ``maxOutputTokens`` and ``stopSequences``.
+    A reader that knew one spelling would residualise the other and fail the run
+    on Google's own sample.
+    """
+
+    @pytest.mark.parametrize(
+        ("body", "check"),
+        [
+            (
+                {"system_instruction": {"parts": [{"text": "be brief"}]}},
+                lambda p: p.conversation.system == (c.Text("be brief"),),
+            ),
+            (
+                {"generation_config": {"max_output_tokens": 8}},
+                lambda p: p.conversation.sampling == {"max_tokens": 8},
+            ),
+            (
+                {"cached_content": "cachedContents/a"},
+                lambda p: p.envelope.extra["cachedContent"] == "cachedContents/a",
+            ),
+            (
+                {"contents": [{"parts": [{"file_data": {"file_uri": "files/example"}}]}]},
+                lambda p: p.conversation.turns[0].parts[0] == c.Image(ref="files/example"),
+            ),
+            (
+                {"tools": [{"function_declarations": [{"name": "f"}]}]},
+                lambda p: p.conversation.tools == (c.ToolDecl("f"),),
+            ),
+            (
+                {"tool_config": {"function_calling_config": {"mode": "ANY"}}},
+                lambda p: p.envelope.extra["tool_choice"] == "any",
+            ),
+        ],
+    )
+    def test_the_snake_case_original_reads_as_the_published_name(self, body: Any, check: Any) -> None:
+        """R3.1 — at the top level and at every depth beneath it."""
+        assert check(project(body))
+
+    @pytest.mark.parametrize("published_first", [True, False])
+    def test_two_spellings_of_one_field_resolve_the_same_way_either_order(self, published_first: bool) -> None:
+        """R3.2 — a body cannot mean two things, and order must not decide which.
+
+        The published spelling wins wherever it appears. Resolving by *position*
+        instead would make the same semantic body project two ways depending on
+        which alias a serialiser emitted first — and §7.4.1 designs key order
+        out of the projection elsewhere for exactly this reason ("canonical JSON
+        rather than the raw wire slice, because a translator that reorders keys
+        must not change the digest").
+
+        The loser residualises rather than vanishing: a silent drop is the shape
+        `consumed` exists to catch.
+        """
+        camel = {"parts": [{"text": "published"}]}
+        snake = {"parts": [{"text": "alias"}]}
+        body = (
+            {"systemInstruction": camel, "system_instruction": snake}
+            if published_first
+            else {"system_instruction": snake, "systemInstruction": camel}
+        )
+
+        projected = project_untotalled(body)
+
+        assert projected.conversation.system == (c.Text("published"),)
+        assert projected.residual == {"system_instruction": snake}
+
+    def test_a_published_key_that_already_begins_with_an_underscore_resolves_to_itself(self) -> None:
+        """R3.3 — `_responseJsonSchema` is a published key, not a snake_case original.
+
+        Converting it would produce `ResponseJsonSchema`, which matches nothing,
+        so the field would residualise and fail the run on a legitimate request.
+        """
+        projected = project({"generationConfig": {"_responseJsonSchema": {"type": "object"}}})
+
+        assert projected.envelope.extra["_responseJsonSchema"] == {"type": "object"}
+
+    def test_an_unrecognised_key_is_not_rescued_by_conversion(self) -> None:
+        """A snake_case key naming nothing published still residualises."""
+        projected = project_untotalled({"kitty_trace": "abc"})
+
+        assert projected.residual == {"kitty_trace": "abc"}
+
+
+# --------------------------------------------------------------------------
+# R4 — the envelope
+# --------------------------------------------------------------------------
+
+
+class TestEnvelope:
+    """Control fields land on the envelope, keyed by the published wire key."""
+
+    def test_store_is_a_named_field(self) -> None:
+        """R4.1 — P17 injects `store`, so it needs its own anchor."""
+        assert project({"store": False}).envelope.store is False
+
+    def test_an_absent_control_field_is_absent_rather_than_none(self) -> None:
+        """P17 injects `store`, so its absence must be observable (§3.3.2 assertion 2)."""
+        projected = project({"contents": []})
+
+        assert projected.envelope.store is None
+        assert projected.envelope.extra == {}
+
+    @pytest.mark.parametrize(
+        ("key", "value"),
+        [
+            ("serviceTier", "SERVICE_TIER_PRIORITY"),
+            ("cachedContent", "cachedContents/abc"),
+            ("safetySettings", [{"category": "HARM_CATEGORY_HATE_SPEECH", "threshold": "OFF"}]),
+        ],
+    )
+    def test_a_top_level_control_field_keeps_its_published_key(self, key: str, value: Any) -> None:
+        """R4.2 — a register row addresses `envelope.extra[<key>]` by that name."""
+        assert project({key: value}).envelope.extra[key] == value
+
+    def test_a_nested_control_field_is_addressed_by_its_leaf_key(self) -> None:
+        """R4.3/R4.4 — `extra_path()` raises on a dotted key.
+
+        §3.3.1a: "`envelope.extra` is diffed one wire key at a time … the
+        dotted-bracket form exists for `residual` alone". Gemini is the first
+        format whose control fields nest, so the leaf is the address.
+        """
+        projected = project(
+            {
+                "generationConfig": {"responseSchema": {"type": "ARRAY"}},
+                "toolConfig": {"retrievalConfig": {"languageCode": "en"}},
+            }
+        )
+
+        assert projected.envelope.extra["responseSchema"] == {"type": "ARRAY"}
+        assert projected.envelope.extra["retrievalConfig"] == {"languageCode": "en"}
+
+    def test_every_extra_key_this_reader_can_emit_is_addressable(self) -> None:
+        """R4.7 — flattening two nested objects into one namespace must not collide.
+
+        Asserted over the tables rather than over one body, because a collision
+        would be introduced by a *schema revision*, not by a request: the loser
+        would silently overwrite the winner with no residual and no delta.
+        """
+        emitted = [
+            r._TOP_LEVEL_EXTRA_KEYS,
+            r._GENERATION_EXTRA_KEYS,
+            r._TOOL_CONFIG_EXTRA_KEYS,
+            r._BUILT_IN_TOOL_KEYS,
+            frozenset({c.TOOL_CHOICE_KEY}),
+        ]
+        flattened = [key for group in emitted for key in group]
+
+        assert len(flattened) == len(set(flattened)), "two extra sources name one key"
+
+        # And every one of them is a legal `envelope.extra` address, which is
+        # what makes the flattening safe rather than merely collision-free.
+        for key in flattened:
+            assert c.extra_path(key) == f"envelope.extra[{key}]"
+
+    @pytest.mark.parametrize("value", [f"models/{_MODEL}", "models/other"])
+    def test_a_body_level_model_residualises_whether_or_not_it_agrees(self, value: str) -> None:
+        """R4.6 — the REST request body has no `model` field.
+
+        The endpoint is `/v1beta/{model=models/*}:generateContent` and the
+        reference's own "Request body" table lists nine fields without it; the
+        discovery document carries one only because that is the proto message.
+        So a body `model` is an unrecognised key.
+
+        **Both cases behave the same, deliberately.** An earlier draft
+        residualised only on disagreement, which put an *assertion* inside a
+        reader: §3.3.1a makes `residual` an illegal register anchor, so that
+        comparison could only ever kill the run, and finding disagreements is
+        §3.3.2's job over a route T-D2 owns.
+        """
+        projected = project_untotalled({"model": value}, model=_MODEL)
+
+        assert projected.envelope.model == _MODEL
+        assert projected.residual == {"model": value}
+
+
+class TestSampling:
+    """`generationConfig` splits into the closed canonical set and the rest."""
+
+    def test_every_member_with_a_canonical_spelling(self) -> None:
+        """R5.1 — §3.3.1b's set is closed and `Conversation` enforces it."""
+        projected = project(
+            {
+                "generationConfig": {
+                    "temperature": 1.0,
+                    "topP": 0.8,
+                    "topK": 10,
+                    "maxOutputTokens": 800,
+                    "presencePenalty": 0.1,
+                    "frequencyPenalty": 0.2,
+                    "seed": 7,
+                    "candidateCount": 2,
+                    "stopSequences": ["Title"],
+                    "responseLogprobs": True,
+                    "logprobs": 5,
+                }
+            }
+        )
+
+        assert projected.conversation.sampling == {
+            "temperature": 1.0,
+            "top_p": 0.8,
+            "top_k": 10,
+            "max_tokens": 800,
+            "presence_penalty": 0.1,
+            "frequency_penalty": 0.2,
+            "seed": 7,
+            "n": 2,
+            "stop": ["Title"],
+            "logprobs": True,
+            "top_logprobs": 5,
+        }
+
+    def test_the_logprobs_name_collision_is_not_carried_across(self) -> None:
+        """R5.2 — the trap this format sets, and the one a careful reader walks into.
+
+        Gemini's `logprobs` is the *count* Chat Completions calls
+        `top_logprobs`; its `responseLogprobs` is the *boolean* Chat Completions
+        calls `logprobs`. Carrying `logprobs` across unchanged types-checks
+        clean and shows a delta on every cross-format comparison that asks for
+        them.
+        """
+        sampling = project({"generationConfig": {"logprobs": 5}}).conversation.sampling
+
+        assert sampling == {"top_logprobs": 5}
+        assert "logprobs" not in sampling
+
+    def test_the_response_format_family_is_control_not_sampling(self) -> None:
+        """R5.3 — none of the five folds onto the Chat Completions union.
+
+        `responseFormat` is per-modality output configuration and the other four
+        are schema constraints; folding any onto `response_format` would put a
+        claim into the projection that the wire does not make.
+        """
+        projected = project(
+            {
+                "generationConfig": {
+                    "responseMimeType": "application/json",
+                    "responseSchema": {"type": "ARRAY"},
+                    "responseJsonSchema": {"type": "array"},
+                    "_responseJsonSchema": {"type": "array"},
+                    "responseFormat": {"text": {}},
+                }
+            }
+        )
+
+        assert "response_format" not in projected.conversation.sampling
+        assert set(projected.envelope.extra) == {
+            "responseMimeType",
+            "responseSchema",
+            "responseJsonSchema",
+            "_responseJsonSchema",
+            "responseFormat",
+        }
+
+    def test_a_true_is_not_read_as_an_integer(self) -> None:
+        """`bool` is a subclass of `int`, so an unguarded isinstance carries it.
+
+        `topK: true` would arrive as the integer 1 — a value the agent never
+        sent, and the coercion §7.4.1 forbids.
+        """
+        projected = project_untotalled({"generationConfig": {"topK": True}})
+
+        assert projected.conversation.sampling == {}
+        assert projected.residual == {"generationConfig.topK": True}
+
+    def test_an_integer_is_accepted_where_the_schema_publishes_a_float(self) -> None:
+        """`"temperature": 1` is a legal JSON number for a float field."""
+        assert project({"generationConfig": {"temperature": 1}}).conversation.sampling == {"temperature": 1}
+
+    def test_an_unrecognised_generation_config_member_residualises_under_its_path(self) -> None:
+        """§7.4.1: failing closed is not a top-level rule."""
+        projected = project_untotalled({"generationConfig": {"kittyKnob": 1}})
+
+        assert projected.residual == {"generationConfig.kittyKnob": 1}
+
+
+class TestToolChoice:
+    """`functionCallingConfig.mode` normalises onto the canonical vocabulary."""
+
+    @pytest.mark.parametrize(
+        ("mode", "expected"),
+        [("AUTO", "auto"), ("ANY", "any"), ("NONE", "none"), ("auto", "auto"), ("any", "any")],
+    )
+    def test_a_published_mode_with_a_canonical_value(self, mode: str, expected: str) -> None:
+        """R4.5 — matched case-insensitively, because Google's own example is lower case."""
+        projected = project({"toolConfig": {"functionCallingConfig": {"mode": mode}}})
+
+        assert projected.envelope.extra["tool_choice"] == expected
+
+    @pytest.mark.parametrize("mode", ["MODE_UNSPECIFIED", "VALIDATED"])
+    def test_a_mode_with_no_canonical_value_residualises(self, mode: str) -> None:
+        """R4.5 — `Envelope` enforces the closed set, so inventing a value raises.
+
+        A `ValueError` out of a reader means the reader mis-routed a field, and
+        T-D1 reads it as a reader bug rather than as an unreadable body — so a
+        mode the vocabulary cannot carry must residualise instead.
+        """
+        projected = project_untotalled({"toolConfig": {"functionCallingConfig": {"mode": mode}}})
+
+        assert "tool_choice" not in projected.envelope.extra
+        assert projected.residual == {"toolConfig.functionCallingConfig.mode": mode}
+
+    def test_any_restricted_to_one_function_is_that_tool(self) -> None:
+        """R4.5 — "must call a function, and only this one" is `tool:<name>`."""
+        projected = project({"toolConfig": {"functionCallingConfig": {"mode": "ANY", "allowedFunctionNames": ["f"]}}})
+
+        assert projected.envelope.extra["tool_choice"] == "tool:f"
+
+    def test_any_restricted_to_several_keeps_the_mode_and_names_what_was_lost(self) -> None:
+        """R4.5 — the restriction has no canonical form; the mode still projects."""
+        projected = project_untotalled(
+            {"toolConfig": {"functionCallingConfig": {"mode": "ANY", "allowedFunctionNames": ["f", "g"]}}}
+        )
+
+        assert projected.envelope.extra["tool_choice"] == "any"
+        assert projected.residual == {"toolConfig.functionCallingConfig.allowedFunctionNames": ["f", "g"]}
+
+
+class TestTools:
+    """Function declarations are content; built-in capabilities are control."""
+
+    def test_a_function_declaration_projects_by_name(self) -> None:
+        """R6.11 — §3.3.1a addresses tools by name, never by index."""
+        projected = project(
+            {
+                "tools": [
+                    {
+                        "functionDeclarations": [
+                            {
+                                "name": "get_weather",
+                                "description": "Look up the weather.",
+                                "parameters": {"type": "object"},
+                            }
+                        ]
+                    }
+                ]
+            }
+        )
+
+        assert projected.conversation.tools == (
+            c.ToolDecl(
+                name="get_weather",
+                description="Look up the weather.",
+                schema={"type": "object"},
+                strict=None,
+            ),
+        )
+
+    def test_strict_is_absent_rather_than_false(self) -> None:
+        """P15's presence and absence must stay distinguishable."""
+        projected = project({"tools": [{"functionDeclarations": [{"name": "f"}]}]})
+
+        assert projected.conversation.tools[0].strict is None
+
+    def test_parameters_json_schema_fills_the_same_slot(self) -> None:
+        """R6.11 — the published mutually exclusive alternative to `parameters`."""
+        projected = project(
+            {"tools": [{"functionDeclarations": [{"name": "f", "parametersJsonSchema": {"type": "object"}}]}]}
+        )
+
+        assert projected.conversation.tools[0].schema == {"type": "object"}
+
+    def test_a_declaration_carrying_both_schemas_keeps_parameters(self) -> None:
+        """R6.11 — carrying both is outside the schema, so the loser residualises."""
+        projected = project_untotalled(
+            {
+                "tools": [
+                    {
+                        "functionDeclarations": [
+                            {
+                                "name": "f",
+                                "parameters": {"type": "object"},
+                                "parametersJsonSchema": {"type": "array"},
+                            }
+                        ]
+                    }
+                ]
+            }
+        )
+
+        assert projected.conversation.tools[0].schema == {"type": "object"}
+        assert projected.residual == {"tools[0].functionDeclarations[0].parametersJsonSchema": {"type": "array"}}
+
+    @pytest.mark.parametrize("key", ["behavior", "response", "responseJsonSchema"])
+    def test_a_declaration_member_the_grammar_cannot_carry_residualises(self, key: str) -> None:
+        """R6.10 — `ToolDecl` has four slots and the format publishes seven keys."""
+        projected = project_untotalled({"tools": [{"functionDeclarations": [{"name": "f", key: "x"}]}]})
+
+        assert projected.residual == {f"tools[0].functionDeclarations[0].{key}": "x"}
+
+    def test_a_declaration_with_no_usable_name_residualises_rather_than_raising(self) -> None:
+        """§3.3.1b settles this, and not the way the leaf rule usually goes.
+
+        "An absent `name` *does* residualise … a call nobody can name cannot be
+        paired or addressed." Absent and `null` residualise as well as a wrong
+        type — but the declaration is still **projected**, because raising would
+        blind the oracle to the rest of a request it could otherwise diff. T-A3
+        takes the same branch; an earlier draft of this reader raised, which was
+        a third answer to a question §3.3.1b had already settled.
+        """
+        projected = project_untotalled({"tools": [{"functionDeclarations": [{"description": "x"}]}]})
+
+        assert projected.conversation.tools == (c.ToolDecl(name="", description="x"),)
+        assert projected.residual == {"tools[0].functionDeclarations[0].name": None}
+
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "googleSearch",
+            "codeExecution",
+            "urlContext",
+            "fileSearch",
+            "computerUse",
+            "googleMaps",
+            "googleSearchRetrieval",
+            "mcpServers",
+        ],
+    )
+    def test_a_built_in_capability_is_control_not_a_tool_declaration(self, key: str) -> None:
+        """R6.12 — `ToolDecl` needs a name, and inventing one is a vendor spelling.
+
+        Residualising instead would fail the run on every request that enables
+        Google Search, which is not a defect signal but a legitimate control
+        field the format publishes.
+        """
+        projected = project({"tools": [{key: {}}]})
+
+        assert projected.conversation.tools == ()
+        assert projected.envelope.extra[key] == {}
+
+    def test_a_second_entry_redeclaring_a_capability_residualises(self) -> None:
+        """R6.12 — `envelope.extra[<key>]` is one address, so the second has none."""
+        projected = project_untotalled({"tools": [{"googleSearch": {}}, {"googleSearch": {"x": 1}}]})
+
+        assert projected.envelope.extra["googleSearch"] == {}
+        assert projected.residual == {"tools[1].googleSearch": {"x": 1}}
+
+
+# --------------------------------------------------------------------------
+# R6 — the conversation
+# --------------------------------------------------------------------------
+
+#: One pixel of PNG, so an image fixture carries real bytes rather than a
+#: placeholder whose digest would be meaningless.
+_PIXEL = base64.b64encode(bytes.fromhex("89504e470d0a1a0a")).decode("ascii")
+
+
+class TestSystemInstruction:
+    """`systemInstruction` lifts into `Conversation.system`, never into a turn."""
+
+    def test_each_text_part_becomes_one_system_entry(self) -> None:
+        """R6.1 — §3.3.1b: the system prompt is a top-level field in this format."""
+        projected = project({"systemInstruction": {"parts": [{"text": "be brief"}, {"text": "be kind"}]}})
+
+        assert projected.conversation.system == (c.Text("be brief"), c.Text("be kind"))
+        assert projected.conversation.turns == ()
+
+    def test_a_non_text_part_in_a_system_instruction_residualises(self) -> None:
+        """The schema says system instructions are "text only"."""
+        projected = project_untotalled({"systemInstruction": {"parts": [{"fileData": {"fileUri": "files/example"}}]}})
+
+        assert projected.conversation.system == ()
+        assert projected.residual == {"systemInstruction.parts[0].fileData": {"fileUri": "files/example"}}
+
+    def test_a_role_on_a_system_instruction_residualises(self) -> None:
+        """`Conversation.system` has no role slot, and the grammar cannot carry one."""
+        projected = project_untotalled({"systemInstruction": {"role": "user", "parts": [{"text": "be brief"}]}})
+
+        assert projected.conversation.system == (c.Text("be brief"),)
+        assert projected.residual == {"systemInstruction.role": "user"}
+
+
+class TestTurns:
+    """`contents` becomes turns, with Gemini's `model` mapping to `assistant`."""
+
+    @pytest.mark.parametrize(
+        ("content", "expected"),
+        [
+            ({"role": "user", "parts": [{"text": "hi"}]}, "user"),
+            ({"role": "model", "parts": [{"text": "hi"}]}, "assistant"),
+            ({"parts": [{"text": "hi"}]}, "user"),
+            ({"role": "", "parts": [{"text": "hi"}]}, "user"),
+        ],
+    )
+    def test_the_published_producers_map_onto_the_closed_role_set(self, content: Any, expected: str) -> None:
+        """R6.2 — §3.3.1b: "Gemini's `model` maps to `assistant`".
+
+        An absent or blank role is `user`: the schema says the field "can be
+        left blank or unset", and request content with no stated producer is the
+        client's. Reading it as anything else would split one turn in two and,
+        because paths are index-based, report a delta on every turn after it.
+        """
+        projected = project({"contents": [content]})
+
+        assert projected.conversation.turns[0].role == expected
+
+    @pytest.mark.parametrize("role", ["system", "assistant", "developer", 7])
+    def test_a_role_outside_the_published_pair_is_unreadable(self, role: Any) -> None:
+        """R2.5 — structural: the turn cannot be built at all.
+
+        `assistant` is in the list deliberately: it is the *projection's* role,
+        not a wire value, and accepting it would let a reader validated against
+        another reader's output pass.
+        """
+        with pytest.raises(c.UnreadableBodyError):
+            project_untotalled({"contents": [{"role": role, "parts": []}]})
+
+    def test_a_singleton_content_and_part_read_as_one_of_each(self) -> None:
+        """R6.3 — Google's published `system_instruction.sh` sends both that way.
+
+        The schema declares repeated fields; the published example does not send
+        lists. Accepting only a list fails the run on Google's own sample.
+        """
+        projected = project(
+            {
+                "system_instruction": {"parts": {"text": "You are a cat. Your name is Neko."}},
+                "contents": {"parts": {"text": "Hello there"}},
+            }
+        )
+
+        assert projected.conversation.system == (c.Text("You are a cat. Your name is Neko."),)
+        assert projected.conversation.turns == (c.Turn("user", [c.Text("Hello there")]),)
+
+
+class TestParts:
+    """Every published `Part` member, into the grammar or into the residual."""
+
+    def test_text(self) -> None:
+        """An empty part is a part with an empty string, never nothing (§3.3.1)."""
+        projected = project({"contents": [{"parts": [{"text": ""}]}]})
+
+        assert projected.conversation.turns[0].parts == (c.Text(""),)
+
+    def test_a_thought_carries_its_signature(self) -> None:
+        """R6.4 — `Thinking.signature` is what M8's carrier repair manipulates."""
+        projected = project(
+            {
+                "contents": [
+                    {
+                        "role": "model",
+                        "parts": [{"text": "hmm", "thought": True, "thoughtSignature": "sig"}],
+                    }
+                ]
+            }
+        )
+
+        assert projected.conversation.turns[0].parts == (c.Thinking("hmm", signature="sig"),)
+
+    def test_a_signature_on_a_part_that_is_not_a_thought_residualises(self) -> None:
+        """R6.10 — `ToolUse` has no signature slot, so there is nowhere to put it.
+
+        Gemini 2.5 and later attach a `thoughtSignature` to a `functionCall`
+        part and clients echo it back, so this **will** fail the oracle run on
+        real traffic — the same shape as KBR-167's block-level `cache_control`.
+        That is the correct signal: the grammar cannot carry it, and a reader
+        that dropped it would hide a field a translator could silently lose.
+        """
+        projected = project_untotalled(
+            {
+                "contents": [
+                    {
+                        "role": "model",
+                        "parts": [{"functionCall": {"name": "f"}, "thoughtSignature": "sig"}],
+                    }
+                ]
+            }
+        )
+
+        assert projected.conversation.turns[0].parts == (c.ToolUse("f"),)
+        assert projected.residual == {"contents[0].parts[0].thoughtSignature": "sig"}
+
+    def test_inline_data_is_identified_by_the_digest_of_its_decoded_bytes(self) -> None:
+        """R6.4 — §3.3.1: the media type is carried separately, not digested.
+
+        `inlineData` is the format's only bytes carrier whatever the media type,
+        so audio and PDF payloads project the same way and `media_type` records
+        which it was.
+        """
+        projected = project({"contents": [{"parts": [{"inlineData": {"mimeType": "image/png", "data": _PIXEL}}]}]})
+
+        assert projected.conversation.turns[0].parts == (
+            c.Image(
+                digest=c.image_digest(base64.b64decode(_PIXEL)),
+                media_type="image/png",
+            ),
+        )
+
+    def test_file_data_carries_a_reference_and_no_digest(self) -> None:
+        """R6.4 — §3.3.1 names this case: "`fileData.fileUri` has no bytes"."""
+        projected = project(
+            {"contents": [{"parts": [{"fileData": {"mimeType": "audio/mpeg", "fileUri": "files/example"}}]}]}
+        )
+
+        assert projected.conversation.turns[0].parts == (
+            c.Image(digest=None, media_type="audio/mpeg", ref="files/example"),
+        )
+
+    def test_a_function_call_carries_the_published_optional_id(self) -> None:
+        """R6.4 — Gemini `v1beta` publishes `FunctionCall.id`, contrary to §3.3.1's note.
+
+        The *decision* that note justifies — an optional id — is unchanged and
+        still right, because Gemini's id is optional too. Only the stated reason
+        was wrong, and KBR-36's comment asked for it to be confirmed rather than
+        assumed.
+        """
+        projected = project(
+            {
+                "contents": [
+                    {
+                        "role": "model",
+                        "parts": [{"functionCall": {"id": "fc-1", "name": "f", "args": {"q": "x"}}}],
+                    }
+                ]
+            }
+        )
+
+        assert projected.conversation.turns[0].parts == (c.ToolUse(name="f", arguments={"q": "x"}, id="fc-1"),)
+
+    def test_a_function_call_without_an_id_still_projects(self) -> None:
+        """§3.3.1: pairing then falls back to name and position."""
+        projected = project({"contents": [{"role": "model", "parts": [{"functionCall": {"name": "f"}}]}]})
+
+        assert projected.conversation.turns[0].parts == (c.ToolUse(name="f", arguments={}),)
+
+    def test_a_function_response_carries_its_struct_as_json(self) -> None:
+        """R6.4 — §3.3.1: "Gemini's `functionResponse.response` is a bare struct"."""
+        projected = project(
+            {
+                "contents": [
+                    {
+                        "parts": [
+                            {
+                                "functionResponse": {
+                                    "id": "fc-1",
+                                    "name": "f",
+                                    "response": {"price": 259.75},
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        )
+
+        assert projected.conversation.turns[0].parts == (
+            c.ToolResult(content=[c.Json({"price": 259.75})], tool_use_id="fc-1", is_error=False),
+        )
+
+    def test_a_function_response_media_part_follows_its_struct(self) -> None:
+        """R6.6 — `FunctionResponsePart` carries inline media beside the struct."""
+        projected = project(
+            {
+                "contents": [
+                    {
+                        "parts": [
+                            {
+                                "functionResponse": {
+                                    "name": "f",
+                                    "response": {"ok": True},
+                                    "parts": [{"inlineData": {"mimeType": "image/png", "data": _PIXEL}}],
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        )
+
+        result = projected.conversation.turns[0].parts[0]
+        assert isinstance(result, c.ToolResult)
+        assert result.content == (
+            c.Json({"ok": True}),
+            c.Image(digest=c.image_digest(base64.b64decode(_PIXEL)), media_type="image/png"),
+        )
+
+    @pytest.mark.parametrize(
+        ("key", "kind"),
+        [
+            ("executableCode", "executable_code"),
+            ("codeExecutionResult", "code_execution_result"),
+            ("toolCall", "tool_call"),
+            ("toolResponse", "tool_response"),
+        ],
+    )
+    def test_an_unmodelled_part_projects_as_opaque_with_a_digest(self, key: str, kind: str) -> None:
+        """R6.4/R6.8 — all four name a concept no other format has.
+
+        KBR-35's stated exception therefore applies and the wire name in
+        snake_case is the canonical `kind`. **T-A5 is not covered by this**: it
+        meets `document` and `searchResult`, which do have a second spelling.
+        """
+        projected = project({"contents": [{"parts": [{key: {"a": 1}}]}]})
+
+        part = projected.conversation.turns[0].parts[0]
+        assert isinstance(part, c.Opaque)
+        assert part.kind == kind
+        assert part.digest is not None
+
+    def test_two_different_payloads_do_not_project_identically(self) -> None:
+        """§3.3.1 put `digest` on `Opaque` to keep unmodelled content detectable.
+
+        A bare `Opaque("executable_code")` would make a swapped program produce
+        no delta at all.
+        """
+        left = project({"contents": [{"parts": [{"executableCode": {"code": "print(1)"}}]}]})
+        right = project({"contents": [{"parts": [{"executableCode": {"code": "print(2)"}}]}]})
+
+        assert left.conversation.turns[0].parts[0] != right.conversation.turns[0].parts[0]
+
+    def test_the_opaque_digest_recipe_is_pinned_to_an_external_literal(self) -> None:
+        """R6.9 — the only assertion that can see a changed recipe.
+
+        Every other digest assertion compares two projections against each
+        other, which cannot detect a recipe change that stays internally
+        consistent: in T-A1 `ensure_ascii=False`, default `separators` and
+        `sort_keys=False` all survived mutation testing until one digest was
+        pinned this way. The payload is deliberately **non-ASCII and
+        multi-key**, because that is the only shape on which all three wrong
+        spellings differ from the right one.
+        """
+        payload = {"language": "PYTHON", "code": "print('héllo — wörld')"}
+        expected = hashlib.sha256(
+            json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
+        ).hexdigest()
+
+        projected = project({"contents": [{"parts": [{"executableCode": payload}]}]})
+        part = projected.conversation.turns[0].parts[0]
+
+        assert isinstance(part, c.Opaque)
+        assert part.digest == expected
+        # Spelled out, so a reader of this test can see what is being pinned
+        # rather than reading the recipe back out of the code under test.
+        assert part.digest == "972e7573e3ff448274e80598557d57cf4b3fd9bdf77b862b02be2c73bb599cbd"
+
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "partMetadata",
+            "videoMetadata",
+            "mediaResolution",
+            "mediaProcessing",
+            "audioTranscription",
+        ],
+    )
+    def test_a_part_modifier_with_no_slot_residualises(self, key: str) -> None:
+        """R6.10 — §7.4.1: a key the mapping does not consume residualises."""
+        projected = project_untotalled({"contents": [{"parts": [{"text": "hi", key: {"a": 1}}]}]})
+
+        assert projected.residual == {f"contents[0].parts[0].{key}": {"a": 1}}
+
+    @pytest.mark.parametrize(
+        ("part", "case"),
+        [
+            ({}, "an empty part"),
+            ({"thought": False}, "only the thought flag, which is not a data member"),
+            ({"thoughtSignature": "s"}, "only a signature, which modifies a member it lacks"),
+            ({"videoMetadata": {"fps": 1.0}}, "only a modifier"),
+        ],
+    )
+    def test_a_part_carrying_no_published_member_is_unreadable(self, part: Any, case: str) -> None:
+        """R2.5 — §7.4.1's "a content block with no type": nothing to salvage.
+
+        `thought` is the one that surprises. It is a part-level *flag*, so
+        `{"thought": true}` alone is a thought part and projects `Thinking("")`
+        — Gemini returns signature-only thoughts — while `{"thought": false}`
+        alone says only that the part the wire forgot to send was not a thought.
+        Dispatching on "is `thought` present" rather than "is it true" would
+        project that as `Text("")`, inventing a part out of a flag.
+        """
+        with pytest.raises(c.UnreadableBodyError):
+            project_untotalled({"contents": [{"parts": [part]}]})
+
+
+class TestMergePipeline:
+    """§3.3.1b's four clauses, in order, and never a re-sort."""
+
+    def test_results_come_first_within_one_content(self) -> None:
+        """R6.13 — clause 3, scoped per content and to `user`.
+
+        Omitting it would project `[Text, ToolResult]` where the Chat
+        Completions and Responses readers both produce `[ToolResult, Text]` for
+        the same content — a delta no mutation caused.
+        """
+        projected = project(
+            {
+                "contents": [
+                    {
+                        "parts": [
+                            {"text": "here you go"},
+                            {"functionResponse": {"name": "f", "response": {}}},
+                        ]
+                    }
+                ]
+            }
+        )
+
+        parts = projected.conversation.turns[0].parts
+        assert [type(part) for part in parts] == [c.ToolResult, c.Text]
+
+    def test_clause_three_never_becomes_a_re_sort_of_the_merged_turn(self) -> None:
+        """R6.13 — the defect §7.4.1 records, spelled as a test.
+
+        `functionResponse -> user(text) -> functionResponse` must project as
+        `[ToolResult, Text, ToolResult]`. A re-sort after the same-role merge
+        gives `[ToolResult, ToolResult, Text]`, hoisting a result ahead of text
+        the agent sent **before** it — moving history the bridge did not move.
+        Because paths are index-based, that invented delta lands on every part
+        of the turn and every turn after it.
+        """
+        projected = project(
+            {
+                "contents": [
+                    {"parts": [{"functionResponse": {"name": "f", "response": {"n": 1}}}]},
+                    {"parts": [{"text": "and also"}]},
+                    {"parts": [{"functionResponse": {"name": "g", "response": {"n": 2}}}]},
+                ]
+            }
+        )
+
+        parts = projected.conversation.turns[0].parts
+        assert [type(part) for part in parts] == [c.ToolResult, c.Text, c.ToolResult]
+
+    def test_an_assistant_content_is_left_in_wire_order(self) -> None:
+        """Clause 3 is about a `user` turn; a model turn is not reordered.
+
+        **The fixture has to carry a `ToolResult` after text**, or this test
+        passes without testing its own name: with a `ToolUse` the partition is a
+        no-op whatever the role guard does, so deleting the guard leaves the
+        suite green. Mutation testing found exactly that here, and T-A1 records
+        the identical defect — "a test can pass without testing its name".
+
+        A `functionResponse` inside a `model` content is unusual but
+        structurally legal, and it is the only shape that makes the guard
+        observable.
+        """
+        projected = project(
+            {
+                "contents": [
+                    {
+                        "role": "model",
+                        "parts": [
+                            {"text": "here it is"},
+                            {"functionResponse": {"name": "f", "response": {}}},
+                        ],
+                    }
+                ]
+            }
+        )
+
+        parts = projected.conversation.turns[0].parts
+        assert [type(part) for part in parts] == [c.Text, c.ToolResult]
+
+    def test_consecutive_same_role_contents_merge(self) -> None:
+        """Clause 4 — the format's own behaviour, and what keeps turn boundaries
+        agreeing with the Chat Completions reader on the standard exchange."""
+        projected = project(
+            {
+                "contents": [
+                    {"role": "user", "parts": [{"text": "one"}]},
+                    {"role": "user", "parts": [{"text": "two"}]},
+                    {"role": "model", "parts": [{"text": "three"}]},
+                ]
+            }
+        )
+
+        assert projected.conversation.turns == (
+            c.Turn("user", [c.Text("one"), c.Text("two")]),
+            c.Turn("assistant", [c.Text("three")]),
+        )
+
+
+# --------------------------------------------------------------------------
+# The published examples
+# --------------------------------------------------------------------------
+
+#: The ``curl`` request bodies the Gemini API reference publishes at
+#: ``https://ai.google.dev/api/generate-content`` (retrieved 2026-09-12), keyed
+#: by the sample file each comes from, with the route each is sent to.
+#:
+#: **Two deviations, and no others.**  ``chat.sh`` and ``controlled_generation.sh``
+#: each carry a **trailing comma** as published, which is not JSON and which
+#: ``json.loads`` rejects; it is removed.  The three File-API samples interpolate
+#: a shell variable into ``file_uri``, so ``files/example`` stands in — the
+#: suite names no host it does not control, which is the same substitution T-A3
+#: made for the Responses examples.
+#:
+#: Note how freely the samples mix ProtoJSON's two spellings: ``file_data``,
+#: ``system_instruction``, ``function_declarations``, ``tool_config`` and
+#: ``response_mime_type`` in snake_case beside ``generationConfig``,
+#: ``stopSequences``, ``maxOutputTokens`` and ``topP`` in camelCase. A reader
+#: that knew only the schema's spelling would fail on five of these ten.
+PUBLISHED_EXAMPLES: dict[str, tuple[str, Any]] = {
+    "text_generation.sh": (
+        "generateContent",
+        {"contents": [{"parts": [{"text": "Write a story about a magic backpack."}]}]},
+    ),
+    "audio.sh": (
+        "generateContent",
+        {
+            "contents": [
+                {
+                    "parts": [
+                        {"text": "Please describe this file."},
+                        {"file_data": {"mime_type": "audio/mpeg", "file_uri": "files/example"}},
+                    ]
+                }
+            ]
+        },
+    ),
+    "video.sh": (
+        "generateContent",
+        {
+            "contents": [
+                {
+                    "parts": [
+                        {
+                            "text": (
+                                "Transcribe the audio from this video, giving timestamps for "
+                                "salient events in the video. Also provide visual descriptions."
+                            )
+                        },
+                        {"file_data": {"mime_type": "video/mp4", "file_uri": "files/example"}},
+                    ]
+                }
+            ]
+        },
+    ),
+    "pdf.sh": (
+        "generateContent",
+        {
+            "contents": [
+                {
+                    "parts": [
+                        {"text": "Can you add a few more lines to this poem?"},
+                        {
+                            "file_data": {
+                                "mime_type": "application/pdf",
+                                "file_uri": "files/example",
+                            }
+                        },
+                    ]
+                }
+            ]
+        },
+    ),
+    "chat.sh": (
+        "generateContent",
+        {
+            "contents": [
+                {"role": "user", "parts": [{"text": "Hello"}]},
+                {
+                    "role": "model",
+                    "parts": [{"text": "Great to meet you. What would you like to know?"}],
+                },
+                {
+                    "role": "user",
+                    "parts": [{"text": "I have two dogs in my house. How many paws are in my house?"}],
+                },
+            ]
+        },
+    ),
+    "controlled_generation.sh": (
+        "generateContent",
+        {
+            "contents": [{"parts": [{"text": "List 5 popular cookie recipes"}]}],
+            "generationConfig": {
+                "response_mime_type": "application/json",
+                "response_schema": {
+                    "type": "ARRAY",
+                    "items": {
+                        "type": "OBJECT",
+                        "properties": {"recipe_name": {"type": "STRING"}},
+                    },
+                },
+            },
+        },
+    ),
+    "configure_model_parameters.sh": (
+        "generateContent",
+        {
+            "contents": [{"parts": [{"text": "Explain how AI works"}]}],
+            "generationConfig": {
+                "stopSequences": ["Title"],
+                "temperature": 1.0,
+                "maxOutputTokens": 800,
+                "topP": 0.8,
+                "topK": 10,
+            },
+        },
+    ),
+    "system_instruction.sh": (
+        "generateContent",
+        {
+            "system_instruction": {"parts": {"text": "You are a cat. Your name is Neko."}},
+            "contents": {"parts": {"text": "Hello there"}},
+        },
+    ),
+    "text_generation_streaming.sh": (
+        "streamGenerateContent",
+        {"contents": [{"parts": [{"text": "Write a story about a magic backpack."}]}]},
+    ),
+    "function_calling.sh": (
+        "generateContent",
+        {
+            "system_instruction": {
+                "parts": {
+                    "text": (
+                        "You are a helpful lighting system bot. You can turn lights on and off, "
+                        "and you can set the color. Do not perform any other tasks."
+                    )
+                }
+            },
+            "tools": [
+                {
+                    "function_declarations": [
+                        {"name": "enable_lights", "description": "Turn on the lighting system."},
+                        {
+                            "name": "set_light_color",
+                            "description": ("Set the light color. Lights must be enabled for this to work."),
+                            "parameters": {
+                                "type": "object",
+                                "properties": {
+                                    "rgb_hex": {
+                                        "type": "string",
+                                        "description": (
+                                            "The light color as a 6-digit hex string, e.g. ff0000 for red."
+                                        ),
+                                    }
+                                },
+                                "required": ["rgb_hex"],
+                            },
+                        },
+                        {"name": "stop_lights", "description": "Turn off the lighting system."},
+                    ]
+                }
+            ],
+            "tool_config": {"function_calling_config": {"mode": "auto"}},
+            "contents": {"role": "user", "parts": {"text": "Turn on the lights please."}},
+        },
+    ),
+}
+
+
+class TestPublishedExamples:
+    """Every published example round-trips with an empty residual.
+
+    This is T-A4's stated acceptance, and §3.3.1's independent-oracle rule is
+    why it is *published* examples rather than captures of kitty: "a reader
+    validated against kitty's output inherits kitty's bugs and the oracle
+    becomes circular".
+    """
+
+    @pytest.mark.parametrize("sample", sorted(PUBLISHED_EXAMPLES))
+    def test_it_round_trips_with_an_empty_residual(self, sample: str) -> None:
+        """The acceptance criterion, one sample at a time so a failure names it."""
+        operation, body = PUBLISHED_EXAMPLES[sample]
+        projected = project(body, operation=operation)
+
+        assert projected.residual == {}
+        assert set(projected.consumed) == set(body)
+
+    def test_the_streaming_sample_is_the_non_streaming_one_on_another_route(self) -> None:
+        """§3.3.5, on Google's own samples: the bodies are identical.
+
+        `text_generation.sh` publishes the same body for both operations, so
+        these two are the published-example form of R7.5 — and evidence that
+        nothing in a Gemini body says whether it streams.
+        """
+        assert PUBLISHED_EXAMPLES["text_generation.sh"][1] == PUBLISHED_EXAMPLES["text_generation_streaming.sh"][1]
+
+        assert project(PUBLISHED_EXAMPLES["text_generation.sh"][1]).envelope.stream is False
+        assert (
+            project(
+                PUBLISHED_EXAMPLES["text_generation_streaming.sh"][1],
+                operation="streamGenerateContent",
+            ).envelope.stream
+            is True
+        )
+
+    def test_the_function_calling_sample_projects_its_three_tools_and_its_choice(self) -> None:
+        """The richest published sample, asserted for content rather than emptiness.
+
+        An empty-residual assertion alone would pass against a reader that read
+        nothing at all, provided it claimed the keys.
+        """
+        operation, body = PUBLISHED_EXAMPLES["function_calling.sh"]
+        projected = project(body, operation=operation)
+
+        assert [tool.name for tool in projected.conversation.tools] == [
+            "enable_lights",
+            "set_light_color",
+            "stop_lights",
+        ]
+        assert projected.envelope.extra["tool_choice"] == "auto"
+        assert projected.conversation.turns == (c.Turn("user", [c.Text("Turn on the lights please.")]),)
+        assert len(projected.conversation.system) == 1
+
+
+# --------------------------------------------------------------------------
+# Schema agreement
+# --------------------------------------------------------------------------
+
+
+class TestSchemaAgreement:
+    """The reader's tables still agree with the published schema.
+
+    Each expected set below is transcribed from the Gemini API discovery
+    document at revision :data:`~harness.reader_gemini.SCHEMA_VERSION`, and
+    exists so that a schema revision adding a key fails **here**, with the key
+    named, rather than silently widening the residual in T-D5 — where it would
+    read as an I1 breach.
+    """
+
+    def test_the_schema_version_is_recorded(self) -> None:
+        """A table with no stated provenance cannot be re-derived."""
+        assert r.SCHEMA_VERSION == "20260910"
+
+    def test_the_request_body_has_nine_keys_and_model_is_not_one(self) -> None:
+        """`GenerateContentRequest`, as the **REST** surface publishes it.
+
+        The discovery document lists ten because it carries the proto message;
+        the reference's "Request body" table lists these nine and puts `model`
+        under "Path parameters". Pinning the REST nine is what makes a body
+        `model` an unrecognised key rather than a tenth classification.
+        """
+        assert set(r.PUBLISHED_TOP_LEVEL_KEYS) == {
+            "cachedContent",
+            "contents",
+            "generationConfig",
+            "safetySettings",
+            "serviceTier",
+            "store",
+            "systemInstruction",
+            "toolConfig",
+            "tools",
+        }
+        assert "model" not in r.PUBLISHED_TOP_LEVEL_KEYS
+
+    def test_generation_config_has_twenty_five_keys(self) -> None:
+        """`GenerationConfig`, split between the canonical set and the envelope."""
+        assert set(r.PUBLISHED_GENERATION_CONFIG_KEYS) == {
+            "_responseJsonSchema",
+            "audioTranscriptionConfig",
+            "candidateCount",
+            "enableAffectiveDialog",
+            "enableEnhancedCivicAnswers",
+            "frequencyPenalty",
+            "imageConfig",
+            "logprobs",
+            "maxOutputTokens",
+            "mediaResolution",
+            "presencePenalty",
+            "responseFormat",
+            "responseJsonSchema",
+            "responseLogprobs",
+            "responseMimeType",
+            "responseModalities",
+            "responseSchema",
+            "seed",
+            "speechConfig",
+            "stopSequences",
+            "temperature",
+            "thinkingConfig",
+            "topK",
+            "topP",
+            "translationConfig",
+        }
+
+    def test_part_has_sixteen_keys(self) -> None:
+        """`Part` — a union discriminated by field name, not by a `type` tag."""
+        assert set(r.PUBLISHED_PART_KEYS) == {
+            "audioTranscription",
+            "codeExecutionResult",
+            "executableCode",
+            "fileData",
+            "functionCall",
+            "functionResponse",
+            "inlineData",
+            "mediaProcessing",
+            "mediaResolution",
+            "partMetadata",
+            "text",
+            "thought",
+            "thoughtSignature",
+            "toolCall",
+            "toolResponse",
+            "videoMetadata",
+        }
+
+    def test_the_remaining_object_tables(self) -> None:
+        """`Tool`, `ToolConfig`, `FunctionCallingConfig`, `FunctionDeclaration`,
+        `FunctionCall`, `FunctionResponse`, `Content`, `Blob` and `FileData`."""
+        assert set(r.PUBLISHED_TOOL_KEYS) == {
+            "codeExecution",
+            "computerUse",
+            "fileSearch",
+            "functionDeclarations",
+            "googleMaps",
+            "googleSearch",
+            "googleSearchRetrieval",
+            "mcpServers",
+            "urlContext",
+        }
+        assert set(r.PUBLISHED_TOOL_CONFIG_KEYS) == {
+            "functionCallingConfig",
+            "includeServerSideToolInvocations",
+            "retrievalConfig",
+        }
+        assert set(r.PUBLISHED_FUNCTION_CALLING_CONFIG_KEYS) == {"mode", "allowedFunctionNames"}
+        assert set(r.PUBLISHED_FUNCTION_DECLARATION_KEYS) == {
+            "behavior",
+            "description",
+            "name",
+            "parameters",
+            "parametersJsonSchema",
+            "response",
+            "responseJsonSchema",
+        }
+        assert set(r.PUBLISHED_FUNCTION_CALL_KEYS) == {"id", "name", "args"}
+        assert set(r.PUBLISHED_FUNCTION_RESPONSE_KEYS) == {
+            "id",
+            "name",
+            "parts",
+            "response",
+            "scheduling",
+            "willContinue",
+        }
+        assert set(r.PUBLISHED_CONTENT_KEYS) == {"parts", "role"}
+        assert set(r.PUBLISHED_BLOB_KEYS) == {"data", "displayName", "mimeType"}
+        assert set(r.PUBLISHED_FILE_DATA_KEYS) == {"displayName", "fileUri", "mimeType"}
+
+    def test_every_published_tool_choice_mode_is_accounted_for(self) -> None:
+        """Five published modes: three carry a canonical value, two residualise.
+
+        Stated as a partition so that a sixth mode cannot be silently dropped
+        into the residualising half by omission.
+        """
+        published = {"MODE_UNSPECIFIED", "AUTO", "ANY", "NONE", "VALIDATED"}
+
+        assert set(r._TOOL_CHOICE_MODES) < published
+        assert published - set(r._TOOL_CHOICE_MODES) == {"MODE_UNSPECIFIED", "VALIDATED"}
+        assert set(r._TOOL_CHOICE_MODES.values()) == c.TOOL_CHOICE_VALUES
+
+    def test_the_canonical_sampling_targets_are_all_canonical(self) -> None:
+        """`Conversation` rejects a non-canonical key, so a typo here would raise."""
+        targets = {canonical for canonical, _ in r._SAMPLING_KEYS.values()}
+
+        assert targets <= c.SAMPLING_KEYS
+        assert len(targets) == len(r._SAMPLING_KEYS), "two Gemini keys share one canonical name"
+
+
+# --------------------------------------------------------------------------
+# The decisions the design review surfaced, each pinned by its own test
+# --------------------------------------------------------------------------
+
+
+class TestEvidencedAndUnpublishedShapes:
+    """Shapes the published schema does not list, and what each one costs."""
+
+    def test_a_function_role_projects_as_a_user_turn(self) -> None:
+        """§7.4.1 evidence rule 1 — the client demonstrably sends it.
+
+        The published `Content.role` is `user` or `model`, but
+        `src/kitty/bridge/gemini/translator.py`'s `_ROLE_MAP` reads
+        `role: "function"` straight off the inbound body — the same shape as
+        that section's worked example, Anthropic's `effort`. `user` is where
+        §3.3.1b already puts a tool result, so nothing is invented.
+
+        Raising instead would be strictly worse than residualising, which is
+        strictly worse than this: an `UnreadableBodyError` aborts the whole
+        projection, so T-D1 would read a legitimate legacy request as a
+        malformed corpus entry and never check it at all — kitty could mutate
+        that request freely and the oracle would never see it.
+        """
+        projected = project(
+            {
+                "contents": [
+                    {
+                        "role": "function",
+                        "parts": [{"functionResponse": {"name": "f", "response": {"n": 1}}}],
+                    }
+                ]
+            }
+        )
+
+        assert projected.conversation.turns == (c.Turn("user", [c.ToolResult(content=[c.Json({"n": 1})])]),)
+
+    def test_a_thought_part_need_not_carry_text(self) -> None:
+        """Gemini returns signature-only thought parts, and they must project.
+
+        §3.3.1 settles the shape: "An empty block is a part with an empty
+        string, never nothing." Raising on one would abort the projection of a
+        request Gemini 3 requires clients to echo back verbatim.
+        """
+        projected = project({"contents": [{"role": "model", "parts": [{"thought": True, "thoughtSignature": "sig"}]}]})
+
+        assert projected.conversation.turns[0].parts == (c.Thinking("", signature="sig"),)
+
+    def test_a_thought_flag_beside_a_data_member_marks_that_member_and_residualises(self) -> None:
+        """`thought` is a part-level flag, not a data member.
+
+        A `thought` beside a `functionCall` marks that call; only a part with no
+        data member at all is itself a thought. The flag has no slot on
+        `ToolUse`, so it residualises rather than being dropped on a branch that
+        did not read it — the partial-consume trap T-A1 hit.
+        """
+        projected = project_untotalled(
+            {
+                "contents": [
+                    {
+                        "role": "model",
+                        "parts": [{"functionCall": {"name": "f"}, "thought": False}],
+                    }
+                ]
+            }
+        )
+
+        assert projected.conversation.turns[0].parts == (c.ToolUse("f"),)
+        assert projected.residual == {"contents[0].parts[0].thought": False}
+
+    def test_a_function_response_name_is_accounted_for_and_then_lost(self) -> None:
+        """A stated blind spot, not an oversight.
+
+        §3.3.1 makes the name load-bearing — "pairing there is by tool name and
+        the k-th unanswered call of that name" — but `ToolResult` has three
+        fields and none of them is a name, so the grammar cannot hold what that
+        sentence promises. Residualising would fail the run on every Gemini tool
+        turn, since `name` is **required** on `FunctionResponse`.
+
+        So it is consumed and the loss is recorded here rather than left
+        implicit: a mutation that rewrote `functionResponse.name` while leaving
+        the payload alone would produce no delta.
+        """
+        projected = project({"contents": [{"parts": [{"functionResponse": {"name": "get_weather", "response": {}}}]}]})
+
+        assert projected.residual == {}
+        assert projected.conversation.turns[0].parts == (c.ToolResult(content=[c.Json({})]),)
+
+    @pytest.mark.parametrize(
+        ("member", "payload"),
+        [
+            ("inlineData", {"mimeType": "image/png", "data": "", "displayName": "my.png"}),
+            ("fileData", {"fileUri": "files/example", "displayName": "my.pdf"}),
+        ],
+    )
+    def test_a_display_name_on_a_media_part_residualises(self, member: str, payload: Any) -> None:
+        """`Image` has three fields and none of them names the blob to the model."""
+        projected = project_untotalled({"contents": [{"parts": [{member: payload}]}]})
+
+        assert projected.residual == {f"contents[0].parts[0].{member}.displayName": payload["displayName"]}
+
+
+class TestResidualsExpectedOnRealTraffic:
+    """The residualisations that will fail the first oracle run, gathered.
+
+    §7.4.1 says of the identical `cache_control` case: "That is the correct
+    signal and it is also a deadline." Each of these is a field the format
+    publishes, real clients send, and the grammar cannot carry — so each fails
+    the run until T-W2 grows a slot or a declared-ignored mechanism.
+
+    All **six** are listed and asserted together, so the ticket that closes them
+    has one inventory rather than six scattered findings — and so that a later
+    reader cannot mistake any of them for an accident.
+
+    A `VALIDATED` tool-calling mode is deliberately **not** here. It also
+    residualises, but it is a gap in `TOOL_CHOICE_VALUES` — a closed vocabulary
+    with no raw companion — rather than a missing slot in the grammar, so it has
+    a different fix and belongs to a different ticket.
+    :meth:`TestToolChoice.test_a_mode_with_no_canonical_value_residualises` owns
+    it.
+    """
+
+    CASES: dict[str, tuple[Any, str]] = {
+        # Gemini 3 *requires* clients to echo a functionCall's thoughtSignature
+        # back verbatim, so this fires on every tool turn.
+        "thoughtSignature on a functionCall": (
+            {"contents": [{"role": "model", "parts": [{"functionCall": {"name": "f"}, "thoughtSignature": "s"}]}]},
+            "contents[0].parts[0].thoughtSignature",
+        ),
+        # Google's own SDKs set a role on the system instruction.
+        "role on a systemInstruction": (
+            {"systemInstruction": {"role": "user", "parts": [{"text": "hi"}]}},
+            "systemInstruction.role",
+        ),
+        # NON_BLOCKING function calling, a live feature.
+        "behavior on a functionDeclaration": (
+            {"tools": [{"functionDeclarations": [{"name": "f", "behavior": "NON_BLOCKING"}]}]},
+            "tools[0].functionDeclarations[0].behavior",
+        ),
+        # The scheduling half of the same feature.
+        "scheduling on a functionResponse": (
+            {"contents": [{"parts": [{"functionResponse": {"name": "f", "response": {}, "scheduling": "SILENT"}}]}]},
+            "contents[0].parts[0].functionResponse.scheduling",
+        ),
+        # Video understanding, also live.
+        "videoMetadata on a part": (
+            {"contents": [{"parts": [{"text": "x", "videoMetadata": {"fps": 1.0}}]}]},
+            "contents[0].parts[0].videoMetadata",
+        ),
+        # Naming a blob or file to the model, which `Image` has no slot for.
+        "displayName on a media part": (
+            {"contents": [{"parts": [{"fileData": {"fileUri": "files/x", "displayName": "my.pdf"}}]}]},
+            "contents[0].parts[0].fileData.displayName",
+        ),
+    }
+
+    def test_the_inventory_is_the_count_the_design_and_the_ticket_quote(self) -> None:
+        """Six, in `TEST_SUITE.md` §7.4.2, in R6.10a, and here.
+
+        Asserted because three documents quote this number and a silent
+        disagreement between them gives whoever picks up the ticket an ambiguous
+        scope.
+        """
+        assert len(self.CASES) == 6
+
+    @pytest.mark.parametrize("case", sorted(CASES))
+    def test_it_residualises_at_the_path_the_ticket_names(self, case: str) -> None:
+        """Each fails closed, at a path a maintainer can act on."""
+        body, path = self.CASES[case]
+        projected = project_untotalled(body)
+
+        assert path in projected.residual
+        with pytest.raises(c.ResidualFieldsError):
+            c.verify_total(projected)
+
+    def test_a_validated_mode_is_not_quietly_mapped_onto_a_near_neighbour(self) -> None:
+        """The alternative to residualising, and why it is worse.
+
+        `VALIDATED` means "constrained to predict either function calls **or**
+        natural language, and ensures function schema adherence" — so it is
+        `auto` with validation, not `any`. Mapping it to either would make an
+        `AUTO` to `VALIDATED` mutation invisible, and `TOOL_CHOICE_VALUES` is
+        closed with no raw companion (unlike `stop_reason`, which §3.3.1b gave
+        `stop_reason_raw` for exactly this reason), so there is no lossless home
+        for it. A loud failure is recoverable; a silent equivalence is not.
+        """
+        projected = project_untotalled({"toolConfig": {"functionCallingConfig": {"mode": "VALIDATED"}}})
+
+        assert "tool_choice" not in projected.envelope.extra
+
+
+# --------------------------------------------------------------------------
+# The two techniques T-A1 measured as worth their cost
+# --------------------------------------------------------------------------
+
+
+class TestEveryOptionalLeafFailsClosed:
+    """§7.4.1's wrongly-typed-leaf rule, over **every** optional leaf.
+
+    "It binds *every* optional leaf, not the ones a bug happened to be found
+    in." T-A1 measured eight of nine leaves failing open when the rule was
+    stated generally and applied field by field, which is why this is a table
+    over the whole surface rather than a sample: the contract validates only
+    roles, sampling keys and `tool_choice`, so an unguarded leaf declared
+    `str | None` carries a dict silently and the residual stays empty.
+
+    Each case asserts **both** halves — the field residualises at its own path,
+    *and* the projection carries the grammar's absent value in its place. Half
+    the rule would be satisfied by a reader that residualised and then coerced.
+    """
+
+    #: ``(case, body, residual path, a check that the field is at its absent value)``.
+    CASES: dict[str, tuple[Any, str, Any]] = {
+        "store": ({"store": "yes"}, "store", lambda p: p.envelope.store is None),
+        "generationConfig.temperature": (
+            {"generationConfig": {"temperature": "hot"}},
+            "generationConfig.temperature",
+            lambda p: "temperature" not in p.conversation.sampling,
+        ),
+        "generationConfig.stopSequences": (
+            {"generationConfig": {"stopSequences": "Title"}},
+            "generationConfig.stopSequences",
+            lambda p: "stop" not in p.conversation.sampling,
+        ),
+        "generationConfig.responseLogprobs": (
+            {"generationConfig": {"responseLogprobs": 1}},
+            "generationConfig.responseLogprobs",
+            lambda p: "logprobs" not in p.conversation.sampling,
+        ),
+        "generationConfig.topP": (
+            {"generationConfig": {"topP": "wide"}},
+            "generationConfig.topP",
+            lambda p: "top_p" not in p.conversation.sampling,
+        ),
+        "generationConfig.topK": (
+            {"generationConfig": {"topK": 1.5}},
+            "generationConfig.topK",
+            lambda p: "top_k" not in p.conversation.sampling,
+        ),
+        "generationConfig.maxOutputTokens": (
+            {"generationConfig": {"maxOutputTokens": "800"}},
+            "generationConfig.maxOutputTokens",
+            lambda p: "max_tokens" not in p.conversation.sampling,
+        ),
+        "generationConfig.presencePenalty": (
+            {"generationConfig": {"presencePenalty": True}},
+            "generationConfig.presencePenalty",
+            lambda p: "presence_penalty" not in p.conversation.sampling,
+        ),
+        "generationConfig.frequencyPenalty": (
+            {"generationConfig": {"frequencyPenalty": []}},
+            "generationConfig.frequencyPenalty",
+            lambda p: "frequency_penalty" not in p.conversation.sampling,
+        ),
+        "generationConfig.seed": (
+            {"generationConfig": {"seed": "7"}},
+            "generationConfig.seed",
+            lambda p: "seed" not in p.conversation.sampling,
+        ),
+        "generationConfig.candidateCount": (
+            {"generationConfig": {"candidateCount": 2.5}},
+            "generationConfig.candidateCount",
+            lambda p: "n" not in p.conversation.sampling,
+        ),
+        "generationConfig.logprobs": (
+            {"generationConfig": {"logprobs": True}},
+            "generationConfig.logprobs",
+            lambda p: "top_logprobs" not in p.conversation.sampling,
+        ),
+        "blob.data": (
+            {"contents": [{"parts": [{"inlineData": {"mimeType": "image/png", "data": 7}}]}]},
+            "contents[0].parts[0].inlineData.data",
+            lambda p: p.conversation.turns[0].parts[0].digest == c.image_digest(b""),
+        ),
+        "functionCallingConfig.mode": (
+            {"toolConfig": {"functionCallingConfig": {"mode": {"a": 1}}}},
+            "toolConfig.functionCallingConfig.mode",
+            lambda p: "tool_choice" not in p.envelope.extra,
+        ),
+        "functionCallingConfig.allowedFunctionNames": (
+            {"toolConfig": {"functionCallingConfig": {"mode": "ANY", "allowedFunctionNames": "f"}}},
+            "toolConfig.functionCallingConfig.allowedFunctionNames",
+            lambda p: p.envelope.extra["tool_choice"] == "any",
+        ),
+        "functionDeclaration.description": (
+            {"tools": [{"functionDeclarations": [{"name": "f", "description": {"a": 1}}]}]},
+            "tools[0].functionDeclarations[0].description",
+            lambda p: p.conversation.tools[0].description is None,
+        ),
+        "functionDeclaration.parametersJsonSchema": (
+            {"tools": [{"functionDeclarations": [{"name": "f", "parametersJsonSchema": ["ab", "cd"]}]}]},
+            "tools[0].functionDeclarations[0].parametersJsonSchema",
+            lambda p: p.conversation.tools[0].schema is None,
+        ),
+        "functionDeclaration.parameters": (
+            {"tools": [{"functionDeclarations": [{"name": "f", "parameters": ["ab", "cd"]}]}]},
+            "tools[0].functionDeclarations[0].parameters",
+            lambda p: p.conversation.tools[0].schema is None,
+        ),
+        "part.thoughtSignature-as-name-placeholder": (
+            {"contents": [{"parts": [{"functionCall": {"name": 7}}]}]},
+            "contents[0].parts[0].functionCall.name",
+            lambda p: p.conversation.turns[0].parts[0] == c.ToolUse(name=""),
+        ),
+        "blob.data undecodable": (
+            {"contents": [{"parts": [{"inlineData": {"mimeType": "image/png", "data": "aGk=\n"}}]}]},
+            "contents[0].parts[0].inlineData.data",
+            lambda p: p.conversation.turns[0].parts[0] == c.Image(media_type="image/png"),
+        ),
+        "part.thought": (
+            {"contents": [{"parts": [{"text": "x", "thought": "yes"}]}]},
+            "contents[0].parts[0].thought",
+            lambda p: p.conversation.turns[0].parts[0] == c.Text("x"),
+        ),
+        "part.thoughtSignature": (
+            {"contents": [{"parts": [{"text": "x", "thought": True, "thoughtSignature": 7}]}]},
+            "contents[0].parts[0].thoughtSignature",
+            lambda p: p.conversation.turns[0].parts[0] == c.Thinking("x"),
+        ),
+        "blob.mimeType": (
+            {"contents": [{"parts": [{"inlineData": {"data": "", "mimeType": 7}}]}]},
+            "contents[0].parts[0].inlineData.mimeType",
+            lambda p: p.conversation.turns[0].parts[0].media_type is None,
+        ),
+        "fileData.fileUri": (
+            {"contents": [{"parts": [{"fileData": {"fileUri": ["a"]}}]}]},
+            "contents[0].parts[0].fileData.fileUri",
+            lambda p: p.conversation.turns[0].parts[0].ref is None,
+        ),
+        "fileData.mimeType": (
+            {"contents": [{"parts": [{"fileData": {"fileUri": "files/x", "mimeType": 7}}]}]},
+            "contents[0].parts[0].fileData.mimeType",
+            lambda p: p.conversation.turns[0].parts[0].media_type is None,
+        ),
+        "functionCall.args": (
+            {"contents": [{"parts": [{"functionCall": {"name": "f", "args": ["ab", "cd"]}}]}]},
+            "contents[0].parts[0].functionCall.args",
+            lambda p: p.conversation.turns[0].parts[0].arguments == {},
+        ),
+        "functionCall.id": (
+            {"contents": [{"parts": [{"functionCall": {"name": "f", "id": 7}}]}]},
+            "contents[0].parts[0].functionCall.id",
+            lambda p: p.conversation.turns[0].parts[0].id is None,
+        ),
+        "functionResponse.response": (
+            {"contents": [{"parts": [{"functionResponse": {"name": "f", "response": "ok"}}]}]},
+            "contents[0].parts[0].functionResponse.response",
+            lambda p: p.conversation.turns[0].parts[0].content == (),
+        ),
+        "functionResponse.id": (
+            {"contents": [{"parts": [{"functionResponse": {"name": "f", "response": {}, "id": 7}}]}]},
+            "contents[0].parts[0].functionResponse.id",
+            lambda p: p.conversation.turns[0].parts[0].tool_use_id is None,
+        ),
+        "systemInstruction part text": (
+            {"systemInstruction": {"parts": [{"text": 7}]}},
+            "systemInstruction.parts[0].text",
+            lambda p: p.conversation.system == (),
+        ),
+    }
+
+    @pytest.mark.parametrize("case", sorted(CASES))
+    def test_it_residualises_and_leaves_the_field_absent(self, case: str) -> None:
+        """Neither coerced nor raised on: `str(7)` and `dict(["ab","cd"])` invent."""
+        body, path, absent = self.CASES[case]
+        projected = project_untotalled(body)
+
+        assert path in projected.residual, f"{case} failed open: residual={dict(projected.residual)}"
+        assert absent(projected), f"{case} residualised but did not fall back to the absent value"
+
+        # The residual's *value* is asserted too, not only its key. A reader can
+        # record the right key and then overwrite it with the default it fell
+        # back to — which tells a maintainer the client sent `null` when it sent
+        # an object. That defect was live in `_read_tool_choice` and 28 of these
+        # cases could not see it, because every one asserted only the key.
+        assert projected.residual[path] == _body_value_at(body, path), (
+            f"{case} residualised the wrong value: the residual must carry what the "
+            f"client actually sent, or the failure report misdiagnoses it"
+        )
+
+    #: The one leaf `_typed_leaf` guards that this table deliberately omits,
+    #: because it **raises** instead of residualising: §7.4.1's exception for a
+    #: value that *is* its part. `Text` and `Thinking` have no absent value to
+    #: fall back to, and `Text("")` would fabricate an empty part — which is
+    #: meaningful in this grammar, since P5e and P8 both inject one.
+    #: `TestUnionMemberValues` pins it directly.
+    STRUCTURAL_LEAVES = frozenset({"text"})
+
+    #: Leaves whose name reaches `_typed_leaf` in a variable rather than as a
+    #: literal, so the source scan below cannot find them. Two today, both in
+    #: `_read_declaration_schema`'s loop over the mutually exclusive parameter
+    #: spellings; listed rather than inferred, because a silently missed call
+    #: site is exactly what this guard exists to prevent.
+    VARIABLE_DRIVEN_LEAVES = frozenset({"parameters", "parametersJsonSchema"})
+
+    def test_the_table_covers_every_leaf_the_reader_guards(self) -> None:
+        """A leaf added later must be added here, or this goes red.
+
+        Derived from the source rather than trusted to an author's memory,
+        because trusting the author is exactly what left eight of nine leaves
+        unguarded in T-A1. `_typed_leaf` is the one helper every optional leaf
+        goes through, so its call sites — plus the sampling table it is driven
+        from in a loop — are the population this table must match.
+        """
+        source = Path(r.__file__).read_text(encoding="utf-8")
+        literal = re.findall(r'_typed_leaf\(\w+, "([^"]+)"', source)
+        guarded = set(literal) | set(r._SAMPLING_KEYS) | self.VARIABLE_DRIVEN_LEAVES
+
+        # The regex above cannot see a call site that passes the leaf name in a
+        # variable, so "derived from the source" would quietly become "derived
+        # from the source, except where it is not". Counting the call sites it
+        # *did* match against the ones it could not keeps that claim honest.
+        assert len(literal) + 2 == source.count("_typed_leaf(") - 1, (
+            "a `_typed_leaf` call site is neither a string literal nor listed in VARIABLE_DRIVEN_LEAVES"
+        )
+
+        guarded -= self.STRUCTURAL_LEAVES
+
+        covered = {path.rpartition(".")[2] or path for _, path, _ in self.CASES.values()}
+        missing = sorted(guarded - covered)
+
+        assert missing == [], f"optional leaves with no wrongly-typed case: {missing}"
+
+
+def _body_value_at(body: Any, path: str) -> Any:
+    """Return the value a body carries at a residual path, or ``None`` if absent.
+
+    The residual's keys are "the body's own path … with array positions as
+    indices" (§7.4.1), so they can be walked straight back against the body.
+    Doing that, rather than hand-maintaining an expected value per case, is what
+    keeps the table's value assertion honest as cases are added.
+
+    Args:
+        body: The request body the case projected.
+        path: A residual key, such as ``contents[0].parts[0].inlineData.data``.
+
+    Returns:
+        The value at that position, or ``None`` when the body does not carry one
+        — which is the value a reader must residualise for an absent required
+        field.
+    """
+    node: Any = body
+    for segment in path.split("."):
+        name, _, indices = segment.partition("[")
+        if name not in node:
+            return None
+        node = node[name]
+        for index in re.findall(r"(\d+)\]", indices):
+            node = node[int(index)]
+
+    return node
+
+
+class TestInjectionProbe:
+    """Replace every position of a maximal body with junk, and with nothing.
+
+    T-A1 ran 938 of these in seconds and found an `Opaque.kind` hole that 103
+    hand-written tests had missed. Two claims, and neither can be made by a
+    hand-written suite of any realistic size:
+
+    1. **Nothing but `UnreadableBodyError` escapes.** The contract names three
+       failure shapes, and a `KeyError` out of a reader would be an undefined
+       fourth on the one path T-D1 uses to tell an unreadable body from an I1
+       breach. A `ValueError` is a *reader bug* by the contract's own
+       definition, so it must not escape either.
+    2. **No projected field violates its declared type.** A residual proves the
+       reader noticed; this proves it did not also carry the junk through.
+    """
+
+    #: A body reaching every branch this reader has, so the walk below covers
+    #: the whole surface rather than the shapes a test author thought of.
+    MAXIMAL: dict[str, Any] = {
+        "contents": [
+            {"role": "user", "parts": [{"text": "hi"}, {"inlineData": {"mimeType": "image/png", "data": ""}}]},
+            {
+                "role": "model",
+                "parts": [
+                    {"text": "thinking", "thought": True, "thoughtSignature": "sig"},
+                    {"functionCall": {"id": "fc-1", "name": "f", "args": {"q": 1}}},
+                    {"executableCode": {"language": "PYTHON", "code": "print(1)"}},
+                ],
+            },
+            {
+                "role": "user",
+                "parts": [
+                    {"functionResponse": {"id": "fc-1", "name": "f", "response": {"n": 1}}},
+                    {"fileData": {"mimeType": "application/pdf", "fileUri": "files/example"}},
+                ],
+            },
+        ],
+        "systemInstruction": {"parts": [{"text": "be brief"}]},
+        "tools": [
+            {
+                "functionDeclarations": [{"name": "f", "description": "d", "parameters": {"type": "object"}}],
+                "googleSearch": {},
+            }
+        ],
+        "toolConfig": {"functionCallingConfig": {"mode": "ANY", "allowedFunctionNames": ["f"]}},
+        "generationConfig": {"temperature": 1.0, "topK": 4, "responseSchema": {"type": "ARRAY"}},
+        "safetySettings": [{"category": "HARM_CATEGORY_HATE_SPEECH", "threshold": "OFF"}],
+        "cachedContent": "cachedContents/abc",
+        "serviceTier": "SERVICE_TIER_PRIORITY",
+        "store": True,
+    }
+
+    #: Twelve junk values plus deletion, chosen to cross every type boundary the
+    #: reader branches on — and `{}`/`[]` because an *empty* container of the
+    #: right shape is the value a guard written as a truth test waves through.
+    JUNK: tuple[Any, ...] = (
+        None,
+        True,
+        0,
+        -1,
+        1.5,
+        "",
+        "x",
+        [],
+        {},
+        [None],
+        {"a": None},
+        ["ab", "cd"],
+    )
+
+    @staticmethod
+    def _positions(node: Any, path: tuple[Any, ...] = ()) -> list[tuple[Any, ...]]:
+        """Return every addressable position in a nested structure.
+
+        Args:
+            node: The structure to walk.
+            path: The path accumulated so far.
+
+        Returns:
+            One tuple of keys and indices per position, the root excluded.
+        """
+        found: list[tuple[Any, ...]] = []
+        if isinstance(node, dict):
+            for key, value in node.items():
+                found.append((*path, key))
+                found.extend(TestInjectionProbe._positions(value, (*path, key)))
+        elif isinstance(node, list):
+            for index, value in enumerate(node):
+                found.append((*path, index))
+                found.extend(TestInjectionProbe._positions(value, (*path, index)))
+        return found
+
+    @staticmethod
+    def _replaced(body: Any, path: tuple[Any, ...], value: Any) -> Any:
+        """Return a deep copy of ``body`` with one position replaced or removed.
+
+        Args:
+            body: The structure to copy.
+            path: The position to change.
+            value: The replacement, or :data:`TestInjectionProbe.DELETE` to
+                remove the position entirely.
+
+        Returns:
+            The mutated copy.
+        """
+        mutated = json.loads(json.dumps(body))
+        node = mutated
+        for step in path[:-1]:
+            node = node[step]
+
+        if value is TestInjectionProbe.DELETE:
+            del node[path[-1]]
+        else:
+            node[path[-1]] = value
+
+        return mutated
+
+    #: The "replacement" that removes a position instead of changing it.
+    DELETE = object()
+
+    def test_nothing_but_an_unreadable_body_error_escapes(self) -> None:
+        """Claim 1, over every position crossed with every junk value."""
+        positions = self._positions(self.MAXIMAL)
+        # 70 positions x 13 replacements is ~900 injections, the order T-A1
+        # needed before the probe found what its 103 hand-written tests had not.
+        # Asserted so that shrinking the maximal body silently weakens the probe.
+        assert len(positions) >= 70, f"the maximal body stopped being maximal: {len(positions)}"
+
+        escapes: list[str] = []
+        for path in positions:
+            for value in (*self.JUNK, self.DELETE):
+                mutated = self._replaced(self.MAXIMAL, path, value)
+                try:
+                    projected = r.GeminiProjection().read_request(captured(mutated))
+                except c.UnreadableBodyError:
+                    continue
+                except Exception as exc:  # noqa: BLE001 - the point of the probe
+                    escapes.append(f"{'.'.join(map(str, path))} := {value!r} raised {exc!r}")
+                    continue
+
+                violation = _type_violation(projected)
+                if violation is not None:
+                    escapes.append(f"{'.'.join(map(str, path))} := {value!r} projected {violation}")
+
+        assert escapes == [], "\n".join(escapes[:20])
+
+
+def _type_violation(projected: c.Request) -> str | None:
+    """Return the first projected field whose value is outside its declared type.
+
+    Claim 2 of the injection probe. A residual proves the reader *noticed* a
+    junk value; this proves it did not also carry one through into a field the
+    grammar declares narrowly, which no amount of residual checking can show.
+
+    Args:
+        projected: A projection to inspect.
+
+    Returns:
+        A description of the first violation, or ``None`` when there is none.
+    """
+    envelope = projected.envelope
+    for name, value, expected in (
+        ("envelope.model", envelope.model, str),
+        ("envelope.stream", envelope.stream, bool),
+        ("envelope.store", envelope.store, bool),
+    ):
+        if value is not None and not isinstance(value, expected):
+            return f"{name}={value!r}"
+
+    for tool in projected.conversation.tools:
+        if not isinstance(tool.name, str):
+            return f"ToolDecl.name={tool.name!r}"
+        if tool.description is not None and not isinstance(tool.description, str):
+            return f"ToolDecl.description={tool.description!r}"
+        if tool.schema is not None and not isinstance(tool.schema, Mapping):
+            return f"ToolDecl.schema={tool.schema!r}"
+
+    for turn in projected.conversation.turns:
+        for part in turn.parts:
+            violation = _part_violation(part)
+            if violation is not None:
+                return violation
+
+    return None
+
+
+def _part_violation(part: c.Part) -> str | None:
+    """Return a description of a part carrying a value outside its declared type.
+
+    Args:
+        part: A projected part.
+
+    Returns:
+        A description, or ``None`` when the part is well typed.
+    """
+    if isinstance(part, c.Text) and not isinstance(part.text, str):
+        return f"Text.text={part.text!r}"
+    if isinstance(part, c.Thinking):
+        if not isinstance(part.text, str):
+            return f"Thinking.text={part.text!r}"
+        if part.signature is not None and not isinstance(part.signature, str):
+            return f"Thinking.signature={part.signature!r}"
+    if isinstance(part, c.ToolUse):
+        if not isinstance(part.name, str):
+            return f"ToolUse.name={part.name!r}"
+        if part.id is not None and not isinstance(part.id, str):
+            return f"ToolUse.id={part.id!r}"
+    if isinstance(part, c.Image):
+        for name, value in (("digest", part.digest), ("media_type", part.media_type), ("ref", part.ref)):
+            if value is not None and not isinstance(value, str):
+                return f"Image.{name}={value!r}"
+    if isinstance(part, c.Opaque) and not isinstance(part.kind, str):
+        return f"Opaque.kind={part.kind!r}"
+    if isinstance(part, c.ToolResult):
+        if part.tool_use_id is not None and not isinstance(part.tool_use_id, str):
+            return f"ToolResult.tool_use_id={part.tool_use_id!r}"
+        for member in part.content:
+            violation = _part_violation(member)
+            if violation is not None:
+                return violation
+    return None
+
+
+class TestUnionMemberValues:
+    """Where a union member's own value is wrong, and where a field of one is.
+
+    §7.4.2 rule 7. The three shipped readers reached three answers here, so this
+    class pins T-A4's and says which rule each follows:
+
+    - **The value that *is* the part** — `Part.text` — raises. `Text` and
+      `Thinking` have no absent value in the grammar, and `Text("")` would
+      fabricate an empty part the agent never sent, which is meaningful here
+      because P5e and P8 both inject one. T-A1 agrees.
+    - **A required *field* of a part** — a `name` — residualises and the part is
+      still projected. §3.3.1b settles it in those words. T-A3 agrees.
+    - **An undecodable payload** — base64 that does not decode — residualises
+      the leaf and the part keeps its place, because `Image.digest` is
+      `str | None` and §7.4.1 says "raising is the other wrong answer".
+
+    The common thread, and the reason all three land here rather than in three
+    different classes: **no branch ever drops a part.** Paths are index-based,
+    so a dropped part shifts every later index and invents a delta on content
+    nobody touched.
+    """
+
+    def test_a_wrongly_typed_text_raises_rather_than_projecting_an_empty_part(self) -> None:
+        """`Text` *is* its value, so there is no partial part to salvage."""
+        with pytest.raises(c.UnreadableBodyError):
+            project_untotalled({"contents": [{"parts": [{"text": {"a": 1}}]}]})
+
+    def test_a_function_call_with_no_name_still_projects(self) -> None:
+        """The call keeps its place; the residual names what was missing."""
+        projected = project_untotalled({"contents": [{"parts": [{"text": "a"}, {"functionCall": {"args": {"q": 1}}}]}]})
+
+        assert projected.conversation.turns[0].parts == (
+            c.Text("a"),
+            c.ToolUse(name="", arguments={"q": 1}),
+        )
+        assert projected.residual == {"contents[0].parts[1].functionCall.name": None}
+
+    def test_line_wrapped_base64_residualises_instead_of_killing_the_request(self) -> None:
+        """A single newline in one blob must not abort the whole projection.
+
+        `validate=True` rejects every RFC 2045 line break, and Google's own
+        image-understanding sample passes `-w0` to `base64(1)` precisely because
+        its default output is wrapped — so this is real traffic, not a
+        hypothetical. If it raised, T-D1 would read a legitimate corpus entry as
+        malformed and never diff it, and kitty could mutate that request freely.
+        """
+        wrapped = base64.b64encode(b"hello world" * 8).decode("ascii")
+        wrapped = wrapped[:20] + "\n" + wrapped[20:]
+
+        projected = project_untotalled(
+            {"contents": [{"parts": [{"inlineData": {"mimeType": "image/png", "data": wrapped}}, {"text": "and"}]}]}
+        )
+
+        # The part keeps its place and the later part keeps its index.
+        assert projected.conversation.turns[0].parts == (
+            c.Image(digest=None, media_type="image/png"),
+            c.Text("and"),
+        )
+        assert projected.residual == {"contents[0].parts[0].inlineData.data": wrapped}
+
+    def test_no_failure_branch_drops_a_part_and_shifts_the_later_indices(self) -> None:
+        """The claim all three branches share, asserted as one fact.
+
+        A reader that returned `None` for a part it could not read would shift
+        every later part's index — §7.4.1: "that invented delta lands on every
+        part of the turn and on every turn after it". T-A3 does exactly that for
+        two of these three cases, which is why rule 7 exists.
+        """
+        projected = project_untotalled(
+            {
+                "contents": [
+                    {
+                        "parts": [
+                            {"functionCall": {"args": {}}},
+                            {"inlineData": {"data": "aGk=\n"}},
+                            {"text": "last"},
+                        ]
+                    }
+                ]
+            }
+        )
+
+        parts = projected.conversation.turns[0].parts
+        assert len(parts) == 3
+        assert parts[2] == c.Text("last")
+
+    def test_a_part_carrying_two_data_members_dispatches_in_the_fixed_order(self) -> None:
+        """R6.4 — a `oneof` carrying two members is ill-formed, and must still be
+        read the same way by every reader of a field-name-discriminated union.
+
+        The loser residualises either way, so the order decides only which field
+        the failure *names* — but two readers naming different fields is a
+        diagnosis that drifts, which is what §7.4.2 rule 6 exists to stop. Data
+        members win over `text`, so the part that *carries content* is the one
+        projected.
+        """
+        projected = project_untotalled(
+            {"contents": [{"parts": [{"text": "shadowed", "fileData": {"fileUri": "files/x"}}]}]}
+        )
+
+        assert projected.conversation.turns[0].parts == (c.Image(ref="files/x"),)
+        assert projected.residual == {"contents[0].parts[0].text": "shadowed"}
+
+
+class TestFailureShapes:
+    """The structural failures R2.5 names, each held by a test.
+
+    Correct behaviour that nothing asserts is behaviour a refactor can delete
+    silently — and two of these guards (`_parse_body`'s `UnicodeDecodeError`
+    arm and its not-an-object check) are single lines that read as redundant.
+    T-D1 tells "this body was unreadable" from "this is an I1 breach" on exactly
+    this exception, so the arms matter more than their size suggests.
+    """
+
+    @pytest.mark.parametrize(
+        ("raw", "case"),
+        [
+            (b"{not json", "malformed JSON"),
+            (b"", "an empty body"),
+            (b"\xff\xfe not utf-8", "bytes that are not UTF-8"),
+            (b"[1, 2]", "a JSON array, which is valid JSON and an invalid request"),
+            (b'"a string"', "a JSON string"),
+            (b"null", "a JSON null"),
+        ],
+    )
+    def test_a_body_that_is_not_a_json_object_is_unreadable(self, raw: bytes, case: str) -> None:
+        """R2.5 — the body has to be an object before anything else is true."""
+        with pytest.raises(c.UnreadableBodyError):
+            project_untotalled(raw)
+
+    @pytest.mark.parametrize("member", ["x", 7, None, ["nested"]])
+    def test_a_contents_member_that_is_not_an_object_is_unreadable(self, member: Any) -> None:
+        """R2.5 — structural: a turn cannot be built from a scalar."""
+        with pytest.raises(c.UnreadableBodyError):
+            project_untotalled({"contents": [member]})
+
+
+class TestTotalityOverTheWholeSurface:
+    """The acceptance criterion for R2.1–R2.3, on a body that uses every key.
+
+    The published examples each carry a handful of keys, and the injection probe
+    only ever projects the maximal body *mutated*. Without this, "every one of
+    the nine published top-level keys is classified" is asserted key by key and
+    never all at once — and a reader can satisfy nine separate tests while
+    mis-handling a body that carries all nine together.
+    """
+
+    def test_the_maximal_body_accounts_for_every_key_it_carries(self) -> None:
+        """Nine keys in, nine consumed, nothing residual."""
+        body = TestInjectionProbe.MAXIMAL
+        assert set(body) == set(r.PUBLISHED_TOP_LEVEL_KEYS), "the maximal body stopped being total"
+
+        projected = project(body)
+
+        assert set(projected.consumed) == set(body)
+        assert projected.residual == {}
+
+    @pytest.mark.parametrize(
+        ("key", "value"),
+        [("store", None), ("cachedContent", None), ("generationConfig", {"temperature": None})],
+    )
+    def test_an_explicit_null_reads_as_the_field_being_absent(self, key: str, value: Any) -> None:
+        """ProtoJSON: "null is an accepted value for all field types and treated
+        as the default value of the corresponding field type".
+
+        Residualising an explicit null would fail an oracle run on a body the
+        API accepts, so the branch that reads it is load-bearing — and it is one
+        line, which is how it would come to be deleted.
+        """
+        projected = project({key: value})
+
+        assert projected.residual == {}
+        assert projected.envelope.store is None
+        assert projected.conversation.sampling == {}
+
+
+class TestSingletonRepeatedFields:
+    """R6.3 applies to every repeated field, not only the two with samples.
+
+    Google's published examples send `contents` and `parts` as bare objects; the
+    other three repeated fields have no published example either way. The rule
+    is applied to all five because the asymmetry costs more than the leniency:
+    accepting a form the API rejects reads a body no client sends, while
+    rejecting one it accepts aborts the projection of a legitimate request.
+    """
+
+    def test_a_singleton_tools_entry(self) -> None:
+        """`tools` — no published sample, same rule."""
+        projected = project({"tools": {"functionDeclarations": {"name": "f"}}})
+
+        assert projected.conversation.tools == (c.ToolDecl("f"),)
+
+    def test_a_singleton_function_response_part(self) -> None:
+        """`functionResponse.parts` — likewise."""
+        projected = project(
+            {
+                "contents": [
+                    {
+                        "parts": [
+                            {
+                                "functionResponse": {
+                                    "name": "f",
+                                    "response": {},
+                                    "parts": {"inlineData": {"data": "", "mimeType": "image/png"}},
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        )
+
+        result = projected.conversation.turns[0].parts[0]
+        assert isinstance(result, c.ToolResult)
+        assert result.content == (c.Json({}), c.Image(digest=c.image_digest(b""), media_type="image/png"))
+
+    @pytest.mark.parametrize("value", [7, "x", None])
+    def test_a_repeated_field_that_is_neither_a_list_nor_an_object_is_unreadable(self, value: Any) -> None:
+        """R2.5's container rule, on the field whose message says both forms."""
+        with pytest.raises(c.UnreadableBodyError):
+            project_untotalled({"tools": value})


### PR DESCRIPTION
Closes **[KBR-36](https://shelpuk.atlassian.net/browse/KBR-36)** — plan task **T-A4**.
Design: `.system_design/TEST_SUITE.md` §3.3.1, §3.3.1a, §3.3.1b, §3.3.5, §7.4.1, and the new **§7.4.2** this PR adds.

## Context for the Product Owner

Kitty Bridge's promise to a user is **transparency**: apart from a short published list of deliberate changes — swap the model, strip kitty's own internal keys — whatever your coding agent sends is what your model provider receives. Proving that needs an impartial referee, because you cannot ask the translator whether it translated correctly.

The referee works by converting both sides of the conversation into one neutral form and diffing them. Each provider format needs its own hand-written converter, written from the vendor's published specification and importing none of kitty's code. There are six. Two shipped (Anthropic, OpenAI Responses). **This is the Gemini one, and it is the hard one.**

Google puts the model name and the streaming choice **in the URL**, not in the message body. So two requests to two entirely different models can have byte-identical bodies. A referee that only reads bodies is blind to a misrouted request — which is the single failure the product most needs to rule out, since changing the model is what kitty exists to do. This converter reads the URL as well, and a test proves it: two captures with identical bodies, correctly told apart.

**Three things this turned up that the project had written down as settled, and which were wrong.** Each is corrected in the shared design rather than worked around, because the next three converters would have inherited the mistake:

1. **Gemini does carry tool-call IDs.** The ticket asked for this to be confirmed rather than assumed, and the assumption was wrong: it came from Google's *enterprise* API reference, while kitty serves the *developer* one, and they differ. No decision changes — the ID was already optional, which is still correct — but a wrong reason sitting in a shared file is how three later authors get misled.
2. **Every Gemini field has two legal spellings**, and Google's own published examples mix them on a single page. A converter that knew only one would have failed on Google's own sample code. This was recorded nowhere.
3. **Six fields that real clients actually send have nowhere to go** in the neutral form — most importantly a "thought signature" that Gemini 3 *requires* clients to echo back. These will make the first full referee run fail. That is the design's intended behaviour (fail loudly rather than lose data silently) and there is precedent for it, but it is scheduled debt, not a surprise — filed as its own ticket with a complete inventory so whoever runs the referee first is not ambushed.

**What is not in scope:** asserting that the request reached the right host and path is T-D2's job (KBR-52), which this unblocks. This PR reads the route; it does not judge it.

## What changed

| File | |
|---|---|
| `tests/harness/reader_gemini.py` | new — the projection |
| `tests/harness/test_reader_gemini.py` | new — 204 L1 tests |
| `.system_design/TEST_SUITE.md` | §7.4.2 added (seven cross-reader rules); §3.3.1's tool-call-id claim corrected |
| `tests/harness/contract.py` | `ToolUse.id`'s docstring corrected — same claim, same reason |

Three decisions that are first of their kind, each recorded in §7.4.2 because T-A5 and T-A6 inherit them:

- **The route is an input.** `envelope.model` from the path, `envelope.stream` from the operation suffix — never from `?alt=sse`, which selects the framing of a method that streams either way. The query string is left entirely to T-D2, and the reason is stated rather than implied: `verify_total` compares `consumed | residual` against the *body*, so a query key in either account would be reported as a claim on a key the body does not have.
- **Control fields nest, and `extra_path()` rejects a dotted key.** So a nested control field is addressed by its leaf published key. The container-keyed alternative is weighed and rejected in the design: it cannot collide, but §3.3.1a compares an `extra` value whole, so it would collapse fourteen independently registrable fields into one address — the coarse-anchor failure that section warns about by name.
- **Both ProtoJSON spellings read**, with the *published* spelling winning a collision rather than the first one seen, so the projection does not depend on the order a serialiser emitted two aliases in.

**§7.4.2 rule 7 is also a correction.** The three shipped readers answer "a union member's own value is wrong" three different ways, and two of them return no part at all — which shifts every later part's index and invents a delta on content nobody touched. The rule settles it by what the bad value is a value *of*, and the reconciliation owed to the two landed readers is tracked rather than done here.

## Verification

- **204 L1 tests.** Every published Google example round-trips with an empty residual, including the five that use snake_case and the two that send singleton objects where the schema declares lists.
- **An injection probe**: ~900 mutations over a maximal body, asserting nothing but `UnreadableBodyError` escapes and no projected field violates its declared type.
- **41 hand-applied mutants, 0 survivors.** Two survived the first pass and each exposed a real weak test — including one whose own name claimed something it was not checking, the failure mode T-A1 measured. Both fixed.
- Every optional leaf has a wrongly-typed case asserting **both** the residual key *and its value*; the guard that enforces that table's completeness is derived from the source, and it found a missing case on the first run.
- `ruff`, `ruff format`, `lint-imports`, `mypy src/kitty` and both layer guards clean. `tests/harness/` defaults to the `l1` marker by path, so no registration was needed.

Reviewed to convergence by `system-design-reviewer` (two rounds) and `code-reviewer`; every accepted finding is applied, and the two I rejected — mapping `VALIDATED` onto `any`, and a claimed error in §3.3.5's existing wording — are rejected with the published evidence quoted in the design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JDdNzJzvNbZzQFzkAQM8Cm


[KBR-36]: https://shelpuk.atlassian.net/browse/KBR-36?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ