### PR TITLE
Give six readers one vocabulary instead of six guesses (KBR-174)

### DIFF
--- a/.system_design/TEST_SUITE.md
+++ b/.system_design/TEST_SUITE.md
@@ -2376,8 +2376,10 @@ and the second is the one that surprises:
 **`Opaque` consumes its block, and carries a payload digest.** A block type the grammar does not
 model projects as `Opaque(kind=…, digest=…)` where:
 
-- `kind` is the wire `type` converted to snake_case, **through `contract.opaque_kind()`** — not
-  restated by each reader. Anthropic's spellings (`document`, `search_result`,
+- `kind` is **named through `contract.opaque_kind()`** — not restated by each reader. For most
+  types that is the wire `type` itself; where two vendors spell one concept differently the table
+  reconciles them, and where a type is not snake_case at all it raises rather than converting (see
+  below). Anthropic's spellings (`document`, `search_result`,
   `redacted_thinking`, `server_tool_use`) are already canonical; a format-unique type keeps its own
   spelling, which is the deliberate exception to "never the wire's spelling".
 

--- a/.system_design/TEST_SUITE.md
+++ b/.system_design/TEST_SUITE.md
@@ -650,11 +650,22 @@ agree on a canonical form. They are six separate tasks, so the agreement is part
   `""` claims a tool *named* empty-string, and a call nobody can name cannot be paired or
   addressed. Apply that test to every required field, not only these two.
 
+  **A value that is not a string at all — including an already-decoded object — residualises
+  too.** Accepting the object form would make a bridge that emitted it where the schema demands a
+  string invisible to the oracle, which is the wire-format breach the readers exist to see. And
+  what residualises is the **raw wire value, unmodified** — `"[1,2]"` stores the *string*, never
+  the decoded list — because T-D8 diffs residual key sets across all six readers, and two
+  renderings of one unreadable value would report a delta neither reader caused.
+
   Six readers cannot quietly disagree about what `arguments: ""` means, and it is not
   hypothetical — `openai_subscription.py:OpenAISubscriptionAdapter._cc_to_responses` writes
   `func.get("arguments", "")`. The residual *path* is format-specific and stays each reader's own;
-  only the decode and the fail-closed policy are shared. Tracked for pinning as code beside
-  `image_digest` — KBR-174.
+  only the decode and the fail-closed policy are shared.
+
+  **Pinned as code: `contract.decode_arguments(raw, path, residual)`** (KBR-174), beside
+  `image_digest` and for the same reason. It takes the residual as a parameter rather than
+  reporting a flag the caller must act on: `mypy` covers `src/kitty` only, so a reader that
+  ignored such a flag would be caught by nothing.
 - **`tool_choice`** unifies four wire keys — CC/Messages `tool_choice`, Converse's
   `toolConfig.toolChoice`, Gemini's `functionCallingConfig.mode` — onto
   `envelope.extra["tool_choice"]`, with the **value** normalised to `auto` · `any` · `none` ·
@@ -2365,13 +2376,46 @@ and the second is the one that surprises:
 **`Opaque` consumes its block, and carries a payload digest.** A block type the grammar does not
 model projects as `Opaque(kind=…, digest=…)` where:
 
-- `kind` is the wire `type` converted to snake_case. Anthropic's spellings (`document`,
-  `search_result`, `redacted_thinking`, `server_tool_use`) are already canonical; Converse writes
-  `searchResult` for the same thing, so **the cross-vendor alias table lands in this section with
-  the first reader that needs one** (T-A5), rather than being invented twice.
-- `digest` is exactly
-  `hashlib.sha256(json.dumps(rest, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode("utf-8")).hexdigest()`,
-  where `rest` is the block without `type` and without `cache_control`.
+- `kind` is the wire `type` converted to snake_case, **through `contract.opaque_kind()`** — not
+  restated by each reader. Anthropic's spellings (`document`, `search_result`,
+  `redacted_thinking`, `server_tool_use`) are already canonical; a format-unique type keeps its own
+  spelling, which is the deliberate exception to "never the wire's spelling".
+
+  **The alias table arrived with T-A3, not T-A5.** This section deferred it to "the first reader
+  that needs one"; that was wrong, and the cost was paid before it was noticed. T-A1 and T-A3
+  landed first and named one concept two ways — Anthropic's `document` and Responses' `file` for
+  an attached file — which is the permanent unclaimed delta the deferral was meant to avoid.
+  `document` is canonical because Anthropic Messages **and** Bedrock Converse both spell it that
+  way on the wire, so exactly one reader moved. The table is `contract.OPAQUE_ALIASES` and it is
+  **enforced**: `Opaque` rejects any key of it, so a reader cannot quietly project a rival name.
+  The lesson generalises — a shared vocabulary deferred to the reader that first needs it is
+  deferred to the *second* reader, because the first has already answered it alone.
+
+  **A non-snake_case wire type with no alias raises.** `opaque_kind` does not convert it: a
+  camelCase splitter with no caller and no corpus is a second source of drift, not a cure for one,
+  so the conversion belongs to the author who first meets a real one. That is **T-A5, nine times**
+  — Converse's `ContentBlock` union is `text` `image` `document` `video` `audio` `toolUse`
+  `toolResult` `guardContent` `cachePoint` `reasoningContent` `citationsContent` `searchResult`
+  `toolAddition` `toolRemoval` (confirmed against the `bedrock-runtime` 2023-09-30 service model),
+  of which nine are camelCase. A **reader** meeting such a type translates the `ValueError` into
+  `UnreadableBodyError`: the body is not projectable, but the reader is not at fault, and
+  `contract` defines a reader-raised `ValueError` as a reader bug. A new *snake_case* vendor type
+  needs no decision and still projects, so a vendor release is not a harness outage.
+- `digest` has **two recipes**, and which applies is a property of the content, not of the format:
+
+  * `contract.opaque_digest(block)` for a block the grammar cannot model — exactly
+    `hashlib.sha256(json.dumps(rest, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode("utf-8")).hexdigest()`,
+    where `rest` is the block without `type` and without `cache_control`.
+  * `contract.text_digest(text)` for content whose identity is a run of text — a refusal is the
+    case. One recipe was considered and rejected on a checked fact: Chat Completions carries a
+    refusal as a **bare string** on the message (`ChatCompletionResponseMessage.refusal` is
+    `anyOf[string, null]`), so there is no block for T-A2 to hash and a single rule would force it
+    to invent a wrapper — and the wrapper's shape would be a new thing six readers could disagree
+    about, which is this rule's own defect one level down.
+
+  Both are pinned in `contract.py` rather than restated here (KBR-174), because prose did not hold
+  the first one: in T-A1 all three wrong spellings survived mutation testing until a test pinned a
+  digest to an external literal.
 - the block's every other key is **consumed** — nothing beneath it residualises — while
   `cache_control` residualises under its path exactly as it does on a modelled block.
 

--- a/tests/harness/contract.py
+++ b/tests/harness/contract.py
@@ -15,8 +15,11 @@ kitty's bugs and the whole of I1 would prove only self-consistency.
 
 **What lives here and what does not.**  This module defines *shapes and rules*.
 It reads no bodies — the six readers do that, each against its format's
