### PR TITLE
Exempt the provider recorder's Windows arrival cell (KBR-188)

### DIFF
--- a/.system_design/TEST_SUITE.md
+++ b/.system_design/TEST_SUITE.md
@@ -3302,8 +3302,8 @@ guessing which set it joins.)
   `tests/bridge/test_crash_resilience.py` rather than inventing a second one. The whole module
   runs in **~0.6 seconds**, measured, of which the socket-binding cases are ~0.1.
 
-**One cross-cutting cost, added by KBR-188's fix.** Every conformance probe now ends by waiting
-for the clock to report a new instant (§8.3). Measured at **79 calls** across the harness suite:
+**One cross-cutting cost, added by KBR-188's fix.** Every conformance probe now begins by waiting
+for the clock to report a new instant (§8.3). Measured at **80 calls** across the harness suite:
 immeasurable on Linux and macOS, where the clock resolves in nanoseconds and the first look
 returns, and a worst case of **~1.2 s** on the Windows leg, whose step is ~15.6 ms. It scales with
 the number of raw-socket probes, so a future recorder adds to it in proportion to the probes it
@@ -3484,15 +3484,34 @@ assertion that is deterministically false on the exempt platform.** Over a racin
 a flaky assertion into a job that is red either way. A nondeterministic platform difference has to
 be removed, not exempted.
 
-Removed here by `recorder_conformance._advance_clock()`, which stands two probes apart by waiting
-— on a **condition**, that the clock has reported a new instant, never on a fixed sleep. It lives
-in the shared driver, so §7.2's four recorders inherit it rather than each carrying a row, and it
-costs nothing measurable where the clock is fine: 79 calls across the harness suite, a worst case
-of ~1.2 s on Windows and immeasurable on Linux and macOS. Its own bound is a **poll count, not a
-deadline**, because a deadline is computed from a clock and the case it exists for is a clock that
-has stopped — the frozen-clock defect `check_arrival_increases` is there to catch, and the first
-draft of the function hung the suite on it. `test_recorder.py` pins the whole property against a
-**simulated** coarse clock, so it is proven on every leg rather than only observed on Windows.
+Removed here by `recorder_conformance._advance_clock()`, which stands a probe apart from whatever
+arrived before it by waiting — on a **condition**, that the clock has reported a new instant,
+never on a fixed sleep. It lives in the shared driver, so §7.2's four recorders inherit it rather
+than each carrying a row, and it costs nothing measurable where the clock is fine: 80 calls across
+the harness suite, a worst case of ~1.2 s on Windows and immeasurable on Linux and macOS. Its own
+bound is a **poll count, not a deadline**, because a deadline is computed from a clock and the case
+it exists for is a clock that has stopped — the frozen-clock defect `check_arrival_increases` is
+there to catch, and the first draft of the function hung the suite on it. The case that pins that
+bound counts polls for the same reason: an earlier version asserted elapsed *wall time* and went
+red on the macOS leg, where `time.sleep(0.001)` takes about eleven milliseconds. Sleep accuracy is
+the platform's business; the count is the only part the driver promises.
+
+**The wait goes before the probe, not after it, and the first fix got that wrong.** Waiting after
+the reply separates a probe from the driver's own previous probe and from nothing else — so a
+probe following a request the driver did **not** send still shares that request's instant. §6.3's
+slow-body pair is exactly that shape: it hand-rolls its first request on a raw socket so that
+arrival order and completion order differ, and the driven probe behind it collided anyway. The
+Windows leg stayed red. Waiting at the *start* of `send_raw` is the general form — every probe is
+separated from everything before it, however the earlier request was produced.
+
+**A clock quantised from real time could not have caught that**, which is the sharper lesson. It
+reproduces the platform but keeps the race: whether a given pair collides still depends on how
+fast the runner is, so a case built on it passes against the defect most of the time. Measured:
+the slow-body pair collided in four runs out of eight at a 50 ms quantum. `test_recorder.py`
+therefore pins the *placement* against a clock that moves **only when something sleeps on it** —
+no real time passes and every run agrees. That clock is sound only away from the event loop, which
+reads `time.monotonic` for its own timers, so the end-to-end cases keep the quantised clock and
+the placement case, which never opens a loop, uses the stepped one.
 
 Only KBR-189's row survives, over a different defect: a mid-stream abort that wins its race
 against the first chunk. That one is deterministic on Windows.

--- a/.system_design/TEST_SUITE.md
+++ b/.system_design/TEST_SUITE.md
@@ -3302,6 +3302,13 @@ guessing which set it joins.)
   `tests/bridge/test_crash_resilience.py` rather than inventing a second one. The whole module
   runs in **~0.6 seconds**, measured, of which the socket-binding cases are ~0.1.
 
