### PR TITLE
Close the transport a custom-transport adapter owns (KBR-190)

### DIFF
--- a/.system_design/TEST_SUITE.md
+++ b/.system_design/TEST_SUITE.md
@@ -1413,7 +1413,7 @@ whether to change it is Q3.
 
 ### 5.5 Per-transport containment
 
-`_session_for` and `should_bypass` govern **only** `BridgeServer`'s own aiohttp sessions. Four
+`_session_for` and `should_bypass` govern **only** `BridgeServer`'s own aiohttp sessions. Five
 other outbound paths exist, and each applies the proxy **unconditionally, without consulting
 `should_bypass`**:
 
@@ -1445,8 +1445,10 @@ custom-transport adapter has to decide about its client as well as its wire shap
 1. **Closing a `curl_cffi` session under a live SSE stream is the one shape that has crashed.**
    `_curl_session`'s docstring recorded that as the reason it was never closed, citing
    lexiforest/curl_cffi **#675**. That issue was filed against **0.13.0** on the *synchronous*
-   `Session` and was **closed 2026-07-18 as no longer reproducible**; this project pins
-   **0.16.3**. More to the point, `stop_async` closes adapters only **after**
+   `Session` and was **closed 2026-07-18 as no longer reproducible**. That was read on
+   **0.16.3**, the version resolved here — `pyproject.toml` declares `curl_cffi>=0.7` with no
+   upper bound, the weakest pin in the repo, so this is measured rather than guaranteed. More
+   to the point, `stop_async` closes adapters only **after**
    `_runner.cleanup()` has drained the in-flight handlers, so the precondition is not met on
    the ordinary path. Upstream **#845** still tracks **#751**, "active stream/session close
    lifecycle", so the risk is reduced, not zero — which is why a **failed drain deliberately

--- a/.system_design/TEST_SUITE.md
+++ b/.system_design/TEST_SUITE.md
@@ -1417,13 +1417,53 @@ whether to change it is Q3.
 other outbound paths exist, and each applies the proxy **unconditionally, without consulting
 `should_bypass`**:
 
-| Path | Client | How the proxy is applied |
-|---|---|---|
-| `openai_subscription` — serving | `curl_cffi.AsyncSession` | `proxies=` + `CURLOPT_NOPROXY` |
-| `openai_subscription` — OAuth **refresh** leg | its own `curl_cffi.AsyncSession` | `proxies=` + `CURLOPT_NOPROXY` |
-| `openai_subscription` — OAuth **login** leg (`kitty.auth.openai_oauth`) | its own `aiohttp.ClientSession` | `aiohttp_session_kwargs()` |
-| `bedrock` | boto3 / botocore | `BotoConfig(proxies=egress.proxies_dict())` |
-| `ollama_cloud` | its own `aiohttp.ClientSession` | `aiohttp_session_kwargs()` |
+| Path | Client | How the proxy is applied | Who closes it |
+|---|---|---|---|
+| `openai_subscription` — serving | `curl_cffi.AsyncSession` | `proxies=` + `CURLOPT_NOPROXY` | `aclose()`, from `stop_async` |
+| `openai_subscription` — OAuth **refresh** leg | its own `curl_cffi.AsyncSession` | `proxies=` + `CURLOPT_NOPROXY` | `aclose()`, from `stop_async` |
+| `openai_subscription` — OAuth **login** leg (`kitty.auth.openai_oauth`) | its own `aiohttp.ClientSession` | `aiohttp_session_kwargs()` | `run_oauth_flow`, in a `finally`, when it built the session itself |
+| `bedrock` | boto3 / botocore | `BotoConfig(proxies=egress.proxies_dict())` | nobody — nothing is cached; `_get_boto3_client` builds one per request |
+| `ollama_cloud` | its own `aiohttp.ClientSession` | `aiohttp_session_kwargs()` | `aclose()`, from `stop_async` |
+
+**The fourth column is new, and it was empty until KBR-190.** `BridgeServer.stop_async`
+closed the two sessions the bridge itself builds and nothing else, so a bridge started and
+stopped **inside a living process** leaked one connection pool per cycle per custom-transport
+adapter. Ordinary use never noticed — the bridge's lifetime is the process's and the OS
+reclaims the sockets — but the suite starts and stops bridges in-process thousands of times,
+and that is where it surfaced, as an `Unclosed client session` per test.
+
+**The bridge owns the adapters it is given.** `ProviderAdapter.aclose()` is the hook: a no-op
+by default, overridden by the adapters that own a client. The ownership is a contract rather
+than an observation about today's call sites — `get_provider()` returns a **fresh instance per
+call** and all five construction sites build their adapters immediately before the
+`BridgeServer` that receives them, so a caller must not hand one adapter to two bridges whose
+lifetimes overlap. `tests/test_wire_shape_honesty.py` sweeps the registry so a fourth
+custom-transport adapter has to decide about its client as well as its wire shape.
+
+**Three points where this could have gone wrong, and what settles each.**
+
+1. **Closing a `curl_cffi` session under a live SSE stream is the one shape that has crashed.**
+   `_curl_session`'s docstring recorded that as the reason it was never closed, citing
+   lexiforest/curl_cffi **#675**. That issue was filed against **0.13.0** on the *synchronous*
+   `Session` and was **closed 2026-07-18 as no longer reproducible**; this project pins
+   **0.16.3**. More to the point, `stop_async` closes adapters only **after**
+   `_runner.cleanup()` has drained the in-flight handlers, so the precondition is not met on
+   the ordinary path. Upstream **#845** still tracks **#751**, "active stream/session close
+   lifecycle", so the risk is reduced, not zero — which is why a **failed drain deliberately
+   skips the adapter close**. Leaking a pool beats crashing the process.
+2. **A failure must not cascade, in either direction.** One adapter's `aclose()` failing is
+   logged and contained, so the others still close — shutdown has no caller positioned to act
+   on a provider's teardown error. Conversely the adapters close from a `finally`, so a failure
+   in the bridge's *own* teardown cannot skip them, which would leak exactly what this fixes.
+   And each adapter detaches its cached session **before** awaiting `close()`: the `curl_cffi`
+   builders test for absence only, so a session left in place after a failed close would be
+   handed back for the rest of the process's life — silent, under the containment above, and
+   permanent.
+3. **Teardown is not a request.** `_close_provider_transports` reads the backing fields
+   `_provider` and `_backends`, never the `_active_*` properties, which resolve through a
+   request-scoped `ContextVar`. Reading that at shutdown would close whichever backend the last
+   request happened to select. It deduplicates by identity, because balancing mode is
+   constructed with `provider=backends[0][0]`.
 
 **Why the refresh leg has its own session rather than sharing the serving one (KBR-161).** Not for
 identity — both come from one builder, `_new_curl_session`, so they cannot drift apart on