-published examples.  It captures nothing — the recorders do that.  It asserts
-nothing about kitty — the oracle does that.
+published examples.  :func:`decode_arguments` is the edge case that proves
+the line rather than crossing it: it reads one *value* whose decoding six
+readers must agree on, and knows nothing of where in a body it was found.
+It captures nothing — the recorders do that.  It asserts nothing about kitty —
+the oracle does that.
 
 **The totality rule is the load-bearing part.**  §3.3.1 requires every key in a
 body to be classified into the envelope, the conversation, or the residual, and
@@ -31,6 +34,8 @@ exactly the falsification case plan §1.4 requires this harness to ship with.
 from __future__ import annotations
 
 import hashlib
+import json
+import re
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from enum import Enum
@@ -187,13 +192,52 @@ class Opaque:
         kind: A canonical snake_case name, never the wire's spelling. Anthropic
             writes ``search_result`` and Converse ``searchResult`` for one
             thing; the wire spellings would be a permanent unclaimed delta.
-        digest: A content digest, as for :class:`Image`.
+        digest: A content digest.  Two recipes, and §7.4.1 states which applies:
+            :func:`opaque_digest` for a block the grammar cannot model,
+            :func:`text_digest` for content whose identity is a run of text.
     """
 
     kind: str
     digest: str | None = None
 
     __hash__ = None  # type: ignore[assignment]
+
+    def __post_init__(self) -> None:
+        """Validate the kind against the canonical vocabulary.
+
+        Checked rather than merely declared, for the reason this module applies
+        to every other closed vocabulary: *a vocabulary declared closed but
+        checked nowhere is a comment, not a rule*.  The docstring above has
+        required a canonical name since T-W2 and named none, so the two readers
+        written against it arrived at ``file`` and ``document`` for one concept
+        (KBR-174).
+
+        Raises:
+            TypeError: When ``kind`` is not a ``str`` — a wrong *type*, which is
+                this module's ``TypeError`` case throughout.
+            ValueError: When ``kind`` is a wire spelling :data:`OPAQUE_ALIASES`
+                reconciles, or is not snake_case.  Construction is not parsing —
+                T-D1 builds expected conversations by hand — so this is a
+                ``ValueError`` and not :class:`UnreadableBodyError`, exactly as
+                for :attr:`Turn.role`.  A reader meeting such a type on the wire
+                translates it (see :func:`opaque_kind`); a reader *constructing*
+                one has a bug.
+        """
+        if not isinstance(self.kind, str):
+            raise TypeError(f"Opaque.kind must be a str, got {type(self.kind).__name__}")
+
+        canonical = OPAQUE_ALIASES.get(self.kind)
+        if canonical is not None:
+            raise ValueError(
+                f"Opaque.kind {self.kind!r} is a wire spelling; the canonical name is {canonical!r} "
+                "(§7.4.1). Readers translate through opaque_kind()."
+            )
+
+        if not _SNAKE_CASE.fullmatch(self.kind):
+            raise ValueError(
+                f"Opaque.kind must be canonical snake_case, got {self.kind!r} (§7.4.1). "
+                "A camelCase wire type needs a canonical name in OPAQUE_ALIASES first."
+            )
 
 
 @dataclass(frozen=True)
@@ -545,6 +589,231 @@ def image_digest(raw: bytes) -> str:
         Lowercase hex SHA-256 of ``raw``.
     """
     return hashlib.sha256(raw).hexdigest()