+**One cross-cutting cost, added by KBR-188's fix.** Every conformance probe now ends by waiting
+for the clock to report a new instant (§8.3). Measured at **79 calls** across the harness suite:
+immeasurable on Linux and macOS, where the clock resolves in nanoseconds and the first look
+returns, and a worst case of **~1.2 s** on the Windows leg, whose step is ~15.6 ms. It scales with
+the number of raw-socket probes, so a future recorder adds to it in proportion to the probes it
+drives, not to its test count.
+
 KBR-10 added the largest one: `tests/cli/test_stream_encoding.py` spawns **35 child interpreters**
 per run, ×4 Python versions. It has no choice — the behaviour it proves is that kitty survives a
 hostile *interpreter start-up encoding*, and `PYTHONIOENCODING` is read before any in-process test
@@ -3462,6 +3469,33 @@ registry row for an assertion no test contains documents a fiction — so it is 
 What arrived first instead were the **Windows cells** of five assertions that the platform legs
 (§8.4) found to be false on Windows and true everywhere else: four over KBR-188 and one over
 KBR-189.
+
+**Four of those five are gone again, and why they could not have worked is the lesson.** KBR-188
+was one defect — Windows' `time.monotonic` advances in ~15.6 ms steps, so two probes sent back to
+back are stamped at the same instant and `check_arrival_increases` is false. Its four rows
+exempted the assertions that observed it. But **whether a given pair collides is a race**, not a
+platform property: a pair that straddles a step boundary is stamped at two instants and the
+assertion *passes*. An exemption fails on an unexpected pass — deliberately, so debt cannot
+outlive its defect — so the leg went red in **both** directions on alternate runs. Measured on
+2026-09-12: one run failed `check_arrival_increases`, the next failed the exemption for passing.
+
+The rule that follows, and it generalises past this defect: **an exemption is only sound over an
+assertion that is deterministically false on the exempt platform.** Over a racing one it converts
+a flaky assertion into a job that is red either way. A nondeterministic platform difference has to
+be removed, not exempted.
+
+Removed here by `recorder_conformance._advance_clock()`, which stands two probes apart by waiting
+— on a **condition**, that the clock has reported a new instant, never on a fixed sleep. It lives
+in the shared driver, so §7.2's four recorders inherit it rather than each carrying a row, and it
+costs nothing measurable where the clock is fine: 79 calls across the harness suite, a worst case
+of ~1.2 s on Windows and immeasurable on Linux and macOS. Its own bound is a **poll count, not a
+deadline**, because a deadline is computed from a clock and the case it exists for is a clock that
+has stopped — the frozen-clock defect `check_arrival_increases` is there to catch, and the first
+draft of the function hung the suite on it. `test_recorder.py` pins the whole property against a
+**simulated** coarse clock, so it is proven on every leg rather than only observed on Windows.
+
+Only KBR-189's row survives, over a different defect: a mid-stream abort that wins its race
+against the first chunk. That one is deterministic on Windows.
 
 They are the parametrised-cell shape above rather than whole-test exemptions, and the reason is
 the rule this section opens with. A `skipif` would have been the obvious move and is the wrong

--- a/tests/exemptions.py
+++ b/tests/exemptions.py
@@ -123,6 +123,15 @@ EXEMPTIONS: Mapping[str, Exemption] = MappingProxyType(
             "requests, so two sends share one timestamp and strict increase fails",
             issue="KBR-188",
         ),