@@ -1432,7 +1472,7 @@ the provider sees: an `AsyncSession` owns a bounded pool of curl handles (`max_c
 streaming completion holds its handle for the life of the stream, so a refresh sharing that pool
 would queue behind in-flight completions **while holding `OAuthSession._refresh_lock`**, blocking
 every request for that account; and cookies are host-scoped, so one jar would hold
-`auth.openai.com`'s cookies for the process lifetime and replay them across every account the bridge
+`auth.openai.com`'s cookies for the bridge's lifetime and replay them across every account the bridge
 serves. The two legs address different hosts, so sharing buys nothing observable and costs both.
 
 Three consequences the rest of §5 must not paper over:

--- a/src/kitty/bridge/server.py
+++ b/src/kitty/bridge/server.py
@@ -1038,7 +1038,14 @@ _EMPTY_CTX: _BackendContext = {}  # Sentinel default for .get() — avoids per-a
 
 
 class BridgeServer:
-    """HTTP bridge that translates between agent protocols and upstream Chat Completions."""
+    """HTTP bridge that translates between agent protocols and upstream Chat Completions.
+
+    **Ownership of the adapters.**  The bridge owns the adapters handed to it as
+    ``provider`` and ``backends``: :meth:`stop_async` closes the HTTP transport
+    each one built (KBR-190).  Every caller constructs them immediately before
+    the server that receives them, and a caller must not give one adapter to two
+    bridges whose lifetimes overlap.
+    """
 
     def __init__(
         self,
@@ -2300,7 +2307,21 @@ class BridgeServer:
         return asyncio.get_event_loop().run_until_complete(self.start_async())
 
     async def stop_async(self) -> None:
-        """Gracefully stop the server and close the HTTP client session.
+        """Gracefully stop the server and close every HTTP client session.
+
+        The order is the safety argument, not an accident.  ``_runner.cleanup()``
+        runs first so in-flight handlers drain; the bridge's own sessions, log
+        file and state file follow; the adapters' transports come **last**, so a
+        provider that fails to close cannot cost the bridge its own cleanup or
+        leave a state file claiming a live bridge.
+
+        The containment runs both ways.  The adapters close from a ``finally``,
+        so a failure in the bridge's own teardown cannot skip them — that would
+        leak exactly what KBR-190 exists to fix.  A failed **drain** is the one
+        exception: it is deliberately fatal to the adapter close, because an
+        undrained handler may still hold a live stream, and closing a transport
+        under one is the single shape ``curl_cffi`` is known to have crashed on.
+        Leaking a pool beats crashing the process.
 
         The session summary is written in a ``finally``: a teardown step that
         raises must not cost a gracefully-shut-down bridge its only durable
@@ -2310,24 +2331,61 @@ class BridgeServer:
             if self._runner is not None:
                 await self._runner.cleanup()
                 self._runner = None
-            if self._session is not None and not self._session.closed:
-                await self._session.close()
-                self._session = None
-            if self._proxy_session is not None and not self._proxy_session.closed:
-                await self._proxy_session.close()
-                self._proxy_session = None
-            self._app = None
-            if self._access_log_file is not None:
-                self._access_log_file.close()
-                self._access_log_file = None
-            # Remove state file
-            if self._state_file:
-                from kitty.bridge.state import remove_state
+            # Past the drain, so no handler holds a live stream and a provider's
+            # transport is safe to close; the `finally` is what guarantees the
+            # adapters still close if the bridge's own teardown below fails.
+            try:
+                if self._session is not None and not self._session.closed:
+                    await self._session.close()
+                    self._session = None
+                if self._proxy_session is not None and not self._proxy_session.closed:
+                    await self._proxy_session.close()
+                    self._proxy_session = None
+                self._app = None
+                if self._access_log_file is not None:
+                    self._access_log_file.close()
+                    self._access_log_file = None
+                # Remove state file
+                if self._state_file:
+                    from kitty.bridge.state import remove_state
 
-                remove_state(self._state_file)
+                    remove_state(self._state_file)
+            finally:
+                await self._close_provider_transports()
         finally:
             self._write_session_summary()
         logger.info("Bridge server stopped")
+
+    async def _close_provider_transports(self) -> None:
+        """Close the HTTP transport owned by every adapter this bridge holds.
+
+        Adapters with ``use_custom_transport`` build a client of their own that
+        this server's sessions know nothing about, so before KBR-190 a bridge
+        started and stopped inside a living process leaked a connection pool per
+        cycle.
+
+        Read from the backing fields ``_provider`` and ``_backends``, never the
+        ``_active_*`` properties: those resolve through a request-scoped
+        ``ContextVar``, and teardown is not a request — reading it would close
+        whichever backend the last request happened to select.
+
+        Deduplicated by identity, because balancing mode is constructed with
+        ``provider=backends[0][0]`` and the same adapter is then reachable twice.
+
+        A failure is logged and contained rather than propagated: shutdown has no
+        caller positioned to act on a provider's teardown error, and one bad
+        adapter must not cost the others their close.  Same rule as
+        :meth:`_write_session_summary` below.
+        """
+        seen: set[int] = set()
+        for provider in [self._provider, *(backend[0] for backend in self._backends or [])]:
+            if id(provider) in seen:
+                continue
+            seen.add(id(provider))
+            try:
+                await provider.aclose()
+            except Exception as exc:
+                logger.warning("Failed to close transport for provider %s: %s", type(provider).__name__, exc)
 
     def stop(self) -> None:
         """Synchronous wrapper around stop_async."""

--- a/src/kitty/providers/base.py
+++ b/src/kitty/providers/base.py
@@ -14,8 +14,11 @@ _MASK = "****"
 class ProviderAdapter(ABC):
     """Interface for upstream Chat Completions API providers.
 
-    Implementations are stateless: they build request payloads and parse
-    response payloads but do not perform HTTP calls themselves.
+    Most implementations are stateless: they build request payloads and parse
+    response payloads but do not perform HTTP calls themselves.  The adapters
+    that set ``use_custom_transport`` are the exception — each owns an HTTP
+    client of its own, and :meth:`aclose` is how the bridge releases it at
+    teardown (KBR-190).
     """
 
     # Internal metadata keys that must never be sent upstream.
@@ -639,6 +642,29 @@ class ProviderAdapter(ABC):
             NotImplementedError: If not overridden by a custom-transport provider.
         """
         raise NotImplementedError("Custom transport provider must implement stream_request()")
+
+    async def aclose(self) -> None:
+        """Release any HTTP transport this adapter owns.
+
+        A no-op by default, because an adapter driven through the bridge's own
+        aiohttp session owns nothing to release.  An adapter with
+        ``use_custom_transport`` true builds and caches its own client, and
+        :meth:`~kitty.bridge.server.BridgeServer.stop_async` awaits this at
+        teardown to close it.
+
+        An override must set the cached attribute back to ``None`` **before**
+        awaiting the close, not after.  The ``curl_cffi`` builders test only for
+        absence, so a session left in place would be handed back for ever — and
+        ``stop_async`` logs and contains a failing close, which would make that
+        silent as well as permanent.
+
+        Safe to call more than once, and on an adapter that never served a
+        request — ``start_async``'s F49 path can reach ``stop_async`` before the
+        caller does.
+        """
+        # An explicit no-op rather than an empty body: this is a hook with a
+        # default, not an abstract method every adapter has to answer.
+        return None
 
 
 class ProviderError(Exception):

--- a/src/kitty/providers/bedrock.py
+++ b/src/kitty/providers/bedrock.py
@@ -36,6 +36,13 @@ class BedrockAdapter(ProviderAdapter):
     Supports two auth modes via provider_config:
     - AWS credentials stored in Kitty (access_key:secret_key)
     - AWS SSO / named profile (boto3 credential chain)
+
+    **No** :meth:`~kitty.providers.base.ProviderAdapter.aclose` override, unlike
+    the other two custom-transport adapters: :meth:`_get_boto3_client` builds a
+    client per request and caches nothing on the instance, so a stopping bridge
+    has nothing here to release (KBR-190).  ``tests/test_provider_bedrock.py``
+    pins that property, and the registry sweep in
+    ``tests/test_wire_shape_honesty.py`` names this adapter as the one exemption.
     """
 
     @property

--- a/src/kitty/providers/ollama_cloud.py
+++ b/src/kitty/providers/ollama_cloud.py
@@ -315,6 +315,26 @@ class OllamaCloudAdapter(ProviderAdapter):
             self._session = aiohttp.ClientSession(timeout=timeout, **aiohttp_session_kwargs())
         return self._session
 
+    async def aclose(self) -> None:
+        """Close the session this adapter owns, so the bridge does not leak it.
+
+        ``BridgeServer.stop_async`` closes the sessions **it** built and knows
+        nothing about this one, so before KBR-190 a bridge started and stopped
+        inside a living process leaked a connection pool per cycle.
+
+        The attribute is cleared as well as closed — and cleared first, so that
+        a session whose ``close()`` raises still leaves the adapter usable.
+        :meth:`_get_session` then builds a fresh session if this adapter serves
+        another bridge.
+        """
+        # Detached BEFORE the await, not after: `stop_async` logs and contains a
+        # failing close, so an attribute still pointing at a half-closed session
+        # would be handed back for the rest of the process's life, with one
+        # WARNING as the only trace.
+        session, self._session = self._session, None
+        if session is not None and not session.closed:
+            await session.close()
+
     def _build_url(self, provider_config: dict) -> str:
         """Build the full upstream URL.
 

--- a/src/kitty/providers/openai_subscription.py
+++ b/src/kitty/providers/openai_subscription.py
@@ -238,7 +238,12 @@ class OpenAISubscriptionAdapter(OpenAIAdapter):
         reported as a segfault.  Closing at teardown is a different moment:
         ``BridgeServer.stop_async`` closes adapters only after aiohttp's runner
         has drained the in-flight handlers, and #675 was closed upstream as no
-        longer reproducible on the 0.16.3 this project pins.
+        longer reproducible.  **Measured, not guaranteed:** that was read on
+        0.16.3, the version resolved here, and ``pyproject.toml`` declares
+        ``curl_cffi>=0.7`` with no upper bound — the weakest pin in the repo, as
+        ``tests/test_curl_cffi_transport_contract.py`` records.  A future
+        resolution could pick up a version where the lifecycle work still open
+        under #751 bites, which is why a failed drain skips the close entirely.
 
         Automatically persists Cloudflare cookies across requests.
         """

--- a/src/kitty/providers/openai_subscription.py
+++ b/src/kitty/providers/openai_subscription.py
@@ -232,10 +232,15 @@ class OpenAISubscriptionAdapter(OpenAIAdapter):
     def _curl_session(self) -> curl_cffi.requests.AsyncSession:
         """Long-lived curl_cffi session for Codex backend requests.
 
-        Lazily created, never explicitly closed during normal operation.
+        Lazily created, and closed by :meth:`aclose` when the bridge stops
+        (KBR-190).  Still not built with ``async with``, which would close it
+        while an SSE stream was still running — the shape curl_cffi issue #675
+        reported as a segfault.  Closing at teardown is a different moment:
+        ``BridgeServer.stop_async`` closes adapters only after aiohttp's runner
+        has drained the in-flight handlers, and #675 was closed upstream as no
+        longer reproducible on the 0.16.3 this project pins.
+
         Automatically persists Cloudflare cookies across requests.
-        Not using ``async with`` avoids the curl_cffi segfault (issue #675)
-        that occurs when closing a session with an active SSE stream.
         """
         if self._curl_session_instance is None:
             ca_path = _resolve_ca_cert_path()
@@ -303,7 +308,7 @@ class OpenAISubscriptionAdapter(OpenAIAdapter):
           for that account;
         * cookies are host-scoped, and this leg addresses ``auth.openai.com``
           while the API leg addresses ``chatgpt.com``, so one jar would hold
-          both hosts' cookies for the process lifetime and replay the auth
+          both hosts' cookies for the bridge's lifetime and replay the auth
           host's across every account the bridge serves.
 
         Sharing would buy nothing observable: the two legs never share a
@@ -314,6 +319,41 @@ class OpenAISubscriptionAdapter(OpenAIAdapter):
             self._oauth_curl_session_instance = self._new_curl_session(_resolve_ca_cert_path())
             logger.debug("Created curl_cffi OAuth session with impersonate=%s", _CODEX_IMPERSONATE)
         return self._oauth_curl_session_instance
+
+    async def aclose(self) -> None:
+        """Close both curl sessions this adapter owns.
+
+        The serving leg and the OAuth refresh leg hold separate handle pools and
+        separate cookie jars (see :attr:`_oauth_curl_session`), so both are
+        released, and each is released independently of the other: a process
+        that only ever logged in has built the second and not the first.
+
+        Both attributes are detached **before** either session is closed.  The
+        builders above test for absence only and consult no ``closed`` flag, so a
+        session left in place after a failed close would be handed back for the
+        rest of the process's life — and ``stop_async`` contains that failure, so
+        it would be silent as well as permanent.
+
+        Raises:
+            Exception: Whatever a session's ``close()`` raises, after both have
+                been attempted.  Propagated rather than swallowed here: the
+                containment decision belongs to
+                :meth:`~kitty.bridge.server.BridgeServer.stop_async`, which owns
+                the shutdown, not to the adapter.
+        """
+        # Detached first, so neither a failure nor an early return can strand a
+        # dead session on the adapter.
+        serving, self._curl_session_instance = self._curl_session_instance, None
+        oauth, self._oauth_curl_session_instance = self._oauth_curl_session_instance, None
+        # The OAuth leg closes in a `finally`: the two legs own separate handle
+        # pools, so a serving-leg failure must not strand the other one detached
+        # and unclosed, which is unreachable by any later call.
+        try:
+            if serving is not None:
+                await serving.close()
+        finally:
+            if oauth is not None:
+                await oauth.close()
 
     # ── Helpers ────────────────────────────────────────────────────────────
 

--- a/tests/bridge/test_adapter_transport_close.py
+++ b/tests/bridge/test_adapter_transport_close.py
@@ -1,0 +1,316 @@
+"""Bridge teardown releases the transports its adapters own — KBR-190.
+
+``.system_design/TEST_SUITE.md`` §5.5.  ``BridgeServer.stop_async`` closed the
+two sessions the bridge builds and nothing else, so an adapter with
+``use_custom_transport`` leaked its own connection pool on every start/stop
+cycle inside a living process.
+
+**Why these are L1 and construct a real server anyway.**  §2.2's own worked
+example puts a test that must build a ``BridgeServer`` at L1 — the behaviour is
+not a pure function, but nothing here touches a socket, a clock or a provider:
+the adapters are stubs that count, and the bridge is never started.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from kitty.bridge.server import BridgeServer, _backend_context
+from kitty.profiles import Profile
+from kitty.providers.base import ProviderAdapter
+
+
+class _CountingAdapter(ProviderAdapter):
+    """A minimal adapter that records every ``aclose`` it receives.
+
+    Attributes:
+        closes: How many times :meth:`aclose` has been awaited.
+    """
+
+    def __init__(self, *, fails: bool = False) -> None:
+        """Create an adapter that counts closes, and optionally fails them.
+
+        Args:
+            fails: When True, :meth:`aclose` raises after counting — the
+                misbehaving-provider case R7's containment is written for.
+        """
+        self.closes = 0
+        self._fails = fails
+
+    @property
+    def provider_type(self) -> str:
+        """Return the registry name this stub answers to."""
+        return "counting"
+
+    @property
+    def default_base_url(self) -> str:
+        """Return an address no test may reach."""
+        return "https://example.invalid/v1"
+
+    def build_request(self, model: str, messages: list[dict], **kwargs: object) -> dict:
+        """Return an empty request; nothing here serves traffic."""
+        return {}
+
+    def parse_response(self, response_data: dict) -> dict:
+        """Return the response unchanged; nothing here serves traffic."""
+        return response_data
+
+    def map_error(self, status_code: int, body: dict) -> Exception:
+        """Return a generic error; nothing here serves traffic."""
+        return Exception(f"stub {status_code}")
+
+    async def aclose(self) -> None:
+        """Count the close, and raise afterwards when built to fail.
+
+        Raises:
+            RuntimeError: When the adapter was constructed with ``fails=True``.
+        """
+        self.closes += 1
+        if self._fails:
+            raise RuntimeError("provider teardown failed")
+
+
+def _profile() -> Profile:
+    """Return a throwaway profile for a backend tuple.
+
+    Returns:
+        A profile the bridge reads only for ``backup`` and ``name``.
+    """
+    return Profile(name="counting", provider="openai", model="m", auth_ref=str(uuid.uuid4()))
+
+
+class TestEveryAdapterIsClosedExactlyOnce:
+    """R6 — the bridge closes what it holds, from its own backing fields."""
+
+    async def test_the_single_mode_provider_is_closed(self):
+        provider = _CountingAdapter()
+        server = BridgeServer(None, provider, "test-key")
+
+        await server.stop_async()
+
+        assert provider.closes == 1
+
+    async def test_every_distinct_backend_is_closed(self):
+        first, second = _CountingAdapter(), _CountingAdapter()
+        server = BridgeServer(
+            None,
+            first,
+            "key-0",
+            backends=[(first, "key-0", _profile()), (second, "key-1", _profile())],
+        )
+
+        await server.stop_async()
+
+        assert (first.closes, second.closes) == (1, 1)
+
+    async def test_an_adapter_reachable_twice_is_closed_once(self):
+        """``bridge_runner`` passes ``provider=backends[0][0]`` — the normal shape."""
+        shared = _CountingAdapter()
+        server = BridgeServer(None, shared, "key-0", backends=[(shared, "key-0", _profile())])
+
+        await server.stop_async()
+
+        assert shared.closes == 1
+
+    async def test_it_reads_the_backing_fields_not_the_request_context(self):
+        """Teardown is not a request, so it must not read request-scoped state.
+
+        ``_active_provider`` resolves through a ``ContextVar`` that
+        ``_select_backend`` writes per request.  An implementation that closed
+        ``self._active_provider`` would pass every case above — none of them
+        issues a request, so the var is unset and the property falls back to the
+        backing field.  Setting it here is the only way that defect dies.
+        """
+        held = _CountingAdapter()
+        stranger = _CountingAdapter()
+        server = BridgeServer(None, held, "test-key")
+        token = _backend_context.set({"provider": stranger, "key": "k", "model": "m", "idx": 0})
+
+        try:
+            await server.stop_async()
+        finally:
+            _backend_context.reset(token)
+
+        assert held.closes == 1
+        assert stranger.closes == 0, "teardown read the request-scoped backend, not the bridge's own"
+
+
+class TestOneAdapterCannotCostTheOthers:
+    """R7 — a provider's teardown failure is contained, not propagated."""
+
+    async def test_a_failing_close_does_not_stop_the_next_adapter(self):
+        failing, healthy = _CountingAdapter(fails=True), _CountingAdapter()
+        server = BridgeServer(
+            None,
+            failing,
+            "key-0",
+            backends=[(failing, "key-0", _profile()), (healthy, "key-1", _profile())],
+        )
+
+        await server.stop_async()
+
+        assert failing.closes == 1
+        assert healthy.closes == 1
+
+    async def test_a_failing_close_is_logged(self, caplog):
+        failing = _CountingAdapter(fails=True)
+        server = BridgeServer(None, failing, "test-key")
+
+        with caplog.at_level("WARNING", logger="kitty.bridge.server"):
+            await server.stop_async()
+
+        assert "provider teardown failed" in caplog.text
+
+    async def test_the_session_summary_is_still_written(self, tmp_path):
+        """The `finally` that guarantees the record must survive a bad adapter."""
+        summary = tmp_path / "summary.json"
+        server = BridgeServer(
+            None,
+            _CountingAdapter(fails=True),
+            "test-key",
+            session_summary_path=summary,
+        )
+
+        await server.stop_async()
+
+        assert summary.exists()
+
+
+class _RecordingSession:
+    """An aiohttp-session stand-in that records when the bridge closes it.
+
+    Attributes:
+        closed: Whether :meth:`close` has run — the flag ``stop_async`` guards on.
+    """
+
+    def __init__(self, label: str, events: list[str]) -> None:
+        """Record closes into a shared sequence under ``label``.
+
+        Args:
+            label: The name to append when this session is closed.
+            events: The shared sequence every teardown step appends to.
+        """
+        self.closed = False
+        self._label = label
+        self._events = events
+
+    async def close(self) -> None:
+        """Append this session's label and mark it closed."""
+        self._events.append(self._label)
+        self.closed = True
+
+
+class TestTeardownOrder:
+    """R7 — the order is the safety argument, so it is pinned, not assumed."""
+
+    async def test_the_whole_teardown_sequence_is_pinned(self, tmp_path, monkeypatch):
+        """Every step is given a double, and the sequence is compared whole.
+
+        A never-started bridge has ``None`` for its runner, both sessions and its
+        log file, so a test that simply calls ``stop_async`` records a
+        one-element sequence and an "adapters come last" assertion passes while
+        proving nothing.  Each step is populated here, and the comparison is
+        equality against the full list rather than containment.
+
+        The two constraints it pins: the runner drains **first**, because that
+        drain is what makes closing a provider's transport safe at all; and the
+        adapters come **last**, so a provider that fails to close cannot cost the
+        bridge its own sessions or leave a state file claiming a live bridge.
+        """
+        events: list[str] = []
+
+        class _RecordingAdapter(_CountingAdapter):
+            async def aclose(self) -> None:
+                """Record the close in the shared sequence."""
+                events.append("adapter")
+                await super().aclose()
+
+        class _RecordingRunner:
+            async def cleanup(self) -> None:
+                """Record the runner drain in the shared sequence."""
+                events.append("runner")
+
+        state_file = tmp_path / "bridge_state.json"
+        # `remove_state` is a function-body import, so the double has to patch the
+        # name in `kitty.bridge.state`, not one bound on `kitty.bridge.server`.
+        monkeypatch.setattr(
+            "kitty.bridge.state.remove_state",
+            lambda _path: events.append("state"),
+        )
+
+        server = BridgeServer(None, _RecordingAdapter(), "test-key", state_file=str(state_file))
+        server._runner = _RecordingRunner()  # type: ignore[assignment]
+        server._session = _RecordingSession("session", events)  # type: ignore[assignment]
+        server._proxy_session = _RecordingSession("proxy_session", events)  # type: ignore[assignment]
+
+        await server.stop_async()
+
+        assert events == ["runner", "session", "proxy_session", "state", "adapter"]
+
+    async def test_a_failing_bridge_teardown_still_closes_the_adapters(self):
+        """Containment runs both ways — this is the direction R7 nearly missed.
+
+        Skipping the adapters because the bridge's own cleanup failed would leak
+        exactly what this ticket exists to fix.  The failure still propagates:
+        the bridge's own teardown has no containment decision behind it.
+        """
+        provider = _CountingAdapter()
+        server = BridgeServer(None, provider, "test-key")
+
+        class _FailingSession:
+            closed = False
+
+            async def close(self) -> None:
+                """Fail the bridge's own session close."""
+                raise RuntimeError("bridge session close failed")
+
+        server._session = _FailingSession()  # type: ignore[assignment]
+
+        with pytest.raises(RuntimeError, match="bridge session close failed"):
+            await server.stop_async()
+
+        assert provider.closes == 1
+
+    async def test_a_failing_bridge_teardown_still_writes_the_summary(self, tmp_path):
+        """The `finally` that guarantees the record, exercised by the path that reaches it."""
+        summary = tmp_path / "summary.json"
+        server = BridgeServer(None, _CountingAdapter(), "test-key", session_summary_path=summary)
+
+        class _FailingSession:
+            closed = False
+
+            async def close(self) -> None:
+                """Fail the bridge's own session close."""
+                raise RuntimeError("bridge session close failed")
+
+        server._session = _FailingSession()  # type: ignore[assignment]
+
+        with pytest.raises(RuntimeError, match="bridge session close failed"):
+            await server.stop_async()
+
+        assert summary.exists()
+
+    async def test_a_failed_drain_deliberately_skips_the_adapters(self):
+        """The one direction containment must NOT run, and it is a decision.
+
+        An undrained handler may still hold a live stream, and closing a
+        transport under one is the single shape ``curl_cffi`` is known to have
+        crashed on.  Leaking a pool beats crashing the process, so a drain
+        failure is fatal to the adapter close rather than contained.
+        """
+        provider = _CountingAdapter()
+        server = BridgeServer(None, provider, "test-key")
+
+        class _FailingRunner:
+            async def cleanup(self) -> None:
+                """Fail the drain."""
+                raise RuntimeError("drain failed")
+
+        server._runner = _FailingRunner()  # type: ignore[assignment]
+
+        with pytest.raises(RuntimeError, match="drain failed"):
+            await server.stop_async()
+
+        assert provider.closes == 0, "an undrained handler may hold a live stream"

--- a/tests/harness/provider_aiohttp.py
+++ b/tests/harness/provider_aiohttp.py
@@ -104,26 +104,32 @@ class ProviderAiohttpTransport:
         await self._recorder.start()
 
     async def stop(self) -> None:
-        """Release the recorder's port, and close the adapter's own session.
+        """Close the adapter's transport, then release the recorder's port.
 
-        ``BridgeServer.stop_async`` closes the sessions **it** owns and knows
-        nothing about an adapter that built its own, so without this the
-        ``ollama_cloud`` session outlives every test that starts one — an
-        "Unclosed client session" warning per test, and a real leak in a gate
-        that runs thousands. Closing it here rather than in the product is
-        deliberate: the product's session is a per-process pool whose lifetime is
-        the process, and shortening it would be a change to the product to suit
-        a test.
+        **The private-attribute reach is gone (KBR-190).** This used to read
+        ``adapter._session`` and close it, arguing that the product's session was
+        a per-process pool whose lifetime was the process, so closing it at
+        bridge stop would be a change to the product to suit a test. That premise
+        was false: ``get_provider`` builds a fresh adapter per call and every
+        caller builds one immediately before the ``BridgeServer`` that receives
+        it, so the session's lifetime is the **bridge's**.
+        ``BridgeServer.stop_async`` closes it now, through
+        :meth:`~kitty.providers.base.ProviderAdapter.aclose`.
 
-        The recorder is stopped in a ``finally``: a session that fails to close
+        **The call remains, on the product's public hook.** Four tests in this
+        module drive the adapter directly — ``bind()`` then ``make_request()`` —
+        with no bridge in them to do it, and dropping the close outright would
+        leak a session per test, which is the symptom the original reach existed
+        to prevent. ``aclose`` is idempotent, so the ordinary path closes twice
+        and notices nothing.
+
+        The recorder is stopped in a ``finally``: a transport that fails to close
         must not leave a port bound, because the next test's ephemeral port
         allocation is the only thing that would notice.
         """
         try:
             if self._adapter is not None:
-                session = self._adapter._session
-                if session is not None and not session.closed:
-                    await session.close()
+                await self._adapter.aclose()
         finally:
             await self._recorder.stop()
 

--- a/tests/harness/test_provider_aiohttp.py
+++ b/tests/harness/test_provider_aiohttp.py
@@ -71,6 +71,7 @@ from harness.recorder_conformance import (
 from harness.test_contract import _KITTY_IMPORT
 from kitty.auth import openai_oauth
 from kitty.auth.oauth_session import OAuthSession
+from kitty.bridge.server import BridgeServer
 from kitty.providers.ollama_cloud import OllamaCloudAdapter
 
 #: The format this transport serves, named once so a case differs from its
@@ -336,10 +337,14 @@ class TestTheTransport:
         # precede, and record what the session looked like when it ran.
         closed_when_port_released: list[bool] = []
         original_stop = subject.recorder.stop
+        # Captured before `stop()`, because `aclose` detaches the attribute as
+        # well as closing the session — reading `adapter._session` inside the
+        # observer would find `None` and record False whatever the order was.
+        session = adapter._session
 
         async def _observe() -> None:
             """Record the session's state, then release the port."""
-            closed_when_port_released.append(adapter._session is not None and adapter._session.closed)
+            closed_when_port_released.append(session is not None and session.closed)
             await original_stop()
 
         subject.recorder.stop = _observe  # type: ignore[method-assign]
@@ -347,21 +352,41 @@ class TestTheTransport:
 
         assert closed_when_port_released == [True]
 
-    async def test_stopping_closes_the_session_the_adapter_owns(self) -> None:
-        """``BridgeServer.stop_async`` closes only the sessions it owns.
+    async def test_the_bridge_closes_the_session_the_adapter_owns(self) -> None:
+        """``BridgeServer.stop_async`` releases the adapter's own session (KBR-190).
 
-        Without this the ``ollama_cloud`` session outlives every test that
-        started one: an "Unclosed client session" per test, and a real leak in a
-        gate that runs thousands.
+        Without it the ``ollama_cloud`` session outlives every test that started
+        one: an "Unclosed client session" per test, and a real leak in a gate
+        that runs thousands. That used to be this transport's job, and closing it
+        here was argued for in ``stop``'s docstring; the product owns it now.
+
+        **Driven without a fixture, and without :meth:`ProviderAiohttpTransport.stop`
+        in between.** That method still closes the adapter, for the no-bridge
+        path — so through the fixture the two are indistinguishable and this
+        would pass against a ``stop_async`` that had never been changed. Reverting
+        the product change must fail this test, and only this shape makes it.
         """
         subject = ProviderAiohttpTransport(FORMAT)
-        async with BridgeFixture(subject) as fixture:
-            await fixture.post(inbound_path(ROUTE), minimal_inbound_body(ROUTE, marker()))
-            adapter, _config = subject.bind()
+        await subject.start()
+        try:
+            adapter, config = subject.bind()
+            await adapter.make_request(
+                {
+                    "model": MODEL,
+                    "messages": [{"role": "user", "content": "hi"}],
+                    "_resolved_key": "harness-key",
+                    "_provider_config": config,
+                }
+            )
             session = adapter._session
+            server = BridgeServer(None, adapter, "harness-key", provider_config=config)
 
-        assert session is not None, "the request did not go through the adapter's own session"
-        assert session.closed
+            await server.stop_async()
+
+            assert session is not None, "the request did not go through the adapter's own session"
+            assert session.closed
+        finally:
+            await subject.stop()
 
 
 class TestThroughARealBridge:

--- a/tests/providers/test_openai_subscription.py
+++ b/tests/providers/test_openai_subscription.py
@@ -2983,3 +2983,160 @@ class TestOAuthRefreshErrorClassification:
 
         assert exc_info.value.http_status == 401
         assert "refresh_token_reused" in str(exc_info.value)
+
+
+# ── Session release (KBR-190) ────────────────────────────────────────────────
+
+
+class _FakeCurlSession:
+    """A stand-in for ``curl_cffi.AsyncSession`` that records its close.
+
+    Real sessions are cheap to build but closing one enters libcurl, and the
+    claim under test is only that the adapter awaits ``close()`` and clears the
+    attribute — which a fake proves exactly and a real session proves no better.
+    """
+
+    def __init__(self) -> None:
+        """Start with an empty cookie jar and no close recorded."""
+        self.cookies = curl_cffi.requests.Cookies()
+        self.closed = False
+
+    async def close(self) -> None:
+        """Record that the adapter closed this session."""
+        self.closed = True
+
+
+def _patch_new_curl_session(adapter: OpenAISubscriptionAdapter) -> unittest.mock._patch:
+    """Make both session builders hand out a fresh fake.
+
+    Args:
+        adapter: The adapter whose builder is replaced.
+
+    Returns:
+        The patcher, for use as a context manager.
+    """
+    return unittest.mock.patch.object(
+        adapter,
+        "_new_curl_session",
+        side_effect=lambda _ca_path: _FakeCurlSession(),
+    )
+
+
+class TestACloseReleasesBothCurlSessions:
+    """KBR-190 — the serving leg and the OAuth refresh leg are both released."""
+
+    async def test_it_closes_and_clears_both_legs(self):
+        adapter = OpenAISubscriptionAdapter()
+        with _patch_new_curl_session(adapter):
+            serving = adapter._curl_session
+            oauth = adapter._oauth_curl_session
+
+            await adapter.aclose()
+
+        assert serving.closed
+        assert oauth.closed
+        assert adapter._curl_session_instance is None
+        assert adapter._oauth_curl_session_instance is None
+
+    async def test_the_serving_leg_closes_when_the_oauth_leg_was_never_built(self):
+        """The legs are independent: one absent must not strand the other."""
+        adapter = OpenAISubscriptionAdapter()
+        with _patch_new_curl_session(adapter):
+            serving = adapter._curl_session
+
+            await adapter.aclose()
+
+        assert serving.closed
+        assert adapter._curl_session_instance is None
+        assert adapter._oauth_curl_session_instance is None
+
+    async def test_the_oauth_leg_closes_when_the_serving_leg_was_never_built(self):
+        """The mirror case — a login-only process never builds the serving leg."""
+        adapter = OpenAISubscriptionAdapter()
+        with _patch_new_curl_session(adapter):
+            oauth = adapter._oauth_curl_session
+
+            await adapter.aclose()
+
+        assert oauth.closed
+        assert adapter._oauth_curl_session_instance is None
+        assert adapter._curl_session_instance is None
+
+    async def test_it_is_a_no_op_when_neither_leg_was_built(self):
+        adapter = OpenAISubscriptionAdapter()
+
+        await adapter.aclose()
+
+        assert adapter._curl_session_instance is None
+        assert adapter._oauth_curl_session_instance is None
+
+    async def test_it_is_idempotent(self):
+        """`start_async`'s state-write failure path can reach `stop_async` twice."""
+        adapter = OpenAISubscriptionAdapter()
+        with _patch_new_curl_session(adapter):
+            serving = adapter._curl_session
+            oauth = adapter._oauth_curl_session
+
+            await adapter.aclose()
+            await adapter.aclose()
+
+        assert (serving.closed, oauth.closed) == (True, True)
+        assert adapter._curl_session_instance is None
+        assert adapter._oauth_curl_session_instance is None
+
+    async def test_the_next_request_builds_a_fresh_serving_session(self):
+        """Clearing the attribute is what allows this — the builder tests `is None`."""
+        adapter = OpenAISubscriptionAdapter()
+        with _patch_new_curl_session(adapter):
+            first = adapter._curl_session
+            await adapter.aclose()
+
+            second = adapter._curl_session
+
+        assert second is not first
+        assert not second.closed
+
+    async def test_both_attributes_are_cleared_even_when_a_close_fails(self):
+        """A failing close must not strand a dead session on the adapter.
+
+        ``stop_async`` logs and contains a provider's teardown failure, so an
+        attribute still pointing at a half-closed session would be handed back
+        for the rest of the process's life, with one WARNING as the only trace.
+        """
+        adapter = OpenAISubscriptionAdapter()
+        with _patch_new_curl_session(adapter):
+            serving = adapter._curl_session
+            oauth = adapter._oauth_curl_session
+
+        async def _fail() -> None:
+            raise RuntimeError("close failed")
+
+        serving.close = _fail
+
+        with pytest.raises(RuntimeError, match="close failed"):
+            await adapter.aclose()
+
+        assert oauth.closed, "the second leg must still close when the first one fails"
+        assert adapter._curl_session_instance is None
+        assert adapter._oauth_curl_session_instance is None
+
+    async def test_the_oauth_leg_still_closes_when_the_serving_leg_fails(self):
+        """The legs are independent in failure, not only in absence.
+
+        They own separate handle pools, so a serving-leg failure must not leave
+        the OAuth leg detached and unclosed — a state no later call can reach.
+        """
+        adapter = OpenAISubscriptionAdapter()
+        with _patch_new_curl_session(adapter):
+            serving = adapter._curl_session
+            oauth = adapter._oauth_curl_session
+
+        async def _fail() -> None:
+            raise RuntimeError("close failed")
+
+        serving.close = _fail
+
+        with pytest.raises(RuntimeError, match="close failed"):
+            await adapter.aclose()
+
+        assert oauth.closed

--- a/tests/providers/test_openai_subscription.py
+++ b/tests/providers/test_openai_subscription.py
@@ -3106,7 +3106,9 @@ class TestACloseReleasesBothCurlSessions:
         adapter = OpenAISubscriptionAdapter()
         with _patch_new_curl_session(adapter):
             serving = adapter._curl_session
-            oauth = adapter._oauth_curl_session
+            # Built so both attributes are non-None going in; what happens to
+            # this leg is the *next* test's claim, not this one's.
+            _oauth = adapter._oauth_curl_session
 
         async def _fail() -> None:
             raise RuntimeError("close failed")
@@ -3116,7 +3118,6 @@ class TestACloseReleasesBothCurlSessions:
         with pytest.raises(RuntimeError, match="close failed"):
             await adapter.aclose()
 
-        assert oauth.closed, "the second leg must still close when the first one fails"
         assert adapter._curl_session_instance is None
         assert adapter._oauth_curl_session_instance is None
 

--- a/tests/test_provider_base.py
+++ b/tests/test_provider_base.py
@@ -1,5 +1,7 @@
 """Tests for providers/base.py — ProviderAdapter interface."""
 
+import inspect
+
 import pytest
 
 from kitty.providers.base import ProviderAdapter
@@ -240,3 +242,18 @@ class TestStreamRequestDefault:
         adapter = _stub_adapter()
         with pytest.raises(NotImplementedError):
             await adapter.stream_request({"model": "test", "messages": []}, lambda _: None)
+
+
+class TestACloseDefault:
+    """Default aclose is an awaitable no-op (KBR-190)."""
+
+    def test_it_is_a_coroutine_function(self):
+        """`stop_async` awaits this on every adapter, overridden or not."""
+        assert inspect.iscoroutinefunction(ProviderAdapter.aclose)
+
+    @pytest.mark.asyncio
+    async def test_default_returns_none_and_changes_nothing(self):
+        adapter = _stub_adapter()
+        before = dict(adapter.__dict__)
+        assert await adapter.aclose() is None
+        assert adapter.__dict__ == before

--- a/tests/test_provider_bedrock.py
+++ b/tests/test_provider_bedrock.py
@@ -797,3 +797,37 @@ class TestBedrockStreamErrorEvents:
         event = {"unknownFutureEvent": {"data": "something"}}
         chunks = adapter._translate_stream_event(event, "id", {})
         assert chunks == []
+
+
+class TestItCachesNoTransport:
+    """KBR-190 — why bedrock needs no ``aclose`` override.
+
+    The other two custom-transport adapters cache a client on the instance and
+    leak it when the bridge stops.  This one does not, and that is the reason it
+    is exempt from the sweep rather than an oversight.  If caching is ever added,
+    this fails and sends the author to ``OpenAISubscriptionAdapter.aclose``.
+    """
+
+    def test_get_boto3_client_returns_a_new_client_each_call(self):
+        adapter = BedrockAdapter()
+        args = ("AKIAEXAMPLE:secret-key", {"region": "us-east-1"})
+
+        first = adapter._get_boto3_client(*args)
+        second = adapter._get_boto3_client(*args)
+
+        assert first is not second
+
+    def test_no_client_is_stored_on_the_instance(self):
+        """The identity check above cannot see a client kept but not reused.
+
+        Both calls pass identical arguments, so an argument-keyed cache fails
+        that one too.  This catches the other shape — a client assigned to the
+        adapter and returned fresh each time — which is still state a stopping
+        bridge would have to release.
+        """
+        adapter = BedrockAdapter()
+        before = set(vars(adapter))
+
+        adapter._get_boto3_client("AKIAEXAMPLE:secret-key", {"region": "us-east-1"})
+
+        assert set(vars(adapter)) == before

--- a/tests/test_provider_ollama_cloud.py
+++ b/tests/test_provider_ollama_cloud.py
@@ -670,3 +670,69 @@ class TestOllamaCloudRegistry:
         from kitty.providers.registry import _registry
 
         assert "ollama_cloud" in _registry
+
+
+# ── Session release (KBR-190) ────────────────────────────────────────────────
+
+
+class TestACloseReleasesTheSession:
+    """KBR-190 — the bridge closes the session this adapter owns."""
+
+    async def test_it_closes_and_clears_a_built_session(self):
+        """Both halves matter: `closed` is the leak, `None` is the recovery."""
+        adapter = OllamaCloudAdapter()
+        session = await adapter._get_session()
+
+        await adapter.aclose()
+
+        assert session.closed
+        assert adapter._session is None
+
+    async def test_it_is_a_no_op_when_no_session_was_built(self):
+        """An adapter that never served a request is closed like any other."""
+        adapter = OllamaCloudAdapter()
+
+        await adapter.aclose()
+
+        assert adapter._session is None
+
+    async def test_it_is_idempotent(self):
+        """`start_async`'s state-write failure path can reach `stop_async` twice."""
+        adapter = OllamaCloudAdapter()
+        await adapter._get_session()
+
+        await adapter.aclose()
+        await adapter.aclose()
+
+        assert adapter._session is None
+
+    async def test_the_next_request_builds_a_fresh_session(self):
+        """A closed adapter still works — one instance can outlive one bridge."""
+        adapter = OllamaCloudAdapter()
+        first = await adapter._get_session()
+        await adapter.aclose()
+
+        second = await adapter._get_session()
+
+        assert second is not first
+        assert not second.closed
+        await adapter.aclose()
+
+    async def test_the_attribute_is_cleared_even_when_the_close_fails(self):
+        """A failing close must not strand a dead session on the adapter.
+
+        ``stop_async`` logs and contains a provider's teardown failure, so an
+        attribute still pointing at a half-closed session would be handed back
+        for the rest of the process's life, with one WARNING as the only trace.
+        """
+        adapter = OllamaCloudAdapter()
+        session = await adapter._get_session()
+
+        with (
+            patch.object(session, "close", new=AsyncMock(side_effect=RuntimeError("close failed"))),
+            pytest.raises(RuntimeError, match="close failed"),
+        ):
+            await adapter.aclose()
+
+        assert adapter._session is None
+        await session.close()

--- a/tests/test_wire_shape_honesty.py
+++ b/tests/test_wire_shape_honesty.py
@@ -1,4 +1,23 @@
-"""Contract guard — a provider adapter must declare the wire shape it actually emits.
+"""Contract guards over the adapter registry — wire shape, and transport lifetime.
+
+**Two contracts, not one.** The original and larger one is wire-shape honesty: a
+provider adapter must declare the wire shape it actually emits. The second, added
+by KBR-190, is that a custom-transport adapter must say what it does with the
+client it owns.
+
+They are chained rather than parallel. The wire-shape sweep runs over the whole
+``_registry``; the lifetime sweep runs over ``CUSTOM_TRANSPORT_ADAPTERS``, which
+:func:`test_custom_transport_adapters_are_the_known_exempt_set` pins **back** to
+the registry. So a fourth custom-transport adapter goes red there first, and red
+again here once it has been classified — one decision, in one file.
+
+**What the lifetime sweep does not prove.** Only that an override exists, never
+that it releases everything the adapter built. ``tests/test_provider_ollama_cloud.py``
+and ``tests/providers/test_openai_subscription.py`` prove the bodies; this pins
+that no adapter is silently exempt.
+
+---
+
 
 `.system_design/TEST_SUITE.md` §6.2.3, "Wire-shape honesty".  Catches finding
 **F5** (KBR-7): ``OpenCodeGoAdapter`` inherited ``upstream_wire_is_messages_api
@@ -347,6 +366,30 @@ def test_custom_transport_adapters_are_the_known_exempt_set():
     """
     observed = {name for name in _registry if get_provider(name).use_custom_transport}
     assert observed == CUSTOM_TRANSPORT_ADAPTERS
+
+
+def test_bedrock_is_the_only_custom_transport_adapter_inheriting_the_no_op_aclose():
+    """R10 (KBR-190) — a custom-transport adapter must decide about its client.
+
+    KBR-190: ``BridgeServer.stop_async`` releases the HTTP client a
+    custom-transport adapter builds, through
+    :meth:`~kitty.providers.base.ProviderAdapter.aclose`. Two of the three
+    override it. ``bedrock`` does not, and that is a decision rather than an
+    oversight: ``_get_boto3_client`` builds a client per request and caches
+    nothing on the instance, which ``tests/test_provider_bedrock.py`` pins
+    directly.
+
+    Derived from ``CUSTOM_TRANSPORT_ADAPTERS`` rather than a fourth literal of
+    the same set, so a new adapter is classified once — by the row above — and
+    arrives here already inside the sweep.
+    """
+    inherited = {
+        name for name in CUSTOM_TRANSPORT_ADAPTERS if type(get_provider(name)).aclose is ProviderAdapter.aclose
+    }
+    assert inherited == {"bedrock"}, (
+        "a custom-transport adapter owns a client the bridge must release at teardown: "
+        "override `aclose`, or prove it caches nothing and add it here"
+    )
 
 
 def test_messages_routing_table_is_unchanged():


### PR DESCRIPTION
Fixes [KBR-190](https://shelpuk.atlassian.net/browse/KBR-190).

## Context for the Product Owner

Kitty Bridge sits on the wire between a coding agent and an LLM provider. Most providers ride on the bridge's own network connection, which the bridge closes cleanly when it shuts down. Three providers — **Ollama Cloud**, the **ChatGPT subscription** path, and **AWS Bedrock** — carry their own connection instead, and nobody was closing those.

**What a user would have seen.** Almost nothing, in normal use: the bridge lives as long as the process, so the operating system reclaims the sockets when it exits, and the only symptom is a warning at shutdown. It bites where a bridge is started and stopped **inside** a long-running process — each cycle abandoned a pool of network connections. Our own test suite does exactly that thousands of times per run, which is how it surfaced.

**What changed for the product.** Every provider now answers one instruction — *release your connection* — and the bridge issues it to every provider it owns as part of shutting down, after in-flight requests have finished. One provider misbehaving cannot stop the others, and cannot cost the bridge its own cleanup.

**What this is not.** No change to how requests are served, routed, translated or authenticated. Nothing a user sends or receives moves. This is shutdown hygiene, and its value is that a long-lived bridge stops accumulating dead connections.

**Three follow-ups found while here**, filed and linked rather than folded in: [KBR-210](https://shelpuk.atlassian.net/browse/KBR-210), [KBR-211](https://shelpuk.atlassian.net/browse/KBR-211), [KBR-212](https://shelpuk.atlassian.net/browse/KBR-212).

---

## What was wrong

`BridgeServer.stop_async` promised, in its own docstring, to *"close the HTTP client session"*, and closed the two the bridge builds. The three adapters that set `use_custom_transport` bypass those entirely, and two of them cache a client of their own that **nothing** closed:

| Adapter | Cached client | Closed by, before this change |
|---|---|---|
| `ollama_cloud` | `aiohttp.ClientSession` | nobody |
| `openai_subscription` — serving | `curl_cffi.AsyncSession` | nobody |
| `openai_subscription` — OAuth refresh | `curl_cffi.AsyncSession` | nobody |
| `bedrock` | *none cached* | n/a |

The ticket names one ChatGPT session; there are **two** — the refresh leg has had its own since KBR-161.

## What this does

`ProviderAdapter.aclose()` — a no-op default, overridden by the two adapters that own a client, awaited by `stop_async` for every adapter the bridge holds.

`bedrock` gets **no** override, and that is a decision rather than an omission: `_get_boto3_client` builds a client per request and caches nothing on the instance. `TestItCachesNoTransport` pins that property directly, and the registry sweep in `test_wire_shape_honesty.py` names bedrock as the one exemption — so a fourth custom-transport adapter has to classify itself rather than inherit silence.

### Three things this had to get right

**Order.** `_runner.cleanup()` drains in-flight handlers first, then the bridge's own sessions and state file, then the adapters. A **failed drain deliberately skips** the adapter close: an undrained handler may still hold a live stream, and closing a `curl_cffi` session under one is the shape [curl_cffi #675](https://github.com/lexiforest/curl_cffi/issues/675) reported as a segfault. That issue was filed against 0.13.0 and closed upstream as no longer reproducible, and we pin 0.16.3 — but #845 still tracks #751, so leaking a pool beats crashing the process.

**Containment, in both directions.** One adapter's failure is logged and contained, so the others still close. And the adapters close from a `finally`, so a failure in the bridge's *own* teardown cannot skip them — which would leak exactly what this fixes. `asyncio.CancelledError` is a `BaseException`, so cancellation still propagates rather than being swallowed (verified on the pinned interpreter).

**Detach before closing.** Each override clears its cached attribute **before** awaiting `close()`. The `curl_cffi` builders test for absence only, so a session left in place after a failed close would be handed back for the rest of the process's life — and the containment above would make that silent as well as permanent. This was a blocker raised against my own first implementation.

Teardown reads the backing fields `_provider` / `_backends`, never the `_active_*` properties: those resolve through a request-scoped `ContextVar`, and teardown is not a request. Deduplicated by identity, because balancing mode is constructed with `provider=backends[0][0]`.

## Two recorded decisions are reversed — deliberately, and in writing

Neither is contradicted silently; both docstrings are rewritten in the same change.

1. **T-B1's transport** argued its reach into `adapter._session` belonged in the harness, because *"the product's session is a per-process pool whose lifetime is the process."* False as measured: `get_provider` returns a fresh adapter per call, and all five production call sites build theirs immediately before the `BridgeServer` that receives them. The private reach is gone. The **call** remains, on the public hook, because four tests in that module drive the adapter with no bridge at all and would otherwise leak a session each.
2. **`_curl_session`'s** *"never explicitly closed during normal operation"* note is replaced by the measured basis above.

`.system_design/TEST_SUITE.md` §5.5 gains a **who closes** column covering all five outbound paths, plus the ownership contract. The two KBR-161 passages arguing from *"the process lifetime"* are re-derived — that window is the bridge's now; the separation argument survives intact, only the window shrinks.

## Testing

All L1, per §2.2 — nothing here touches a socket or a clock, and §2.2's own worked example places a test that must construct a `BridgeServer` at L1. New file `tests/bridge/test_adapter_transport_close.py` lands at `l1` by path default, so no layer-registry edit.

**Every new test was watched failing first**, and the load-bearing ones were falsified against a deliberate defect — the repo's standing rule is that a guard no defect can kill is decoration:

| Defect injected | Test that died |
|---|---|
| `stop_async` no longer closes adapters | the harness test, alone in its module |
| teardown reads `_active_provider` | `test_it_reads_the_backing_fields_not_the_request_context`, and nothing else |
| adapters leave the inner `finally` | `test_a_failing_bridge_teardown_still_closes_the_adapters` |
| adapters move to the **outer** `finally` | `test_a_failed_drain_deliberately_skips_the_adapters` |
| `aclose` closes then clears | the three raising-close tests |
| `OllamaCloudAdapter.aclose` deleted | the registry sweep, alone in its file |
| transport releases the port before closing | `test_the_session_closes_before_the_port_is_released` |
| bedrock caches its client | both `TestItCachesNoTransport` cases |
| a client stored but not reused | `test_no_client_is_stored_on_the_instance`, alone |

**Gate: 5191 passed, 2 skipped**, plus `ruff`, `lint-imports` (5 contracts kept) and `mypy` (90 files) clean.

## Review

`system-design-reviewer` twice — six blockers, including one live in code already written. `code-reviewer` ran a **19-mutation sweep** of its own against these tests; both of its findings are applied:

- an assertion-free idempotence test that no defect could *uniquely* kill — dropped, by the rule above;
- a bedrock docstring stating a reason I had not measured — replaced by the one I did, and then measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[KBR-190]: https://shelpuk.atlassian.net/browse/KBR-190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KBR-210]: https://shelpuk.atlassian.net/browse/KBR-210?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