+
+
+def text_digest(text: str) -> str:
+    """Return the canonical digest of content identified by a run of text.
+
+    The second of :attr:`Opaque.digest`'s two recipes.  A refusal is the case
+    that needs it: Responses carries one as a typed content part, Chat
+    Completions as a **bare string** on the message
+    (``ChatCompletionResponseMessage.refusal`` is ``anyOf[string, null]``), so
+    there is no block for :func:`opaque_digest` to hash.  Pinning one recipe for
+    both would force the Chat Completions reader to invent a block wrapper, and
+    the wrapper's shape would be a new thing six readers could disagree about.
+
+    The digest is what makes a *rewritten* refusal visible rather than only a
+    removed one — :attr:`Opaque.kind` alone would project every refusal alike.
+
+    Args:
+        text: The text whose identity the digest carries.
+
+    Returns:
+        Lowercase hex SHA-256 of ``text`` encoded as UTF-8.  The encoding is
+        pinned because ``latin-1`` raises and ``cp1252`` silently differs on the
+        same content.
+    """
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def opaque_digest(block: Mapping[str, Any]) -> str:
+    """Return the canonical digest of an unmodelled block's payload.
+
+    The first of :attr:`Opaque.digest`'s two recipes, for a block type the
+    grammar does not model.  Pinned here for the reason :func:`image_digest` is:
+    six independently written readers must produce one digest for one block, and
+    prose did not achieve it — in T-A1 **all three** wrong spellings of this
+    recipe survived mutation testing, because every assertion compared two
+    projections against each other and a recipe change that stays internally
+    consistent is invisible to that.
+
+    Three details are load-bearing:
+
+    * **Canonical JSON, not the raw wire slice** — a translator that reorders
+      keys must not change the digest, which is the whole reason this is not
+      ``sha256(raw_block_bytes)``.
+    * ``ensure_ascii`` **pinned** — its default is ``True`` while the surrounding
+      prose says UTF-8, so an author "fixing" it to ``False`` gets a different
+      digest for the same block, visible only on non-ASCII content.
+    * ``cache_control`` **excluded** — otherwise one field behaves two ways: a
+      diagnosed residual on a modelled block, an unexplained digest change on an
+      unmodelled one (KBR-167).
+
+    Args:
+        block: The block, whose ``type`` is excluded because it is already
+            :attr:`Opaque.kind`, and whose ``cache_control`` is excluded because
+            it residualises under its own path instead.
+
+    Returns:
+        Lowercase hex SHA-256 of the canonical payload.
+    """
+    payload = {key: value for key, value in block.items() if key not in ("type", "cache_control")}
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+#: What a canonical :attr:`Opaque.kind` may look like.  Four rules turn on this
+#: predicate, so it is spelled once rather than left to each author's intuition:
+#: lowercase segments of letters and digits, joined by single underscores, never
+#: leading with a digit.  Accepts every kind the shipped readers emit; rejects
+#: every camelCase member of Converse's ``ContentBlock`` union.
+_SNAKE_CASE = re.compile(r"[a-z][a-z0-9]*(_[a-z0-9]+)*")
+
+#: Wire spellings that name a concept another format already names differently,
+#: mapped to the canonical :attr:`Opaque.kind`.  **Enforced**, not merely
+#: declared: :class:`Opaque` rejects any key of this table, so a reader cannot
+#: quietly project a rival name.
+#:
+#: An attached file is the concept that forced the table early.  §7.4.1 deferred
+#: it to T-A5 "with the first reader that needs one", but T-A1 and T-A3 landed
+#: first and named one thing two ways — ``document`` and ``file`` — which is the
+#: permanent unclaimed delta the deferral was meant to avoid.  ``document`` wins
+#: because Anthropic Messages *and* Bedrock Converse both spell it that way on
+#: the wire, so exactly one reader moved (KBR-174).
+#:
+#: **The canonical kinds in use today, per format — NOT a closed set.**  It
+#: cannot be closed: a format-unique type keeps its own wire spelling by the
+#: stated exception, so this list is documentation for the next reader's author,
+#: held honest by ``test_contract.py`` rather than by a membership check.
+#:
+#: * shared across formats — ``document``, ``search_result``
+#: * Anthropic Messages — ``redacted_thinking``, ``server_tool_use``
+#: * OpenAI Responses — ``refusal``, plus its 27 format-unique item types
+#:   (``web_search_call``, ``mcp_call``, ``apply_patch_call`` …)
+OPAQUE_ALIASES: Mapping[str, str] = MappingProxyType(
+    {
+        # OpenAI Responses' attachment, and the name T-A3 first shipped for it.
+        "input_file": "document",
+        "file": "document",
+        # Bedrock Converse, whose union is camelCase throughout (T-A5).
+        "searchResult": "search_result",
+    }
+)
+
+
+def opaque_kind(wire_type: str) -> str:
+    """Return the canonical :attr:`Opaque.kind` for a wire block type.
+
+    A format-unique type passes through unchanged: it names a concept no other
+    format has, so there is no second spelling to reconcile and the wire's own
+    word is already canonical.  That is the deliberate exception to
+    :attr:`Opaque.kind`'s "never the wire's spelling".
+
+    **A non-snake_case type raises rather than being converted.**  Converting
+    would mean shipping a camelCase splitter with no caller, no corpus and no
+    test — and a splitter whose edge cases nobody has exercised is a second
+    source of drift, not a cure for one.  Raising puts the next author at this
+    module at the moment they meet the first such type, with a real corpus in
+    hand.  That is **nine** types for Bedrock Converse, not one: its
+    ``ContentBlock`` union carries ``toolUse``, ``toolResult``, ``guardContent``,
+    ``cachePoint``, ``reasoningContent``, ``citationsContent``, ``searchResult``,
+    ``toolAddition`` and ``toolRemoval``.
+
+    Args:
+        wire_type: The block or item type as the format spells it.
+
+    Returns:
+        The canonical name — the alias when :data:`OPAQUE_ALIASES` reconciles the
+        spelling, and ``wire_type`` itself otherwise.
+
+    Raises:
+        ValueError: When no alias exists and ``wire_type`` is not snake_case, so
+            no canonical name can be derived without a decision.  A reader
+            meeting this on the wire translates it into
+            :class:`UnreadableBodyError`: the body is not projectable, but the
+            reader is not at fault.
+    """
+    canonical = OPAQUE_ALIASES.get(wire_type)
+    if canonical is not None:
+        return canonical
+
+    # Not an alias and not snake_case means nobody has decided what this is
+    # called; guessing here is how two readers end up with two names.
+    if not isinstance(wire_type, str) or not _SNAKE_CASE.fullmatch(wire_type):
+        raise ValueError(
+            f"no canonical Opaque.kind for wire type {wire_type!r} (§7.4.1): it is neither snake_case "
+            "nor listed in OPAQUE_ALIASES. Add it to OPAQUE_ALIASES with its canonical name."
+        )
+
+    return wire_type
+
+
+def decode_arguments(raw: Any, path: str, residual: dict[str, Any]) -> Mapping[str, Any]:
+    """Decode a tool call's JSON-string arguments, failing closed into the residual.
+
+    Chat Completions and Responses both encode arguments as a JSON *string*
+    while :attr:`ToolUse.arguments` is a mapping, so both readers decode and
+    §3.3.1b requires them to decode alike.  Pinned here (KBR-174) because the two
+    sit on opposite sides of register rows P13–P17: a disagreement on the
+    malformed path would surface as an unclaimed delta at
+    ``conversation.turns[*].parts[*]`` that no row claims, which §3.3.1a calls
+    the unrecoverable direction.
+
+    **Only an absent or blank value is silently empty.**  An absent ``arguments``
+    honestly means *no arguments*, which is why it does not residualise the way
+    an absent tool ``name`` does even though the schema requires both.  The test
+    generalises to every required field: *can the projection represent the
+    absence losslessly?*  ``{}`` is a true statement about a call — seen and
+    classified, the same ground on which :data:`STOP_REASONS` gives ``other`` its
+    escape instead of the residual.  ``""`` for a name is not: it claims a tool
+    *named* empty-string, and a call nobody can name cannot be paired with its
+    result or addressed by a register row.
+
+    The blank form is real corpus traffic, not a hypothesis — kitty's own
+    ``openai_subscription.py`` writes ``func.get("arguments", "")``.
+
+    **An already-decoded object is rejected, not accepted.**  Taking it would
+    make a bridge that emitted the object form where the schema demands a string
+    invisible to the oracle, which is the wire-format breach the readers exist to
+    see.
+
+    **Never raises.**  This module defines a reader-raised ``ValueError`` as
+    "the reader mis-routed a field — a reader bug", so failing closed into the
+    residual keeps the diagnosis honest.
+
+    Args:
+        raw: The wire value, of any type.
+        path: The residual key for this argument, which is **format-specific and
+            stays the caller's** — ``input[<i>].arguments`` for Responses,
+            ``messages[<i>].tool_calls[<j>].function.arguments`` for Chat
+            Completions.
+        residual: The reader's accumulator of unclassifiable values, mutated
+            here.  Taken as a parameter rather than reported through a return
+            flag so the fail-closed step cannot be skipped: ``mypy`` covers
+            ``src/kitty`` only, so a caller that ignored such a flag would be
+            caught by nothing.
+
+    Returns:
+        The decoded arguments, empty whenever the value did not carry a JSON
+        object.
+    """
+    # Absent is a true empty, and the only non-string that is.
+    if raw is None:
+        return {}
+
+    # Everything else that is not a string is a shape the schema forbids,
+    # including the decoded object form.
+    if not isinstance(raw, str):
+        residual[path] = raw
+        return {}
+
+    if not raw.strip():
+        return {}
+
+    try:
+        decoded = json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        residual[path] = raw
+        return {}
+
+    # The raw string, never `decoded`: a residual key set is diffed across all
+    # six readers (T-D8), so storing two different renderings of one unreadable
+    # value would report a delta neither reader caused.
+    if not isinstance(decoded, dict):
+        residual[path] = raw
+        return {}
+
+    return decoded
 
 
 # --------------------------------------------------------------------------

--- a/tests/harness/contract.py
+++ b/tests/harness/contract.py
@@ -671,10 +671,13 @@ _SNAKE_CASE = re.compile(r"[a-z][a-z0-9]*(_[a-z0-9]+)*")
 #: because Anthropic Messages *and* Bedrock Converse both spell it that way on
 #: the wire, so exactly one reader moved (KBR-174).
 #:
-#: **The canonical kinds in use today, per format — NOT a closed set.**  It
-#: cannot be closed: a format-unique type keeps its own wire spelling by the
-#: stated exception, so this list is documentation for the next reader's author,
-#: held honest by ``test_contract.py`` rather than by a membership check.
+#: **The canonical kinds in use today, per format — NOT a closed set**, and not
+#: a checked one either.  It cannot be closed: a format-unique type keeps its own
+#: wire spelling by the stated exception.  So this list is *documentation* for
+#: the next reader's author, and it is the one thing here that is not enforced —
+#: only the Responses row has a test that derives its members from the reader's
+#: own frozensets rather than restating them.  Treat it as a starting point to
+#: check against the readers, never as an authority.
 #:
 #: * shared across formats — ``document``, ``search_result``
 #: * Anthropic Messages — ``redacted_thinking``, ``server_tool_use``
