### PR TITLE
Read the status the provider actually sends (KBR-182)

### DIFF
--- a/.github/review/README.md
+++ b/.github/review/README.md
@@ -209,7 +209,7 @@ step 2 above.
 ## Changing the review system
 
 `.github/workflows/ci.yml` runs `tests/test_review_scripts.py` on every pull
-request — 691 tests over the selector, the classifier, the notices, the redactor,
+request — 692 tests over the selector, the classifier, the notices, the redactor,
 the schema and the workflow's own wiring, plus the workflow parser, the
 runner-ceiling table and the `ci-required` aggregation. Run them locally the same
 way:

--- a/.github/review/README.md
+++ b/.github/review/README.md
@@ -209,7 +209,7 @@ step 2 above.
 ## Changing the review system
 
 `.github/workflows/ci.yml` runs `tests/test_review_scripts.py` on every pull
-request — 687 tests over the selector, the classifier, the notices, the redactor,
+request — 691 tests over the selector, the classifier, the notices, the redactor,
 the schema and the workflow's own wiring, plus the workflow parser, the
 runner-ceiling table and the `ci-required` aggregation. Run them locally the same
 way:

--- a/.github/review/README.md
+++ b/.github/review/README.md
@@ -209,7 +209,7 @@ step 2 above.
 ## Changing the review system
 
 `.github/workflows/ci.yml` runs `tests/test_review_scripts.py` on every pull
-request — 664 tests over the selector, the classifier, the notices, the redactor,
+request — 687 tests over the selector, the classifier, the notices, the redactor,
 the schema and the workflow's own wiring, plus the workflow parser, the
 runner-ceiling table and the `ci-required` aggregation. Run them locally the same
 way:

--- a/.github/review/scripts/interpret_claude_result.py
+++ b/.github/review/scripts/interpret_claude_result.py
@@ -598,7 +598,6 @@ def _extract_structured_output(raw_output: str, execution_text: str) -> dict | N
 #: ⚠️ ``message`` and ``content`` are deliberately absent: that is where tool results and model
 #: prose live, and both quote the code under review.
 #:
-#: 🔴 **One field in this tuple is never actually read, and knowing which one matters here.**
 #: 🔴 **KBR-182 fixed the field that was listed here and never read.**
 #: ``api_error_status`` arrives as a JSON NUMBER, and :func:`_strings_in` collects string
 #: leaves only, so it used to be discarded before any pattern saw it -- one of the six was
@@ -612,6 +611,14 @@ def _extract_structured_output(raw_output: str, execution_text: str) -> dict | N
 #: any 400 pre-empt every quota and credential tier below. Anthropic reports a spent
 #: balance as HTTP 400, so that is KBR-145's defect rather than a theoretical ordering
 #: concern. The measurement is in :class:`StatusMatrixTests`.