+        "provider-recorder-arrival-increases-per-session": Exemption(
+            assertion="request arrival times increase across a session recorded by the "
+            "provider-session recorder",
+            condition="on Windows the clock is too coarse to separate two adjacent "
+            "requests, so two sends share one timestamp and strict increase fails. The "
+            "same defect as the row above, at a second site: T-B1's recorder is judged by "
+            "the same conformance checks, and it landed after KBR-164 measured them",
+            issue="KBR-188",
+        ),
         "recorder-arrival-increases-across-requests": Exemption(
             assertion="arrival moves forward from one request to the next",
             condition="on Windows the clock is too coarse to separate two sequential "

--- a/tests/exemptions.py
+++ b/tests/exemptions.py
@@ -117,45 +117,6 @@ class Exemption:
 #: ticket, not a platform difference.
 EXEMPTIONS: Mapping[str, Exemption] = MappingProxyType(
     {
-        "recorder-arrival-increases-per-session": Exemption(
-            assertion="request arrival times increase across a recorded session",
-            condition="on Windows the clock is too coarse to separate two adjacent "
-            "requests, so two sends share one timestamp and strict increase fails",
-            issue="KBR-188",
-        ),
-        "provider-recorder-arrival-increases-per-session": Exemption(
-            assertion="request arrival times increase across a session recorded by the "
-            "provider-session recorder",
-            condition="on Windows the clock is too coarse to separate two adjacent "
-            "requests, so two sends share one timestamp and strict increase fails. The "
-            "same defect as the row above, at a second site: T-B1's recorder is judged by "
-            "the same conformance checks, and it landed after KBR-164 measured them",
-            issue="KBR-188",
-        ),
-        "recorder-arrival-increases-across-requests": Exemption(
-            assertion="arrival moves forward from one request to the next",
-            condition="on Windows the clock is too coarse to separate two sequential "
-            "requests, so both are stamped with the same instant",
-            issue="KBR-188",
-        ),
-        "recorder-falsification-reordering-only-order-check": Exemption(
-            assertion="a reordering recorder is rejected by the order check alone",
-            condition="on Windows the coarse clock also trips check_arrival_increases, "
-            "so a second check fires and the defect is caught by two, not one",
-            issue="KBR-188",
-        ),
-        "recorder-falsification-miscount-only-connection-check": Exemption(
-            assertion="a miscounting connection log is rejected by the connection check alone",
-            condition="on Windows the coarse clock also trips check_arrival_increases, "
-            "so a second check fires and the defect is caught by two, not one",
-            issue="KBR-188",
-        ),
-        "recorder-falsification-probe-passes-real-recorder": Exemption(
-            assertion="the falsification probe passes cleanly against the real recorder",
-            condition="on Windows the coarse clock trips check_arrival_increases against "
-            "a recorder that has no defect at all",
-            issue="KBR-188",
-        ),
         "recorder-responder-abort-emits-before-dropping": Exemption(
             assertion="a responder that aborts mid-stream still delivers a data frame first",
             condition="on Windows the abort wins the race against the first chunk, so the "

--- a/tests/harness/recorder_conformance.py
+++ b/tests/harness/recorder_conformance.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 import asyncio
 import socket
 import ssl
+import time
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 from typing import Any
@@ -79,6 +80,20 @@ __all__ = [
 #: fast and loudly: these tests run in the `l1` gate, where a socket that never
 #: answers would otherwise stall the job rather than fail it.
 PROBE_TIMEOUT = 5.0
+
+#: How long :func:`_advance_clock` will wait for the clock to report a new
+#: instant, expressed as a **number of polls** rather than a deadline. Windows'
+#: ``time.monotonic`` advances in ~15.6 ms steps, so 100 polls of a millisecond
+#: is several ticks of headroom.
+#:
+#: Counted rather than timed on purpose: a deadline has to be computed from a
+#: clock, and the case this budget exists for is a clock that has **stopped** —
+#: under which ``now < deadline`` stays true forever and the bound never fires.
+#: That is not hypothetical. The first draft of this function bounded itself with
+#: ``time.monotonic()`` and hung the suite on the frozen-clock case
+#: :func:`check_arrival_increases` exists to catch.
+_CLOCK_TICK_POLLS = 100
+_CLOCK_TICK_POLL = 0.001
 
 #: The header every probe request carries its correlation marker in. See
 #: :func:`marker_of` for why it must be a header and nothing else.
@@ -244,7 +259,46 @@ def send_raw(
     finally:
         sock.close()
 
+    # Leave the clock strictly past this request's arrival stamp, so the next
+    # probe cannot share it. See :func:`_advance_clock`.
+    _advance_clock()
+
     return _parse_sent(raw, source_port, marker)
+
+
+def _advance_clock() -> None:
+    """Block until ``time.monotonic()`` reports an instant later than now.
+
+    **Why the driver owns this.** :func:`check_arrival_increases` asserts that
+    arrival stamps *strictly* increase across a recorded session. That is a claim
+    about the recorder, but whether it can be true at all depends on the
+    platform's clock: ``time.monotonic()`` resolves to ~15.6 ms on Windows and to
+    nanoseconds on Linux and macOS, so two probes sent back to back are stamped
+    at the same instant on one platform and at different instants on the others.
+    Measured on CI: the same assertion failed on Windows in one run and passed in
+    the next, and KBR-188's exemptions — which fail when the assertion
+    *unexpectedly passes* — made the leg red in both directions.
+
+    Separating the probes is therefore the driver's job, not each test's, and not
+    an exemption's. It is done here, once, so every recorder and every check
+    inherits it: §7.2's four recorders are judged by one driver.
+
+    **A condition, never a fixed sleep.** It returns as soon as the clock has
+    moved, which on Linux and macOS is the first look and costs nothing
+    measurable. The rule the repo states about waiting is exactly this: wait on a
+    condition with a timeout.
+
+    On a clock that never advances it gives up after :data:`_CLOCK_TICK_POLLS`
+    looks and returns rather than raising. A stopped clock is the *constant
+    clock* defect :func:`check_arrival_increases` exists to catch, so the honest
+    outcome is to let that check fail — not to hang the gate, and not to report
+    the driver's own impatience as a recorder defect.
+    """
+    started = time.monotonic()
+    for _ in range(_CLOCK_TICK_POLLS):
+        if time.monotonic() != started:
+            return
+        time.sleep(_CLOCK_TICK_POLL)
 
 
 async def send(

--- a/tests/harness/recorder_conformance.py
+++ b/tests/harness/recorder_conformance.py
@@ -244,6 +244,11 @@ def send_raw(
     Returns:
         The :class:`SentRequest`, carrying the socket's own source port.
     """
+    # Stand this probe apart from whatever arrived before it, and do it *before*
+    # the request can reach the recorder: the earlier arrival may have been
+    # produced by hand rather than by this driver. See :func:`_advance_clock`.
+    _advance_clock()
+
     sock = socket.create_connection((host, port), timeout=PROBE_TIMEOUT)
     try:
         if ssl_context is not None:
@@ -258,10 +263,6 @@ def send_raw(
         _drain(sock)
     finally:
         sock.close()
-
-    # Leave the clock strictly past this request's arrival stamp, so the next
-    # probe cannot share it. See :func:`_advance_clock`.
-    _advance_clock()
 
     return _parse_sent(raw, source_port, marker)
 
@@ -282,6 +283,13 @@ def _advance_clock() -> None:
     Separating the probes is therefore the driver's job, not each test's, and not
     an exemption's. It is done here, once, so every recorder and every check
     inherits it: §7.2's four recorders are judged by one driver.
+
+    **Called before the exchange, not after it.** Waiting at the end of
+    :func:`send_raw` would separate a probe only from the driver's own previous
+    probe, leaving one that follows a hand-rolled request — §6.3's slow-body
+    pair sends its first request on a raw socket — sharing that request's
+    instant. Waiting at the start separates every probe from everything before
+    it, whoever sent it.
 
     **A condition, never a fixed sleep.** It returns as soon as the clock has
     moved, which on Linux and macOS is the first look and costs nothing

--- a/tests/harness/test_provider_aiohttp.py
+++ b/tests/harness/test_provider_aiohttp.py
@@ -24,15 +24,12 @@ remove them from every gate.
 from __future__ import annotations
 
 import json
-import sys
 import time
-from contextlib import nullcontext
 from dataclasses import dataclass, field, replace
 from pathlib import Path
 
 import aiohttp
 import pytest
-from exemptions import ratchet
 
 import harness.provider_recorder as provider_recorder_module
 from harness.bridge import (
@@ -160,13 +157,7 @@ class TestTheRecorderPassesEveryConformanceCheck:
             await send(recorder.host, recorder.port, probe(name, path=OLLAMA_CHAT_SUFFIX), marker=name)
             for name in ("first", "second")
         ]
-        # KBR-188: exempt the WINDOWS CELL only -- this assertion gates normally
-        # on the Linux and macOS legs, and fails the job the day Windows starts
-        # passing. §8.3's parametrised-cell shape, as `test_recorder.py` does for
-        # the same check against the primary recorder.
-        exempt = sys.platform == "win32" and check.__name__ == "check_arrival_increases"
-        with ratchet("provider-recorder-arrival-increases-per-session") if exempt else nullcontext():
-            check(recording_of(recorder), sent, [s.source_port for s in sent])
+        check(recording_of(recorder), sent, [s.source_port for s in sent])
 
 
 class TestTheRepliesItSends:

--- a/tests/harness/test_provider_aiohttp.py
+++ b/tests/harness/test_provider_aiohttp.py
@@ -24,12 +24,15 @@ remove them from every gate.
 from __future__ import annotations
 
 import json
+import sys
 import time
+from contextlib import nullcontext
 from dataclasses import dataclass, field, replace
 from pathlib import Path
 
 import aiohttp
 import pytest
+from exemptions import ratchet
 
 import harness.provider_recorder as provider_recorder_module
 from harness.bridge import (
@@ -157,7 +160,13 @@ class TestTheRecorderPassesEveryConformanceCheck:
             await send(recorder.host, recorder.port, probe(name, path=OLLAMA_CHAT_SUFFIX), marker=name)
             for name in ("first", "second")
         ]
-        check(recording_of(recorder), sent, [s.source_port for s in sent])
+        # KBR-188: exempt the WINDOWS CELL only -- this assertion gates normally
+        # on the Linux and macOS legs, and fails the job the day Windows starts
+        # passing. §8.3's parametrised-cell shape, as `test_recorder.py` does for
+        # the same check against the primary recorder.
+        exempt = sys.platform == "win32" and check.__name__ == "check_arrival_increases"
+        with ratchet("provider-recorder-arrival-increases-per-session") if exempt else nullcontext():
+            check(recording_of(recorder), sent, [s.source_port for s in sent])
 
 
 class TestTheRepliesItSends:

--- a/tests/harness/test_recorder.py
+++ b/tests/harness/test_recorder.py
@@ -22,6 +22,7 @@ import gzip
 import json
 import socket
 import sys
+import time
 from collections.abc import Callable
 from contextlib import nullcontext
 from pathlib import Path
@@ -45,6 +46,7 @@ from harness.recorder_conformance import (
     PER_EXCHANGE_CHECKS,
     PER_SESSION_CHECKS,
     RICH_PROBE,
+    check_arrival_increases,
     check_connection_logged,
     correlate,
     probe,
@@ -87,6 +89,113 @@ _SETTLE_STEP = 0.005
 _REPLY_TIMEOUT = 5.0
 
 
+#: A clock step far coarser than a probe pair takes, so two back-to-back probes
+#: land in one bucket unless something waits. Windows' real step is ~15.6 ms and
+#: a probe pair is a couple of milliseconds, which is the same relationship; this
+#: widens the gap so the property is exercised rather than raced for. It must
+#: stay inside the driver's poll budget, or it would rightly give up waiting.
+_COARSE_CLOCK_STEP = 0.05
+
+
+class TestTheDriverSeparatesProbesOnACoarseClock:
+    """KBR-188 — the Windows failure, reproduced on every platform.
+
+    ``check_arrival_increases`` asserts arrival stamps *strictly* increase. Two
+    probes sent back to back are separated by far less than Windows'
+    ~15.6 ms clock step, so the recorder stamps both at the same instant there
+    and the assertion is false — while on Linux and macOS, which resolve to
+    nanoseconds, it is true. KBR-164 met that as a red leg and KBR-188 exempted
+    the cells; but an exemption fails when its assertion *passes*, and whether a
+    given pair collides is a race, so the leg went red in **both** directions on
+    alternate runs (measured on CI, 2026-09-12: one run failed the assertion,
+    the next failed the exemption for passing).
+
+    :func:`~harness.recorder_conformance._advance_clock` moves the fix into the
+    driver, where §7.2's four recorders share it. These cases pin it against a
+    **simulated** coarse clock, so the property is proven on the platform this
+    suite actually runs on rather than only by watching a Windows leg go green.
+    """
+
+    @staticmethod
+    def _coarse(monkeypatch: pytest.MonkeyPatch, step: float) -> None:
+        """Quantise ``time.monotonic`` to ``step``, process-wide.
+
+        Patching the stdlib module object is what makes this faithful: the
+        recorder stamps arrivals with the same clock the driver waits on, which
+        is exactly the situation on Windows.
+
+        Args:
+            monkeypatch: Reverts the patch, which is what contains a change this
+                broad.
+            step: The quantum. Zero freezes the clock outright.
+        """
+        real = time.monotonic
+        origin = real()
+
+        def quantised() -> float:
+            """Return the current instant, floored to ``step``.
+
+            Returns:
+                A non-decreasing time that changes only once per step.
+            """
+            if not step:
+                return origin
+            return (real() // step) * step
+
+        monkeypatch.setattr(time, "monotonic", quantised)
+
+    def test_it_waits_until_the_clock_reports_a_new_instant(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The guarantee the whole fix rests on, asserted directly.
+
+        Args:
+            monkeypatch: Installs the coarse clock.
+        """
+        self._coarse(monkeypatch, _COARSE_CLOCK_STEP)
+        before = time.monotonic()
+
+        conformance_module._advance_clock()
+
+        assert time.monotonic() > before
+
+    def test_a_stopped_clock_bounds_the_wait_instead_of_hanging(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A clock that never moves is a defect to report, not a reason to hang.
+
+        ``check_arrival_increases`` is the check that catches a constant clock,
+        and it can only do so if the driver returns and lets it run.
+
+        Args:
+            monkeypatch: Freezes the clock outright.
+        """
+        real = time.monotonic
+        self._coarse(monkeypatch, 0)
+        started = real()
+
+        conformance_module._advance_clock()
+
+        budget = conformance_module._CLOCK_TICK_POLLS * conformance_module._CLOCK_TICK_POLL
+        assert real() - started < budget * 5
+
+    async def test_two_probes_are_stamped_at_different_instants(
+        self, recorder: RecordingUpstream, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The end-to-end claim, on a clock too coarse to give it away.
+
+        Delete the wait and this fails: a probe pair takes a couple of
+        milliseconds against a 50 ms quantum, so the two share a bucket unless
+        the driver stands them apart. The two cases above are what pin the wait
+        deterministically; this is what proves it reaches the recorder's stamps.
+
+        Args:
+            recorder: The running recorder.
+            monkeypatch: Installs the coarse clock.
+        """
+        self._coarse(monkeypatch, _COARSE_CLOCK_STEP)
+
+        sent = [await send(recorder.host, recorder.port, probe(m), marker=m) for m in ("first", "second")]
+
+        check_arrival_increases(recording_of(recorder), sent, [s.source_port for s in sent])
+
+
 class TestTheRecorderPassesEveryConformanceCheck:
     """R3.3 — the primary recorder satisfies the contract Epic B inherits."""
 
@@ -114,12 +223,7 @@ class TestTheRecorderPassesEveryConformanceCheck:
             await send(recorder.host, recorder.port, probe(marker), marker=marker)
             for marker in ("first", "second")
         ]
-        # KBR-188/189: exempt the WINDOWS CELL only -- this assertion gates
-        # normally on the Linux and macOS legs, and fails the job the day
-        # Windows starts passing. §8.3's parametrised-cell shape.
-        exempt = sys.platform == "win32" and check.__name__ == "check_arrival_increases"
-        with ratchet("recorder-arrival-increases-per-session") if exempt else nullcontext():
-            check(recording_of(recorder), sent, [s.source_port for s in sent])
+        check(recording_of(recorder), sent, [s.source_port for s in sent])
 
 
 class TestCaptureFidelity:
@@ -311,12 +415,7 @@ class TestCaptureFidelity:
         first, second = recorder.requests
         assert first.arrival is not None and second.arrival is not None
 
-        # KBR-188: the Windows cell only. Gates normally on the four Linux legs
-        # and on macOS, and fails the job the day Windows starts passing. The
-        # block holds this one assertion and nothing else, per §8.3.
-        exempt = sys.platform == "win32"
-        with ratchet("recorder-arrival-increases-across-requests") if exempt else nullcontext():
-            assert second.arrival > first.arrival
+        assert second.arrival > first.arrival
 
     async def test_a_request_that_never_completes_is_not_published(
         self, recorder: RecordingUpstream

--- a/tests/harness/test_recorder.py
+++ b/tests/harness/test_recorder.py
@@ -96,6 +96,15 @@ _REPLY_TIMEOUT = 5.0
 #: stay inside the driver's poll budget, or it would rightly give up waiting.
 _COARSE_CLOCK_STEP = 0.05
 
+#: Windows' real ``time.monotonic`` step, used by the *stepped* clock below
+#: rather than by the quantised one -- there the value only has to be visible,
+#: here it stands for the platform being modelled.
+_STEPPING_CLOCK_STEP = 0.0156
+
+
+class _ReachedTheSocket(Exception):
+    """Stop a probe at the socket boundary, where the placement case reads it."""
+
 
 class TestTheDriverSeparatesProbesOnACoarseClock:
     """KBR-188 — the Windows failure, reproduced on every platform.
@@ -144,6 +153,46 @@ class TestTheDriverSeparatesProbesOnACoarseClock:
 
         monkeypatch.setattr(time, "monotonic", quantised)
 
+    @staticmethod
+    def _stepping(monkeypatch: pytest.MonkeyPatch) -> None:
+        """Install a clock that moves only when something sleeps on it.
+
+        :meth:`_coarse` quantises *real* time, which leaves a collision a race:
+        a pair that straddles a step boundary does not collide, so a case built
+        on it can pass against the very defect it exists to catch. That is not
+        hypothetical -- it is how the placement defect below survived its first
+        fix. Here nothing but ``time.sleep`` moves the clock, so the claim is
+        settled by the code rather than by how fast the runner happened to be.
+
+        Sound only because the case using it never touches the event loop:
+        asyncio reads ``time.monotonic`` for its own timers, and a clock real
+        time cannot move would stall them.
+
+        Args:
+            monkeypatch: Reverts both patches.
+        """
+        now = 1000.0
+
+        def stepped() -> float:
+            """Return the current instant.
+
+            Returns:
+                The clock, which only :func:`slept` advances.
+            """
+            return now
+
+        def slept(_seconds: float) -> None:
+            """Advance the clock one step instead of waiting.
+
+            Args:
+                _seconds: The requested delay, unused; no real time passes.
+            """
+            nonlocal now
+            now += _STEPPING_CLOCK_STEP
+
+        monkeypatch.setattr(time, "monotonic", stepped)
+        monkeypatch.setattr(time, "sleep", slept)
+
     def test_it_waits_until_the_clock_reports_a_new_instant(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """The guarantee the whole fix rests on, asserted directly.
 
@@ -163,17 +212,80 @@ class TestTheDriverSeparatesProbesOnACoarseClock:
         ``check_arrival_increases`` is the check that catches a constant clock,
         and it can only do so if the driver returns and lets it run.
 
+        The bound is a poll count, so this counts polls. An earlier draft
+        asserted elapsed wall time instead and went red on the macOS leg, where
+        ``time.sleep(0.001)`` takes about eleven milliseconds: sleep accuracy is
+        the platform's business, and the count is the only part the driver
+        promises. Counting also turns the regression it guards against -- a
+        deadline computed from a clock that has stopped -- from a hung job into
+        a failed assertion.
+
         Args:
-            monkeypatch: Freezes the clock outright.
+            monkeypatch: Freezes the clock outright and counts the polls.
         """
-        real = time.monotonic
         self._coarse(monkeypatch, 0)
-        started = real()
+        polls = 0
+
+        def counted(_seconds: float) -> None:
+            """Count one poll, failing rather than hanging if the bound is gone.
+
+            Args:
+                _seconds: The requested delay, unused; no real time need pass
+                    for a clock that is frozen anyway.
+            """
+            nonlocal polls
+            polls += 1
+            assert polls <= conformance_module._CLOCK_TICK_POLLS, "the wait is unbounded"
+
+        monkeypatch.setattr(time, "sleep", counted)
 
         conformance_module._advance_clock()
 
-        budget = conformance_module._CLOCK_TICK_POLLS * conformance_module._CLOCK_TICK_POLL
-        assert real() - started < budget * 5
+        assert polls == conformance_module._CLOCK_TICK_POLLS
+
+    def test_the_clock_is_advanced_before_the_request_is_sent(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The wait has to precede the exchange, not follow it.
+
+        Waiting *after* the reply stands a probe apart from the driver's own
+        previous probe and from nothing else. A probe that follows a request the
+        driver did not send still shares that request's instant -- and that is
+        how the Windows leg stayed red after the first fix: §6.3's slow-body
+        pair hand-rolls its first request on a raw socket, so nothing separated
+        it from the driven probe that follows. Measured before the move, at a
+        50 ms quantum: the pair collided in four runs out of eight.
+
+        Read at the socket rather than at the recorder, because the connection
+        is opened before any arrival can be stamped -- if the clock has already
+        moved by then, no arrival of this probe can reuse an earlier instant.
+
+        Args:
+            monkeypatch: Installs the stepped clock and the stub connector.
+        """
+        reached: list[float] = []
+
+        def connector(*_args: object, **_kwargs: object) -> None:
+            """Record the instant the driver reached the socket, then stop it.
+
+            Args:
+                *_args: The address and timeout, unused.
+                **_kwargs: The same, unused.
+
+            Raises:
+                _ReachedTheSocket: Always. The probe has nothing left to prove
+                    once the connection would have been opened, and there is no
+                    server on the other end to answer it.
+            """
+            reached.append(time.monotonic())
+            raise _ReachedTheSocket
+
+        self._stepping(monkeypatch)
+        monkeypatch.setattr(conformance_module.socket, "create_connection", connector)
+        began = time.monotonic()
+
+        with pytest.raises(_ReachedTheSocket):
+            conformance_module.send_raw("h", 1, probe("placement"), marker="placement")
+
+        assert reached[0] > began, f"connection opened at {reached[0]}, call began at {began}"
 
     async def test_two_probes_are_stamped_at_different_instants(
         self, recorder: RecordingUpstream, monkeypatch: pytest.MonkeyPatch

--- a/tests/harness/test_recorder_falsification.py
+++ b/tests/harness/test_recorder_falsification.py
@@ -31,16 +31,13 @@ from __future__ import annotations
 
 import asyncio
 import socket
-import sys
 import time
 from collections.abc import Sequence
-from contextlib import nullcontext
 from dataclasses import replace
 from typing import Any
 
 import pytest
 from aiohttp import web
-from exemptions import ratchet
 
 from harness.contract import CapturedRequest, WireFormat
 from harness.recorder import ConnectionRecord, RecordingUpstream, _ConnectionLoggingServer
@@ -642,12 +639,7 @@ class TestSessionDefectsAreCaughtByExactlyTheirOwnCheck:
         """Assert misordering is attributable to the ordering check alone."""
         failing = next(c for c in PER_SESSION_CHECKS if c.__name__ == "check_request_order")
         recording, sent, opened = await self._run_pair(ReorderingRecorder)
-        # KBR-188/189: exempt the WINDOWS CELL only -- this assertion gates
-        # normally on the Linux and macOS legs, and fails the job the day
-        # Windows starts passing. §8.3's parametrised-cell shape.
-        exempt = sys.platform == "win32"
-        with ratchet("recorder-falsification-reordering-only-order-check") if exempt else nullcontext():
-            self._assert_only(failing, recording, sent, opened, "request order")
+        self._assert_only(failing, recording, sent, opened, "request order")
 
     async def test_a_dropping_recorder_fails_only_the_coverage_check(self) -> None:
         """Assert a lost request is attributable to the coverage check alone."""
@@ -665,12 +657,7 @@ class TestSessionDefectsAreCaughtByExactlyTheirOwnCheck:
         """
         failing = next(c for c in PER_SESSION_CHECKS if c.__name__ == "check_connection_logged")
         recording, sent, opened = await self._run_pair(MiscountingConnectionRecorder)
-        # KBR-188/189: exempt the WINDOWS CELL only -- this assertion gates
-        # normally on the Linux and macOS legs, and fails the job the day
-        # Windows starts passing. §8.3's parametrised-cell shape.
-        exempt = sys.platform == "win32"
-        with ratchet("recorder-falsification-miscount-only-connection-check") if exempt else nullcontext():
-            self._assert_only(failing, recording, sent, opened, "accounts for 0 requests")
+        self._assert_only(failing, recording, sent, opened, "accounts for 0 requests")
 
     async def test_a_frozen_clock_fails_only_the_arrival_check(self) -> None:
         """Assert a constant clock is attributable to the arrival check alone."""
@@ -712,21 +699,8 @@ class TestSessionDefectsAreCaughtByExactlyTheirOwnCheck:
         finally:
             await upstream.stop()
 
-        # 🔴 The ratchet goes INSIDE the loop and names one check, not around it.
-        # Wrapping the loop would amnesty all four checks on Windows, so a check
-        # failing there for an unrelated reason would be suppressed by a row that
-        # names `check_arrival_increases` -- the blanket amnesty §8 rejects,
-        # rebuilt inside the mechanism meant to prevent it. §8.3 says the block
-        # holds exactly one assertion and that nothing detects a second; this is
-        # what heeding that looks like. Raised in PR review.
         for check in PER_SESSION_CHECKS:
-            exempt = sys.platform == "win32" and check.__name__ == "check_arrival_increases"
-            with (
-                ratchet("recorder-falsification-probe-passes-real-recorder")
-                if exempt
-                else nullcontext()
-            ):
-                check(recording, sent, opened)
+            check(recording, sent, opened)
 
     async def test_a_lazily_logged_connection_log_fails_the_connection_check(self) -> None:
         """Assert a log that only sees request-bearing connections is caught.


### PR DESCRIPTION
## Context for the Product Owner

We now run the test suite on Windows and macOS as well as Linux (KBR-164). Windows has a known quirk: its clock is too coarse to tell two fast requests apart, so an assertion that "the second request arrived after the first" is simply false there. That debt is tracked as KBR-188, and the existing recorder already carries a narrow exemption for it.

The recorder added yesterday by KBR-40 is judged by the same checks and was written from a branch cut **before** the Windows leg existed, so it very likely carries the same failure — and it has never actually been measured, because the CI run for its merge was cancelled when the next merge superseded it. This PR gives it the same narrow exemption.

## What this does

- One row in `tests/exemptions.py`, naming the assertion, the condition, and KBR-188.
- The `ratchet` wrapped around **one parametrised cell** in `tests/harness/test_provider_aiohttp.py`, exactly as `tests/harness/test_recorder.py` does for the same check.

It is not a skip and not a blanket amnesty: the assertion still gates normally on the four Linux legs and on macOS, and the job **fails the day Windows starts passing**, so the debt cannot quietly become permanent.

## This PR is also the measurement

The ratchet fails on an *unexpected pass*. So:

- **Windows green** → the diagnosis was right, and this is the fix.
- **Windows red with "unexpected pass"** → the diagnosis was wrong, the module was fine on Windows all along, and this must be reverted rather than merged.

I would rather have CI answer that than assume it. Linux is green locally with the exemption in place (inert there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)