@@ -717,19 +720,28 @@ def opaque_kind(wire_type: str) -> str:
         spelling, and ``wire_type`` itself otherwise.
 
     Raises:
+        TypeError: When ``wire_type`` is not a ``str`` — this module's split
+            between a wrong *type* and a wrong *value*, matching
+            :class:`Opaque`'s own check so the two cannot disagree.
         ValueError: When no alias exists and ``wire_type`` is not snake_case, so
             no canonical name can be derived without a decision.  A reader
             meeting this on the wire translates it into
             :class:`UnreadableBodyError`: the body is not projectable, but the
             reader is not at fault.
     """
+    # Checked before the lookup, not after: an unhashable value raises
+    # `TypeError: unhashable type` from `.get()` itself, which a reader's
+    # `except ValueError` cannot catch, so it would escape as a raw crash.
+    if not isinstance(wire_type, str):
+        raise TypeError(f"opaque_kind() wire_type must be a str, got {type(wire_type).__name__}")
+
     canonical = OPAQUE_ALIASES.get(wire_type)
     if canonical is not None:
         return canonical
 
     # Not an alias and not snake_case means nobody has decided what this is
     # called; guessing here is how two readers end up with two names.
-    if not isinstance(wire_type, str) or not _SNAKE_CASE.fullmatch(wire_type):
+    if not _SNAKE_CASE.fullmatch(wire_type):
         raise ValueError(
             f"no canonical Opaque.kind for wire type {wire_type!r} (§7.4.1): it is neither snake_case "
             "nor listed in OPAQUE_ALIASES. Add it to OPAQUE_ALIASES with its canonical name."
@@ -767,9 +779,12 @@ def decode_arguments(raw: Any, path: str, residual: dict[str, Any]) -> Mapping[s
     invisible to the oracle, which is the wire-format breach the readers exist to
     see.
 
-    **Never raises.**  This module defines a reader-raised ``ValueError`` as
-    "the reader mis-routed a field — a reader bug", so failing closed into the
-    residual keeps the diagnosis honest.
+    **Never raises on a value the wire can carry.**  This module defines a
+    reader-raised ``ValueError`` as "the reader mis-routed a field — a reader
+    bug", so failing closed into the residual keeps the diagnosis honest.  The
+    qualifier is literal: ``json.loads`` still raises ``RecursionError`` on
+    pathologically nested input, which every body-level parse in the harness
+    shares and no corpus produces.
 
     Args:
         raw: The wire value, of any type.
@@ -802,7 +817,9 @@ def decode_arguments(raw: Any, path: str, residual: dict[str, Any]) -> Mapping[s
 
     try:
         decoded = json.loads(raw)
-    except (json.JSONDecodeError, ValueError):
+    # `ValueError` alone: `JSONDecodeError` subclasses it, and naming both reads
+    # as though two distinct cases existed.
+    except ValueError:
         residual[path] = raw
         return {}
 

--- a/tests/harness/reader_anthropic_messages.py
+++ b/tests/harness/reader_anthropic_messages.py
@@ -28,7 +28,6 @@ from __future__ import annotations
 
 import base64
 import binascii
-import hashlib
 import json
 from collections.abc import Mapping, Sequence
 from typing import Any
@@ -678,35 +677,24 @@ def _read_opaque(block: Mapping[str, Any], kind: str, path: str, residual: dict[
 
     Returns:
         The opaque part, carrying a digest of its payload.
+
+    Raises:
+        UnreadableBodyError: When the wire type has no canonical name — a block
+            the projection cannot address, not a reader that mis-routed a field.
     """
     # `cache_control` residualises exactly as it does on a modelled block, so
     # one field does not behave two ways — inside the digest it would produce a
     # delta with no named cause (KBR-167).
     _residualise(block, set(block) - {"cache_control"}, path, residual)
-    return c.Opaque(kind=kind, digest=_payload_digest(block))
+    # `opaque_kind` raises when no canonical name can be derived. That is not a
+    # reader bug — the wire said it — so it is translated, per §7.4.1's rule that
+    # raising is right only when there is no partial projection to salvage.
+    try:
+        canonical = c.opaque_kind(kind)
+    except ValueError as exc:
+        raise c.UnreadableBodyError(f"{path}: {exc}") from exc
 