+#:
+#: ⚠️ **The rule governs PARSEABLE records, and the exception is pre-existing rather
+#: than introduced here.** When :func:`_parse_events` fails, :func:`_outcome_text`
+#: returns None and :func:`classify` searches the raw text whole -- so a record that is
+#: not JSON reaches tier 1 carrying whatever its text says, ``"api_error_status": 400``
+#: included, as it always has. That is the fallback family
+#: :func:`_provider_outcome_text` documents at length, and it is unchanged: this rule
+#: is about where the COERCED number is admitted, not about the raw-text path.
 OUTCOME_FIELDS = (
     "error",
     "result",
@@ -623,6 +630,12 @@ OUTCOME_FIELDS = (
 
 #: Per-field cap, so one oversized field cannot reintroduce the problem above.
 OUTCOME_FIELD_CHARS = 4000
+
+#: The same cap for numbers, which :data:`OUTCOME_FIELD_CHARS` cannot express because
+#: the conversion is what overflows. Nine digits is far beyond any HTTP status and beyond
+#: this module's largest real code (``1310``); the point is only that a number arriving
+#: from a provider cannot be large enough to raise on `str()`. See :func:`_numbers_in`.
+OUTCOME_NUMBER_BOUND = 10**9
 
 #: 🔴 KBR-172. The one outcome field the MODEL writes. On a structured-output failure
 #: `result` carries the review it was trying to return, so every status code in it is the
@@ -857,7 +870,7 @@ def _strings_in(value: object, depth: int = 0) -> list[str]:
 
 
 def _numbers_in(value: object) -> list[str]:
-    """Collect an outcome field that arrived as a number, as text.
+    r"""Collect an outcome field that arrived as a number, as text.
 
     🔴 **KBR-182. `api_error_status` is listed in :data:`OUTCOME_FIELDS` as one of the
     six fields describing a run's outcome, and it is the one whose whole purpose is to
@@ -868,8 +881,10 @@ def _numbers_in(value: object) -> list[str]:
     :data:`FATAL_UNLESS_PROVIDER_NAMED_PATTERNS` and was reported as a broken workflow,
     with the re-run refused.
 
-    ⚠️ **What this function returns is admitted to the PROVIDER-SCOPED text only, and
-    that is the load-bearing decision rather than an implementation detail.**
+    ⚠️ **What this function returns is admitted to the PROVIDER-SCOPED text only -- of
+    a record that PARSED -- and that is the load-bearing decision rather than an
+    implementation detail.** (An unparseable record is searched whole by
+    :func:`classify`, unchanged and pre-existing; see :data:`OUTCOME_FIELDS`.)
     :data:`FATAL_PATTERNS` is tier 1 and carries ``\b400\b``, so a bare status in the
     full haystack would let any 400 pre-empt every body-derived verdict below it.
     Measured, and not hypothetical: Anthropic reports a spent credit balance as HTTP
@@ -902,9 +917,20 @@ def _numbers_in(value: object) -> list[str]:
     # collect `True` as the string "True".
     if isinstance(value, bool):
         return []
-    if isinstance(value, int):
-        return [str(value)]
-    return []
+    if not isinstance(value, int):
+        return []
+    # 🔴 The numeric twin of `OUTCOME_FIELD_CHARS`, which cannot express this because
+    # the CONVERSION is what grows: without it a 4,000-digit status becomes 4,000
+    # characters of haystack, which is the problem that cap exists to prevent.
+    #
+    # ⚠️ It does NOT stop the related crash, and claiming otherwise would be worse than
+    # not bounding at all. Python 3.11+ refuses `str()` on an integer over 4,300
+    # digits -- but `json.loads` hits that limit FIRST, inside `_parse_events`, which
+    # catches only `JSONDecodeError`. So an absurd status still raises there, on `main`
+    # exactly as here. Filed separately; this bound is about size, not about that.
+    if not -OUTCOME_NUMBER_BOUND < value < OUTCOME_NUMBER_BOUND:
+        return []
+    return [str(value)]
 
 
 def _first_match(patterns: tuple[str, ...], haystack: str) -> str | None:

--- a/.github/review/scripts/interpret_claude_result.py
+++ b/.github/review/scripts/interpret_claude_result.py
@@ -629,7 +629,8 @@ OUTCOME_FIELD_CHARS = 4000
 #: The same cap for numbers, which :data:`OUTCOME_FIELD_CHARS` cannot express because
 #: the conversion is what overflows. Nine digits is far beyond any HTTP status and beyond
 #: this module's largest real code (``1310``); the point is only that a number arriving
-#: from a provider cannot be large enough to raise on `str()`. See :func:`_numbers_in`.
+#: from a provider cannot become an unbounded amount of haystack. :func:`_numbers_in`
+#: applies it as a half-open range from zero, because a negative number is not a status.
 OUTCOME_NUMBER_BOUND = 10**9
 
 #: 🔴 KBR-172. The one outcome field the MODEL writes. On a structured-output failure
@@ -897,6 +898,8 @@ def _numbers_in(value: object) -> list[str]:
     -- the defect this module already documents beside :data:`QUOTA_PATTERNS`. Nesting
     is excluded because a number inside a provider's error object is a parameter, not a
     status: a ``retry_after`` of 401 would otherwise be read as a rejected credential.
+    Negative values are excluded for the same reason a ``float`` is -- ``-401`` matches
+    ``\b40[13]\b``, because the word boundary falls between the sign and the digits.
     The Agent SDK reference puts ``api_error_status`` at the top level of the ``result``
     message, so the bound is the production carrier rather than a guess.
 
@@ -916,16 +919,23 @@ def _numbers_in(value: object) -> list[str]:
         return []
     if not isinstance(value, int):
         return []
-    # 🔴 The numeric twin of `OUTCOME_FIELD_CHARS`, which cannot express this because
-    # the CONVERSION is what grows: without it a 4,000-digit status becomes 4,000
-    # characters of haystack, which is the problem that cap exists to prevent.
+    # 🔴 Negative is excluded because a status is not negative, and the exclusion is a
+    # DECISION rather than an inherited accident: `-401` stringifies to "-401", and
+    # `\b40[13]\b` matches inside it -- `-` is a non-word character, so the word
+    # boundary falls right before the digits. Left unbounded, a negative number would
+    # route through the credential tier. Measured; a PR review asserted the opposite.
+    #
+    # 🔴 The upper bound is the numeric twin of `OUTCOME_FIELD_CHARS`, which cannot
+    # express this because the CONVERSION is what grows: without it a 4,000-digit
+    # status becomes 4,000 characters of haystack.
     #
     # ⚠️ It does NOT stop the related crash, and claiming otherwise would be worse than
-    # not bounding at all. Python 3.11+ refuses `str()` on an integer over 4,300
-    # digits -- but `json.loads` hits that limit FIRST, inside `_parse_events`, which
-    # catches only `JSONDecodeError`. So an absurd status still raises there, on `main`
-    # exactly as here. Filed separately; this bound is about size, not about that.
-    if not -OUTCOME_NUMBER_BOUND < value < OUTCOME_NUMBER_BOUND:
+    # not bounding at all. The 4,300-digit ceiling belongs to `int()`, which `json`'s
+    # integer parser calls, so `json.loads` raises inside `_parse_events` -- which
+    # catches only `JSONDecodeError` -- before this function is ever reached. An absurd
+    # status still raises there, on `main` exactly as here. Filed as KBR-209; this
+    # bound is about size, and about the band below that ceiling where it does the work.
+    if not 0 <= value < OUTCOME_NUMBER_BOUND:
         return []
     return [str(value)]
 

--- a/.github/review/scripts/interpret_claude_result.py
+++ b/.github/review/scripts/interpret_claude_result.py
@@ -606,19 +606,14 @@ def _extract_structured_output(raw_output: str, execution_text: str) -> dict | N
 #: ⚠️ **The rule that replaced the defect, and the one to preserve: a numeric outcome
 #: field is admitted to the PROVIDER-SCOPED text only** -- what
 #: :func:`_provider_outcome_text` returns -- **and must never reach the haystack
-#: :func:`_outcome_text` returns.** That haystack is read first by
-#: :data:`FATAL_PATTERNS`, which carries ``\b400\b``, so a bare status in it would let
-#: any 400 pre-empt every quota and credential tier below. Anthropic reports a spent
-#: balance as HTTP 400, so that is KBR-145's defect rather than a theoretical ordering
-#: concern. The measurement is in :class:`StatusMatrixTests`.
+#: :func:`_outcome_text` returns**, which is read first by :data:`FATAL_PATTERNS`.
+#: :func:`_numbers_in` carries the argument and the measurement; it is not repeated
+#: here, because a third copy is the one that goes stale.
 #:
-#: ⚠️ **The rule governs PARSEABLE records, and the exception is pre-existing rather
-#: than introduced here.** When :func:`_parse_events` fails, :func:`_outcome_text`
-#: returns None and :func:`classify` searches the raw text whole -- so a record that is
-#: not JSON reaches tier 1 carrying whatever its text says, ``"api_error_status": 400``
-#: included, as it always has. That is the fallback family
-#: :func:`_provider_outcome_text` documents at length, and it is unchanged: this rule
-#: is about where the COERCED number is admitted, not about the raw-text path.
+#: ⚠️ The rule governs **parseable** records. An unparseable one is searched whole by
+#: :func:`classify` and always has been, ``"api_error_status": 400`` in its text
+#: included -- that is the fallback family :func:`_provider_outcome_text` documents,
+#: unchanged here.
 OUTCOME_FIELDS = (
     "error",
     "result",
@@ -914,7 +909,9 @@ def _numbers_in(value: object) -> list[str]:
     """
 
     # `bool` FIRST: it is an `int` subclass, so the check below would otherwise
-    # collect `True` as the string "True".
+    # collect `True` as the string "True". Deleting this branch as a tidy-up is a
+    # MUTATION, not a simplification --
+    # `test_a_bool_is_not_collected_even_though_it_is_an_int` is the row that dies.
     if isinstance(value, bool):
         return []
     if not isinstance(value, int):

--- a/.github/review/scripts/interpret_claude_result.py
+++ b/.github/review/scripts/interpret_claude_result.py
@@ -213,10 +213,16 @@ CREDENTIAL_PATTERNS = (
     r"\bauthentication_failed\b",
     # upstream: Anthropic's documented 401 and 403 types, per
     # `platform.claude.com/docs/en/api/errors`. They earn their place beside the status
-    # tier below rather than duplicating it: a body can name its cause and carry NO
-    # number, because a numeric `api_error_status` never reaches the haystack at all
-    # (KBR-182). They are also consulted FIRST, so an operator reads
+    # tier below rather than duplicating it: a body can name its cause and carry no
+    # number anywhere. They are also consulted FIRST, so an operator reads
     # "authentication_error" rather than "401" -- both true, one more useful.
+    #
+    # 🔴 KBR-182 narrowed the first half of that reasoning and made the second half
+    # load-bearing. It used to read "a numeric `api_error_status` never reaches the
+    # haystack at all", which was a statement about the DEFECT, not about the design;
+    # the status now reaches the provider-scoped text, so this ordering decides what an
+    # operator actually reads rather than winning by default.
+    # `test_a_named_type_still_outranks_the_status_that_arrives_beside_it` is the row.
     r"\bauthentication_error\b",
     r"\bpermission_error\b",
     r"model_not_found",
@@ -593,12 +599,19 @@ def _extract_structured_output(raw_output: str, execution_text: str) -> dict | N
 #: prose live, and both quote the code under review.
 #:
 #: 🔴 **One field in this tuple is never actually read, and knowing which one matters here.**
+#: 🔴 **KBR-182 fixed the field that was listed here and never read.**
 #: ``api_error_status`` arrives as a JSON NUMBER, and :func:`_strings_in` collects string
-#: leaves only, so it is discarded before any pattern sees it. Every numeric pattern in this
-#: module therefore matches text -- the CLI's ``API Error: NNN`` line or a message body --
-#: and never the field that exists to report the status. Filed as KBR-182, deliberately not
-#: fixed here: making numbers visible would wake `\b400\b` in :data:`FATAL_PATTERNS`, which
-#: is consulted first, and that needs its own before/after measurement across the tier order.
+#: leaves only, so it used to be discarded before any pattern saw it -- one of the six was
+#: dead weight while looking live. :func:`_numbers_in` now collects it.
+#:
+#: ⚠️ **The rule that replaced the defect, and the one to preserve: a numeric outcome
+#: field is admitted to the PROVIDER-SCOPED text only** -- what
+#: :func:`_provider_outcome_text` returns -- **and must never reach the haystack
+#: :func:`_outcome_text` returns.** That haystack is read first by
+#: :data:`FATAL_PATTERNS`, which carries ``\b400\b``, so a bare status in it would let
+#: any 400 pre-empt every quota and credential tier below. Anthropic reports a spent
+#: balance as HTTP 400, so that is KBR-145's defect rather than a theoretical ordering
+#: concern. The measurement is in :class:`StatusMatrixTests`.
 OUTCOME_FIELDS = (
     "error",
     "result",
@@ -669,7 +682,7 @@ def _parse_events(execution_text: str) -> list | None:
     return events or None
 
 
-def _outcome_parts(events: list) -> tuple[list[str], list[str]]:
+def _outcome_parts(events: list) -> tuple[list[str], list[str], list[str]]:
     """Split a record's outcome fields by who wrote them.
 
     🔴 **Derived once and consumed twice, because two copies of this loop would have to
@@ -683,19 +696,31 @@ def _outcome_parts(events: list) -> tuple[list[str], list[str]]:
         events: Decoded execution-record events, as :func:`_parse_events` returns them.
 
     Returns:
-        A ``(provider_parts, model_parts)`` pair of string lists. ``model_parts`` holds
-        only :data:`MODEL_AUTHORED_FIELD`; everything else the provider wrote.
+        A ``(provider_parts, model_parts, status_parts)`` triple of string lists.
+        ``model_parts`` holds only :data:`MODEL_AUTHORED_FIELD`; ``status_parts`` holds
+        the provider-authored fields that arrived as numbers, coerced by
+        :func:`_numbers_in`; everything else the provider wrote is in
+        ``provider_parts``. The numbers are kept apart so that only the
+        provider-scoped haystack can join them -- KBR-182.
     """
 
     provider_parts: list[str] = []
     model_parts: list[str] = []
+    status_parts: list[str] = []
     for event in events:
         if not isinstance(event, dict):
             continue
         for field in OUTCOME_FIELDS:
-            target = model_parts if field == MODEL_AUTHORED_FIELD else provider_parts
-            target.extend(_strings_in(event.get(field)))
-    return provider_parts, model_parts
+            value = event.get(field)
+            if field == MODEL_AUTHORED_FIELD:
+                model_parts.extend(_strings_in(value))
+                continue
+            # Numbers are collected into their OWN bucket, never into `provider_parts`.
+            # Only `_provider_outcome_text` joins it, which is what keeps a bare status
+            # out of the tier-1 haystack -- see `_numbers_in` for why that matters.
+            provider_parts.extend(_strings_in(value))
+            status_parts.extend(_numbers_in(value))
+    return provider_parts, model_parts, status_parts
 
 
 def _outcome_text(execution_text: str) -> str | None:
@@ -722,7 +747,7 @@ def _outcome_text(execution_text: str) -> str | None:
     if events is None:
         return None
 
-    provider_parts, model_parts = _outcome_parts(events)
+    provider_parts, model_parts, _ = _outcome_parts(events)
 
     # The marker is read only from fields the model does not author. Reading it from
     # `result` too would let a review that merely MENTIONS the subtype scope out its own
@@ -796,8 +821,11 @@ def _provider_outcome_text(execution_text: str) -> str:
             return ""
         return execution_text
 
-    provider_parts, _ = _outcome_parts(events)
-    return "\n".join(provider_parts)
+    # 🔴 KBR-182. The numeric status joins HERE and nowhere else. `_outcome_text` --
+    # the tier-1 haystack -- must never see it; `_numbers_in` records what happens if
+    # it does.
+    provider_parts, _, status_parts = _outcome_parts(events)
+    return "\n".join(provider_parts + status_parts)
 
 
 def _strings_in(value: object, depth: int = 0) -> list[str]:
@@ -825,6 +853,57 @@ def _strings_in(value: object, depth: int = 0) -> list[str]:
         return [s for item in value.values() for s in _strings_in(item, depth + 1)]
     if isinstance(value, list):
         return [s for item in value for s in _strings_in(item, depth + 1)]
+    return []
+
+
+def _numbers_in(value: object) -> list[str]:
+    """Collect an outcome field that arrived as a number, as text.
+
+    🔴 **KBR-182. `api_error_status` is listed in :data:`OUTCOME_FIELDS` as one of the
+    six fields describing a run's outcome, and it is the one whose whole purpose is to
+    carry the provider's HTTP status.** HTTP statuses are JSON numbers, and
+    :func:`_strings_in` collects string leaves only, so the integer form -- the one
+    production writes -- was discarded before any pattern saw it. A rejected key whose
+    message named no credential vocabulary reached
+    :data:`FATAL_UNLESS_PROVIDER_NAMED_PATTERNS` and was reported as a broken workflow,
+    with the re-run refused.
+
+    ⚠️ **What this function returns is admitted to the PROVIDER-SCOPED text only, and
+    that is the load-bearing decision rather than an implementation detail.**
+    :data:`FATAL_PATTERNS` is tier 1 and carries ``\b400\b``, so a bare status in the
+    full haystack would let any 400 pre-empt every body-derived verdict below it.
+    Measured, and not hypothetical: Anthropic reports a spent credit balance as HTTP
+    **400** ``invalid_request_error`` -- *"Your credit balance is too low to access the
+    Anthropic API"* -- so the full-haystack form turns that record from
+    ``exhausted``/quota into ``fatal`` with ``retryable`` false. That is KBR-145's filed
+    defect arriving through a new door. KBR-166 already established that the separable
+    question is who WROTE a field; a numeric status is the most unambiguously
+    provider-authored value in the record, so this applies that mechanism once more
+    rather than widening what KBR-166 narrowed.
+
+    The bounds are measured too. ``bool`` is excluded because it is an ``int`` subclass
+    in Python and ``True`` would enter the haystack as ``"True"``. ``float`` is excluded
+    because no status is fractional and both ``402.0`` and ``0.402`` match ``\b402\b``
+    -- the defect this module already documents beside :data:`QUOTA_PATTERNS`. Nesting
+    is excluded because a number inside a provider's error object is a parameter, not a
+    status: a ``retry_after`` of 401 would otherwise be read as a rejected credential.
+    The Agent SDK reference puts ``api_error_status`` at the top level of the ``result``
+    message, so the bound is the production carrier rather than a guess.
+
+    Args:
+        value: An outcome field's value, as the event carried it.
+
+    Returns:
+        A single-element list holding the decimal form of ``value`` when it is a
+        top-level integer, and an empty list otherwise.
+    """
+
+    # `bool` FIRST: it is an `int` subclass, so the check below would otherwise
+    # collect `True` as the string "True".
+    if isinstance(value, bool):
+        return []
+    if isinstance(value, int):
+        return [str(value)]
     return []
 
 

--- a/.github/review/tests/test_review_scripts.py
+++ b/.github/review/tests/test_review_scripts.py
@@ -16849,10 +16849,16 @@ class OperatorSurfacesAgreeTests(unittest.TestCase):
         # ⚠️ KBR-182 AC4. `api_error_status` is now READ, and on this record it still
         # contributes NOTHING -- deliberately, and recorded rather than quietly left.
         # `\b402\b` is absent from every provider-scoped tuple, so the verdict comes
-        # entirely from `result`. Changing 402 to any other number leaves this record's
-        # classification identical, and
-        # `test_the_status_field_is_inert_on_this_record_and_that_is_recorded` pins that
-        # so the follow-up ticket adding `\b402\b` fails here and forces a re-read.
+        # entirely from `result`. `test_the_status_field_is_inert_on_this_record_and_
+        # that_is_recorded` demonstrates that by mutating the status and observing an
+        # identical verdict.
+        #
+        # ⚠️ That row is NOT the guard for KBR-207, and an earlier version of this
+        # comment claimed it was. Code review falsified the claim: `QUOTA_PATTERNS`
+        # matches `DEEPSEEK_NO_BALANCE` at tier 2, above anything a status can reach, so
+        # adding `\b402\b` leaves this record untouched and the row still passes. The
+        # guard that actually fails when KBR-207 lands is
+        # `StatusMatrixTests.test_a_status_that_matches_no_pattern_changes_nothing`.
         record = json.dumps(
             [
                 {
@@ -16866,36 +16872,6 @@ class OperatorSurfacesAgreeTests(unittest.TestCase):
         )
         interpreted = _interpret_outputs(record=record)
         return interpreted, resolve_outcome(status=interpreted["status"])
-
-    def test_the_status_field_is_inert_on_this_record_and_that_is_recorded(self):
-        """KBR-182 AC4, answered in the negative and proved rather than asserted.
-
-        The ticket asks that this fixture gain an assertion depending on its status
-        field, OR a comment saying it deliberately does not. It is the second: `402` is
-        not in any tier this record can reach, so the honest thing is to demonstrate the
-        inertness by MUTATING the input, not to claim it in prose.
-
-        🔴 The mutation is the control. An inspection of the code would pass under any
-        implementation; replacing the status with an unrelated number and observing an
-        identical verdict is the only form of this claim that can fail.
-        """
-
-        baseline = interpret.classify(
-            status_record(402, subtype="success", terminal_reason="api_error",
-                          result=DEEPSEEK_NO_BALANCE)
-        )
-
-        for mutated in (418, 599, None):
-            with self.subTest(status=mutated):
-                self.assertEqual(
-                    interpret.classify(
-                        status_record(mutated, subtype="success",
-                                      terminal_reason="api_error",
-                                      result=DEEPSEEK_NO_BALANCE)
-                    ),
-                    baseline,
-                    "the status is recorded as inert here; it no longer is",
-                )
 
     def test_the_observed_payload_is_retried_rather_than_abandoned(self):
         """KBR-145's AC4, in this repository's terms.
@@ -16956,6 +16932,53 @@ class OperatorSurfacesAgreeTests(unittest.TestCase):
 
         self.assertIn("Top up or wait, then re-run", printed)
         self.assertNotIn("the workflow", printed.split("::error::")[-1].lower())
+
+
+class ResolvedRecordStatusIsInertTests(unittest.TestCase):
+    """KBR-182 AC4, kept OUT of :class:`OperatorSurfacesAgreeTests` on purpose.
+
+    🔴 That class is `skipIf(BASH is None)` because its other rows execute workflow
+    steps through bash. This one never shells out, and inheriting the skip would let
+    AC4's evidence vanish silently on a runner without bash -- which `TEST_SUITE.md` 8
+    calls a failure, not an absence.
+    """
+
+    def test_the_status_field_is_inert_on_this_record_and_that_is_recorded(self):
+        """KBR-182 AC4, answered in the negative and proved rather than asserted.
+
+        The ticket asks that this fixture gain an assertion depending on its status
+        field, OR a comment saying it deliberately does not. It is the second: `402` is
+        not in any tier this record can reach, so the honest thing is to demonstrate the
+        inertness by MUTATING the input, not to claim it in prose.
+
+        🔴 The mutation is the control rather than an inspection of the code, which
+        would pass under any implementation.
+
+        ⚠️ **It is a weak control, and saying so is better than implying otherwise.**
+        `QUOTA_PATTERNS` claims this record at tier 2, above every tier a status can
+        reach, so no change to the status tiers can move it -- which is exactly what
+        "inert" means here, and also why this row survives mutants that a stronger
+        guard would kill. An earlier docstring called it "the only form of this claim
+        that can fail"; code review measured it failing under none of eleven.
+        """
+
+        baseline = interpret.classify(
+            status_record(402, subtype="success", terminal_reason="api_error",
+                          result=DEEPSEEK_NO_BALANCE)
+        )
+
+        for mutated in (418, 599, None):
+            with self.subTest(status=mutated):
+                self.assertEqual(
+                    interpret.classify(
+                        status_record(mutated, subtype="success",
+                                      terminal_reason="api_error",
+                                      result=DEEPSEEK_NO_BALANCE)
+                    ),
+                    baseline,
+                    "the status is recorded as inert here; it no longer is",
+                )
+
 
 
 class QuotaAdviceNamesNoRetiredProviderTests(unittest.TestCase):
@@ -17480,10 +17503,11 @@ class CredentialCarrierTests(unittest.TestCase):
             ]
         )
 
-        self.assertNotIn(
-            "403",
-            interpret._provider_outcome_text(record),
-            "the fixture must carry no number at all, or it proves nothing",
+        self.assertIsNone(
+            re.search(r"\d", interpret._provider_outcome_text(record)),
+            "the fixture must carry no number AT ALL, or it proves nothing -- "
+            "`assertNotIn('403', ...)` was the first version and re-adding a 401 "
+            "would have passed it",
         )
         status, reason = interpret.classify(record)
         self.assertEqual(status, "exhausted")
@@ -17746,7 +17770,7 @@ class NumericOutcomeFieldTests(unittest.TestCase):
         self.assertEqual(interpret._numbers_in(True), [])
 
     def test_a_float_is_not_collected(self):
-        """Excluded on measured grounds, not by omission.
+        r"""Excluded on measured grounds, not by omission.
 
         No status is fractional, and both `402.0` and `0.402` match `\b402\b`. The
         module already records a live defect of exactly that shape -- `"billed $0.402"`
@@ -17759,6 +17783,46 @@ class NumericOutcomeFieldTests(unittest.TestCase):
         """A missing status is not a status; `"None"` is noise in the haystack."""
 
         self.assertEqual(interpret._numbers_in(None), [])
+
+    def test_an_absurd_integer_is_bounded_rather_than_flooding_the_haystack(self):
+        """The numeric twin of :data:`OUTCOME_FIELD_CHARS`, which cannot express it.
+
+        🔴 `_strings_in` caps each field at 4,000 characters so one oversized field
+        cannot flood the haystack. A number has the same exposure through a different
+        door -- the CONVERSION is what grows -- and `_numbers_in` shipped without the
+        cap until code review measured a 4,000-digit status becoming 4,000 characters
+        of searchable text.
+
+        ⚠️ This does not claim to stop the related crash. `json.loads` refuses an
+        integer over 4,300 digits before this function is ever reached, on `main`
+        exactly as here; that is filed separately and is not what the bound is for.
+        """
+
+        self.assertEqual(interpret._numbers_in(999999999), ["999999999"])
+        self.assertEqual(interpret._numbers_in(interpret.OUTCOME_NUMBER_BOUND), [])
+
+        # End to end, on the carrier a provider would actually send: a long-but-legal
+        # integer must not reach the haystack the tiers search.
+        record = '[{"type":"result","subtype":"error","api_error_status":' + "4" * 4000 + "}]"
+
+        self.assertNotIn("4444", interpret._provider_outcome_text(record))
+
+    def test_a_number_the_model_wrote_is_not_collected_as_a_status(self):
+        """🔴 KBR-166's authorship boundary, extended to the numeric bucket.
+
+        `result` is the one outcome field the MODEL writes, and `_outcome_parts` must not
+        route numbers from it into the status bucket -- a review that returned a bare
+        number would otherwise vote on why the run failed, which is the whole defect
+        KBR-172 and KBR-166 were filed over.
+
+        Code review found this boundary held by nothing: a mutant that collected numbers
+        under `result` too survived the entire suite.
+        """
+
+        record = json.dumps([{"type": "result", "result": 401}])
+
+        self.assertEqual(interpret._provider_outcome_text(record), "")
+        self.assertNotIn("401", interpret._outcome_text(record))
 
     def test_a_nested_integer_is_not_collected(self):
         """The bound that keeps a provider's PARAMETERS from being read as statuses.
@@ -17923,11 +17987,17 @@ class StatusNeverReachesTheFatalTierTests(unittest.TestCase):
 
         self.assertEqual(status, "exhausted")
 
-    def test_every_quota_fixture_is_unchanged_by_its_own_status(self):
-        """The quota set, carried with the status each body names. None may move."""
+    def test_every_quota_fixture_is_unchanged_by_every_status(self):
+        """The quota set, carried with every status. None may leave the quota tier.
+
+        🔴 Swept across all of :data:`STATUS_MATRIX_STATUSES` rather than the three each
+        body names. Code review found the narrow version left ~56 of the measured rows
+        unpinned, and the whole risk of this ticket is a status arriving beside a body
+        that does not name it.
+        """
 
         for name, body in QUOTA_FIXTURES:
-            for code in (400, 402, 429):
+            for code in STATUS_MATRIX_STATUSES:
                 with self.subTest(fixture=name, status=code):
                     status, reason = interpret.classify(status_record(code, result=body))
 
@@ -17963,6 +18033,15 @@ STATUS_MATRIX_BODIES = (
         "type": "server_error", "message": "Overloaded"}}),
     ("nested retry_after 401", {"error": {
         "type": "rate_limit_error", "message": "slow down", "retry_after": 401}}),
+    # 🔴 Both added after code review found the recorded "10 reason-only moves"
+    # irreproducible from this file: the matrix yielded 6, and the missing 4 came from
+    # shapes no row carried. The second also carries the INCOHERENT row the design
+    # records -- a status beside a structured-output subtype -- which the design claimed
+    # was "pinned in the table" while the table could not express it, because
+    # `status_record` fixes `subtype` unless a row overrides it.
+    ("model not found prose", {"result": "There's an issue with the selected model "
+                                         "(nonexistent-model)"}),
+    ("structured output give up", {"subtype": "error_max_structured_output_retries"}),
 )
 
 #: The rows KBR-182 MOVES, measured on `origin/main` @ `11a5c88` before the change.
@@ -18018,6 +18097,7 @@ class StatusMatrixTests(unittest.TestCase):
         sharpen a verdict, and may rescue one from `fatal`, but may never create one.
         """
 
+        checked = 0
         for name, fields in STATUS_MATRIX_BODIES:
             without, _ = self._classify(None, fields)
             if without == "fatal":
@@ -18034,6 +18114,14 @@ class StatusMatrixTests(unittest.TestCase):
                         f"body {name!r} alone is {without}; adding "
                         f"api_error_status={status} made it fatal ({reason!r})",
                     )
+                    checked += 1
+
+        # 🔴 The guard skips bodies that are already `fatal`, so a change making more
+        # of them fatal would shrink it toward vacuity in silence. Code review caught
+        # the same shape once already in this class.
+        self.assertGreater(
+            checked, 90, "the fatal-alone skip has eaten most of this guard"
+        )
 
     def test_every_recorded_move_actually_happened(self):
         """The other direction: a claimed move that did not happen is a stale record.
@@ -18078,6 +18166,30 @@ class StatusMatrixTests(unittest.TestCase):
                     )
                 )
 
+    def test_the_top_up_paragraph_fires_on_a_spent_balance(self):
+        """🔴 The POSITIVE CONTROL, without which the row below cannot fail.
+
+        Code review found the agreement assertion vacuous: `_write_diagnostic`'s quota
+        branch keys on the RECORD's evidence and never on the verdict it is handed, so
+        for a record carrying no quota vocabulary `_quota_diagnostic` returns False
+        whatever it is told -- under the fix, under `main`, and under every mutant. An
+        `assertFalse` alone therefore asserted the fixture's vocabulary, not the
+        classifier's behaviour.
+
+        This row establishes that the helper CAN say True, so the one below is a
+        statement about agreement rather than about silence.
+        """
+
+        record = status_record(402, result=DEEPSEEK_NO_BALANCE)
+        verdict, reason = interpret.classify(record)
+
+        self.assertEqual(verdict, "exhausted")
+        self.assertTrue(
+            _quota_diagnostic(record, verdict, reason),
+            "the top-up paragraph must fire on a spent balance, or the agreement "
+            "assertion below is asserting nothing",
+        )
+
     def test_the_advice_still_agrees_with_the_verdict_on_every_moved_row(self):
         """KBR-145's invariant, re-checked on the rows this ticket disturbs.
 
@@ -18085,6 +18197,9 @@ class StatusMatrixTests(unittest.TestCase):
         the two can disagree without either being obviously wrong. A credential verdict
         must not be handed a top-up paragraph: the operator would be told to spend money
         on a key that needs replacing.
+
+        Read together with the positive control above -- alone this row is satisfied by
+        a fixture that simply has no billing words in it.
         """
 
         for (status, name), _ in STATUS_MATRIX_MOVED.items():
@@ -18093,11 +18208,43 @@ class StatusMatrixTests(unittest.TestCase):
             with self.subTest(status=status, body=name):
                 verdict, reason = interpret.classify(record)
 
+                self.assertTrue(verdict.startswith("exhausted"))
+                self.assertIn("credentials", reason)
                 self.assertFalse(
                     _quota_diagnostic(record, verdict, reason),
                     f"status {status} with {name!r}: verdict says credentials, "
                     "advice says top up a balance",
                 )
+
+    def test_the_cli_prefixed_spent_balance_disagrees_with_its_own_advice(self):
+        """⚠️ KBR-206, pinned rather than fixed -- and it is an I-C4 violation.
+
+        Anthropic's spent balance arrives with the CLI's `API Error: 400` prefix, so
+        `\\b400\\b` matches PROSE and tier 1 calls it a workflow fault. The diagnostic,
+        which reads the evidence rather than the verdict, prints the top-up paragraph
+        anyway. The operator is told the workflow is broken and, a paragraph later, to
+        top up a balance -- the exact disagreement `TEST_SUITE.md` I-C4 forbids and
+        KBR-145 was filed over.
+
+        🔴 Pre-existing and identical on `main`, and pinned HERE because this ticket's
+        own matrix is what surfaced it. Recording only half of it -- the `fatal` verdict
+        without the contradicting advice -- would hide the part that costs an operator
+        their afternoon. KBR-206 deletes or inverts this row.
+        """
+
+        record = (
+            'API Error: 400 {"type":"error","error":{"type":"invalid_request_error",'
+            '"message":"Your credit balance is too low to access the Anthropic API. '
+            'Please go to Plans & Billing to upgrade or purchase credits."}}'
+        )
+        verdict, reason = interpret.classify(record)
+
+        self.assertEqual(verdict, "fatal")
+        self.assertTrue(
+            _quota_diagnostic(record, verdict, reason),
+            "if the advice stopped contradicting the verdict here, KBR-206 landed "
+            "and this row should have gone with it",
+        )
 
     def test_a_status_that_matches_no_pattern_changes_nothing(self):
         """The statuses this repository can produce but does not yet READ.

--- a/.github/review/tests/test_review_scripts.py
+++ b/.github/review/tests/test_review_scripts.py
@@ -16846,6 +16846,13 @@ class OperatorSurfacesAgreeTests(unittest.TestCase):
             A ``(interpret outputs, resolve outputs)`` pair.
         """
 
+        # ⚠️ KBR-182 AC4. `api_error_status` is now READ, and on this record it still
+        # contributes NOTHING -- deliberately, and recorded rather than quietly left.
+        # `\b402\b` is absent from every provider-scoped tuple, so the verdict comes
+        # entirely from `result`. Changing 402 to any other number leaves this record's
+        # classification identical, and
+        # `test_the_status_field_is_inert_on_this_record_and_that_is_recorded` pins that
+        # so the follow-up ticket adding `\b402\b` fails here and forces a re-read.
         record = json.dumps(
             [
                 {
@@ -16859,6 +16866,36 @@ class OperatorSurfacesAgreeTests(unittest.TestCase):
         )
         interpreted = _interpret_outputs(record=record)
         return interpreted, resolve_outcome(status=interpreted["status"])
+
+    def test_the_status_field_is_inert_on_this_record_and_that_is_recorded(self):
+        """KBR-182 AC4, answered in the negative and proved rather than asserted.
+
+        The ticket asks that this fixture gain an assertion depending on its status
+        field, OR a comment saying it deliberately does not. It is the second: `402` is
+        not in any tier this record can reach, so the honest thing is to demonstrate the
+        inertness by MUTATING the input, not to claim it in prose.
+
+        🔴 The mutation is the control. An inspection of the code would pass under any
+        implementation; replacing the status with an unrelated number and observing an
+        identical verdict is the only form of this claim that can fail.
+        """
+
+        baseline = interpret.classify(
+            status_record(402, subtype="success", terminal_reason="api_error",
+                          result=DEEPSEEK_NO_BALANCE)
+        )
+
+        for mutated in (418, 599, None):
+            with self.subTest(status=mutated):
+                self.assertEqual(
+                    interpret.classify(
+                        status_record(mutated, subtype="success",
+                                      terminal_reason="api_error",
+                                      result=DEEPSEEK_NO_BALANCE)
+                    ),
+                    baseline,
+                    "the status is recorded as inert here; it no longer is",
+                )
 
     def test_the_observed_payload_is_retried_rather_than_abandoned(self):
         """KBR-145's AC4, in this repository's terms.
@@ -17419,9 +17456,15 @@ class CredentialCarrierTests(unittest.TestCase):
     def test_a_named_cause_carries_a_body_that_has_no_number(self):
         """The reason the named types exist beside the status tier at all.
 
-        A body can name its cause and carry no status code anywhere the classifier can
-        see it, because a numeric ``api_error_status`` never reaches the haystack
-        (KBR-182). Without this fixture that rationale is prose nothing exercises.
+        A body can name its cause and carry no status code anywhere, so the named types
+        are the only thing identifying it.
+
+        🔴 **The fixture carried `api_error_status: 403` until KBR-182, and relied on a
+        DEFECT to make it invisible.** The status was dropped before any pattern saw it,
+        so a record with a number in it satisfied a test named "has no number". Once the
+        field reaches the classifier the fixture has to actually have no number, or it
+        proves nothing -- so the status is gone from here and lives in the ordering test
+        below, which is what that pairing is really evidence for.
         """
 
         record = json.dumps(
@@ -17429,7 +17472,6 @@ class CredentialCarrierTests(unittest.TestCase):
                 {
                     "type": "result",
                     "subtype": "error",
-                    "api_error_status": 403,
                     "error": {
                         "type": "permission_error",
                         "message": "not permitted to use this resource",
@@ -17440,12 +17482,44 @@ class CredentialCarrierTests(unittest.TestCase):
 
         self.assertNotIn(
             "403",
-            interpret._outcome_text(record),
-            "the numeric status must stay invisible, or this fixture proves nothing",
+            interpret._provider_outcome_text(record),
+            "the fixture must carry no number at all, or it proves nothing",
         )
         status, reason = interpret.classify(record)
         self.assertEqual(status, "exhausted")
         self.assertIn("permission_error", reason)
+
+    def test_a_named_type_still_outranks_the_status_that_arrives_beside_it(self):
+        """🔴 KBR-182 made this ordering live, and nothing else exercises it.
+
+        `CREDENTIAL_PATTERNS` is consulted before `CREDENTIAL_STATUS_PATTERNS` so that an
+        operator reads `permission_error` rather than `403` -- both true, one more
+        useful. Until this ticket the ordering could not be tested with a real record:
+        the numeric status never reached any haystack, so the named type won by default
+        and deleting the whole status tier would not have failed a single row.
+
+        Now that the status IS read, the pairing is the common production shape and the
+        order decides what the operator sees.
+        """
+
+        record = status_record(
+            403,
+            error={
+                "type": "permission_error",
+                "message": "not permitted to use this resource",
+            },
+        )
+
+        self.assertIn(
+            "403",
+            interpret._provider_outcome_text(record),
+            "the status must be visible, or the ordering is untested again",
+        )
+        status, reason = interpret.classify(record)
+
+        self.assertEqual(status, "exhausted")
+        self.assertIn("permission_error", reason)
+        self.assertNotIn("403", reason)
 
 
 class QuotaWordingTests(unittest.TestCase):
@@ -17574,6 +17648,474 @@ class ProsePatternGuardTests(unittest.TestCase):
                     matched,
                     f"{prose!r} no longer trips a grandfathered pattern -- if KBR-181 "
                     "fixed it, delete the entry and this row together",
+                )
+
+
+# ---------------------------------------------------------------------------
+# KBR-182 -- the provider's numeric status must reach the classifier
+# ---------------------------------------------------------------------------
+
+#: Anthropic's own spent-balance body, which arrives as HTTP **400**, not 402.
+#:
+#: 🔴 **This fixture is the one that killed the obvious fix.** KBR-182's ticket text
+#: proposes coercing numbers inside `_strings_in`, which puts the status in the FULL
+#: haystack -- and `FATAL_PATTERNS` is tier 1 and carries `\b400\b`. Measured, that
+#: turns this record from `exhausted`/quota into `fatal`/"workflow-level failure",
+#: with `retryable` flipped to false: KBR-145's filed defect, reintroduced through a
+#: new door. It is the reason the status is admitted to the provider-scoped text only.
+#:
+#: ⚠️ **Vendor-documented rather than run-observed, and the file's verbatim rule is
+#: suspended for it deliberately.** The wording is Anthropic's own
+#: (`platform.claude.com/docs/en/api/errors`, and reproduced in
+#: `anthropics/claude-code` bug reports); the status is what matters here and
+#: inventing a 400 body would have proved nothing about a real provider.
+ANTHROPIC_400_LOW_CREDIT = (
+    'API Error: 400 {"type":"error","error":{"type":"invalid_request_error",'
+    '"message":"Your credit balance is too low to access the Anthropic API. '
+    'Please go to Plans & Billing to upgrade or purchase credits."}}'
+)
+
+#: The same condition with the status in the FIELD instead of the text.
+#:
+#: 🔴 **This is the carrier that decides the design, and the one above is not.** With
+#: the CLI's `API Error: 400` prefix present, `\b400\b` matches the TEXT and tier 1
+#: claims the record whatever this ticket does -- a pre-existing defect of the same
+#: family as KBR-145, filed separately rather than fixed here. Strip the prefix and the
+#: only 400 left is the structured field, which is precisely the shape
+#: `api_error_status` exists for: measured, admitting it to the full haystack turns
+#: this record from `exhausted`/quota into `fatal` with the re-run refused.
+ANTHROPIC_LOW_CREDIT_NO_NUMBER = {
+    "type": "invalid_request_error",
+    "message": (
+        "Your credit balance is too low to access the Anthropic API. "
+        "Please go to Plans & Billing to upgrade or purchase credits."
+    ),
+}
+
+
+def status_record(status=None, **fields):
+    """Build a one-event execution record carrying a numeric status.
+
+    Args:
+        status: The value of ``api_error_status``, or None to omit the field.
+        **fields: Any other outcome fields to place on the event.
+
+    Returns:
+        The execution record as a JSON string.
+    """
+
+    event = {"type": "result", "subtype": "error"}
+    event.update(fields)
+    if status is not None:
+        event["api_error_status"] = status
+    return json.dumps([event])
+
+
+class NumericOutcomeFieldTests(unittest.TestCase):
+    """KBR-182. `OUTCOME_FIELDS` lists a numeric field; it must actually be read.
+
+    `_strings_in` collects string leaves only, so `api_error_status` -- a JSON NUMBER
+    in every record production writes -- was discarded before any pattern saw it. The
+    field was dead weight while looking live, and every numeric pattern in the module
+    could only ever match the CLI's `API Error: NNN` text.
+    """
+
+    def test_a_top_level_integer_is_collected_as_its_decimal_string(self):
+        """The defect, at the function that caused it."""
+
+        self.assertEqual(interpret._numbers_in(402), ["402"])
+
+    def test_zero_is_collected_rather_than_treated_as_absent(self):
+        """🔴 A falsy int is still an int, and `if value` would drop it.
+
+        `_strings_in` guards its string branch with `if value` -- correctly, an empty
+        string carries nothing. Copying that guard here would silently drop `0`, so the
+        distinction is pinned rather than left to the next reader's care.
+        """
+
+        self.assertEqual(interpret._numbers_in(0), ["0"])
+
+    def test_a_bool_is_not_collected_even_though_it_is_an_int(self):
+        """🔴 The trap this function is most likely to be 'simplified' into.
+
+        `isinstance(True, int)` is True in Python -- `bool` is an `int` subclass -- so a
+        bare `isinstance(value, int)` check turns `True` into the string `"True"` and
+        puts it in a haystack the module searches with regular expressions.
+        """
+
+        self.assertEqual(interpret._numbers_in(True), [])
+
+    def test_a_float_is_not_collected(self):
+        """Excluded on measured grounds, not by omission.
+
+        No status is fractional, and both `402.0` and `0.402` match `\b402\b`. The
+        module already records a live defect of exactly that shape -- `"billed $0.402"`
+        classifying as a spent balance -- so admitting floats reintroduces it.
+        """
+
+        self.assertEqual(interpret._numbers_in(402.0), [])
+
+    def test_a_missing_status_is_not_collected(self):
+        """A missing status is not a status; `"None"` is noise in the haystack."""
+
+        self.assertEqual(interpret._numbers_in(None), [])
+
+    def test_a_nested_integer_is_not_collected(self):
+        """The bound that keeps a provider's PARAMETERS from being read as statuses.
+
+        🔴 Measured: without it, `{"error": {"type": "rate_limit_error",
+        "retry_after": 401}}` starts reporting "provider rejected the credentials".
+        The bound is the vendor's own carrier rather than a guess -- the Agent SDK
+        reference puts `api_error_status` at the TOP LEVEL of the result message,
+        beside `subtype`, defined as "the HTTP status code of the API error that
+        terminated the conversation".
+        """
+
+        self.assertEqual(
+            interpret._numbers_in({"type": "rate_limit_error", "retry_after": 400}), []
+        )
+        self.assertEqual(interpret._numbers_in([400, 401]), [])
+
+
+class StatusReachesTheCredentialTierTests(unittest.TestCase):
+    """KBR-182. A status the provider reported structurally must route like one.
+
+    Before this ticket `\\b40[13]\\b` could only match the CLI's `API Error: NNN` text,
+    so a rejected key that arrived with its status in the structured field and an
+    unrecognised message fell through to the generic tier and was called a workflow
+    fault -- with the re-run refused.
+    """
+
+    def test_a_401_that_is_the_only_signal_reaches_the_credential_tier(self):
+        """The ticket's headline case, with nothing else in the record to carry it."""
+
+        status, reason = interpret.classify(status_record(401))
+
+        self.assertEqual(status, "exhausted")
+        self.assertTrue(
+            reason.startswith("provider rejected the credentials or model"), reason
+        )
+        self.assertIn("401", reason)
+
+    def test_a_403_that_is_the_only_signal_reaches_the_credential_tier(self):
+        """The other half of `\\b40[13]\\b`, which no fixture exercised structurally."""
+
+        status, reason = interpret.classify(status_record(403))
+
+        self.assertEqual(status, "exhausted")
+        self.assertTrue(
+            reason.startswith("provider rejected the credentials or model"), reason
+        )
+        self.assertIn("403", reason)
+
+    def test_a_dead_key_behind_a_generic_code_is_no_longer_a_workflow_fault(self):
+        """🔴 The defect, in the shape that costs an operator the most.
+
+        `OPENAI_401_MESSAGE_ONLY` carries no credential vocabulary at all, so when the
+        CLI puts it in `result` -- model-authored, and scoped out by KBR-166 -- the only
+        thing left identifying it is the status field. Measured on `origin/main`: this
+        record was `fatal` "workflow-level failure: 'invalid_request'" with
+        `retryable` false, so an operator was sent to debug a correct workflow while
+        their key was dead, and the free re-run was refused.
+        """
+
+        record = status_record(401, result=OPENAI_401_MESSAGE_ONLY)
+
+        status, reason = interpret.classify(record)
+
+        self.assertEqual(status, "exhausted")
+        self.assertIn("401", reason)
+        self.assertTrue(
+            interpret.retry_verdict(
+                status, record_present=True, cause_named=False, elapsed_seconds=600
+            ),
+            "a rejected credential bills nothing, so the one free re-run must survive",
+        )
+
+    def test_the_string_form_still_routes_as_it_always_did(self):
+        """The route that DID work must not be disturbed by the one that did not.
+
+        A provider that sends the status as a JSON string reached the haystack through
+        `_strings_in` before this ticket. That path is untouched, and saying so here is
+        cheaper than discovering it moved.
+        """
+
+        status, reason = interpret.classify(status_record("401"))
+
+        self.assertEqual(status, "exhausted")
+        self.assertIn("401", reason)
+
+
+class StatusNeverReachesTheFatalTierTests(unittest.TestCase):
+    """KBR-182. The bound that makes the fix safe, asserted rather than described.
+
+    🔴 **`FATAL_PATTERNS` is tier 1 and carries `\\b400\\b`.** A bare status in the full
+    haystack lets any 400 pre-empt every quota and credential tier below it -- and
+    Anthropic reports a SPENT BALANCE as HTTP 400, so that is not a hypothetical
+    ordering argument but KBR-145's filed defect arriving through a new door. These
+    rows fail the moment the coercion is moved into `_strings_in`, which is the fix
+    KBR-182's own ticket text proposes.
+    """
+
+    def test_the_numeric_status_is_absent_from_the_tier_one_haystack(self):
+        """The structural claim, at the function that decides it."""
+
+        self.assertNotIn("400", interpret._outcome_text(status_record(400)))
+
+    def test_the_numeric_status_is_present_in_the_provider_scoped_haystack(self):
+        """🔴 The other half, without which the test above passes on a no-op.
+
+        A fix that simply dropped the field would satisfy the exclusion and deliver
+        nothing. Both halves together are what pin the design.
+        """
+
+        self.assertIn("400", interpret._provider_outcome_text(status_record(400)))
+
+    def test_a_spent_balance_reported_as_a_400_is_still_a_spent_balance(self):
+        """🔴 KBR-145's defect, in the one body that would reintroduce it.
+
+        Anthropic's spent-balance response is HTTP 400 `invalid_request_error`, not
+        402, and here the 400 is ONLY in the structured field -- the shape the field
+        exists for. Measured: with the status in the full haystack this record becomes
+        `fatal` "workflow-level failure: '400'" and `retryable` false -- an operator
+        with an empty balance sent to debug a correct workflow, and the re-run refused.
+        """
+
+        record = status_record(400, error=ANTHROPIC_LOW_CREDIT_NO_NUMBER)
+
+        status, reason = interpret.classify(record)
+
+        self.assertEqual(status, "exhausted")
+        self.assertTrue(reason.startswith("provider quota exhausted"), reason)
+        self.assertTrue(
+            interpret.retry_verdict(
+                status, record_present=True, cause_named=False, elapsed_seconds=600
+            ),
+            "a spent balance must keep the re-run this module already grants it",
+        )
+
+    def test_the_cli_prefixed_form_is_claimed_by_tier_one_and_that_is_pre_existing(self):
+        """⚠️ Pinned as UNCHANGED, not endorsed -- and it is a real defect.
+
+        With the CLI's `API Error: 400` prefix in the text, `\\b400\\b` matches prose and
+        tier 1 claims the record before the quota tier is ever consulted, so Anthropic's
+        spent balance reads as a broken workflow. That is live on `main`, is the same
+        family as KBR-145, and is filed separately: distinguishing it from the
+        context-management refusal -- also a 400, also carrying a billing word -- needs
+        the body, and tier 1 never gives the body a turn.
+
+        The row is here so the pre-existing verdict is visible rather than implied, and
+        so the follow-up ticket has something that fails when it lands.
+        """
+
+        status, _ = interpret.classify(status_record(400, result=ANTHROPIC_400_LOW_CREDIT))
+
+        self.assertEqual(status, "fatal")
+
+    def test_a_bare_400_is_not_promoted_to_a_workflow_fault(self):
+        """The same bound with no body at all to rescue the verdict.
+
+        A transport 400 says the request was rejected; it does not say BY WHAT, and
+        Anthropic's balance response proves the two are not the same question.
+        """
+
+        status, _ = interpret.classify(status_record(400))
+
+        self.assertEqual(status, "exhausted")
+
+    def test_every_quota_fixture_is_unchanged_by_its_own_status(self):
+        """The quota set, carried with the status each body names. None may move."""
+
+        for name, body in QUOTA_FIXTURES:
+            for code in (400, 402, 429):
+                with self.subTest(fixture=name, status=code):
+                    status, reason = interpret.classify(status_record(code, result=body))
+
+                    self.assertEqual(status, "exhausted", name)
+                    self.assertTrue(
+                        reason.startswith("provider quota exhausted"),
+                        f"{name} at {code}: resolved by {reason!r}, not by the quota tier",
+                    )
+
+
+#: Every status this repository can produce, and the bodies each may arrive with.
+#:
+#: 🔴 **Incoherent pairs are deliberate, and excluding them is how the first version of
+#: this measurement missed a regression.** Revision 1 of the design measured only
+#: "coherent" rows -- each body paired with the status its own text names -- which is
+#: constructed so it cannot see the hazard: a body whose text names NO status, carried
+#: beside a numeric one, is the only shape `api_error_status` exists for. A gateway's
+#: status need not match a passed-through upstream body either.
+STATUS_MATRIX_STATUSES = (None, 400, 401, 402, 403, 404, 429, 500, 502, 503, 529)
+
+STATUS_MATRIX_BODIES = (
+    ("no body", {}),
+    ("anthropic low credit, no number", {"error": ANTHROPIC_LOW_CREDIT_NO_NUMBER}),
+    ("deepseek no balance", {"result": DEEPSEEK_NO_BALANCE}),
+    ("openrouter no credits", {"result": OPENROUTER_NO_CREDITS}),
+    ("anthropic named 401", {"result": ANTHROPIC_401_AUTHENTICATION_ERROR}),
+    ("anthropic named 403", {"result": ANTHROPIC_403_PERMISSION_ERROR}),
+    ("openai 401 message only", {"result": OPENAI_401_MESSAGE_ONLY}),
+    ("billed generic invalid_request", {"error": {
+        "type": "invalid_request_error", "message": "the request was rejected"}}),
+    ("coding plan 1308", {"result": CODING_PLAN_5H_QUOTA}),
+    ("transient server error", {"error": {
+        "type": "server_error", "message": "Overloaded"}}),
+    ("nested retry_after 401", {"error": {
+        "type": "rate_limit_error", "message": "slow down", "retry_after": 401}}),
+)
+
+#: The rows KBR-182 MOVES, measured on `origin/main` @ `11a5c88` before the change.
+#:
+#: Each is the same defect: the provider rejected the credentials, said so only in the
+#: structured status, and was reported as a broken workflow with the free re-run
+#: refused. Every other cell of the matrix keeps the verdict it already had, which is
+#: what :meth:`StatusMatrixTests.test_no_row_becomes_a_workflow_fault` holds it to.
+STATUS_MATRIX_MOVED = {
+    (401, "openai 401 message only"): ("fatal", "exhausted"),
+    (401, "billed generic invalid_request"): ("fatal", "exhausted"),
+    (403, "openai 401 message only"): ("fatal", "exhausted"),
+    (403, "billed generic invalid_request"): ("fatal", "exhausted"),
+}
+
+
+class StatusMatrixTests(unittest.TestCase):
+    """KBR-182 AC3. The before/after verdict, for every status against every body.
+
+    🔴 **The ticket asks for this measurement because the fix is behaviour-changing.**
+    Turning a dormant field on wakes every numeric pattern that reads the haystack it
+    joins, so the question is not "does the fix work" but "what else moved". The answer
+    must be a table a reader can check, not a claim in a commit message.
+    """
+
+    def _classify(self, status, fields):
+        """Classify one cell of the matrix.
+
+        Args:
+            status: The ``api_error_status`` value, or None to omit it.
+            fields: The other outcome fields on the event.
+
+        Returns:
+            The ``(status, reason)`` pair :func:`classify` returned.
+        """
+
+        return interpret.classify(status_record(status, **fields))
+
+    def test_no_status_turns_a_record_into_a_workflow_fault(self):
+        """🔴 The invariant the design exists to hold: nothing moves INTO `fatal`.
+
+        A row that gains a `fatal` verdict also loses its re-run -- `retry_verdict`
+        refuses one whenever a record is present -- so an operator is both misdirected
+        and denied the retry that would have proved the misdirection wrong. That is
+        KBR-145's defect, and `\\b400\\b` in tier 1 is the loaded gun.
+
+        🔴 **The control is the SAME BODY with the status removed, not a table of
+        expected verdicts.** A hardcoded table was the first version and it was
+        vacuous: rows it did not list compared against `None` and passed whatever the
+        code did, so the rejected full-haystack design -- which turns a bodyless 400
+        into a workflow fault -- walked straight through the guard that existed to stop
+        it. Classifying the body alone asks the question directly: adding a status may
+        sharpen a verdict, and may rescue one from `fatal`, but may never create one.
+        """
+
+        for name, fields in STATUS_MATRIX_BODIES:
+            without, _ = self._classify(None, fields)
+            if without == "fatal":
+                # The body is a workflow fault on its own; the status cannot make that
+                # worse, and rows it RESCUES are asserted elsewhere.
+                continue
+            for status in STATUS_MATRIX_STATUSES:
+                with self.subTest(status=status, body=name):
+                    verdict, reason = self._classify(status, fields)
+
+                    self.assertNotEqual(
+                        verdict,
+                        "fatal",
+                        f"body {name!r} alone is {without}; adding "
+                        f"api_error_status={status} made it fatal ({reason!r})",
+                    )
+
+    def test_every_recorded_move_actually_happened(self):
+        """The other direction: a claimed move that did not happen is a stale record.
+
+        Without this, :data:`STATUS_MATRIX_MOVED` could name rows the code no longer
+        touches and the guard above would quietly weaken -- it reads the table as a
+        list of permitted exceptions.
+        """
+
+        for (status, name), (before, after) in STATUS_MATRIX_MOVED.items():
+            fields = dict(STATUS_MATRIX_BODIES)[name]
+            with self.subTest(status=status, body=name):
+                verdict, reason = self._classify(status, fields)
+
+                self.assertEqual(
+                    verdict,
+                    after,
+                    f"status {status} with {name!r} was {before} on main and is "
+                    f"recorded as moving to {after}; it is {verdict} ({reason!r})",
+                )
+
+    def test_every_moved_row_regains_the_free_re_run(self):
+        """AC3's cost half. A verdict that moves must move `retryable` with it.
+
+        🔴 Asserted through `retry_verdict` rather than read off the status name: the
+        module's own header says reading one off the other is the mistake upstream was
+        filed over.
+        """
+
+        for (status, name), (_, after) in STATUS_MATRIX_MOVED.items():
+            fields = dict(STATUS_MATRIX_BODIES)[name]
+            with self.subTest(status=status, body=name):
+                verdict, _ = self._classify(status, fields)
+
+                self.assertEqual(verdict, after)
+                self.assertTrue(
+                    interpret.retry_verdict(
+                        verdict,
+                        record_present=True,
+                        cause_named=False,
+                        elapsed_seconds=600,
+                    )
+                )
+
+    def test_the_advice_still_agrees_with_the_verdict_on_every_moved_row(self):
+        """KBR-145's invariant, re-checked on the rows this ticket disturbs.
+
+        `_write_diagnostic` reads the EVIDENCE while `classify` reads pattern order, so
+        the two can disagree without either being obviously wrong. A credential verdict
+        must not be handed a top-up paragraph: the operator would be told to spend money
+        on a key that needs replacing.
+        """
+
+        for (status, name), _ in STATUS_MATRIX_MOVED.items():
+            fields = dict(STATUS_MATRIX_BODIES)[name]
+            record = status_record(status, **fields)
+            with self.subTest(status=status, body=name):
+                verdict, reason = interpret.classify(record)
+
+                self.assertFalse(
+                    _quota_diagnostic(record, verdict, reason),
+                    f"status {status} with {name!r}: verdict says credentials, "
+                    "advice says top up a balance",
+                )
+
+    def test_a_status_that_matches_no_pattern_changes_nothing(self):
+        """The statuses this repository can produce but does not yet READ.
+
+        402, 404 and 529 reach the generic fallthrough on a bodyless record: `\\b402\\b`
+        is deliberately absent from the quota set, `\\b40[13]\\b` excludes 404, and
+        `\\b50[023]\\b` does not cover 529. Pinned so a reader of the matrix does not
+        assume every status improved, and so the follow-up ticket that adds 402 and 404
+        has a row that fails when it lands.
+        """
+
+        for code in (402, 404, 529):
+            with self.subTest(status=code):
+                verdict, reason = self._classify(code, {})
+
+                self.assertEqual(verdict, "exhausted")
+                self.assertEqual(
+                    reason, "ran but returned no payload and no recognisable error"
                 )
 
 

--- a/.github/review/tests/test_review_scripts.py
+++ b/.github/review/tests/test_review_scripts.py
@@ -18118,7 +18118,9 @@ class StatusMatrixTests(unittest.TestCase):
 
         # 🔴 The guard skips bodies that are already `fatal`, so a change making more
         # of them fatal would shrink it toward vacuity in silence. Code review caught
-        # the same shape once already in this class.
+        # the same shape once already in this class. The skipped direction -- a status
+        # RESCUING a fatal body -- is asserted by
+        # `test_every_recorded_move_actually_happened`, which is the other half.
         self.assertGreater(
             checked, 90, "the fatal-alone skip has eaten most of this guard"
         )
@@ -18129,6 +18131,12 @@ class StatusMatrixTests(unittest.TestCase):
         Without this, :data:`STATUS_MATRIX_MOVED` could name rows the code no longer
         touches and the guard above would quietly weaken -- it reads the table as a
         list of permitted exceptions.
+
+        🔴 **This is also the RESCUE half of the invariant, and the pairing is easy to
+        break by halves.** `test_no_status_turns_a_record_into_a_workflow_fault` skips
+        any body that is already `fatal` alone, so the direction it cannot see -- a
+        status rescuing a fatal body into `exhausted` -- is asserted only here. Reduce
+        one of these two and check the other first.
         """
 
         for (status, name), (before, after) in STATUS_MATRIX_MOVED.items():

--- a/.github/review/tests/test_review_scripts.py
+++ b/.github/review/tests/test_review_scripts.py
@@ -17784,6 +17784,28 @@ class NumericOutcomeFieldTests(unittest.TestCase):
 
         self.assertEqual(interpret._numbers_in(None), [])
 
+    def test_a_negative_number_is_not_a_status(self):
+        r"""🔴 Decided explicitly, because the default was wrong in a surprising way.
+
+        `-401` stringifies to `"-401"`, and `\b40[13]\b` **matches inside it** -- `-` is a
+        non-word character, so the word boundary falls right before the digits. An
+        unbounded coercion therefore routed a negative number through the credential
+        tier, which no provider ever sends and nothing had decided.
+
+        ⚠️ A PR review raised this and asserted the opposite -- that the leading minus
+        made such a value inert. Measured before acting on it: it routed. The finding
+        was right that the behaviour was unpinned; its reasoning was backwards, and
+        pinning the claim rather than the measurement would have frozen a fiction.
+        """
+
+        self.assertEqual(interpret._numbers_in(-401), [])
+        self.assertEqual(interpret._numbers_in(-1), [])
+
+        status, reason = interpret.classify(status_record(-401))
+
+        self.assertEqual(status, "exhausted")
+        self.assertNotIn("401", reason)
+
     def test_an_absurd_integer_is_bounded_rather_than_flooding_the_haystack(self):
         """The numeric twin of :data:`OUTCOME_FIELD_CHARS`, which cannot express it.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       contents: read
     uses: ./.github/workflows/tests.yml
 
-  # The review system's own suite: 687 tests over the rule selector, the result
+  # The review system's own suite: 691 tests over the rule selector, the result
   # classifier, the failure and superseded notices, the prompt redactor, the
   # findings schema, and the wiring of `claude-code-review.yml` and this file.
   #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       contents: read
     uses: ./.github/workflows/tests.yml
 
-  # The review system's own suite: 664 tests over the rule selector, the result
+  # The review system's own suite: 687 tests over the rule selector, the result
   # classifier, the failure and superseded notices, the prompt redactor, the
   # findings schema, and the wiring of `claude-code-review.yml` and this file.
   #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       contents: read
     uses: ./.github/workflows/tests.yml
 
-  # The review system's own suite: 691 tests over the rule selector, the result
+  # The review system's own suite: 692 tests over the rule selector, the result
   # classifier, the failure and superseded notices, the prompt redactor, the
   # findings schema, and the wiring of `claude-code-review.yml` and this file.
   #

--- a/.system_design/TEST_SUITE.md
+++ b/.system_design/TEST_SUITE.md
@@ -3692,6 +3692,13 @@ first by `FATAL_PATTERNS`, which carries `\b400\b`. Anthropic reports a spent ba
 verdict with the re-run refused. The bound is at the field's own value: a number nested inside
 a provider's error object is a parameter, not a status.
 
+⚠️ Two qualifications, because the rule is easy to state more absolutely than it holds. It
+governs **parseable** records: when `_parse_events` fails, `classify` searches the raw text
+whole and always has, status text included. And `_provider_outcome_text` has a **second
+consumer** — `_write_diagnostic`'s quota branch — so a numeric pattern added to
+`QUOTA_WORD_PATTERNS` would fire the top-up paragraph off a bare status, including under a
+`fatal` verdict. That is the door KBR-207 has to walk through carefully.
+
 **I-C4 — The verdict, the `retryable` flag and the diagnostic's advice must agree.** They are
 computed by three different functions from three different inputs — pattern order, cost, and
 the evidence text — so they can disagree without any one of them being obviously wrong.

--- a/.system_design/TEST_SUITE.md
+++ b/.system_design/TEST_SUITE.md
@@ -3658,6 +3658,57 @@ Running `mypy src/kitty` on the Windows leg is therefore not redundant with the 
 a **new detector over code no check has ever read**. That is also why the platform legs run the
 whole step list rather than pytest alone.
 
+### 8.5 The review classifier's tier order
+
+The gate is not the only thing that decides whether a pull request is reviewed.
+`.github/review/scripts/interpret_claude_result.py` reads the wreckage of a failed review
+attempt and answers a question no test in `tests/` asks: **who fixes this** — top up a
+balance, or edit a workflow. It also decides whether the one automatic retry is spent. Its
+entire rationale has lived in module comments, which is why three tickets (KBR-145, KBR-172,
+KBR-166) each re-derived the same reasoning from scratch. The invariants are recorded here so
+the next change to it has something to contradict.
+
+**I-C1 — Tier order is a cost ordering, not a specificity ordering.** `FATAL_PATTERNS` is
+consulted first, then quota, then credentials, then the generic-code tier, then transients.
+"Generic loses to everything more specific" reads well and is wrong: `EXHAUSTED_PATTERNS`
+carries the bare words `timeout` and `capacity`, which a model can write in its own prose, so
+yielding to them would let a billed rejection be retried at full price. The order is justified
+by what each misclassification costs, and each entry's position is measured rather than
+argued.
+
+**I-C2 — A pattern weak enough to appear in ordinary prose is scoped by AUTHORSHIP, never by
+a tighter regex.** KBR-172 and KBR-166 each measured anchoring — on vendor vocabulary, on the
+CLI's line shape, on proximity to a spending verb — and every version lost a real provider
+body while still leaking model prose. The separable question is not what the text says but who
+wrote it, and the execution record already answers it: `_provider_outcome_text` is the
+narrower haystack, and the weak patterns read only that.
+
+**I-C3 — A numeric outcome field is admitted to the provider-scoped haystack only.** KBR-182.
+`api_error_status` is a JSON number and was discarded before any pattern saw it, so the field
+whose purpose is to report the provider's status was dead weight while looking live. It is now
+read — but it must never reach the haystack `_outcome_text` returns, because that one is read
+first by `FATAL_PATTERNS`, which carries `\b400\b`. Anthropic reports a spent balance as HTTP
+400, so a bare status in the tier-1 haystack turns an empty account into a "broken workflow"
+verdict with the re-run refused. The bound is at the field's own value: a number nested inside
+a provider's error object is a parameter, not a status.
+
+**I-C4 — The verdict, the `retryable` flag and the diagnostic's advice must agree.** They are
+computed by three different functions from three different inputs — pattern order, cost, and
+the evidence text — so they can disagree without any one of them being obviously wrong.
+KBR-145 was filed because they did: an operator was told to top up a balance and, one
+paragraph up, that the workflow was broken. Any change to the tier order re-checks all three.
+
+**How it is proven.** `.github/review/tests/test_review_scripts.py`, run directly by `ci.yml`
+rather than through `pytest`, so it is outside §8.1's marker matrix and carries no layer
+marker. That is deliberate: the suite must stay runnable with a bare interpreter and no
+installed dependencies, because a broken review workflow has to be diagnosable before an
+environment is provisioned. Its content is L1 in kind. Behaviour-changing edits to the tier
+order carry a before/after table over the full cross product of statuses and body fixtures —
+incoherent pairs included, since a gateway's status need not match a passed-through upstream
+body — and `StatusMatrixTests` is the pattern to copy.
+
+---
+
 ## 9. Gap register
 
 ### 9.1 What the current suite already does well

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,7 +125,7 @@ target-version = "py310"
 # next carried-across fix would arrive as a conflict. `.github/review/rules/ci.md`
 # records the same rule for anyone reviewing a change there.
 #
-# NOTE: this is not "that code is unchecked". `ci.yml` runs its 691-case suite
+# NOTE: this is not "that code is unchecked". `ci.yml` runs its 692-case suite
 # on every pull request, and that suite carries guards this linter could not
 # express - the private-reference sweep, the runner-ceiling pairing, the
 # aggregate's dependency set.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,7 +125,7 @@ target-version = "py310"
 # next carried-across fix would arrive as a conflict. `.github/review/rules/ci.md`
 # records the same rule for anyone reviewing a change there.
 #
-# NOTE: this is not "that code is unchecked". `ci.yml` runs its 687-case suite
+# NOTE: this is not "that code is unchecked". `ci.yml` runs its 691-case suite
 # on every pull request, and that suite carries guards this linter could not
 # express - the private-reference sweep, the runner-ceiling pairing, the
 # aggregate's dependency set.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,7 +125,7 @@ target-version = "py310"
 # next carried-across fix would arrive as a conflict. `.github/review/rules/ci.md`
 # records the same rule for anyone reviewing a change there.
 #
-# NOTE: this is not "that code is unchecked". `ci.yml` runs its 664-case suite
+# NOTE: this is not "that code is unchecked". `ci.yml` runs its 687-case suite
 # on every pull request, and that suite carries guards this linter could not
 # express - the private-reference sweep, the runner-ceiling pairing, the
 # aggregate's dependency set.


### PR DESCRIPTION
Fixes [KBR-182](https://shelpuk.atlassian.net/browse/KBR-182).

## Context for the Product Owner

When the automated code reviewer fails on a pull request, a small program reads the wreckage and decides **who fixes it**: *"the provider is out of money or your key is dead — top up and re-run"* versus *"the workflow itself is broken — go edit it."* Those two answers send an engineer to opposite ends of the building, and the same verdict also decides whether we spend money on a second attempt.

That program lists the provider's HTTP status code among the six things it reads. **It has never actually read it.** Status codes arrive as numbers, the code collected only text, and the number was thrown away before anything looked at it. The one field whose entire job is to say *"401 — your key is dead"* was decoration; the program was inferring the cause from prose instead.

**What changes for an engineer.** A rejected API key that arrives behind a generic error code used to come back as *"workflow-level failure"* with the free retry refused. Someone would spend an afternoon auditing a config file that was correct, while the real fix was a new key. Four such real-world shapes now route correctly and get their retry back. Nothing else moves.

**Cost of getting this wrong, and why the obvious fix was rejected.** The ticket proposed a one-line type check. Design review and an independent check of Anthropic's documentation found that **Anthropic bills a spent credit balance as HTTP 400, not 402** — and "400" is this module's single strongest signal for *"your workflow is broken."* The one-line fix would have told a customer with an empty account that their pipeline was broken **and** refused the retry — the exact failure the team already fixed once in KBR-145, re-entering through a new door. The fix here shows the status only to the checks that should see it, never to the one that would misfire.

**Three defects were found and filed rather than folded in**, per the repository's standing policy: KBR-206, KBR-207, KBR-209. Two are pre-existing on `main`; each has a test on this branch that fails when its ticket lands.

---

## The defect

`OUTCOME_FIELDS` lists six outcome-bearing fields. `_outcome_parts` collects them through `_strings_in`, which collects **string leaves only**, so a JSON number falls through to `return []`.

```
_strings_in(402)    -> []        # int: the form production sends
_strings_in("402")  -> ['402']   # str: the form the field was written for
```

Every numeric pattern in the module — `\b400\b`, `\b40[13]\b`, `\b429\b`, `\b50[023]\b`, `\b1308\b` — could therefore only ever match the CLI's `API Error: NNN` text, never the structured field.

## The fix, and why it is shaped this way

`_numbers_in` collects a top-level integer. **Where its output goes is the load-bearing decision**: the status is admitted to the provider-scoped haystack (`_provider_outcome_text`) and never to the full one `FATAL_PATTERNS` reads first.

This is KBR-166's own mechanism applied once more, not a new idea. That ticket established that the separable question is **who wrote a field**, and a numeric `api_error_status` is the most unambiguously provider-authored value in the record. The full-haystack alternative widens exactly what KBR-166 narrowed.

Bounds, each with a measured trigger: `bool` excluded (it is an `int` subclass — `True` would enter the haystack as `"True"`); `float` excluded (`0.402` matches `\b402\b`, the defect this module already documents); nested numbers excluded (a `retry_after` of 401 would read as a rejected credential); and a size cap, the numeric twin of `OUTCOME_FIELD_CHARS`.

The `depth == 0` bound is the vendor's carrier, not taste: the Agent SDK reference puts `api_error_status` at the **top level** of the `result` message, defined as *"the HTTP status code of the API error that terminated the conversation."*

## Deviation from the ticket's AC-1, stated plainly

AC-1 literally asks for the coercion inside `_strings_in`. That is satisfiable only by the design that regresses, so it was not done. AC-3 is the ticket's own authority for narrowing — *"any row that moves is either intended and recorded, or the change is narrowed until it does not move."* The deviation is recorded in the module, in `TEST_SUITE.md` §8.5, and in the task spec.

## Measurement

Full cross product, before vs after. Incoherent pairs are included deliberately: a body that names no status is the shape this field exists for, and the first version of the measurement excluded exactly those and therefore could not see the regression.

⚠️ **Two numbers, and they answer different questions.** The design was driven by a throwaway harness carrying 18 bodies × 11 statuses = **198 rows** — that is where the four moves and the rejected design's three regressions were found. What ships is `StatusMatrixTests`: 13 bodies × 11 statuses = **143 cells**, plus the quota sweep at 7 × 11 = **77**, for **220 committed assertions**. The harness is not in the tree, so the committed figure is the one to quote.

**4 verdict changes, zero moving into `fatal`:**

| status | body | before | after |
|---|---|---|---|
| 401 | OpenAI message-only, in `result` | `fatal` `'invalid_request'`, retryable=false | `exhausted` `'401'`, retryable=true |
| 401 | billed generic `invalid_request` object | `fatal`, retryable=false | `exhausted` `'401'`, retryable=true |
| 403 | OpenAI message-only, in `result` | `fatal`, retryable=false | `exhausted` `'403'`, retryable=true |
| 403 | billed generic `invalid_request` object | `fatal`, retryable=false | `exhausted` `'403'`, retryable=true |

Plus 10 reason-only changes where the verdict is identical and the diagnostic names the status instead of *"no recognisable error."*

**Nine mutants, all killed** — including the rejected full-haystack design, killed by exactly the four tier-1 guards written for it.

## Review history, since it changed the design twice

- **Design review** falsified the original justification with the Anthropic 400 fact and proved the rejected alternative was strictly better. The measurement method was rebuilt because its "coherent pairs only" rule was constructed so it could not find the regression.
- **Code review** verified the behaviour and rejected the *evidence*: the verdict/advice assertion could not fail, the authorship boundary for numbers was held by nothing, and two comments made claims that measurement falsified. All corrected in `0957794`, and the false claims are corrected rather than softened.

## Also in this PR

- `TEST_SUITE.md` §8.5 records the classifier's tier-order invariants (I-C1…I-C4). Three tickets have now each re-derived them from module comments; the design doc did not mention this module at all.
- `test_a_named_cause_carries_a_body_that_has_no_number` is repaired — its fixture relied on the defect to hide its own `403`, so a test named "has no number" was passing on a record with a number in it. The numbered pairing is kept as the ordering test it is really evidence for.

## Verification

- `python .github/review/tests/test_review_scripts.py` — **691 passed** (was 664).
- `mypy` clean on the changed module; `ruff` excludes `.github/` by design.
- `pytest tests/test_pypi_packaging.py tests/test_github_actions.py tests/test_layer_markers.py tests/test_layer_selection.py` — passed.
- The quoted test count is updated in all three documents that pin it.

## Not fixed here, filed instead

| Ticket | |
|---|---|
| [KBR-206](https://shelpuk.atlassian.net/browse/KBR-206) | Anthropic's spent balance carries `API Error: 400` in its **text**, so tier 1 still calls it a workflow fault — and the diagnostic prints "top up the balance" anyway, contradicting its own verdict. Pre-existing. Both halves pinned. |
| [KBR-207](https://shelpuk.atlassian.net/browse/KBR-207) | 402 and 404 are now readable but match nothing, so the two statuses that name their own fix land in the fallthrough. The recorded reason for excluding `\b402\b` was dissolved by KBR-166. Blocked by this ticket. |
| [KBR-209](https://shelpuk.atlassian.net/browse/KBR-209) | `_parse_events` catches only `JSONDecodeError`, but `json.loads` raises plain `ValueError` on an integer over 4,300 digits, so an absurd status crashes the classifier and no diagnostic is written. Pre-existing. |

One pre-existing issue noted and deliberately **not** touched, per the surgical-changes rule: `test_a_named_type_is_reported_in_preference_to_its_status_code` has `\b40[13]\b` in a non-raw docstring, so its rendered text contains literal backspace characters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[KBR-182]: https://shelpuk.atlassian.net/browse/KBR-182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KBR-206]: https://shelpuk.atlassian.net/browse/KBR-206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
