### PR TITLE
Stop a model's own prose deciding why a run failed (KBR-166)

### DIFF
--- a/.github/review/README.md
+++ b/.github/review/README.md
@@ -205,7 +205,7 @@ step 2 above.
 ## Changing the review system
 
 `.github/workflows/ci.yml` runs `tests/test_review_scripts.py` on every pull
-request — 648 tests over the selector, the classifier, the notices, the redactor,
+request — 664 tests over the selector, the classifier, the notices, the redactor,
 the schema and the workflow's own wiring, plus the workflow parser, the
 runner-ceiling table and the `ci-required` aggregation. Run them locally the same
 way:

--- a/.github/review/scripts/interpret_claude_result.py
+++ b/.github/review/scripts/interpret_claude_result.py
@@ -165,9 +165,45 @@ QUOTA_PATTERNS = (
     # The wording alone catches the real 402 -- its body carries
     # "Insufficient credits" -- so the code bought nothing and cost that.
     r"insufficient credits",
-    # Generic quota and billing.
-    r"quota",
+    # upstream: Anthropic's documented 402 type. `\bbilling\b` could never match it --
+    # `_` is a word character -- so the one status that means "your balance is the
+    # problem" reached nothing in this set. See `platform.claude.com/docs/en/api/errors`.
+    r"billing_error",
     r"exceeded your current",
+)
+
+# 🔴 **KBR-166. The same words, searched ONLY over what the PROVIDER wrote.**
+#
+# `quota` and `\bbilling\b` lived in the set above until this ticket, where they were
+# searched over a haystack that includes `result` -- the model's own answer. So a
+# reviewer that merely WROTE "quota" turned a $1.79 billed rejection into `exhausted`,
+# and `retry_verdict`'s exhausted branch then spent the $1.79 again.
+#
+# ⚠️ **They are MOVED, not anchored, and three attempts to anchor them are the reason.**
+# Anchoring was measured three times -- on named vendor vocabulary, on the CLI's
+# `API Error: NNN {` line shape, and on the word beside a spending verb. Every version
+# lost a real body, and each loss landed in `FATAL_UNLESS_PROVIDER_NAMED_PATTERNS`: an
+# operator with a spent balance sent to debug a correct workflow, which is KBR-145's
+# filed defect one tier across. Measured: an anchored quota word missed four of ten real
+# wordings, and all four became `fatal` with no retry because the body also carried the
+# generic error code -- exactly what DeepSeek sends for a spent balance.
+#
+# That reproduces, a third time, what KBR-172 recorded for the eight bare status codes:
+# **no anchor matches every real body while leaking no prose.** The separable question is
+# not what the text says but WHO WROTE IT, and the record already answers it -- so the
+# fix is the condition KBR-172 built, applied unconditionally to the weak patterns only.
+#
+# ⚠️ Residual, stated so it cannot read as an oversight: a PROVIDER that writes "quota"
+# as prose in its own error message is still read as a quota failure. This module can say
+# who wrote a field; it cannot say whether a provider meant its own word.
+#
+# ⚠️ One self-match, recorded rather than discovered later: `classify` returns
+# "provider quota exhausted: ...", which `quota` matches. Not live -- that string goes to
+# `$GITHUB_OUTPUT` and the diagnostic, neither of which re-enters a haystack -- but
+# `OUTCOME_FIELDS` warns about exactly this class, so the next person measuring it should
+# find it written down.
+QUOTA_WORD_PATTERNS = (
+    r"quota",
     r"\bbilling\b",
 )
 