-
-def _payload_digest(block: Mapping[str, Any]) -> str:
-    """Return the digest of an unmodelled block's payload.
-
-    Over **canonical** JSON rather than the raw wire slice, so a translator that
-    reorders keys does not change the digest. ``ensure_ascii`` is pinned
-    alongside ``sort_keys`` and ``separators`` because its default is ``True``
-    while the surrounding prose says UTF-8: an author who passed ``False`` would
-    get a different digest for the same block, visible only on non-ASCII
-    content, which is the cross-reader disagreement §7.4.1 exists to prevent.
-
-    Args:
-        block: The block, whose ``type`` and ``cache_control`` are excluded —
-            ``type`` because it is already :attr:`~harness.contract.Opaque.kind`,
-            ``cache_control`` because it residualises instead.
-
-    Returns:
-        Lowercase hex SHA-256 of the canonical payload.
-    """
-    payload = {key: value for key, value in block.items() if key not in ("type", "cache_control")}
-    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
-    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    return c.Opaque(kind=canonical, digest=c.opaque_digest(block))
 
 
 def _typed_leaf(

--- a/tests/harness/reader_responses.py
+++ b/tests/harness/reader_responses.py
@@ -773,21 +773,24 @@ class ResponsesProjection:
         # answer would project identically, so a bridge that turned one into the
         # other would be invisible.
         #
-        # The digest carries the text's identity without the grammar having a
-        # refusal type: `kind` alone would make a *rewritten* refusal invisible,
-        # which is the same blindness one step down.
+        # `text_digest`, not `opaque_digest`: a refusal is identified by its
+        # text, and Chat Completions carries one as a bare string with no block
+        # to hash, so the two recipes are pinned separately (§7.4.1).
         if kind == "refusal":
             text = entry.get("refusal")
             if not isinstance(text, str):
                 residual[path] = entry
                 return None
-            return c.Opaque("refusal", digest=c.image_digest(text.encode("utf-8")))
+            return c.Opaque("refusal", digest=c.text_digest(text))
 
         if kind == "input_image":
             return self._read_image(entry, path, residual)
 
+        # Named through the shared table, not restated: Anthropic and Converse
+        # both spell this `document`, and T-A3 first shipped `file` for it —
+        # one concept under two names is the delta no register row can claim.
         if kind == "input_file":
-            return c.Opaque("file")
+            return c.Opaque(c.opaque_kind("input_file"))
 
         residual[path] = entry
         return None
@@ -873,65 +876,9 @@ class ResponsesProjection:
 
         return c.ToolUse(
             name=name,
-            arguments=self._read_arguments(item.get("arguments"), f"{path}.arguments", residual),
+            arguments=c.decode_arguments(item.get("arguments"), f"{path}.arguments", residual),
             id=call_id,
         )
-
-    @staticmethod
-    def _read_arguments(raw: Any, path: str, residual: dict[str, Any]) -> Mapping[str, Any]:
-        """Decode a tool call's JSON-string arguments.
-
-        Chat Completions and Responses both encode arguments as a *string*, while
-        Messages sends an object; normalising here stops a spurious delta on
-        every cross-format comparison.
-
-        Only an absent or blank value is silently empty — an absent ``arguments``
-        honestly means *no arguments*, which is why it does **not** residualise
-        the way an absent tool ``name`` does even though the schema requires
-        both: a name is unrecoverable, an empty argument set is not. And kitty
-        already emits the blank form: its Responses builder writes ``arguments`` as ``""`` whenever a
-        Chat Completions tool call carried none, so the empty string is real
-        corpus traffic rather than a hypothetical. Every other shape the schema
-        forbids residualises, because mapping it to ``{}`` would claim the agent
-        sent no arguments when it sent something — and would hide the breach
-        where kitty *drops* them.
-
-        Args:
-            raw: The wire value.
-            path: The residual path for this field.
-            residual: Accumulator of unclassifiable values, mutated here.
-
-        Returns:
-            The decoded arguments, empty when the wire value carried none.
-        """
-        if raw is None:
-            return {}
-
-        # `FunctionToolCall.arguments` is a string in the published schema. A
-        # decoded object is NOT accepted: it would make a bridge that emitted the
-        # object form instead of the string invisible to the oracle, which is the
-        # wire-format breach this reader exists to see.
-        if not isinstance(raw, str):
-            residual[path] = raw
-            return {}
-
-        if not raw.strip():
-            return {}
-
-        try:
-            decoded = json.loads(raw)
-        except json.JSONDecodeError:
-            # Never an exception: `contract` defines a reader-raised ValueError
-            # as "the reader mis-routed a field", so failing closed into the
-            # residual keeps the diagnosis honest.
-            residual[path] = raw
-            return {}
-
-        if not isinstance(decoded, dict):
-            residual[path] = raw
-            return {}
-
-        return decoded
 
     def _read_function_output(self, item: Mapping[str, Any], path: str, residual: dict[str, Any]) -> c.ToolResult:
         """Project a ``function_call_output`` item.

--- a/tests/harness/test_contract.py
+++ b/tests/harness/test_contract.py
@@ -1158,6 +1158,306 @@ class _StubReader:
         return _project(consumed=set(), residual={}, source={})
 
 
+class TestArgumentsDecode:
+    """The one rule two formats' readers share for a JSON-string `arguments` (§3.3.1b).
+
+    Chat Completions and Responses both carry tool-call arguments as a JSON
+    *string* while `ToolUse.arguments` is a mapping, so both readers decode.
+    Pinned here — KBR-174 — because the two lived on opposite sides of register
+    rows P13-P17: if they decoded the malformed path differently, the
+    disagreement would surface as an unclaimed delta at
+    `conversation.turns[*].parts[*]` that no row claims, which §3.3.1a calls the
+    unrecoverable direction.
+    """
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            (None, {}),
+            ("", {}),
+            ("   ", {}),
+            ("\t\n ", {}),
+            ('{"a": 1}', {"a": 1}),
+            ("{}", {}),
+            ('{"nested": {"b": [1, 2]}}', {"nested": {"b": [1, 2]}}),
+        ],
+    )
+    def test_a_clean_value_decodes_and_leaves_the_residual_untouched(
+        self, raw: object, expected: dict[str, object]
+    ) -> None:
+        """Absent, blank and object-valued arguments are all fully accounted for."""
+        residual: dict[str, object] = {}
+
+        assert c.decode_arguments(raw, "input[0].arguments", residual) == expected
+        assert residual == {}
+
+    @pytest.mark.parametrize(
+        "raw",
+        ["[1, 2]", '"a string"', "7", "true", "null", "{oops", "", " "],
+    )
+    def test_every_shape_the_schema_forbids_is_either_clean_or_residualised(self, raw: str) -> None:
+        """Blank is clean, everything else the schema forbids residualises — never both, never neither."""
+        residual: dict[str, object] = {}
+
+        decoded = c.decode_arguments(raw, "p", residual)
+
+        assert decoded == {}
+        assert bool(residual) == bool(raw.strip())
+
+    @pytest.mark.parametrize("raw", ["[1, 2]", '"a string"', "7", "true", "null", "{oops"])
+    def test_a_residualised_string_stores_the_raw_wire_value_not_the_decoded_one(self, raw: str) -> None:
+        """`"[1,2]"` residualises as the *string*, never as `[1, 2]`.
+
+        Unpinned, T-A2 could store the decoded form and the two readers' residual
+        key sets would differ on content neither altered — which is exactly what
+        T-D8 diffs across all six readers.
+        """
+        residual: dict[str, object] = {}
+
+        c.decode_arguments(raw, "p", residual)
+
+        assert residual == {"p": raw}
+
+    @pytest.mark.parametrize("raw", [{"a": 1}, 7, ["a"], True, 1.5, b"{}"])
+    def test_a_value_that_is_not_a_string_residualises_including_a_decoded_object(self, raw: object) -> None:
+        """The already-decoded object form is NOT accepted, and that is the point.
+
+        A bridge that emitted an object where the schema demands a string is the
+        wire-format breach the readers exist to see; accepting it here would make
+        it invisible.
+        """
+        residual: dict[str, object] = {}
+
+        assert c.decode_arguments(raw, "p", residual) == {}
+        assert residual == {"p": raw}
+
+    def test_the_residual_path_is_the_caller_s_own(self) -> None:
+        """The decode is shared; the path is format-specific and stays each reader's."""
+        residual: dict[str, object] = {}
+
+        c.decode_arguments("{oops", "messages[1].tool_calls[0].function.arguments", residual)
+
+        assert residual == {"messages[1].tool_calls[0].function.arguments": "{oops"}
+
+    @pytest.mark.parametrize(
+        "raw",
+        [None, "", "{", "[", '{"a": 1}', 0, -1, 1.5, True, False, b"", b"{}", [], {}, set(), object(), ...],
+    )
+    def test_no_input_raises(self, raw: object) -> None:
+        """`contract` defines a reader-raised `ValueError` as a reader bug, so this fails closed.
+
+        Fuzzed over ill-typed values because that is how the harness's one
+        unhashable-membership defect reached the corpus.
+        """
+        c.decode_arguments(raw, "p", {})
+
+    def test_the_decoded_mapping_is_not_the_caller_s_object(self) -> None:
+        """A reader must not be able to mutate a projection's arguments through the body it read."""
+        residual: dict[str, object] = {}
+
+        decoded = c.decode_arguments('{"a": 1}', "p", residual)
+
+        assert c.ToolUse(name="t", arguments=decoded).arguments == {"a": 1}
+
+
+class TestOpaqueDigests:
+    """The two recipes that make unmodelled content detectable (§7.4.1, KBR-174).
+
+    `Opaque.digest` has **two** recipes and the boundary is stated: a block the
+    grammar cannot model digests as canonical JSON; content whose identity is a
+    run of text digests as its UTF-8 bytes. Chat Completions carries a refusal as
+    a bare string with no block to digest, so one recipe would force that reader
+    to invent a wrapper — a new thing six readers could disagree about.
+    """
+
+    #: A block that is non-ASCII, multi-key, and inserted in an order that is
+    #: **not** sorted order, with a nested object also out of order.  All three
+    #: properties are load-bearing: without them the `ensure_ascii`, `sort_keys`
+    #: and `separators` mutations are each invisible.  Do not simplify.
+    BLOCK = {
+        "type": "document",
+        "title": "Traité économique — 中文",
+        "cache_control": {"type": "ephemeral"},
+        "source": {"media_type": "application/pdf", "data": "JVBERi0x"},
+        "context": "résumé",
+    }
+
+    #: Computed by an independent route and pasted, never by calling
+    #: :func:`harness.contract.opaque_digest`.  This is the whole point: in T-A1
+    #: all three wrong spellings of the recipe survived mutation testing because
+    #: every other assertion compared two projections against each other, which
+    #: cannot see a recipe change that stays internally consistent.
+    EXPECTED = "dba40a0282b92fdb9c8155eb0d8490b27238531d3e5afd59e023e14adbd2c6a3"
+
+    def test_the_recipe_matches_an_externally_computed_literal(self) -> None:
+        """Pins `sort_keys`, `separators` and `ensure_ascii` against a value this module cannot produce."""
+        assert c.opaque_digest(self.BLOCK) == self.EXPECTED
+
+    def test_the_type_is_excluded_because_it_is_already_the_kind(self) -> None:
+        """Otherwise `kind` and `digest` would report one change twice."""
+        renamed = dict(self.BLOCK, type="search_result")
+
+        assert c.opaque_digest(renamed) == self.EXPECTED
+
+    def test_cache_control_is_excluded_because_it_residualises_instead(self) -> None:
+        """One field must not behave two ways — a diagnosed residual here, an unexplained digest change there."""
+        without = {k: v for k, v in self.BLOCK.items() if k != "cache_control"}
+        changed = dict(self.BLOCK, cache_control={"type": "persistent"})
+
+        assert c.opaque_digest(without) == self.EXPECTED
+        assert c.opaque_digest(changed) == self.EXPECTED
+
+    def test_reordering_keys_does_not_change_the_digest(self) -> None:
+        """A translator that reorders keys must not report a delta — the reason it is not `sha256(raw_bytes)`."""
+        reordered = dict(reversed(list(self.BLOCK.items())))
+
+        assert c.opaque_digest(reordered) == self.EXPECTED
+
+    @pytest.mark.parametrize("key", ["title", "source", "context"])
+    def test_changing_any_other_key_does_change_the_digest(self, key: str) -> None:
+        """The exclusions must be exactly two — a digest blind to content is worse than none."""
+        assert c.opaque_digest(dict(self.BLOCK, **{key: "altered"})) != self.EXPECTED
+
+    def test_a_nested_value_is_covered(self) -> None:
+        """`sort_keys` recurses, so a swapped nested payload is visible."""
+        nested = dict(self.BLOCK, source={"media_type": "application/pdf", "data": "T1RIRVI="})
+
+        assert c.opaque_digest(nested) != self.EXPECTED
+
+    def test_text_digest_is_sha256_of_the_utf8_encoding(self) -> None:
+        """Pinned against `hashlib` directly, not against itself."""
+        assert c.text_digest("no") == hashlib.sha256(b"no").hexdigest()
+
+    def test_text_digest_round_trips_non_ascii(self) -> None:
+        """UTF-8, not the platform encoding — `latin-1` would raise here and `cp1252` would differ."""
+        assert c.text_digest("résumé — 中文") == hashlib.sha256("résumé — 中文".encode()).hexdigest()
+
+    def test_the_two_recipes_are_different_and_that_is_deliberate(self) -> None:
+        """A refusal digests from its text, a block from its JSON — §7.4.1 states which applies."""
+        assert c.text_digest("no") != c.opaque_digest({"type": "refusal", "refusal": "no"})
+
+
+class TestOpaqueKindVocabulary:
+    """`Opaque.kind` is canonical, and canonical now means checked (KBR-174).
+
+    The docstring already required "a canonical snake_case name, never the wire's
+    spelling" and then named no vocabulary, so six readers had to invent the same
+    names independently — the failure that sentence describes. Two shipped
+    readers already named one concept two ways (`file` vs `document`).
+    """
+
+    def test_the_alias_table_is_read_only(self) -> None:
+        """A mutable shared vocabulary is one a reader can quietly extend."""
+        with pytest.raises(TypeError):
+            c.OPAQUE_ALIASES["x"] = "y"  # type: ignore[index]
+
+    @pytest.mark.parametrize(
+        ("wire", "canonical"),
+        [("input_file", "document"), ("file", "document"), ("searchResult", "search_result")],
+    )
+    def test_a_known_wire_spelling_maps_to_its_canonical_name(self, wire: str, canonical: str) -> None:
+        """Anthropic and Converse both write `document`; Responses writes `input_file` for the same thing."""
+        assert c.opaque_kind(wire) == canonical
+
+    def test_no_alias_resolves_to_another_alias(self) -> None:
+        """One hop, or `opaque_kind` would depend on iteration order."""
+        assert not set(c.OPAQUE_ALIASES.values()) & set(c.OPAQUE_ALIASES)
+
+    def test_every_canonical_name_is_itself_legal(self) -> None:
+        """The table cannot hand a reader a value `Opaque` would reject."""
+        for canonical in c.OPAQUE_ALIASES.values():
+            assert c.Opaque(canonical).kind == canonical
+
+    @pytest.mark.parametrize(
+        "wire",
+        ["web_search_call", "redacted_thinking", "server_tool_use", "search_result", "refusal", "brand_new_block"],
+    )
+    def test_a_format_unique_type_passes_through_unchanged(self, wire: str) -> None:
+        """The deliberate exception: with no second spelling, there is nothing to reconcile."""
+        assert c.opaque_kind(wire) == wire
+
+    @pytest.mark.parametrize(
+        "wire",
+        ["guardContent", "cachePoint", "reasoningContent", "citationsContent", "toolAddition", "toolRemoval"],
+    )
+    def test_a_camel_case_wire_type_raises_rather_than_being_converted(self, wire: str) -> None:
+        """Converse has nine of these. Raising is what puts T-A5's author here with a real corpus.
+
+        Converting instead would mean shipping a camelCase splitter with no caller
+        and no corpus, whose unexercised edge cases become a second source of
+        drift rather than a cure for one.
+        """
+        with pytest.raises(ValueError, match=wire):
+            c.opaque_kind(wire)
+
+    @pytest.mark.parametrize("wire", ["", "_x", "x_", "x__y", "2x", "X", "a-b", "a.b", "a b"])
+    def test_the_snake_case_predicate_is_pinned_at_its_edges(self, wire: str) -> None:
+        """Four rules hinge on this predicate, so it is defined by test and not by intuition."""
+        with pytest.raises(ValueError):
+            c.opaque_kind(wire)
+
+    def test_a_digit_inside_a_segment_is_legal(self) -> None:
+        """`sha256`-style names are snake_case; only a *leading* digit is not."""
+        assert c.opaque_kind("mcp_call_2") == "mcp_call_2"
+
+
+class TestOpaqueRejectsANonCanonicalKind:
+    """The construction check — the half that makes the vocabulary a rule rather than a comment."""
+
+    @pytest.mark.parametrize("kind", ["input_file", "file"])
+    def test_a_known_alias_is_rejected_and_the_message_names_the_canonical_form(self, kind: str) -> None:
+        """A reader that bypasses `opaque_kind` must fail loudly, not project a rival name."""
+        with pytest.raises(ValueError, match="document"):
+            c.Opaque(kind)
+
+    @pytest.mark.parametrize("kind", ["guardContent", "myCustomBlock", "_x", "x_", "2x", "a-b", ""])
+    def test_a_kind_that_is_not_snake_case_is_rejected_even_with_no_alias_for_it(self, kind: str) -> None:
+        """The second branch, and it needs a value **no alias covers** to exercise at all.
+
+        An earlier version of this test used `searchResult`, which
+        :data:`OPAQUE_ALIASES` reconciles — so it was proving the alias branch
+        twice and the snake_case branch never. Deleting the snake_case check left
+        the suite green, which is how the falsification sweep caught it.
+        """
+        assert kind not in c.OPAQUE_ALIASES
+
+        with pytest.raises(ValueError):
+            c.Opaque(kind)
+
+    def test_an_alias_is_rejected_by_the_alias_branch_not_by_the_spelling_one(self) -> None:
+        """`searchResult` is camelCase *and* aliased; the message must name the canonical form."""
+        with pytest.raises(ValueError, match="search_result"):
+            c.Opaque("searchResult")
+
+    @pytest.mark.parametrize("kind", [7, None, b"document", ["document"]])
+    def test_a_kind_that_is_not_a_string_is_a_TypeError(self, kind: object) -> None:
+        """`contract`'s split: `TypeError` for a wrong type, `ValueError` for a wrong value."""
+        with pytest.raises(TypeError):
+            c.Opaque(kind)  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize(
+        "kind",
+        ["document", "search_result", "refusal", "redacted_thinking", "server_tool_use", "web_search_call"],
+    )
+    def test_every_canonical_kind_still_constructs(self, kind: str) -> None:
+        """The control: a check that rejected everything would satisfy the tests above."""
+        assert c.Opaque(kind, digest="d").kind == kind
+
+    def test_the_twenty_seven_opaque_responses_item_types_stay_legal(self) -> None:
+        """The stated exception, asserted over the reader's own sets rather than a copy.
+
+        A hand-listed copy here would be a second source of truth that stays green
+        while the reader moves.
+        """
+        from harness import reader_responses as r
+
+        item_types = r._OPAQUE_USER_ITEMS | r._OPAQUE_ASSISTANT_ITEMS
+
+        assert len(item_types) == 27
+        for kind in item_types:
+            assert c.Opaque(kind).kind == kind
+
+
 def test_unreadable_body_error_is_named_by_the_contract() -> None:
     """Six readers would otherwise raise six types and T-D1 would catch `Exception` (R2.10)."""
     assert issubclass(c.UnreadableBodyError, Exception)

--- a/tests/harness/test_contract.py
+++ b/tests/harness/test_contract.py
@@ -1251,11 +1251,14 @@ class TestArgumentsDecode:
         """
         c.decode_arguments(raw, "p", {})
 
-    def test_the_decoded_mapping_is_not_the_caller_s_object(self) -> None:
-        """A reader must not be able to mutate a projection's arguments through the body it read."""
-        residual: dict[str, object] = {}
+    def test_the_decoded_mapping_is_accepted_by_ToolUse(self) -> None:
+        """The decode's whole purpose is to feed `ToolUse.arguments`, so prove the pair composes.
 
-        decoded = c.decode_arguments('{"a": 1}', "p", residual)
+        Renamed from a claim about aliasing it did not test: `json.loads` always
+        returns a fresh object, so that claim was true for a reason the test
+        never exercised.
+        """
+        decoded = c.decode_arguments('{"a": 1}', "p", {})
 
         assert c.ToolUse(name="t", arguments=decoded).arguments == {"a": 1}
 
@@ -1396,6 +1399,19 @@ class TestOpaqueKindVocabulary:
         with pytest.raises(ValueError):
             c.opaque_kind(wire)
 
+    @pytest.mark.parametrize("wire", [7, None, ["a"], b"document", {"a": 1}])
+    def test_a_wire_type_that_is_not_a_string_is_a_TypeError_here_too(self, wire: object) -> None:
+        """`opaque_kind` and `Opaque` must agree on the split, or D12 holds in one place only.
+
+        The unhashable case is the sharp one: a list reached
+        `OPAQUE_ALIASES.get()` before any guard and raised `TypeError:
+        unhashable type`, which the readers' `except ValueError` cannot catch —
+        so it escaped as a raw crash instead of `UnreadableBodyError`. That is
+        the membership defect this harness has already shipped once.
+        """
+        with pytest.raises(TypeError, match="must be a str"):
+            c.opaque_kind(wire)  # type: ignore[arg-type]
+
     def test_a_digit_inside_a_segment_is_legal(self) -> None:
         """`sha256`-style names are snake_case; only a *leading* digit is not."""
         assert c.opaque_kind("mcp_call_2") == "mcp_call_2"
@@ -1431,8 +1447,17 @@ class TestOpaqueRejectsANonCanonicalKind:
 
     @pytest.mark.parametrize("kind", [7, None, b"document", ["document"]])
     def test_a_kind_that_is_not_a_string_is_a_TypeError(self, kind: object) -> None:
-        """`contract`'s split: `TypeError` for a wrong type, `ValueError` for a wrong value."""
-        with pytest.raises(TypeError):
+        """`contract`'s split: `TypeError` for a wrong type, `ValueError` for a wrong value.
+
+        **The message is pinned, and that is what makes this test able to fail.**
+        A bare `pytest.raises(TypeError)` passed with the guard deleted: every
+        parameter raises an *incidental* `TypeError` further down — `fullmatch`
+        rejects an int and a bytes pattern, and `OPAQUE_ALIASES.get` rejects an
+        unhashable list. Three tests in this change have now been caught proving
+        a guard by way of some other guard; when two checks raise the same type,
+        only the message tells them apart.
+        """
+        with pytest.raises(TypeError, match="must be a str"):
             c.Opaque(kind)  # type: ignore[arg-type]
 
     @pytest.mark.parametrize(

--- a/tests/harness/test_reader_anthropic_messages.py
+++ b/tests/harness/test_reader_anthropic_messages.py
@@ -726,6 +726,60 @@ class TestContentBlocks:
             canonical.encode("utf-8")
         ).hexdigest()
 
+    @pytest.mark.parametrize("kind", ["brand_new_block", "server_tool_use_2", "a_b_c"])
+    def test_a_vendor_type_nobody_has_seen_still_projects_when_it_is_snake_case(self, kind: str) -> None:
+        """The fallthrough stays open (KBR-174).
+
+        Anthropic adds block types, and a new *snake_case* one needs no decision:
+        it names a concept no other format has, so its own spelling is already
+        canonical. Failing the run on it would turn a vendor release into a
+        harness outage.
+        """
+        projected = _read(_minimal(messages=[{"role": "user", "content": [{"type": kind, "x": 1}]}]))
+
+        part = projected.conversation.turns[0].parts[0]
+
+        assert isinstance(part, c.Opaque)
+        assert part.kind == kind
+        c.verify_total(projected)
+
+    @pytest.mark.parametrize("kind", ["myCustomBlock", "guardContent", "toolAddition"])
+    def test_a_type_with_no_canonical_name_is_an_unreadable_body_not_a_reader_bug(self, kind: str) -> None:
+        """KBR-174 — the diagnosis must name the wire, not the harness.
+
+        `contract` defines a reader-raised `ValueError` as "the reader mis-routed
+        a field: a reader bug", and `Opaque` now raises exactly that on a
+        non-canonical kind. The body is untrusted input, so the reader translates
+        it — matching the branch above, which already raises `UnreadableBodyError`
+        for a non-string `type`. Left untranslated, a camelCase vendor type would
+        be reported as a defect in this harness.
+        """
+        body = _minimal(messages=[{"role": "user", "content": [{"type": kind, "x": 1}]}])
+
+        with pytest.raises(c.UnreadableBodyError, match=kind):
+            _read(body)
+
+    def test_a_wire_spelling_the_shared_table_reconciles_is_translated_not_rejected(self) -> None:
+        """KBR-174 — this is what proves the reader names kinds *through* the contract.
+
+        `searchResult` is Converse's spelling of Anthropic's `search_result`. No
+        Anthropic body carries it, but the reader must not be free to invent its
+        own answer either: routing every kind through `opaque_kind` is what stops
+        the next reader disagreeing, and a pass-through-only test could not tell
+        the wiring from its absence.
+        """
+        projected = _read(_minimal(messages=[{"role": "user", "content": [{"type": "searchResult"}]}]))
+
+        assert projected.conversation.turns[0].parts[0].kind == "search_result"
+
+    def test_the_translation_covers_a_tool_result_s_content_too(self) -> None:
+        """`_read_opaque` has two call sites and only one passes through `_read_block`."""
+        block = {"type": "tool_result", "tool_use_id": "t1", "content": [{"type": "myCustomBlock"}]}
+        body = _minimal(messages=[{"role": "user", "content": [block]}])
+
+        with pytest.raises(c.UnreadableBodyError, match="myCustomBlock"):
+            _read(body)
+
     def test_cache_control_on_an_opaque_block_residualises_and_leaves_the_digest_alone(self) -> None:
         """R4.6 — one field must not behave two ways: it residualises on modelled blocks too."""
         bare = {"type": "document", "title": "t"}

--- a/tests/harness/test_reader_responses.py
+++ b/tests/harness/test_reader_responses.py
@@ -482,7 +482,7 @@ class TestContentParts:
         answer = project({"input": [{"role": "assistant", "content": [{"type": "output_text", "text": "no"}]}]})
 
         assert refusal.conversation != answer.conversation
-        assert refusal.conversation.turns[0].parts == (c.Opaque("refusal", digest=c.image_digest(b"no")),)
+        assert refusal.conversation.turns[0].parts == (c.Opaque("refusal", digest=c.text_digest("no")),)
 
     def test_a_rewritten_refusal_is_visible(self) -> None:
         """`kind` alone would make a rewritten refusal invisible.
@@ -518,7 +518,7 @@ class TestContentParts:
             }
         )
 
-        assert projected.conversation.turns[0].parts == (c.Opaque("file"),)
+        assert projected.conversation.turns[0].parts == (c.Opaque("document"),)
 
     def test_a_data_url_image_is_digested(self) -> None:
         """`image_digest` is pinned so six readers agree on one image.
@@ -780,7 +780,7 @@ class TestFunctionCallOutput:
         assert result.content == (
             c.Text("see attached"),
             c.Image(digest=hashlib.sha256(raw).hexdigest(), media_type="image/png"),
-            c.Opaque("file"),
+            c.Opaque("document"),
         )
 
     def test_a_content_type_the_output_branch_does_not_publish_residualises(self) -> None:


### PR DESCRIPTION
## Context for the Product Owner

Kitty Bridge sits between a coding agent and an AI provider and translates between vendor formats. Its test harness exists to prove nothing is **lost or altered** in that translation — that is the product's core promise.

The harness proves this by having one "reader" per vendor format convert each request into a single common shape, then comparing. **That only works if the readers describe the same thing with the same words.** When two readers disagree on a name, the harness reports a difference that isn't real — and a false alarm in the tool that guards correctness is worse than no tool, because it trains people to ignore it.

Two readers exist today and **they had already drifted**: one called an attached file `document`, the other called it `file`. Four more readers are still to be written, each of which would have guessed again.

This change moves three such rules out of comments and into enforced code, so the remaining four readers cannot invent new answers. No product behaviour changes — this is entirely test infrastructure — but it protects the reliability of the checks that gate every future release.

Closes KBR-174.

---

## What was pinned

| Rule | Was | Now |
|---|---|---|
| Decoding a tool call's arguments | One private copy in one reader | `contract.decode_arguments()` |
| Naming content the grammar can't model | Prose; two readers already disagreed | `contract.OPAQUE_ALIASES` + `opaque_kind()`, enforced by `Opaque` |
| Fingerprinting that content | Prose; two different recipes in use | `contract.opaque_digest()` and `contract.text_digest()` |

**An attached file is now `document`.** Anthropic *and* Bedrock Converse both spell it that way on the wire — confirmed against AWS's `bedrock-runtime` 2023-09-30 service model, not from memory — so exactly one reader had to move rather than two.

**The fingerprint has two recipes, deliberately.** A block is hashed from its canonical JSON; content identified by text is hashed from its text. One recipe was considered and dropped on a checked fact: Chat Completions carries a refusal as a **bare string** with no block to hash, so a single rule would force that reader to invent a wrapper — reintroducing this exact defect one level down.

**A camelCase vendor type raises rather than being auto-converted.** Shipping a name-conversion routine with no caller and no test data would be a second source of drift, not a cure for one. The reader that first meets real ones (Bedrock, nine of them) writes it then, with a corpus in hand. A *new snake_case* vendor type still passes through and projects normally, so a vendor release is not a harness outage.

## A correction to the design document

`TEST_SUITE.md` §7.4.1 told authors to defer this shared vocabulary "to the first reader that needs one". That advice was wrong, and the `document`/`file` split is what it cost. The section now records why: **a shared rule deferred to the first consumer is really deferred to the second**, because the first has already answered it alone and moved on.

## Verification

- Full gate green — **4858 passed**, 2 pre-existing skips, 0 failures.
- `ruff check`, `mypy src/kitty`, `lint-imports` (5 contracts) all clean.
- **17-mutation falsification sweep**, each injected alone and reverted.

Sixteen mutations went red immediately. **The seventeenth survived, and was right to.** The test for one guard used an input that a *different* guard rejected first, so the guard it named had no test at all — a green suite, a correct-sounding test name, and dead code underneath. Fixed and re-verified. That is the same class of defect this ticket exists to prevent, caught on this ticket's own work.

## Found and deliberately left out

Three more rules that are declared but unchecked, filed rather than folded in: KBR-191, KBR-192, KBR-193. KBR-193 is written as a judgement call rather than a defect, since already-planned work may cover it. KBR-179 also stays separate by agreement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J2sAEXym49SsSKWadFLDqf