@@ -175,11 +211,32 @@ QUOTA_PATTERNS = (
 # key, or a different provider's model name, is exactly what may fix them.
 CREDENTIAL_PATTERNS = (
     r"\bauthentication_failed\b",
-    r"\b401\b",
-    r"\b403\b",
+    # upstream: Anthropic's documented 401 and 403 types, per
+    # `platform.claude.com/docs/en/api/errors`. They earn their place beside the status
+    # tier below rather than duplicating it: a body can name its cause and carry NO
+    # number, because a numeric `api_error_status` never reaches the haystack at all
+    # (KBR-182). They are also consulted FIRST, so an operator reads
+    # "authentication_error" rather than "401" -- both true, one more useful.
+    r"\bauthentication_error\b",
+    r"\bpermission_error\b",
     r"model_not_found",
     r"\bmodel not found\b",
 )
+
+# 🔴 **KBR-166. The bare status codes, searched ONLY over what the PROVIDER wrote.**
+#
+# `\b401\b` and `\b403\b` lived in the set above and are merged here unchanged. The
+# reasoning is the one beside `QUOTA_WORD_PATTERNS` and the evidence is sharper: a
+# reviewer of THIS repository writes status codes constantly, and KBR-172's own ticket
+# text quotes `API Error: 402 {"error"...}` verbatim.
+#
+# ⚠️ **Deleting them was tried and is wrong.** `OPENAI_401_MESSAGE_ONLY` --
+# `API Error: 401 {"error":{"message":"Incorrect API key provided",...}}` -- carries no
+# credential vocabulary whatsoever, so the status code is the ONLY thing identifying it.
+# So is `{"error":{"message":"HTTP 401 Unauthorized","type":"invalid_request_error"}}`,
+# the nested carrier `BILLED_INVALID_REQUEST` itself uses. Both were measured falling
+# through to the generic tier and being called workflow faults.
+CREDENTIAL_STATUS_PATTERNS = (r"\b40[13]\b",)
 
 # Universal: the workflow itself is wrong and any provider would reject it the
 # same way, so re-running is pure waste. Both failures seen on the first live
@@ -218,13 +275,20 @@ FATAL_PATTERNS = (
 # includes `result`. Yielding to those would let a $1.79 billed rejection be
 # called `exhausted` -- and `retry_verdict` then spends the $1.79 again.
 #
-# ⚠️ **The accepted exposure, stated so it cannot read as an oversight.** This
-# tier DOES yield to `quota`, `\bbilling\b`, `\b401\b` and `\b403\b`, all of
-# which are unanchored and can appear in prose. KBR-145 took that trade
-# knowingly: it fixes the two misclassifications anyone has observed -- the live
-# 402 and a 401 reported with this same generic code, which `map_error` fixtures
-# show OpenAI and Fireworks both do -- at the cost of four prose shapes nobody
-# has observed. Anchoring those four patterns is KBR-166.
+# 🔴 **KBR-166 CLOSED the exposure KBR-145 accepted here, and not by anchoring.**
+# This tier still yields to `quota`, `\bbilling\b`, `\b401\b` and `\b403\b`, but
+# those four now live in `QUOTA_WORD_PATTERNS` and `CREDENTIAL_STATUS_PATTERNS` and are
+# searched only over what the PROVIDER wrote. Three anchoring schemes were measured and
+# each lost a real body to this very tier; the reasoning is recorded beside those two
+# tuples.
+#
+# ⚠️ **`EXHAUSTED_PATTERNS` keeps its bare words, and that asymmetry is deliberate.**
+# `\btimeout\b`, `\bcapacity\b`, `\b429\b` and `\b50[023]\b` are every bit as
+# writable in prose, and they are safe for one reason only: that set is consulted
+# BELOW this tier, so a prose word in it cannot promote a billed rejection -- it can
+# only fail to rescue one. The sets above this line had the opposite exposure, which is
+# why KBR-166 moved those and left these alone. Do not "finish the job" here without
+# first moving this tier.
 FATAL_UNLESS_PROVIDER_NAMED_PATTERNS = (r"invalid[_ ]request",)
 
 # upstream. Anchored on the beta's own dated slug, or on the refusal's distinctive
@@ -527,6 +591,14 @@ def _extract_structured_output(raw_output: str, execution_text: str) -> dict | N
 #:
 #: ⚠️ ``message`` and ``content`` are deliberately absent: that is where tool results and model
 #: prose live, and both quote the code under review.
+#:
+#: 🔴 **One field in this tuple is never actually read, and knowing which one matters here.**
+#: ``api_error_status`` arrives as a JSON NUMBER, and :func:`_strings_in` collects string
+#: leaves only, so it is discarded before any pattern sees it. Every numeric pattern in this
+#: module therefore matches text -- the CLI's ``API Error: NNN`` line or a message body --
+#: and never the field that exists to report the status. Filed as KBR-182, deliberately not
+#: fixed here: making numbers visible would wake `\b400\b` in :data:`FATAL_PATTERNS`, which
+#: is consulted first, and that needs its own before/after measurement across the tier order.
 OUTCOME_FIELDS = (
     "error",
     "result",
@@ -597,6 +669,35 @@ def _parse_events(execution_text: str) -> list | None:
     return events or None
 
 
+def _outcome_parts(events: list) -> tuple[list[str], list[str]]:
+    """Split a record's outcome fields by who wrote them.
+
+    🔴 **Derived once and consumed twice, because two copies of this loop would have to
+    be edited together and nothing would say so.** :data:`MODEL_AUTHORED_FIELD` is a bare
+    string today; the day a second model-authored field is added it becomes a tuple, and
+    a duplicated split would keep one reader honest and silently leave the other wrong.
+    That is the rule :func:`retry_verdict` already states for ``timed_out_attempt`` --
+    one finding, derived once, consumed everywhere.
+
+    Args:
+        events: Decoded execution-record events, as :func:`_parse_events` returns them.
+
+    Returns:
+        A ``(provider_parts, model_parts)`` pair of string lists. ``model_parts`` holds
+        only :data:`MODEL_AUTHORED_FIELD`; everything else the provider wrote.
+    """
+
+    provider_parts: list[str] = []
+    model_parts: list[str] = []
+    for event in events:
+        if not isinstance(event, dict):
+            continue
+        for field in OUTCOME_FIELDS:
+            target = model_parts if field == MODEL_AUTHORED_FIELD else provider_parts
+            target.extend(_strings_in(event.get(field)))
+    return provider_parts, model_parts
+
+
 def _outcome_text(execution_text: str) -> str | None:
     """Return only the outcome-bearing fields of the record.
 
@@ -621,16 +722,7 @@ def _outcome_text(execution_text: str) -> str | None:
     if events is None:
         return None
 
-    # Split by who WROTE the field, not by what it says. `result` is the only outcome
-    # field the model can author, and on a schema failure that is exactly what it holds.
-    provider_parts: list[str] = []
-    model_parts: list[str] = []
-    for event in events:
-        if not isinstance(event, dict):
-            continue
-        for field in OUTCOME_FIELDS:
-            target = model_parts if field == MODEL_AUTHORED_FIELD else provider_parts
-            target.extend(_strings_in(event.get(field)))
+    provider_parts, model_parts = _outcome_parts(events)
 
     # The marker is read only from fields the model does not author. Reading it from
     # `result` too would let a review that merely MENTIONS the subtype scope out its own
@@ -643,6 +735,72 @@ def _outcome_text(execution_text: str) -> str | None:
     if schema_failure:
         return provider_text
     return "\n".join(provider_parts + model_parts)
+
+
+def _provider_outcome_text(execution_text: str) -> str:
+    """Return only the outcome fields the PROVIDER authored.
+
+    The same field split :func:`_outcome_text` performs, applied unconditionally:
+    :data:`MODEL_AUTHORED_FIELD` is always excluded, where :func:`_outcome_text` excludes
+    it only on a structured-output failure. Patterns weak enough to appear in ordinary
+    prose -- :data:`QUOTA_WORD_PATTERNS` and :data:`CREDENTIAL_STATUS_PATTERNS` -- are
+    searched over this rather than over the full haystack, so what the model wrote cannot
+    vote on why the run failed.
+
+    🔴 **Its fallback contract is its own, and inheriting :func:`_outcome_text`'s was a
+    defect design review caught.** That function searches an unparseable record whole,
+    justified as "a CLI-level failure message with no tool results in it" -- an argument
+    about ``message``/``content``, not about ``result``, which does not transfer to the
+    who-wrote-this question. Measured: a pretty-printed array with one line appended
+    fails :func:`_parse_events`, and the whole text including ``result`` then reached the
+    status tier, so a prose ``401`` was retried at full price.
+
+    ⚠️ **Returning "" unconditionally is equally wrong**, which is what makes this
+    narrow. The CLI-prefix carrier ``API Error: 401 {...}`` is ALSO unparseable, and it is
+    the only path by which a 401 whose message reads merely "Incorrect API key provided"
+    is recognised at all. So the two unparseable cases are separated by the fact that
+    distinguishes them: raw CLI output has no ``result`` key to exclude, while a record
+    that failed to parse does. Claiming nothing for the latter is the conservative
+    direction -- it falls through to ``fatal``, which spends nothing on a record that
+    cannot be read.
+
+    Args:
+        execution_text: Raw execution record text.
+
+    ⚠️ **The first fallback branch is narrower than "nothing model-authored", and the
+    difference is recorded rather than hidden.** A transcript truncated before its result
+    event carries no ``result`` key, so its ``message``/``content`` -- which the model
+    DID author -- is handed back. The leak is pre-existing and identical in
+    :func:`_outcome_text` on every branch, so this is not a regression; narrowing the
+    sentinel to those carriers is not available either, because a real CLI error body is
+    ``{"error":{"message": ...}}`` and would be refused with it. Read the contract as
+    "no ``result`` FIELD to exclude", not as "no model wrote this".
+
+    Args:
+        execution_text: Raw execution record text.
+
+    Returns:
+        The joined provider-authored outcome fields. For a record that is not JSON:
+        the whole text when it carries no ``result`` key, and ``""`` when it does.
+    """
+
+    events = _parse_events(execution_text)
+
+    # Not JSON. Either raw CLI output with no `result` field, or a record too broken to
+    # attribute -- and the presence of a `result` KEY is what tells them apart.
+    #
+    # 🔴 The `\s*:` is load-bearing and is NOT a tidy-up. Every CLI result event carries
+    # `"type": "result"`, so a sentinel of `"result"` alone matches the string as a
+    # VALUE and refuses records that have no `result` field at all -- measured, that
+    # turns a truncated 401 back into a workflow fault. `test_a_result_value_is_not_a_
+    # result_key` is the row that fails when the colon is dropped.
+    if events is None:
+        if re.search(r'"result"\s*:', execution_text):
+            return ""
+        return execution_text
+
+    provider_parts, _ = _outcome_parts(events)
+    return "\n".join(provider_parts)
 
 
 def _strings_in(value: object, depth: int = 0) -> list[str]:
@@ -761,11 +919,27 @@ def classify(
     if hit:
         return "fatal", f"workflow-level failure: {hit!r}"
 
+    # 🔴 KBR-166. The weak patterns read a NARROWER text than everything around them:
+    # only what the provider wrote. Derived once, here, and consulted by both tiers below
+    # -- one finding, derived once, is the only shape in which two readers cannot
+    # disagree, which is the rule `retry_verdict` already states about `timed_out_attempt`.
+    provider_scoped = _provider_outcome_text(execution_text).lower()
+
     hit = _first_match(QUOTA_PATTERNS, haystack)
     if hit:
         return "exhausted", f"provider quota exhausted: {hit!r}"
 
+    # Immediately after the anchored set and reported identically: this is the same
+    # verdict reached on narrower evidence, not a weaker one.
+    hit = _first_match(QUOTA_WORD_PATTERNS, provider_scoped)
+    if hit:
+        return "exhausted", f"provider quota exhausted: {hit!r}"
+
     hit = _first_match(CREDENTIAL_PATTERNS, haystack)
+    if hit:
+        return "exhausted", f"provider rejected the credentials or model: {hit!r}"
+
+    hit = _first_match(CREDENTIAL_STATUS_PATTERNS, provider_scoped)
     if hit:
         return "exhausted", f"provider rejected the credentials or model: {hit!r}"
 
@@ -1247,6 +1421,7 @@ def _write_diagnostic(
     # confusing; the wrong instruction costs money.
     scoped = _outcome_text(execution_text)
     evidence = execution_text if scoped is None else scoped
+    provider_evidence = _provider_outcome_text(execution_text)
 
     # A missing execution record is the least self-explanatory failure, so spell
     # out what to check rather than leaving an empty log.
@@ -1330,7 +1505,17 @@ def _write_diagnostic(
             "is the knob.",
             "",
         ]
-    elif any(re.search(p, evidence, re.I) for p in QUOTA_PATTERNS):
+    elif any(re.search(p, evidence, re.I) for p in QUOTA_PATTERNS) or any(
+        re.search(p, provider_evidence, re.I) for p in QUOTA_WORD_PATTERNS
+    ):
+        # 🔴 KBR-166: this branch must mirror `classify`'s split, and forgetting the
+        # second half strips the advice from the wordings the branch exists for.
+        # Measured while implementing: with `quota` moved out of `QUOTA_PATTERNS` and
+        # this condition left alone, "Quota limit exceeded" classified `exhausted` and
+        # printed no guidance at all -- the verdict-and-advice invariant KBR-145 was
+        # filed over, broken in the opposite direction. Each half reads the text its
+        # own tier reads, so the two cannot disagree.
+        #
         # Quota exhaustion is not a defect in the change under review, and it is
         # now the most likely reason this check is red. Spell out what to do
         # rather than leaving a reader to infer it from the record tail.

--- a/.github/review/scripts/interpret_claude_result.py
+++ b/.github/review/scripts/interpret_claude_result.py
@@ -764,9 +764,6 @@ def _provider_outcome_text(execution_text: str) -> str:
     direction -- it falls through to ``fatal``, which spends nothing on a record that
     cannot be read.
 
-    Args:
-        execution_text: Raw execution record text.
-
     ⚠️ **The first fallback branch is narrower than "nothing model-authored", and the
     difference is recorded rather than hidden.** A transcript truncated before its result
     event carries no ``result`` key, so its ``message``/``content`` -- which the model

--- a/.github/review/tests/test_review_scripts.py
+++ b/.github/review/tests/test_review_scripts.py
@@ -16290,6 +16290,39 @@ class NoDocumentAttributesTheCatalogueRefreshToTheGateTests(unittest.TestCase):
 # KBR-145 -- a spent balance is not a workflow fault
 # ---------------------------------------------------------------------------
 
+#: OpenAI's spent-quota body, **verbatim**.
+#:
+#: ⚠️ **The verbatim-fixture rule is suspended for this fixture and the next, and the
+#: suspension is deliberate** -- the protocol
+#: :data:`BILLED_INVALID_REQUEST_WITH_TRANSIENT_PROSE` established. Neither comes from a
+#: run of ours: this one is quoted from a public bug report (StackOverflow 77583070) and
+#: the next from Anthropic's own error reference. **A vendor stating its own error
+#: vocabulary is admissible where a fabrication is not** -- authenticity is exactly what
+#: the rule protects, and what it forbids is an author *inventing* wording so a pattern
+#: looks covered.
+OPENAI_INSUFFICIENT_QUOTA = json.dumps(
+    [
+        {
+            "type": "result",
+            "subtype": "error",
+            "error": {
+                "message": "You exceeded your current quota, please check your plan "
+                "and billing details.",
+                "type": "insufficient_quota",
+                "code": "insufficient_quota",
+            },
+        }
+    ]
+)
+
+#: Anthropic's documented 402. `platform.claude.com/docs/en/api/errors`, read 2026-09-12:
+#: `402 - billing_error`. Nothing in the quota set matched it before this ticket --
+#: `\bbilling\b` cannot, because `_` is a word character.
+ANTHROPIC_402_BILLING_ERROR = (
+    'API Error: 402 {"type":"error","error":{"type":"billing_error",'
+    '"message":"Your credit balance is too low"}}'
+)
+
 #: Every record whose correct verdict is reached through `QUOTA_PATTERNS`.
 #:
 #: Named as a set so the classifier/diagnostic agreement below is asserted over all
@@ -16301,6 +16334,10 @@ QUOTA_FIXTURES = (
     ("DEEPSEEK_NO_BALANCE", DEEPSEEK_NO_BALANCE),
     ("DEEPSEEK_NO_BALANCE_ABRIDGED", DEEPSEEK_NO_BALANCE_ABRIDGED),
     ("OPENROUTER_NO_CREDITS", OPENROUTER_NO_CREDITS),
+    # KBR-166. Both are vendor-stated rather than run-observed; the suspension of
+    # the verbatim rule is argued beside each fixture.
+    ("OPENAI_INSUFFICIENT_QUOTA", OPENAI_INSUFFICIENT_QUOTA),
+    ("ANTHROPIC_402_BILLING_ERROR", ANTHROPIC_402_BILLING_ERROR),
 )
 
 #: Quota patterns that no fixture above matches, each with the reason it is exempt.
@@ -16314,10 +16351,6 @@ QUOTA_FIXTURES = (
 QUOTA_PATTERNS_WITHOUT_FIXTURES = {
     # Inherited-unobservable. May legitimately never earn a fixture.
     r"\b1113\b": "inherited numeric code; no record on this endpoint carries it",
-    r"exceeded your current": "inherited wording; never observed in this repository",
-    # Unanchored-harmful. KBR-166's subject; these must disappear, not gain fixtures.
-    r"quota": "unanchored word -- KBR-166 anchors or deletes it",
-    r"\bbilling\b": "unanchored word -- KBR-166 anchors or deletes it",
 }
 
 #: A billed `invalid_request` whose prose matches ONLY `EXHAUSTED_PATTERNS`.
@@ -16355,6 +16388,23 @@ CREDENTIAL_401_WITH_GENERIC_CODE = (
 )
 
 
+def _every_quota_pattern():
+    """Return every pattern that can produce a quota verdict, in tier order.
+
+    🔴 **Both tuples, because KBR-166 split them and the accountability claim is about
+    the verdict, not about which tuple reaches it.** `QUOTA_WORD_PATTERNS` is searched
+    over provider-authored text only, but a hit there returns the same
+    ``provider quota exhausted`` status and fires the same advice branch -- so a pattern
+    added to it with no fixture behind it is exactly the untested classification this
+    class exists to catch.
+
+    Returns:
+        The concatenation of the anchored and provider-scoped quota tuples.
+    """
+
+    return interpret.QUOTA_PATTERNS + interpret.QUOTA_WORD_PATTERNS
+
+
 class QuotaVocabularyTests(unittest.TestCase):
     """KBR-145. The quota fixtures must be accountable to the quota patterns.
 
@@ -16372,7 +16422,7 @@ class QuotaVocabularyTests(unittest.TestCase):
         provider vocabulary this file forbids. So they are declared instead.
         """
 
-        for pattern in interpret.QUOTA_PATTERNS:
+        for pattern in _every_quota_pattern():
             with self.subTest(pattern=pattern):
                 covered = [
                     name
@@ -16414,7 +16464,7 @@ class QuotaVocabularyTests(unittest.TestCase):
             with self.subTest(pattern=pattern):
                 self.assertIn(
                     pattern,
-                    interpret.QUOTA_PATTERNS,
+                    _every_quota_pattern(),
                     f"{pattern!r} is declared exempt but is no longer a quota "
                     "pattern -- delete the exemption",
                 )
@@ -16429,9 +16479,11 @@ class QuotaVocabularyTests(unittest.TestCase):
 
         self.assertEqual(
             len(QUOTA_PATTERNS_WITHOUT_FIXTURES),
-            4,
-            "this list may only shrink -- KBR-166 removes `quota` and `\\bbilling\\b`; "
-            "a NEW quota pattern needs a verbatim fixture, not an exemption",
+            1,
+            "this list may only SHRINK -- a NEW quota pattern needs a fixture, not an "
+            "exemption. KBR-166 took it from four to one: `quota` and `\\bbilling\\b` "
+            "moved to `QUOTA_WORD_PATTERNS` and `exceeded your current` was retired by "
+            "the verbatim OpenAI body that arrived with them",
         )
 
 
@@ -16917,6 +16969,595 @@ class QuotaAdviceNamesNoRetiredProviderTests(unittest.TestCase):
 
         advice = body.split("--- execution record (tail) ---")[0]
         self.assertNotIn("OpenRouter", advice)
+
+# ---------------------------------------------------------------------------
+# KBR-166 -- a model's own prose must not decide why a run failed
+# ---------------------------------------------------------------------------
+
+#: Anthropic's documented 401 and 403, same source: `401 - authentication_error`,
+#: `403 - permission_error`. Both carry a named cause and a status code.
+ANTHROPIC_401_AUTHENTICATION_ERROR = (
+    'API Error: 401 {"type":"error","error":{"type":"authentication_error",'
+    '"message":"invalid x-api-key"}}'
+)
+ANTHROPIC_403_PERMISSION_ERROR = (
+    'API Error: 403 {"type":"error","error":{"type":"permission_error",'
+    '"message":"not permitted to use this resource"}}'
+)
+
+#: OpenAI's 401 as a gateway that forwards only `message` and `type` delivers it.
+#:
+#: 🔴 **This fixture is the one that killed three candidate fixes.** Its message carries
+#: no credential vocabulary at all -- `Incorrect API key provided` matches neither
+#: `invalid[_ ]api[_ ]key` nor any named type -- so the ONLY thing identifying it is the
+#: status code. Every design that deleted or anchored `\b401\b` sent this record to
+#: `FATAL_UNLESS_PROVIDER_NAMED_PATTERNS` and told the operator their workflow was
+#: broken while their key was dead: KBR-145's defect, one tier across.
+OPENAI_401_MESSAGE_ONLY = (
+    'API Error: 401 {"error":{"message":"Incorrect API key provided",'
+    '"type":"invalid_request_error"}}'
+)
+
+#: The **nested** carrier: a status code inside `error.message`, with no `API Error:`
+#: prefix and no brace beside the number. `BILLED_INVALID_REQUEST` uses this shape, so
+#: any rule keyed on the CLI's line shape is blind to it.
+NESTED_401_STATUS_IN_MESSAGE = json.dumps(
+    [
+        {
+            "type": "result",
+            "subtype": "error",
+            "error": {"type": "invalid_request_error", "message": "HTTP 401 Unauthorized"},
+        }
+    ]
+)
+NESTED_403_STATUS_IN_MESSAGE = json.dumps(
+    [
+        {
+            "type": "result",
+            "subtype": "error",
+            "error": {
+                "type": "invalid_request_error",
+                "message": "Request failed with status 403",
+            },
+        }
+    ]
+)
+
+#: Ten real ways a provider says "your quota is gone", each in the **hostile** carrier:
+#: the body also carries the generic `invalid_request_error` code, which is what DeepSeek
+#: does for a spent balance and the reason KBR-145 exists.
+#:
+#: 🔴 **The carrier is the point.** With no generic code a missed wording degrades
+#: harmlessly to the transient tier; with one, `FATAL_UNLESS_PROVIDER_NAMED_PATTERNS`
+#: claims it and the run is `fatal`, not retried, with no advice. Measured: an anchored
+#: quota pattern missed four of these and all four failed that way.
+QUOTA_WORDINGS = (
+    "You exceeded your current quota, please check your plan and billing details.",
+    "Quota exceeded for quota metric 'generate requests'",
+    "Monthly quota reached for this key",
+    "Quota exhausted for project p",
+    "Quota limit exceeded.",
+    "quota_exceeded",
+    "You have insufficient quota for this model",
+    "The organisation is out of quota",
+    "Your quota has been used up",
+    "RESOURCE_EXHAUSTED: quota metric exceeded",
+)
+
+
+def billed_rejection(message, result=None):
+    """Build a billed gateway rejection, optionally carrying model-authored prose.
+
+    The shape of :data:`BILLED_INVALID_REQUEST` -- a record that exists, so the model ran
+    and was billed, carrying the CLI's generic ``invalid_request_error`` code and nothing
+    an operator could top up.
+
+    Args:
+        message: The provider-authored ``error.message`` text.
+        result: Model-authored ``result`` text, or None to omit the field entirely.
+
+    Returns:
+        The execution record as a JSON string.
+    """
+
+    event = {
+        "type": "result",
+        "subtype": "error",
+        "error": {"type": "invalid_request_error", "message": message},
+    }
+    if result is not None:
+        event["result"] = result
+    return json.dumps([event])
+
+
+def quota_rejection(message):
+    """Build a 429 whose body also carries the generic error code.
+
+    Args:
+        message: The provider's quota wording.
+
+    Returns:
+        The execution record as a CLI error string.
+    """
+
+    body = json.dumps({"error": {"message": message, "type": "invalid_request_error"}})
+    return f"API Error: 429 {body}"
+
+
+#: Lines this repository ALREADY contains, verbatim, which a reviewer reading those
+#: files would quote back into `result`.
+#:
+#: 🔴 **Seeded rather than composed, and code review is why.** An earlier version of this
+#: corpus claimed exactly this provenance and had none -- every string was author-written,
+#: so the defence it was offered for ("an author who picks the strings can always pick
+#: ones that miss") was unearned, in a file whose whole culture is *measured, not
+#: assumed*. These five are real: `grep` finds each at the path named beside it. They are
+#: drawn from the README and the workflow and deliberately **not** from
+#: `interpret_claude_result.py` or this file, both of which quote every pattern by
+#: construction -- self-matching there is an accepted residual, not a defect.
+SEEDED_PROSE_FROM_THIS_REPOSITORY = (
+    # .github/review/README.md -- the `exhausted` bullet
+    "the provider could not serve the request (quota, credentials,",
+    # .github/workflows/claude-code-review.yml -- the token-scope comment
+    "that API. A read grant would 403 on exactly the run that has nothing else",
+    # .github/workflows/claude-code-review.yml -- a PR NUMBER that reads as a status code
+    "re-emit all of it. Measured on PR #401 run 32487762502: 224s of model",
+    # .github/workflows/claude-code-review.yml -- the pipefail comment
+    "without pipefail a curl 429/403 flows to `bash -s` reading empty",
+    # .github/workflows/claude-code-review.yml -- the failure annotation
+    "The provider could not serve the review request -- quota, credentials or a",
+)
+
+#: Sentences a reviewer of this repository could plausibly write into `result`.
+#:
+#: ⚠️ Author-composed, and said plainly. :data:`SEEDED_PROSE_FROM_THIS_REPOSITORY` is the
+#: half that cannot be curated around a pattern; these are the shapes that half does not
+#: reach. Both are swept by the same guard.
+REVIEWER_PROSE_SHAPES = SEEDED_PROSE_FROM_THIS_REPOSITORY + (
+    "the request was rejected after a quota problem",
+    "quota exhaustion is handled at the tier below",
+    "the quota tier wins over the generic tier",
+    "check your plan and quota settings in the console",
+    "the quota check exceeded its timeout",
+    "we reached the quota module while reviewing",
+    "this exceeded the line quota for the file",
+    "this change affects the billing details shown to the operator",
+    "the billing account must be topped up before the next run",
+    "the handler returns 401 when the key is dead",
+    "a 403 from the egress gateway means the address is not allowed",
+    "status 403 means forbidden, not unauthorised",
+    "error 401 is fatal here",
+    "http 403 forbidden is returned by the proxy",
+    "the 401 path and the 403 path share a tier",
+)
+
+#: Patterns that still match ordinary prose, named so the exposure cannot hide.
+#:
+#: 🔴 **Filed as KBR-181, not fixed here.** Two of them match this file's own live line
+#: numbers -- it is 16,922 lines long, so "test_review_scripts.py:1308" is a citation a
+#: reviewer of this area really would write. KBR-166 scopes itself to the four patterns
+#: its title names; listing these by name is what stops a sixth being added quietly.
+GRANDFATHERED_PROSE_LEAKS = {
+    r"\b1308\b": "bare code; matches this file's own line 1308 -- KBR-181",
+    r"\b1310\b": "bare code; matches this file's own line 1310 -- KBR-181",
+    r"\b1113\b": "bare code -- KBR-181",
+    r"limit will reset": "ordinary English -- KBR-181",
+    r"exceeded your current": "ordinary English -- KBR-181",
+}
+
+#: Prose that trips a grandfathered pattern, kept so KBR-181 has its evidence to hand.
+GRANDFATHERED_LEAK_EVIDENCE = (
+    "see test_review_scripts.py:1308 for the assertion",
+    "line 1310 of the workflow sets the cap",
+    "row 1113 of the table is the one that matters",
+    "the retry limit will reset after the backoff window",
+    "the budget exceeded your current API_TIMEOUT_MS",
+)
+
+
+def _advice_section(execution_text, status, reason):
+    """Render a diagnostic and return only the part above the record echo.
+
+    The echo reproduces ``execution_text`` verbatim, so a search over the whole body
+    would be satisfied by the fixture's own text rather than by the advice branch.
+
+    Args:
+        execution_text: The execution record to classify and embed.
+        status: The verdict written into the diagnostic header.
+        reason: The reason line written beneath it.
+
+    Returns:
+        Everything above the execution-record echo.
+    """
+
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "diagnostic.txt"
+        interpret._write_diagnostic(
+            str(path),
+            tier="kitty-bridge",
+            status=status,
+            reason=reason,
+            retryable=False,
+            record_present=True,
+            execution_text=execution_text,
+        )
+        body = path.read_text(encoding="utf-8")
+    return body.split("--- execution record (tail) ---")[0]
+
+
+class ModelAuthoredProseTests(unittest.TestCase):
+    """KBR-166. What the MODEL wrote must not decide why the run failed.
+
+    `_outcome_text` includes `result`, and on a record with no structured-output marker
+    that field carries the model's own answer. Four patterns it searched were a bare word
+    or a bare number, so a reviewer that merely *wrote* "quota" changed the verdict on a
+    $1.79 billed rejection -- and `retry_verdict`'s exhausted branch then spent the $1.79
+    again.
+    """
+
+    def test_model_authored_prose_cannot_make_a_billed_rejection_retryable(self):
+        """The headline claim, across both record shapes and all three consequences.
+
+        🔴 **The unparseable shape is not decoration.** `_parse_events` returns None for
+        any record with text prepended or appended -- a shape its own docstring says has
+        been observed -- and a first version of this fix then searched the whole record,
+        `result` included, putting the prose straight back into the haystack.
+        """
+
+        for word in ("quota", "billing", "401", "403"):
+            prose = f"The handler returns a {word} problem when the key is stale."
+            shapes = {
+                "well-formed": billed_rejection("the request was rejected", prose),
+                "unparseable": billed_rejection("the request was rejected", prose)
+                + "\nAPI Error: connection reset",
+            }
+            for shape, record in shapes.items():
+                with self.subTest(word=word, shape=shape):
+                    status, reason = interpret.classify(record)
+
+                    self.assertEqual(status, "fatal", f"{word}/{shape}: verdict")
+                    self.assertIn("invalid_request", reason)
+                    self.assertFalse(
+                        interpret.retry_verdict(
+                            status,
+                            record_present=True,
+                            cause_named=False,
+                            elapsed_seconds=120,
+                        ),
+                        f"{word}/{shape}: a billed rejection was retried",
+                    )
+                    self.assertNotIn(
+                        "Top up the balance",
+                        _advice_section(record, status, reason),
+                        f"{word}/{shape}: advice contradicts the verdict",
+                    )
+
+    def test_the_prose_words_reach_no_provider_tier(self):
+        """Pin *why* the verdict above is `fatal`, not merely that it is.
+
+        Without this, the test above passes for any reason at all -- including a future
+        change that routes the record somewhere else entirely. The haystack is derived
+        through the real scoping functions rather than hand-built, matching
+        :meth:`TierPositionTests.test_the_generic_tier_is_consulted_before_transients`.
+        """
+
+        for word in ("quota", "billing", "401", "403"):
+            with self.subTest(word=word):
+                record = billed_rejection(
+                    "the request was rejected", f"a {word} problem is handled below"
+                )
+                haystack = interpret._outcome_text(record).lower()
+                provider = interpret._provider_outcome_text(record).lower()
+
+                for name, patterns in (
+                    ("QUOTA_PATTERNS", interpret.QUOTA_PATTERNS),
+                    ("CREDENTIAL_PATTERNS", interpret.CREDENTIAL_PATTERNS),
+                ):
+                    self.assertIsNone(
+                        interpret._first_match(patterns, haystack),
+                        f"{name} matched the model's prose",
+                    )
+                for name, patterns in (
+                    ("QUOTA_WORD_PATTERNS", interpret.QUOTA_WORD_PATTERNS),
+                    ("CREDENTIAL_STATUS_PATTERNS", interpret.CREDENTIAL_STATUS_PATTERNS),
+                ):
+                    self.assertIsNone(
+                        interpret._first_match(patterns, provider),
+                        f"{name} saw model-authored text",
+                    )
+
+
+class ProviderScopeTests(unittest.TestCase):
+    """KBR-166. `_provider_outcome_text` needs its OWN fallback contract.
+
+    🔴 Inheriting `_outcome_text`'s was the defect design review caught twice over. That
+    function searches an unparseable record whole, justified as *"a CLI-level failure
+    message with no tool results in it"* -- an argument about `message`/`content`, not
+    about `result`, which does not transfer to the who-wrote-this question.
+    """
+
+    def test_raw_cli_output_is_searched_whole(self):
+        """A record that is not JSON has no `result` field to exclude.
+
+        This is the path `OPENAI_401_MESSAGE_ONLY` depends on: returning "" here would
+        strip its only identifying signal and reopen the defect in the other direction.
+        """
+
+        self.assertIsNone(interpret._parse_events(OPENAI_401_MESSAGE_ONLY))
+        self.assertIn("401", interpret._provider_outcome_text(OPENAI_401_MESSAGE_ONLY))
+
+    def test_an_unreadable_record_claims_nothing(self):
+        """An unparseable record carrying a `result` key yields no provider text.
+
+        Its contents cannot be attributed to a writer, so the honest answer is to claim
+        nothing rather than to guess -- and guessing costs money, because the guess that
+        matters promotes a billed rejection to `exhausted`.
+        """
+
+        broken = (
+            billed_rejection("the request was rejected", "returns 401 when stale")
+            + "\nAPI Error: connection reset"
+        )
+
+        self.assertIsNone(interpret._parse_events(broken))
+        self.assertEqual(interpret._provider_outcome_text(broken), "")
+        self.assertEqual(interpret.classify(broken)[0], "fatal")
+
+    def test_a_result_value_is_not_a_result_key(self):
+        """🔴 The colon in the sentinel, pinned. Code review found nothing pinned it.
+
+        Every CLI result event carries ``"type": "result"``, so a sentinel of
+        ``"result"`` alone matches the string as a VALUE and refuses a record that has no
+        ``result`` field at all. Measured with the colon dropped: this shape -- a
+        truncated record whose only signal is its status code -- classified `fatal`,
+        which is KBR-145's defect and the one this ticket exists to close.
+        """
+
+        broken = (
+            json.dumps(
+                [
+                    {
+                        "type": "result",
+                        "subtype": "error",
+                        "error": {
+                            "type": "invalid_request_error",
+                            "message": "HTTP 401 Unauthorized",
+                        },
+                    }
+                ],
+                indent=2,
+            )
+            + "\nAPI Error: connection reset"
+        )
+
+        self.assertIsNone(interpret._parse_events(broken), "the fixture must be broken")
+        self.assertIn("401", interpret._provider_outcome_text(broken))
+        self.assertEqual(interpret.classify(broken)[0], "exhausted")
+
+    def test_the_scope_splits_by_author_not_by_content(self):
+        """The same string decides differently depending on which field carries it."""
+
+        provider_side = billed_rejection("HTTP 401 Unauthorized")
+        model_side = billed_rejection("the request was rejected", "HTTP 401 Unauthorized")
+
+        self.assertIn("401", interpret._provider_outcome_text(provider_side))
+        self.assertNotIn("401", interpret._provider_outcome_text(model_side))
+        self.assertIn("401", interpret._outcome_text(model_side))
+
+
+class CredentialCarrierTests(unittest.TestCase):
+    """KBR-166. A rejected key must read as a rejected key in EVERY carrier it arrives in.
+
+    🔴 **Three candidate fixes died here, and each died on a different row.** Named
+    vocabulary alone lost `OPENAI_401_MESSAGE_ONLY`; a structural anchor on the CLI's
+    `API Error: NNN {` shape lost both nested rows. Each failure was the same one:
+    `FATAL_UNLESS_PROVIDER_NAMED_PATTERNS` claimed the record and an operator with a dead
+    key was sent to debug a correct workflow -- KBR-145's filed defect, one tier across.
+    """
+
+    CARRIERS = (
+        ("anthropic 401, named type", ANTHROPIC_401_AUTHENTICATION_ERROR),
+        ("anthropic 403, named type", ANTHROPIC_403_PERMISSION_ERROR),
+        ("generic code, CLI prefix", CREDENTIAL_401_WITH_GENERIC_CODE),
+        ("message only, CLI prefix", OPENAI_401_MESSAGE_ONLY),
+        ("status in message, nested", NESTED_401_STATUS_IN_MESSAGE),
+        ("status in message, nested 403", NESTED_403_STATUS_IN_MESSAGE),
+    )
+
+    def test_a_credential_rejection_is_not_a_workflow_fault_in_either_carrier(self):
+        """Every carrier resolves through a credential tier, not the generic one."""
+
+        for label, record in self.CARRIERS:
+            with self.subTest(carrier=label):
+                status, reason = interpret.classify(record)
+
+                self.assertEqual(status, "exhausted", label)
+                self.assertTrue(
+                    reason.startswith("provider rejected the credentials or model"),
+                    f"{label}: resolved by {reason!r}",
+                )
+
+    def test_a_named_type_is_reported_in_preference_to_its_status_code(self):
+        """Tuple order is load-bearing for the reason an operator reads.
+
+        `authentication_error` names a cause; `401` names a number. Both are correct and
+        one is more useful, so the named set is consulted first -- and without this
+        assertion that ordering is untested prose.
+
+        🔴 **Both types, because code review found the 403 half unpinned.** Its row in
+        :data:`CARRIERS` passed through `\b40[13]\b` instead, so deleting
+        `\bpermission_error\b` left the suite green while the pattern did nothing.
+        """
+
+        for named, record in (
+            ("authentication_error", ANTHROPIC_401_AUTHENTICATION_ERROR),
+            ("permission_error", ANTHROPIC_403_PERMISSION_ERROR),
+        ):
+            with self.subTest(type=named):
+                _, reason = interpret.classify(record)
+
+                self.assertIn(named, reason)
+
+    def test_a_named_cause_carries_a_body_that_has_no_number(self):
+        """The reason the named types exist beside the status tier at all.
+
+        A body can name its cause and carry no status code anywhere the classifier can
+        see it, because a numeric ``api_error_status`` never reaches the haystack
+        (KBR-182). Without this fixture that rationale is prose nothing exercises.
+        """
+
+        record = json.dumps(
+            [
+                {
+                    "type": "result",
+                    "subtype": "error",
+                    "api_error_status": 403,
+                    "error": {
+                        "type": "permission_error",
+                        "message": "not permitted to use this resource",
+                    },
+                }
+            ]
+        )
+
+        self.assertNotIn(
+            "403",
+            interpret._outcome_text(record),
+            "the numeric status must stay invisible, or this fixture proves nothing",
+        )
+        status, reason = interpret.classify(record)
+        self.assertEqual(status, "exhausted")
+        self.assertIn("permission_error", reason)
+
+
+class QuotaWordingTests(unittest.TestCase):
+    """KBR-166. Every real way a provider says "your quota is gone" still lands.
+
+    🔴 **Measured against the hostile carrier on purpose.** An anchored quota pattern
+    missed four of these ten, and design review proved the miss was not the cheap kind
+    claimed for it: with the generic code present the run became `fatal` with no retry and
+    no advice, not `exhausted` with a vaguer reason.
+    """
+
+    def test_every_real_quota_wording_still_reaches_the_quota_tier(self):
+        """Status, reason and advice, for all ten wordings."""
+
+        for wording in QUOTA_WORDINGS:
+            with self.subTest(wording=wording):
+                record = quota_rejection(wording)
+                status, reason = interpret.classify(record)
+
+                self.assertEqual(status, "exhausted", wording)
+                self.assertTrue(
+                    reason.startswith("provider quota exhausted"),
+                    f"{wording!r}: resolved by {reason!r}",
+                )
+                self.assertIn(
+                    "Top up the balance",
+                    _advice_section(record, status, reason),
+                    f"{wording!r}: verdict says quota, advice does not",
+                )
+
+    def test_a_documented_billing_error_is_a_spent_balance(self):
+        """Anthropic's 402 -- coverage that did not exist before this ticket.
+
+        `\\bbilling\\b` could never match `billing_error`, because `_` is a word
+        character, so the one documented status meaning "your balance is the problem"
+        reached nothing in the quota set.
+        """
+
+        status, reason = interpret.classify(ANTHROPIC_402_BILLING_ERROR)
+
+        self.assertEqual(status, "exhausted")
+        self.assertIn("billing_error", reason)
+
+
+class ProsePatternGuardTests(unittest.TestCase):
+    """KBR-166. No pattern searched over model-authored text may match ordinary prose.
+
+    Iterates the LIVE tuples, so a bare word added later goes red without anyone
+    remembering this test exists. The two provider-scoped tuples are exempt **by
+    construction** rather than by listing -- they never see model-authored text, which
+    :class:`ProviderScopeTests` asserts directly.
+    """
+
+    def test_no_classifier_pattern_matches_a_reviewers_prose(self):
+        """The guard itself, over both whole-haystack sets."""
+
+        patterns = interpret.QUOTA_PATTERNS + interpret.CREDENTIAL_PATTERNS
+        for pattern in patterns:
+            if pattern in GRANDFATHERED_PROSE_LEAKS:
+                continue
+            for prose in REVIEWER_PROSE_SHAPES:
+                with self.subTest(pattern=pattern, prose=prose):
+                    self.assertIsNone(
+                        re.search(pattern, prose),
+                        f"{pattern!r} matches a sentence a reviewer could write",
+                    )
+
+    def test_the_seeded_prose_really_comes_from_this_repository(self):
+        """🔴 The provenance claim, made checkable so it cannot rot as the last one did.
+
+        An earlier corpus asserted in its docstring that it was seeded from repo text and
+        was entirely author-written. A claim nothing checks is the failure mode this whole
+        module is about, so the claim now reads the files.
+        """
+
+        searched = [REVIEW_DIR / "README.md", *sorted(WORKFLOW_DIR.glob("*.yml"))]
+        corpus = [path.read_text(encoding="utf-8") for path in searched]
+
+        for line in SEEDED_PROSE_FROM_THIS_REPOSITORY:
+            with self.subTest(line=line[:48]):
+                self.assertTrue(
+                    any(line in text for text in corpus),
+                    f"{line!r} is presented as repo text but appears in none of "
+                    f"{[p.name for p in searched]} -- quote a real line or drop it",
+                )
+
+    def test_the_grandfather_list_only_shrinks(self):
+        """Freeze the count so growing it is a deliberate, reviewed act.
+
+        ⚠️ A **review trigger, not an enforcement**. A future author can edit this number;
+        the point is that they cannot do it without editing a line that says it may only
+        go down, and why.
+        """
+
+        self.assertEqual(
+            len(GRANDFATHERED_PROSE_LEAKS),
+            5,
+            "this list may only SHRINK -- KBR-181 removes these; a new pattern that "
+            "matches reviewer prose needs scoping or anchoring, not an entry here",
+        )
+
+    def test_no_grandfathered_pattern_is_retired(self):
+        """Fixing a leak must not leave a phantom entry behind."""
+
+        live = set(interpret.QUOTA_PATTERNS) | set(interpret.CREDENTIAL_PATTERNS)
+        for pattern in GRANDFATHERED_PROSE_LEAKS:
+            with self.subTest(pattern=pattern):
+                self.assertIn(
+                    pattern,
+                    live,
+                    f"{pattern!r} is grandfathered but is no longer a live pattern "
+                    "-- delete the entry",
+                )
+
+    def test_the_grandfathered_leaks_are_real(self):
+        """KBR-181's evidence, kept executable so it cannot rot before it is fixed."""
+
+        for prose in GRANDFATHERED_LEAK_EVIDENCE:
+            with self.subTest(prose=prose):
+                matched = [
+                    pattern
+                    for pattern in GRANDFATHERED_PROSE_LEAKS
+                    if re.search(pattern, prose)
+                ]
+                self.assertTrue(
+                    matched,
+                    f"{prose!r} no longer trips a grandfathered pattern -- if KBR-181 "
+                    "fixed it, delete the entry and this row together",
+                )
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       contents: read
     uses: ./.github/workflows/tests.yml
 
-  # The review system's own suite: 648 tests over the rule selector, the result
+  # The review system's own suite: 664 tests over the rule selector, the result
   # classifier, the failure and superseded notices, the prompt redactor, the
   # findings schema, and the wiring of `claude-code-review.yml` and this file.
   #

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,7 +125,7 @@ target-version = "py310"
 # next carried-across fix would arrive as a conflict. `.github/review/rules/ci.md`
 # records the same rule for anyone reviewing a change there.
 #
-# NOTE: this is not "that code is unchecked". `ci.yml` runs its 648-case suite
+# NOTE: this is not "that code is unchecked". `ci.yml` runs its 664-case suite
 # on every pull request, and that suite carries guards this linter could not
 # express - the private-reference sweep, the runner-ceiling pairing, the
 # aggregate's dependency set.


### PR DESCRIPTION
Closes [KBR-166](https://shelpuk.atlassian.net/browse/KBR-166).

## Context for the Product Owner

Every pull request here is reviewed automatically by an AI reviewer. When that review fails, a small classifier reads the failure record and decides two things: **who has to fix it** — "top up the account" versus "fix the workflow" — and **whether to automatically try again**.

It decided by searching the failure record for tell-tale words. The problem: part of that record is **text the AI reviewer wrote itself**. Four of the search terms were ordinary English words and bare numbers — `quota`, `billing`, `401`, `403`. So a reviewer that merely *wrote the word "quota"* in its own answer changed the verdict on why the run failed.

**That costs real money.** One failure we have on record burned **$1.79 across 24 turns** before dying. Misclassified, it is retried automatically — so we pay the $1.79 a second time for a run that cannot succeed. On two of the four words the operator was also handed contradictory instructions: a headline saying the workflow is broken, and a paragraph underneath telling them to top up a balance that was never spent.

**What changes for the product:** failures now name the right cause, money is not spent twice, and the "top up the balance" instruction appears exactly when it is true. As a side effect the classifier recognises **three provider errors it could not see before**, including Anthropic's documented "your credit balance is too low".

---

## The defect, measured on `main`

`classify` searches `_outcome_text`, which on a record with no structured-output marker includes `result` — the model's own answer. Four patterns it searched were a bare word or a bare number. Measured on the observed `BILLED_INVALID_REQUEST` record with one prose word changed:

| prose word | status | retried | top-up advice |
| --- | --- | --- | --- |
| *(none)* | `fatal` ✅ | no ✅ | no ✅ |
| *"timeout"* | `fatal` ✅ | no ✅ | no ✅ |
| **"quota"** | **`exhausted` ❌** | **yes ❌** | **yes ❌** |
| **"billing"** | **`exhausted` ❌** | **yes ❌** | **yes ❌** |
| **"401"** | **`exhausted` ❌** | **yes ❌** | no ✅ |
| **"403"** | **`exhausted` ❌** | **yes ❌** | no ✅ |

This supersedes both the ticket's table and its correction comment, which were measured before KBR-145 landed.

## Not by anchoring — three attempts are why

The obvious fix is to anchor the four patterns on the vocabulary they were written for. **That was tried three times and each version lost a real body:**

| attempt | what it broke |
| --- | --- |
| named vendor vocabulary only | a CLI 401 whose message is merely `Incorrect API key provided` → `fatal` |
| + structural `\b40[13]\b\s*\{` | the nested carrier `error.message = "HTTP 401 Unauthorized"` → `fatal` |
| + anchored quota word | 4 of 10 real quota wordings → `fatal` when the body carries the generic code |

Every one is **KBR-145's filed defect one tier across**: once a provider-naming tier stops answering, `FATAL_UNLESS_PROVIDER_NAMED_PATTERNS` claims the record and an operator with a dead key or a spent balance is sent to debug a correct workflow. It reproduces, three more times, what KBR-172 recorded for the eight bare status codes: *no anchor matches every real body while leaking no prose.*

## The mechanism: not what the text says, but who wrote it

`_outcome_text` already answers that. KBR-172 built the split — `provider_parts` versus `model_parts` — and applies it **conditionally**. This change applies the same split **unconditionally**, to the weak patterns only:

* `QUOTA_WORD_PATTERNS` = (`quota`, `\bbilling\b`)
* `CREDENTIAL_STATUS_PATTERNS` = (`\b40[13]\b`)

both searched over a new `_provider_outcome_text` and consulted immediately after their anchored counterparts — the tier position the moved patterns already held. **Nothing is deleted and no pattern is rewritten.**

Three anchored patterns are added, each closing a body that names a cause but carries no number (reachable because of KBR-182): `billing_error`, `\bauthentication_error\b`, `\bpermission_error\b`, all from Anthropic's published error reference.

### `_provider_outcome_text` has its own fallback contract

Inheriting `_outcome_text`'s is wrong in **both** directions, and this is the subtle part:

* Searching an unparseable record whole is justified there as *"a CLI-level failure message with no tool results in it"* — an argument about `message`/`content`, not `result`. Measured: a pretty-printed array with one line appended fails `_parse_events`, and the whole text including `result` then reached the status tier.
* Returning `""` is equally wrong: the CLI-prefix carrier is **also** unparseable and is the only path by which a 401 with no credential vocabulary is recognised at all.

So the two cases are split by the fact that distinguishes them — raw CLI output has no `result` **key**, a broken record does. The `\s*:` is load-bearing: every result event carries `"type": "result"` as a *value*.

## Verification

* **664 tests pass** (648 → 664), under both `pytest` and CI's own `python …` invocation.
* **13 of 13 falsification mutants killed.** Every part of the fix was broken in turn and every break was caught. Two mutants survived the first sweep — the missing `\s*:` coverage and an unpinned `\bpermission_error\b` — both found by code review and now pinned.
* All ten real quota wordings classify **in the hostile carrier** with their advice; none regresses.
* Six credential carriers classify, two of which did not before.
* Verdict-and-advice agreement swept over 138 generated records: 0 violations.

`ruff` deliberately excludes `.github/` (`exclude = [".github"]`) because that tree is carried byte-for-byte from another repository; no reformatting was done there. The 648 → 664 bump in three documents is required by the existing `test_every_document_quotes_the_real_count` guard.

## Filed while measuring, deliberately not fixed here

Per the standing policy in `.system_design/TEST_SUITE.md`:

* **[KBR-181](https://shelpuk.atlassian.net/browse/KBR-181)** — five more quota patterns leak the same way, two of them matching **this test file's own live line numbers** (it is 16,900+ lines, so `test_review_scripts.py:1308` is a citation a reviewer really would write). Grandfathered by name in a frozen guard so a sixth cannot be added quietly.
* **[KBR-182](https://shelpuk.atlassian.net/browse/KBR-182)** — `api_error_status` is listed as an outcome field and never read, because JSON sends status codes as numbers and `_strings_in` collects strings only.

## Residual exposure, stated rather than hidden

1. A **provider** writing `quota`/`401` as prose in its own error message still reads as that signal. This module can say who wrote a field; it cannot say whether a provider meant its own word. A product-owner decision, taken on measured costs.
2. A review that quotes a **verbatim provider body** still matches it — irreducible and pre-existing, shared by `insufficient balance` and `authentication_failed`.
3. An unparseable record carrying a `result` key gets no provider-scoped match and is `fatal` with no retry. Deliberate: it spends nothing on a record that cannot be read.
4. `EXHAUSTED_PATTERNS` keeps its bare words on purpose — that tier sits *below* the generic one, so a prose word there cannot promote a billed rejection. Recorded in the module so it cannot read as an oversight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HdkFBQQRUhxJaL2Sj1Ep4t


[KBR-166]: https://shelpuk.atlassian.net/browse/KBR-166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KBR-181]: https://shelpuk.atlassian.net/browse/KBR-181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